### PR TITLE
HSEARCH-4300 Fix build timeout after 1 hour when testing against DB2

### DIFF
--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/limitations/ConcurrentEmbeddedUpdateLimitationIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/limitations/ConcurrentEmbeddedUpdateLimitationIT.java
@@ -95,7 +95,7 @@ public class ConcurrentEmbeddedUpdateLimitationIT {
 	}
 
 	private void reproducer() throws Throwable {
-		with( sessionFactory ).run( session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			Book book = new Book();
 			book.setTitle( "The Caves Of Steel" );
 
@@ -172,7 +172,7 @@ public class ConcurrentEmbeddedUpdateLimitationIT {
 	}
 
 	long countByEditionAndAuthor(String editionLabel, String authorName) {
-		return with( sessionFactory ).apply( session -> {
+		return with( sessionFactory ).applyInTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			return searchSession.search( Book.class )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingConcurrentModificationInDifferentTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingConcurrentModificationInDifferentTypeIT.java
@@ -11,30 +11,33 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.OneToOne;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
 
 public class AutomaticIndexingConcurrentModificationInDifferentTypeIT {
-	@Rule
-	public BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
 
 	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
 
-	private SessionFactory sessionFactory;
-
-	@Before
-	public void setup() {
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		backendMock.expectSchema( ParentEntity.NAME, b -> b
 				.field( "name", String.class )
 				.objectField( "child", b2 -> b2
@@ -48,13 +51,12 @@ public class AutomaticIndexingConcurrentModificationInDifferentTypeIT {
 				.field( "name", String.class )
 		);
 
-		sessionFactory = ormSetupHelper.start()
-				.setup( ParentEntity.class, ChildEntity.class, OtherEntity.class );
+		setupContext.withAnnotatedTypes( ParentEntity.class, ChildEntity.class, OtherEntity.class );
+	}
 
-		backendMock.verifyExpectationsMet();
-
-		// Data init
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+	@Before
+	public void initData() {
+		setupHolder.runInTransaction( session -> {
 			ChildEntity entity1 = new ChildEntity();
 			entity1.setId( 1 );
 			entity1.setName( "edouard" );
@@ -93,7 +95,7 @@ public class AutomaticIndexingConcurrentModificationInDifferentTypeIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3857")
 	public void updateTriggeringReindexingOfPreviouslyUnknownEntityType() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			ChildEntity entity1 = session.load( ChildEntity.class, 1 );
 			entity1.setName( "updated" );
 			// Add another type to the indexing plan so that we're not done iterating over all types

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingAssociationDeletionBytecodeEnhancementIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingAssociationDeletionBytecodeEnhancementIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.association;
 
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
@@ -23,10 +24,9 @@ import org.junit.runner.RunWith;
 public class AutomaticIndexingAssociationDeletionBytecodeEnhancementIT
 		extends AutomaticIndexingAssociationDeletionIT {
 
-	@Override
-	protected OrmSetupHelper.SetupContext configure(OrmSetupHelper.SetupContext ctx) {
-		return ctx
-				// Necessary for BytecodeEnhancerRunner, see BytecodeEnhancementIT.setup
-				.withTcclLookupPrecedenceBefore();
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext) {
+		// Necessary for BytecodeEnhancerRunner, see BytecodeEnhancementIT.setup
+		setupContext.withTcclLookupPrecedenceBefore();
 	}
 }

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingAssociationDeletionIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingAssociationDeletionIT.java
@@ -546,6 +546,7 @@ public class AutomaticIndexingAssociationDeletionIT {
 
 		@IndexedEmbedded(includePaths = {"basic", "elementCollection"})
 		@ManyToMany(mappedBy = "manyToMany")
+		@OrderBy("id")
 		private List<AssociationOwner> manyToMany = new ArrayList<>();
 
 		AssociationNonOwner() {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingGenericPolymorphicAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingGenericPolymorphicAssociationIT.java
@@ -63,7 +63,8 @@ public class AutomaticIndexingGenericPolymorphicAssociationIT {
 				ContainedEntity.class
 		);
 
-		dataClearConfig.clearOrder( IndexedEntity.class, ContainingEntity.class, ContainedEntity.class );
+		dataClearConfig.clearOrder( IndexedEntity.class, ContainingEntity.class, MiddleContainingEntity.class,
+				UnrelatedContainingEntity.class, ContainedEntity.class );
 	}
 
 	@Test

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingPolymorphicInverseSideAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingPolymorphicInverseSideAssociationIT.java
@@ -66,7 +66,8 @@ public class AutomaticIndexingPolymorphicInverseSideAssociationIT {
 				ContainedEntity.class
 		);
 
-		dataClearConfig.clearOrder( IndexedEntity.class, ContainingEntity.class, ContainedEntity.class );
+		dataClearConfig.clearOrder( IndexedEntity.class, ContainingEntity.class, UnrelatedContainingEntity.class,
+				FirstMiddleContainingEntity.class, SecondMiddleContainingEntity.class, ContainedEntity.class );
 	}
 
 	/**

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingPolymorphicInverseSideAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingPolymorphicInverseSideAssociationIT.java
@@ -19,17 +19,17 @@ import javax.persistence.OneToOne;
 import javax.persistence.OrderBy;
 import javax.persistence.Transient;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
 
 /**
  * Test automatic indexing based on Hibernate ORM entity events
@@ -37,16 +37,17 @@ import org.junit.Test;
  */
 public class AutomaticIndexingPolymorphicInverseSideAssociationIT {
 
-	@Rule
-	public BackendMock backendMock = new BackendMock();
+	@ClassRule
+	public static BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
 
 	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
 
-	private SessionFactory sessionFactory;
-
-	@Before
-	public void setup() {
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext, ReusableOrmSetupHolder.DataClearConfig dataClearConfig) {
 		backendMock.expectSchema( IndexedEntity.INDEX, b -> b
 				.objectField( "child", b3 -> b3
 						.objectField( "containedSingle", b2 -> b2
@@ -55,17 +56,17 @@ public class AutomaticIndexingPolymorphicInverseSideAssociationIT {
 				)
 		);
 
-		sessionFactory = ormSetupHelper.start()
-				.setup(
-						IndexedEntity.class,
-						ContainingEntity.class,
-						UnrelatedContainingEntity.class,
-						AbstractMiddleContainingEntity.class,
-						FirstMiddleContainingEntity.class,
-						SecondMiddleContainingEntity.class,
-						ContainedEntity.class
-				);
-		backendMock.verifyExpectationsMet();
+		setupContext.withAnnotatedTypes(
+				IndexedEntity.class,
+				ContainingEntity.class,
+				UnrelatedContainingEntity.class,
+				AbstractMiddleContainingEntity.class,
+				FirstMiddleContainingEntity.class,
+				SecondMiddleContainingEntity.class,
+				ContainedEntity.class
+		);
+
+		dataClearConfig.clearOrder( IndexedEntity.class, ContainingEntity.class, ContainedEntity.class );
 	}
 
 	/**
@@ -75,7 +76,7 @@ public class AutomaticIndexingPolymorphicInverseSideAssociationIT {
 	 */
 	@Test
 	public void inversePathIgnoresUnrelatedTypes() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity indexedEntity = new IndexedEntity();
 			indexedEntity.setId( 1 );
 
@@ -117,7 +118,7 @@ public class AutomaticIndexingPolymorphicInverseSideAssociationIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating the value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 5 );
 			containedEntity.setIncludedInSingle( "updatedValue" );
 
@@ -142,7 +143,7 @@ public class AutomaticIndexingPolymorphicInverseSideAssociationIT {
 	 */
 	@Test
 	public void inversePathDependsOnConcreteType() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity indexedEntity1 = new IndexedEntity();
 			indexedEntity1.setId( 1 );
 
@@ -200,7 +201,7 @@ public class AutomaticIndexingPolymorphicInverseSideAssociationIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating the value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 5 );
 			containedEntity.setIncludedInSingle( "updatedValue" );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingPolymorphicOriginalSideAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingPolymorphicOriginalSideAssociationIT.java
@@ -18,17 +18,17 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.OrderBy;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
 
 /**
  * Test automatic indexing based on Hibernate ORM entity events
@@ -36,16 +36,17 @@ import org.junit.Test;
  */
 public class AutomaticIndexingPolymorphicOriginalSideAssociationIT {
 
-	@Rule
-	public BackendMock backendMock = new BackendMock();
+	@ClassRule
+	public static BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
 
 	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
 
-	private SessionFactory sessionFactory;
-
-	@Before
-	public void setup() {
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		backendMock.expectSchema( IndexedEntity.INDEX, b -> b
 				.objectField( "child", b3 -> b3
 						.objectField( "containedSingle", b2 -> b2
@@ -54,15 +55,13 @@ public class AutomaticIndexingPolymorphicOriginalSideAssociationIT {
 				)
 		);
 
-		sessionFactory = ormSetupHelper.start()
-				.setup(
-						IndexedEntity.class,
-						ContainingEntity.class,
-						FirstMiddleContainingEntity.class,
-						SecondMiddleContainingEntity.class,
-						ContainedEntity.class
-				);
-		backendMock.verifyExpectationsMet();
+		setupContext.withAnnotatedTypes(
+				IndexedEntity.class,
+				ContainingEntity.class,
+				FirstMiddleContainingEntity.class,
+				SecondMiddleContainingEntity.class,
+				ContainedEntity.class
+		);
 	}
 
 	/**
@@ -75,7 +74,7 @@ public class AutomaticIndexingPolymorphicOriginalSideAssociationIT {
 	 */
 	@Test
 	public void inversePathDependsOnConcreteType() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity indexedEntity1 = new IndexedEntity();
 			indexedEntity1.setId( 1 );
 
@@ -135,7 +134,7 @@ public class AutomaticIndexingPolymorphicOriginalSideAssociationIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating the value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 5 );
 			containedEntity.setIncludedInSingle( "updatedValue" );
 
@@ -188,7 +187,8 @@ public class AutomaticIndexingPolymorphicOriginalSideAssociationIT {
 	}
 
 	@Entity(name = "containing")
-	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS) // Necessary because subtypes declare columns with identical names
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	// Necessary because subtypes declare columns with identical names
 	public abstract static class ContainingEntity {
 		@Id
 		private Integer id;

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/AbstractAutomaticIndexingMultiValuedAssociationBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/AbstractAutomaticIndexingMultiValuedAssociationBaseIT.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.association.bytype;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
-
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Test;
@@ -41,7 +39,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 
 	@Test
 	public void directMultiValuedAssociationUpdate_indexedEmbedded() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			session.persist( entity1 );
@@ -52,7 +50,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 2 );
@@ -73,7 +71,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a second value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 3 );
@@ -97,7 +95,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = session.get( primitives.getContainedClass(), 2 );
@@ -125,7 +123,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3199")
 	public void directMultiValuedAssociationReplace_indexedEmbedded() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContained contained = primitives.newContained( 2 );
@@ -146,7 +144,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 3 );
@@ -182,7 +180,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3199")
 	public void directMultiValuedAssociationMultiValuedUpdate_nonIndexedEmbedded() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			session.persist( entity1 );
@@ -193,7 +191,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 2 );
@@ -209,7 +207,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a second value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 3 );
@@ -225,7 +223,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = session.get( primitives.getContainedClass(), 2 );
@@ -249,7 +247,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3204")
 	public void directMultiValuedAssociationReplace_nonIndexedEmbedded() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContained contained = primitives.newContained( 2 );
@@ -266,7 +264,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 3 );
@@ -296,7 +294,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-4001")
 	public void directMultiValuedAssociationUpdate_indexedEmbeddedShallowReindexOnUpdate() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			session.persist( entity1 );
@@ -307,7 +305,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 2 );
@@ -328,7 +326,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a second value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 3 );
@@ -352,7 +350,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = session.get( primitives.getContainedClass(), 2 );
@@ -381,7 +379,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-4001")
 	public void directMultiValuedAssociationReplace_indexedEmbeddedShallowReindexOnUpdate() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContained contained = primitives.newContained( 2 );
@@ -402,7 +400,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 3 );
@@ -438,7 +436,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3206")
 	public void directMultiValuedAssociationUpdate_indexedEmbeddedNoReindexOnUpdate() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			session.persist( entity1 );
@@ -449,7 +447,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 2 );
@@ -465,7 +463,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a second value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 3 );
@@ -481,7 +479,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = session.get( primitives.getContainedClass(), 2 );
@@ -505,7 +503,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3204")
 	public void directMultiValuedAssociationReplace_indexedEmbeddedNoReindexOnUpdate() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContained contained = primitives.newContained( 2 );
@@ -526,7 +524,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 3 );
@@ -557,7 +555,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 
 	@Test
 	public void indirectMultiValuedAssociationUpdate_indexedEmbedded() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -580,7 +578,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 4 );
@@ -603,7 +601,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding another value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 5 );
@@ -629,7 +627,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining deeplyNestedContainingEntity1 = session.get( primitives.getContainingClass(), 3 );
 
 			TContained contained = primitives.newContained( 6 );
@@ -645,7 +643,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
@@ -676,7 +674,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3199")
 	public void indirectMultiValuedAssociationReplace_indexedEmbedded() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -703,7 +701,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 4 );
@@ -741,7 +739,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3199")
 	public void indirectMultiValuedAssociationUpdate_nonIndexedEmbedded() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -759,7 +757,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 4 );
@@ -775,7 +773,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding another value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 5 );
@@ -791,7 +789,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
@@ -815,7 +813,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3204")
 	public void indirectMultiValuedAssociationReplace_nonIndexedEmbedded() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -838,7 +836,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 4 );
@@ -871,7 +869,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-4001")
 	public void indirectMultiValuedAssociationUpdate_indexedEmbeddedShallowReindexOnUpdate() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -889,7 +887,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 4 );
@@ -912,7 +910,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding another value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 5 );
@@ -938,7 +936,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
@@ -972,7 +970,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-4001")
 	public void indirectMultiValuedAssociationReplace_indexedEmbeddedShallowReindexOnUpdate() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -999,7 +997,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 4 );
@@ -1038,7 +1036,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3206")
 	public void indirectMultiValuedAssociationUpdate_indexedEmbeddedNoReindexOnUpdate() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -1056,7 +1054,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 4 );
@@ -1072,7 +1070,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding another value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 5 );
@@ -1088,7 +1086,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
@@ -1113,7 +1111,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3204")
 	public void indirectMultiValuedAssociationReplace_indexedEmbeddedNoReindexOnUpdate() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -1140,7 +1138,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 4 );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontained/AutomaticIndexingManyToManyOwnedByContainedListBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontained/AutomaticIndexingManyToManyOwnedByContainedListBaseIT.java
@@ -273,26 +273,32 @@ public class AutomaticIndexingManyToManyOwnedByContainedListBaseIT
 		private ContainingEntity child;
 
 		@ManyToMany(mappedBy = "containingAsIndexedEmbedded")
+		@OrderBy("id asc") // Make sure the iteration order is predictable
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		private List<ContainedEntity> containedIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany(mappedBy = "containingAsNonIndexedEmbedded")
+		@OrderBy("id asc") // Make sure the iteration order is predictable
 		private List<ContainedEntity> containedNonIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany(mappedBy = "containingAsIndexedEmbeddedShallowReindexOnUpdate")
+		@OrderBy("id asc") // Make sure the iteration order is predictable
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 		private List<ContainedEntity> containedIndexedEmbeddedShallowReindexOnUpdate = new ArrayList<>();
 
 		@ManyToMany(mappedBy = "containingAsIndexedEmbeddedNoReindexOnUpdate")
+		@OrderBy("id asc") // Make sure the iteration order is predictable
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.NO)
 		private List<ContainedEntity> containedIndexedEmbeddedNoReindexOnUpdate = new ArrayList<>();
 
 		@ManyToMany(mappedBy = "containingAsUsedInCrossEntityDerivedProperty")
+		@OrderBy("id asc") // Make sure the iteration order is predictable
 		private List<ContainedEntity> containedUsedInCrossEntityDerivedProperty = new ArrayList<>();
 
 		@ManyToMany(mappedBy = "containingAsIndexedEmbeddedWithCast", targetEntity = ContainedEntity.class)
+		@OrderBy("id asc") // Make sure the iteration order is predictable
 		@IndexedEmbedded(includePaths = "indexedField", targetType = ContainedEntity.class)
 		private List<Object> containedIndexedEmbeddedWithCast = new ArrayList<>();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontained/AutomaticIndexingManyToManyOwnedByContainedListBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontained/AutomaticIndexingManyToManyOwnedByContainedListBaseIT.java
@@ -412,37 +412,44 @@ public class AutomaticIndexingManyToManyOwnedByContainedListBaseIT
 		private Integer id;
 
 		@ManyToMany
-		@JoinTable(name = "i_containedIndexedEmbedded")
+		@JoinTable(name = "i_containedIndexedEmbedded",
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		private List<ContainingEntity> containingAsIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany
-		@JoinTable(name = "i_containedNonIndexedEmbedded", joinColumns = @JoinColumn(name = "containedNonIndexedEmbedded"),
-				inverseJoinColumns = @JoinColumn(name = "containingNonIndexedEmbedded"))
+		@JoinTable(name = "i_containedNonIndexedEmbedded",
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		private List<ContainingEntity> containingAsNonIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany
 		@JoinTable(name = "i_indexedEmbeddedShallow",
-				joinColumns = @JoinColumn(name = "indexedEmbeddedShallow"))
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		private List<ContainingEntity> containingAsIndexedEmbeddedShallowReindexOnUpdate = new ArrayList<>();
 
 		@ManyToMany
 		@JoinTable(name = "i_indexedEmbeddedNoReindex",
-				joinColumns = @JoinColumn(name = "indexedEmbeddedNoReindex"))
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		private List<ContainingEntity> containingAsIndexedEmbeddedNoReindexOnUpdate = new ArrayList<>();
 
 		@ManyToMany
-		@JoinTable(name = "i_containedCrossEntityDP", joinColumns = @JoinColumn(name = "containedCrossEntityDP"),
-				inverseJoinColumns = @JoinColumn(name = "containingCrossEntityDP"))
+		@JoinTable(name = "i_containedCrossEntityDP",
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		private List<ContainingEntity> containingAsUsedInCrossEntityDerivedProperty = new ArrayList<>();
 
 		@ManyToMany(targetEntity = ContainingEntity.class)
-		@JoinTable(name = "i_containedIndexedEmbeddedCast", joinColumns = @JoinColumn(name = "containedIndexedEmbeddedCast"),
-				inverseJoinColumns = @JoinColumn(name = "containingIndexedEmbeddedCast"))
+		@JoinTable(name = "i_containedIndexedEmbeddedCast",
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		private List<Object> containingAsIndexedEmbeddedWithCast = new ArrayList<>();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingListBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingListBaseIT.java
@@ -273,37 +273,44 @@ public class AutomaticIndexingManyToManyOwnedByContainingListBaseIT
 		private ContainingEntity child;
 
 		@ManyToMany
-		@JoinTable(name = "i_containedIndexedEmbedded")
+		@JoinTable(name = "i_containedIndexedEmbedded",
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		private List<ContainedEntity> containedIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany
-		@JoinTable(name = "i_containedNonIndexedEmbedded", joinColumns = @JoinColumn(name = "containingNonIndexedEmbedded"),
-			inverseJoinColumns = @JoinColumn(name = "containedNonIndexedEmbedded"))
+		@JoinTable(name = "i_containedNonIndexedEmbedded",
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		private List<ContainedEntity> containedNonIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany
 		@JoinTable(name = "i_indexedEmbeddedShallow",
-			inverseJoinColumns = @JoinColumn(name = "indexedEmbeddedShallow"))
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 		private List<ContainedEntity> containedIndexedEmbeddedShallowReindexOnUpdate = new ArrayList<>();
 
 		@ManyToMany
 		@JoinTable(name = "i_indexedEmbeddedNoReindex",
-			inverseJoinColumns = @JoinColumn(name = "indexedEmbeddedNoReindex"))
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.NO)
 		private List<ContainedEntity> containedIndexedEmbeddedNoReindexOnUpdate = new ArrayList<>();
 
 		@ManyToMany
-		@JoinTable(name = "i_containedCrossEntityDP", joinColumns = @JoinColumn(name = "containingCrossEntityDP"),
-				inverseJoinColumns = @JoinColumn(name = "containedCrossEntityDP"))
+		@JoinTable(name = "i_containedCrossEntityDP",
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		private List<ContainedEntity> containedUsedInCrossEntityDerivedProperty = new ArrayList<>();
 
 		@ManyToMany(targetEntity = ContainedEntity.class)
-		@JoinTable(name = "i_containedIndexedEmbeddedCast", joinColumns = @JoinColumn(name = "containingIndexedEmbeddedCast"),
-				inverseJoinColumns = @JoinColumn(name = "containedIndexedEmbeddedCast"))
+		@JoinTable(name = "i_containedIndexedEmbeddedCast",
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		@IndexedEmbedded(includePaths = "indexedField", targetType = ContainedEntity.class)
 		private List<Object> containedIndexedEmbeddedWithCast = new ArrayList<>();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT.java
@@ -287,11 +287,11 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 		@ElementCollection
 		@JoinTable(
 				name = "i_containedIndexedEmbedded",
-				joinColumns = @JoinColumn(name = "mapHolder")
+				joinColumns = @JoinColumn(name = "containing")
 		)
-		@MapKeyJoinColumn(name = "map_key")
+		@MapKeyJoinColumn(name = "contained")
 		@Column(name = "value")
-		@OrderBy("map_key asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
+		@OrderBy("contained asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
 		@IndexedEmbedded(
 				includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" },
 				extraction = @ContainerExtraction(BuiltinContainerExtractors.MAP_KEY)
@@ -301,21 +301,21 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 		@ElementCollection
 		@JoinTable(
 				name = "i_containedNonIndexedEmbedded",
-				joinColumns = @JoinColumn(name = "mapHolder")
+				joinColumns = @JoinColumn(name = "containing")
 		)
-		@MapKeyJoinColumn(name = "map_key")
+		@MapKeyJoinColumn(name = "contained")
 		@Column(name = "value")
-		@OrderBy("map_key asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
+		@OrderBy("contained asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
 		private Map<ContainedEntity, String> containedNonIndexedEmbedded = new LinkedHashMap<>();
 
 		@ElementCollection
 		@JoinTable(
 				name = "i_indexedEmbeddedShallow",
-				joinColumns = @JoinColumn(name = "mapHolder")
+				joinColumns = @JoinColumn(name = "containing")
 		)
-		@MapKeyJoinColumn(name = "map_key")
+		@MapKeyJoinColumn(name = "contained")
 		@Column(name = "value")
-		@OrderBy("map_key asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
+		@OrderBy("contained asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
 		@IndexedEmbedded(
 				includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" },
 				extraction = @ContainerExtraction(BuiltinContainerExtractors.MAP_KEY)
@@ -329,11 +329,11 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 		@ElementCollection
 		@JoinTable(
 				name = "i_indexedEmbeddedNoReindex",
-				joinColumns = @JoinColumn(name = "mapHolder")
+				joinColumns = @JoinColumn(name = "containing")
 		)
-		@MapKeyJoinColumn(name = "map_key")
+		@MapKeyJoinColumn(name = "contained")
 		@Column(name = "value")
-		@OrderBy("map_key asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
+		@OrderBy("contained asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
 		@IndexedEmbedded(
 				includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" },
 				extraction = @ContainerExtraction(BuiltinContainerExtractors.MAP_KEY)
@@ -347,22 +347,22 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 		@ElementCollection
 		@JoinTable(
 				name = "i_containedCrossEntityDP",
-				joinColumns = @JoinColumn(name = "mapHolder")
+				joinColumns = @JoinColumn(name = "containing")
 		)
-		@MapKeyJoinColumn(name = "map_key")
+		@MapKeyJoinColumn(name = "contained")
 		@Column(name = "value")
-		@OrderBy("map_key asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
+		@OrderBy("contained asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
 		private Map<ContainedEntity, String> containedUsedInCrossEntityDerivedProperty = new LinkedHashMap<>();
 
 		@ElementCollection
 		@JoinTable(
 				name = "i_containedIndexedEmbeddedCast",
-				joinColumns = @JoinColumn(name = "mapHolder")
+				joinColumns = @JoinColumn(name = "containing")
 		)
 		@MapKeyClass(ContainedEntity.class)
-		@MapKeyJoinColumn(name = "map_key")
+		@MapKeyJoinColumn(name = "contained")
 		@Column(name = "value")
-		@OrderBy("map_key asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
+		@OrderBy("contained asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
 		@IndexedEmbedded(
 				includePaths = { "indexedField" },
 				extraction = @ContainerExtraction(BuiltinContainerExtractors.MAP_KEY),
@@ -492,7 +492,9 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 		 * and ends up adding all kind of wrong foreign keys.
 		 */
 		@ManyToMany
-		@JoinTable(name = "contained_mapHolder")
+		@JoinTable(name = "contained_indEmd",
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		@AssociationInverseSide(
 				inversePath = @ObjectPath(
@@ -508,8 +510,9 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 		 * No mappedBy here, same reasons as above.
 		 */
 		@ManyToMany
-		@JoinTable(name = "contained_nonIndexedMapHolder",
-				inverseJoinColumns = @JoinColumn(name = "containingNonIndexedEmbedded"))
+		@JoinTable(name = "contained_nonIndEmd",
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		private List<ContainingEntity> containingAsNonIndexedEmbedded = new ArrayList<>();
 
@@ -517,8 +520,9 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 		 * No mappedBy here, same reasons as above.
 		 */
 		@ManyToMany
-		@JoinTable(name = "contained_indexedShallowMapHolder",
-				inverseJoinColumns = @JoinColumn(name = "containingIndexedShallow"))
+		@JoinTable(name = "contained_indEmdShallow",
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		@AssociationInverseSide(
 				inversePath = @ObjectPath(
@@ -534,8 +538,9 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 		 * No mappedBy here, same reasons as above.
 		 */
 		@ManyToMany
-		@JoinTable(name = "contained_indexedNoReindexMapHolder",
-				inverseJoinColumns = @JoinColumn(name = "containingIndexedNoReindex"))
+		@JoinTable(name = "contained_indEmdNoReindex",
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		@AssociationInverseSide(
 				inversePath = @ObjectPath(
@@ -551,7 +556,9 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 		 * No mappedBy here, same reasons as above.
 		 */
 		@ManyToMany
-		@JoinTable(inverseJoinColumns = @JoinColumn(name = "containingCrossEntityPD"))
+		@JoinTable(name = "contained_usedInCEDP",
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		@AssociationInverseSide(
 				inversePath = @ObjectPath(
@@ -569,8 +576,9 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 		 * and ends up adding all kind of wrong foreign keys.
 		 */
 		@ManyToMany(targetEntity = ContainingEntity.class)
-		@JoinTable(name = "contained_withCastMapHolder",
-			inverseJoinColumns = @JoinColumn(name = "containingIndexedEmbeddedCast"))
+		@JoinTable(name = "contained_indEmdWithCast",
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		@AssociationInverseSide(
 				inversePath = @ObjectPath(

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT.java
@@ -42,6 +42,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmb
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyValue;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 
 
 /**
@@ -60,6 +61,18 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 
 	public AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT() {
 		super( new ModelPrimitivesImpl() );
+	}
+
+	@ReusableOrmSetupHolder.Setup
+	public void setup(ReusableOrmSetupHolder.DataClearConfig dataClearConfig) {
+		dataClearConfig.preClear( ContainedEntity.class, contained -> {
+			contained.getContainingAsIndexedEmbedded().clear();
+			contained.getContainingAsNonIndexedEmbedded().clear();
+			contained.getContainingAsIndexedEmbeddedShallowReindexOnUpdate().clear();
+			contained.getContainingAsIndexedEmbeddedNoReindexOnUpdate().clear();
+			contained.getContainingAsUsedInCrossEntityDerivedProperty().clear();
+			contained.getContainingAsIndexedEmbeddedWithCast().clear();
+		} );
 	}
 
 	private static class ModelPrimitivesImpl

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingMapValuesBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingMapValuesBaseIT.java
@@ -287,8 +287,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapValuesBaseIT
 		@ManyToMany
 		@JoinTable(
 				name = "i_containedIndexedEmbedded",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
@@ -298,8 +298,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapValuesBaseIT
 		@ManyToMany
 		@JoinTable(
 				name = "i_containedNonIndexedEmbedded",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@OrderBy("id asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
@@ -308,8 +308,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapValuesBaseIT
 		@ManyToMany
 		@JoinTable(
 				name = "i_indexedEmbeddedShallow",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
@@ -320,8 +320,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapValuesBaseIT
 		@ManyToMany
 		@JoinTable(
 				name = "i_indexedEmbeddedNoReindex",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
@@ -332,8 +332,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapValuesBaseIT
 		@ManyToMany
 		@JoinTable(
 				name = "i_containedCrossEntityDP",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@OrderBy("id asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
@@ -342,8 +342,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapValuesBaseIT
 		@ManyToMany(targetEntity = ContainedEntity.class)
 		@JoinTable(
 				name = "i_containedIndexedEmbeddedCast",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@IndexedEmbedded(includePaths = "indexedField", targetType = ContainedEntity.class)

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingSortedMapValuesBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingSortedMapValuesBaseIT.java
@@ -290,8 +290,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingSortedMapValuesBaseIT
 		@ManyToMany
 		@JoinTable(
 				name = "i_containedIndexedEmbedded",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
@@ -301,8 +301,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingSortedMapValuesBaseIT
 		@ManyToMany
 		@JoinTable(
 				name = "i_containedNonIndexedEmbedded",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@SortNatural
@@ -311,8 +311,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingSortedMapValuesBaseIT
 		@ManyToMany
 		@JoinTable(
 				name = "i_indexedEmbeddedShallow",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
@@ -323,8 +323,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingSortedMapValuesBaseIT
 		@ManyToMany
 		@JoinTable(
 				name = "i_indexedEmbeddedNoReindex",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
@@ -335,8 +335,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingSortedMapValuesBaseIT
 		@ManyToMany
 		@JoinTable(
 				name = "i_containedCrossEntityDP",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@SortNatural
@@ -345,8 +345,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingSortedMapValuesBaseIT
 		@ManyToMany(targetEntity = ContainedEntity.class)
 		@JoinTable(
 				name = "i_containedIndexedEmbeddedCast",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@IndexedEmbedded(includePaths = "indexedField", targetType = ContainedEntity.class)

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingSortedSetBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingSortedSetBaseIT.java
@@ -277,20 +277,24 @@ public class AutomaticIndexingManyToManyOwnedByContainingSortedSetBaseIT
 		private ContainingEntity child;
 
 		@ManyToMany
-		@JoinTable(name = "i_containedIndexedEmbedded")
+		@JoinTable(name = "i_containedIndexedEmbedded",
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@SortNatural
 		private SortedSet<ContainedEntity> containedIndexedEmbedded = new TreeSet<>();
 
 		@ManyToMany
-		@JoinTable(name = "i_containedNonIndexedEmbedded", joinColumns = @JoinColumn(name = "containingNonIndexedEmbedded"),
-				inverseJoinColumns = @JoinColumn(name = "containedNonIndexedEmbedded"))
+		@JoinTable(name = "i_containedNonIndexedEmbedded",
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		@SortNatural
 		private SortedSet<ContainedEntity> containedNonIndexedEmbedded = new TreeSet<>();
 
 		@ManyToMany
 		@JoinTable(name = "i_indexedEmbeddedShallow",
-				inverseJoinColumns = @JoinColumn(name = "indexedEmbeddedShallow"))
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 		@SortNatural
@@ -298,21 +302,24 @@ public class AutomaticIndexingManyToManyOwnedByContainingSortedSetBaseIT
 
 		@ManyToMany
 		@JoinTable(name = "i_indexedEmbeddedNoReindex",
-				inverseJoinColumns = @JoinColumn(name = "indexedEmbeddedNoReindex"))
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.NO)
 		@SortNatural
 		private SortedSet<ContainedEntity> containedIndexedEmbeddedNoReindexOnUpdate = new TreeSet<>();
 
 		@ManyToMany
-		@JoinTable(name = "i_containedCrossEntityDP", joinColumns = @JoinColumn(name = "containingCrossEntityDP"),
-				inverseJoinColumns = @JoinColumn(name = "containedCrossEntityDP"))
+		@JoinTable(name = "i_containedCrossEntityDP",
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		@SortNatural
 		private SortedSet<ContainedEntity> containedUsedInCrossEntityDerivedProperty = new TreeSet<>();
 
 		@ManyToMany(targetEntity = ContainedEntity.class)
-		@JoinTable(name = "i_containedIndexedEmbeddedCast", joinColumns = @JoinColumn(name = "containingIndexedEmbeddedCast"),
-				inverseJoinColumns = @JoinColumn(name = "containedIndexedEmbeddedCast"))
+		@JoinTable(name = "i_containedIndexedEmbeddedCast",
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		@IndexedEmbedded(includePaths = "indexedField", targetType = ContainedEntity.class)
 		@SortNatural
 		private SortedSet<Object> containedIndexedEmbeddedWithCast = new TreeSet<>();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedBaseIT.java
@@ -303,23 +303,19 @@ public class AutomaticIndexingOneToOneOwnedByContainedBaseIT
 		private ContainedEntity containedNonIndexedEmbedded;
 
 		@OneToOne(mappedBy = "containingAsIndexedEmbeddedShallowReindexOnUpdate")
-		@JoinColumn(name = "CIndexedEmbeddedSROU")
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 		private ContainedEntity containedIndexedEmbeddedShallowReindexOnUpdate;
 
 		@OneToOne(mappedBy = "containingAsIndexedEmbeddedNoReindexOnUpdate")
-		@JoinColumn(name = "CIndexedEmbeddedNROU")
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.NO)
 		private ContainedEntity containedIndexedEmbeddedNoReindexOnUpdate;
 
 		@OneToOne(mappedBy = "containingAsUsedInCrossEntityDerivedProperty")
-		@JoinColumn(name = "CCrossEntityDerived")
 		private ContainedEntity containedUsedInCrossEntityDerivedProperty;
 
 		@OneToOne(mappedBy = "containingAsIndexedEmbeddedWithCast", targetEntity = ContainedEntity.class)
-		@JoinColumn(name = "CIndexedEmbeddedCast")
 		@IndexedEmbedded(includePaths = { "indexedField" }, targetType = ContainedEntity.class)
 		private Object containedIndexedEmbeddedWithCast;
 
@@ -442,21 +438,27 @@ public class AutomaticIndexingOneToOneOwnedByContainedBaseIT
 		private Integer id;
 
 		@OneToOne
+		@JoinColumn(name = "CIndexedEmbedded")
 		private ContainingEntity containingAsIndexedEmbedded;
 
 		@OneToOne
+		@JoinColumn(name = "CNonIndexedEmbedded")
 		private ContainingEntity containingAsNonIndexedEmbedded;
 
 		@OneToOne
+		@JoinColumn(name = "CIndexedEmbeddedSROU")
 		private ContainingEntity containingAsIndexedEmbeddedShallowReindexOnUpdate;
 
 		@OneToOne
+		@JoinColumn(name = "CIndexedEmbeddedNROU")
 		private ContainingEntity containingAsIndexedEmbeddedNoReindexOnUpdate;
 
 		@OneToOne
+		@JoinColumn(name = "CCrossEntityDerived")
 		private ContainingEntity containingAsUsedInCrossEntityDerivedProperty;
 
 		@OneToOne(targetEntity = ContainingEntity.class)
+		@JoinColumn(name = "CIndexedEmbeddedCast")
 		private Object containingAsIndexedEmbeddedWithCast;
 
 		@Basic

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedLazyOnContainingSideBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedLazyOnContainingSideBaseIT.java
@@ -36,6 +36,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDe
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyValue;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
@@ -62,11 +63,10 @@ public class AutomaticIndexingOneToOneOwnedByContainedLazyOnContainingSideBaseIT
 		super( new ModelPrimitivesImpl() );
 	}
 
-	@Override
-	protected OrmSetupHelper.SetupContext configure(OrmSetupHelper.SetupContext setupContext) {
-		return super.configure( setupContext )
-				// Necessary for BytecodeEnhancerRunner, see BytecodeEnhancementIT.setup
-				.withTcclLookupPrecedenceBefore();
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext) {
+		// Necessary for BytecodeEnhancerRunner, see BytecodeEnhancementIT.setup
+		setupContext.withTcclLookupPrecedenceBefore();
 	}
 
 	@Override

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedLazyOnContainingSideBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedLazyOnContainingSideBaseIT.java
@@ -319,23 +319,19 @@ public class AutomaticIndexingOneToOneOwnedByContainedLazyOnContainingSideBaseIT
 		private ContainedEntity containedNonIndexedEmbedded;
 
 		@OneToOne(mappedBy = "containingAsIndexedEmbeddedShallowReindexOnUpdate", fetch = FetchType.LAZY)
-		@JoinColumn(name = "CIndexedEmbeddedSROU")
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 		private ContainedEntity containedIndexedEmbeddedShallowReindexOnUpdate;
 
 		@OneToOne(mappedBy = "containingAsIndexedEmbeddedNoReindexOnUpdate", fetch = FetchType.LAZY)
-		@JoinColumn(name = "CIndexedEmbeddedNROU")
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.NO)
 		private ContainedEntity containedIndexedEmbeddedNoReindexOnUpdate;
 
 		@OneToOne(mappedBy = "containingAsUsedInCrossEntityDerivedProperty", fetch = FetchType.LAZY)
-		@JoinColumn(name = "CCrossEntityDerived")
 		private ContainedEntity containedUsedInCrossEntityDerivedProperty;
 
 		@OneToOne(mappedBy = "containingAsIndexedEmbeddedWithCast", targetEntity = ContainedEntity.class, fetch = FetchType.LAZY)
-		@JoinColumn(name = "CIndexedEmbeddedCast")
 		@IndexedEmbedded(includePaths = { "indexedField" }, targetType = ContainedEntity.class)
 		private Object containedIndexedEmbeddedWithCast;
 
@@ -458,21 +454,27 @@ public class AutomaticIndexingOneToOneOwnedByContainedLazyOnContainingSideBaseIT
 		private Integer id;
 
 		@OneToOne
+		@JoinColumn(name = "CIndexedEmbedded")
 		private ContainingEntity containingAsIndexedEmbedded;
 
 		@OneToOne
+		@JoinColumn(name = "CNonIndexedEmbedded")
 		private ContainingEntity containingAsNonIndexedEmbedded;
 
 		@OneToOne
+		@JoinColumn(name = "CIndexedEmbeddedSROU")
 		private ContainingEntity containingAsIndexedEmbeddedShallowReindexOnUpdate;
 
 		@OneToOne
+		@JoinColumn(name = "CIndexedEmbeddedNROU")
 		private ContainingEntity containingAsIndexedEmbeddedNoReindexOnUpdate;
 
 		@OneToOne
+		@JoinColumn(name = "CCrossEntityDerived")
 		private ContainingEntity containingAsUsedInCrossEntityDerivedProperty;
 
 		@OneToOne(targetEntity = ContainingEntity.class)
+		@JoinColumn(name = "CIndexedEmbeddedCast")
 		private Object containingAsIndexedEmbeddedWithCast;
 
 		@Basic

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/coordination/databasepolling/DatabasePollingAutomaticIndexingEdgeCasesIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/coordination/databasepolling/DatabasePollingAutomaticIndexingEdgeCasesIT.java
@@ -160,7 +160,7 @@ public class DatabasePollingAutomaticIndexingEdgeCasesIT {
 		} );
 
 		// Make events visible one by one, so that they are processed in separate batches.
-		List<Long> eventIds = with( sessionFactory ).apply( outboxEventFinder::findOutboxEventIdsNoFilter );
+		List<Long> eventIds = with( sessionFactory ).applyInTransaction( outboxEventFinder::findOutboxEventIdsNoFilter );
 		assertThat( eventIds ).hasSize( 2 );
 		for ( Long eventId : eventIds ) {
 			outboxEventFinder.showOnlyEvents( Collections.singletonList( eventId ) );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/coordination/databasepolling/FilteringOutboxEventFinder.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/coordination/databasepolling/FilteringOutboxEventFinder.java
@@ -36,6 +36,11 @@ class FilteringOutboxEventFinder {
 	public FilteringOutboxEventFinder() {
 	}
 
+	public synchronized void reset() {
+		filter = true;
+		allowedIds.clear();
+	}
+
 	public OutboxEventFinderProvider provider() {
 		return new Provider();
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/session/AutomaticIndexingIdentiferRollbackIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/session/AutomaticIndexingIdentiferRollbackIT.java
@@ -7,25 +7,25 @@
 package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.session;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import java.util.concurrent.atomic.AtomicReference;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 import org.hibernate.search.util.impl.test.annotation.PortedFromSearch5;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
 
 /**
  * Test that Hibernate Search manages to delete entities even when {@code hibernate.use_identifier_rollback=true}.
@@ -34,30 +34,28 @@ import org.junit.Test;
 @PortedFromSearch5(original = "org.hibernate.search.test.engine.UsingIdentifierRollbackTest")
 public class AutomaticIndexingIdentiferRollbackIT {
 
-	@Rule
-	public BackendMock backendMock = new BackendMock();
+	@ClassRule
+	public static BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
 
 	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
 
-	private SessionFactory sessionFactory;
-
-	@Before
-	public void before() {
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		backendMock.expectAnySchema( EntityWithJpaIdAsDocumentId.NAME );
 		backendMock.expectAnySchema( EntityWithNonJpaIdAsDocumentId.NAME );
-		sessionFactory = ormSetupHelper
-				.start()
-				.withProperty( AvailableSettings.USE_IDENTIFIER_ROLLBACK, "true" )
-				.setup( EntityWithJpaIdAsDocumentId.class, EntityWithNonJpaIdAsDocumentId.class );
-		backendMock.verifyExpectationsMet();
+		setupContext.withProperty( AvailableSettings.USE_IDENTIFIER_ROLLBACK, "true" )
+				.withAnnotatedTypes( EntityWithJpaIdAsDocumentId.class, EntityWithNonJpaIdAsDocumentId.class );
 	}
 
 	@Test
 	public void jpaIdAsDocumentId() {
 		AtomicReference<Integer> entity1Id = new AtomicReference<>();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			EntityWithJpaIdAsDocumentId entity1 = new EntityWithJpaIdAsDocumentId();
 
 			session.persist( entity1 );
@@ -69,7 +67,7 @@ public class AutomaticIndexingIdentiferRollbackIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			EntityWithJpaIdAsDocumentId entity1 = session.getReference( EntityWithJpaIdAsDocumentId.class,
 					entity1Id.get() );
 
@@ -90,7 +88,7 @@ public class AutomaticIndexingIdentiferRollbackIT {
 	public void nonJpaIdAsDocumentId() {
 		AtomicReference<Integer> entity1Id = new AtomicReference<>();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			EntityWithNonJpaIdAsDocumentId entity1 = new EntityWithNonJpaIdAsDocumentId();
 			entity1.setDocumentId( "document1" );
 
@@ -103,7 +101,7 @@ public class AutomaticIndexingIdentiferRollbackIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			EntityWithNonJpaIdAsDocumentId entity1 = session.getReference( EntityWithNonJpaIdAsDocumentId.class,
 					entity1Id.get() );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/session/AutomaticIndexingOutOfTransactionIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/session/AutomaticIndexingOutOfTransactionIT.java
@@ -6,12 +6,9 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.session;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinSession;
-
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.work.SearchIndexingPlan;
@@ -19,36 +16,36 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericFie
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
 
 @TestForIssue(jiraKey = "HSEARCH-3068")
 public class AutomaticIndexingOutOfTransactionIT {
 
-	@Rule
-	public BackendMock backendMock = new BackendMock();
+	@ClassRule
+	public static BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
 
 	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
 
-	private SessionFactory sessionFactory;
-
-	@Before
-	public void before() {
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		backendMock.expectAnySchema( IndexedEntity.INDEX_NAME );
-		sessionFactory = ormSetupHelper
-				.start()
-				.withProperty( AvailableSettings.ALLOW_UPDATE_OUTSIDE_TRANSACTION, true )
-				.setup( IndexedEntity.class );
-		backendMock.verifyExpectationsMet();
+		setupContext.withProperty( AvailableSettings.ALLOW_UPDATE_OUTSIDE_TRANSACTION, true )
+				.withAnnotatedTypes( IndexedEntity.class );
 	}
 
 	@Test
 	public void add() {
-		withinSession( sessionFactory, session -> {
+		setupHolder.runNoTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity( 1, "number1" );
 			session.persist( entity1 );
 
@@ -65,7 +62,7 @@ public class AutomaticIndexingOutOfTransactionIT {
 
 	@Test
 	public void clear() {
-		withinSession( sessionFactory, session -> {
+		setupHolder.runNoTransaction( session -> {
 			SearchIndexingPlan indexingPlan = Search.session( session ).indexingPlan();
 
 			IndexedEntity entity1 = new IndexedEntity( 1, "number1" );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/session/AutomaticIndexingSessionFlushIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/session/AutomaticIndexingSessionFlushIT.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.session;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
@@ -15,17 +14,18 @@ import javax.persistence.Id;
 
 import org.hibernate.FlushMode;
 import org.hibernate.Session;
-import org.hibernate.SessionFactory;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
 
 /**
  * Tests the impact of different kinds of {@link Session#flush()} on automatic indexing.
@@ -34,24 +34,24 @@ import org.junit.Test;
 @TestForIssue( jiraKey = "HSEARCH-3360" )
 public class AutomaticIndexingSessionFlushIT {
 
-	@Rule
-	public BackendMock backendMock = new BackendMock();
+	@ClassRule
+	public static BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
 
 	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
 
-	private SessionFactory sessionFactory;
-
-	@Before
-	public void before() {
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		backendMock.expectAnySchema( IndexedEntity.INDEX_NAME );
-		sessionFactory = ormSetupHelper.start().setup( IndexedEntity.class );
-		backendMock.verifyExpectationsMet();
+		setupContext.withAnnotatedTypes( IndexedEntity.class );
 	}
 
 	@Test
 	public void onExplicitFlush() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity( 1, "number1" );
 			session.setHibernateFlushMode( FlushMode.AUTO );
 			session.persist( entity1 );
@@ -61,7 +61,7 @@ public class AutomaticIndexingSessionFlushIT {
 					.add( "1", b -> b.field( "text", "number1" ) );
 
 			session.flush();
-			if ( ormSetupHelper.areEntitiesProcessedInSession() ) {
+			if ( setupHolder.areEntitiesProcessedInSession() ) {
 				// Entities should be processed and works created on flush
 				backendMock.verifyExpectationsMet();
 			}
@@ -75,7 +75,7 @@ public class AutomaticIndexingSessionFlushIT {
 
 	@Test
 	public void onAutoFlush() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity( 1, "number1" );
 			session.setHibernateFlushMode( FlushMode.AUTO );
 			session.persist( entity1 );
@@ -89,7 +89,7 @@ public class AutomaticIndexingSessionFlushIT {
 					.setHibernateFlushMode( FlushMode.AUTO )
 					.getResultList();
 
-			if ( ormSetupHelper.areEntitiesProcessedInSession() ) {
+			if ( setupHolder.areEntitiesProcessedInSession() ) {
 				// Entities should be processed and works created on flush
 				backendMock.verifyExpectationsMet();
 			}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/schema/management/manager/AbstractSearchSchemaManagerValidatingSimpleOperationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/schema/management/manager/AbstractSearchSchemaManagerValidatingSimpleOperationIT.java
@@ -22,7 +22,7 @@ public abstract class AbstractSearchSchemaManagerValidatingSimpleOperationIT
 
 	@Test
 	public void failure_single() {
-		SearchSchemaManager manager = Search.mapping( sessionFactory )
+		SearchSchemaManager manager = Search.mapping( setupHolder.sessionFactory() )
 				.scope( Object.class )
 				.schemaManager();
 
@@ -42,7 +42,7 @@ public abstract class AbstractSearchSchemaManagerValidatingSimpleOperationIT
 
 	@Test
 	public void failure_multiple() {
-		SearchSchemaManager manager = Search.mapping( sessionFactory )
+		SearchSchemaManager manager = Search.mapping( setupHolder.sessionFactory() )
 				.scope( Object.class )
 				.schemaManager();
 
@@ -67,7 +67,7 @@ public abstract class AbstractSearchSchemaManagerValidatingSimpleOperationIT
 
 	@Test
 	public void failure_exception() {
-		SearchSchemaManager manager = Search.mapping( sessionFactory )
+		SearchSchemaManager manager = Search.mapping( setupHolder.sessionFactory() )
 				.scope( Object.class )
 				.schemaManager();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/SearchQueryBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/SearchQueryBaseIT.java
@@ -22,7 +22,6 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.search.engine.search.aggregation.AggregationKey;
 import org.hibernate.search.engine.search.aggregation.SearchAggregation;
 import org.hibernate.search.engine.search.predicate.SearchPredicate;
@@ -47,14 +46,16 @@ import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.projection.impl.StubSearchProjection;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.sort.impl.StubSearchSort;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.SlowerLoadingListener;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.TimeoutLoadingListener;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
 
 /**
  * Test everything related to the search query itself.
@@ -73,30 +74,88 @@ public class SearchQueryBaseIT {
 	private static final String TITLE_AVENUE_OF_MYSTERIES = "Avenue of Mysteries";
 	private static final String AUTHOR_AVENUE_OF_MYSTERIES = "John Irving";
 
-	@Rule
-	public BackendMock backendMock = new BackendMock();
+	@ClassRule
+	public static BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
 
 	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
 
-	private SessionFactory sessionFactory;
-
-	@Before
-	public void setup() {
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext, ReusableOrmSetupHolder.DataClearConfig dataClearConfig) {
 		backendMock.expectAnySchema( Book.NAME );
 		backendMock.expectAnySchema( Author.NAME );
 
-		sessionFactory = ormSetupHelper.start()
-				.setup( Book.class, Author.class );
+		setupContext.withAnnotatedTypes( Book.class, Author.class );
+		dataClearConfig.clearOrder( Book.class, Author.class );
+	}
+
+	@Before
+	public void initData() {
+		setupHolder.runInTransaction( session -> {
+			Author author4321 = new Author( 1, AUTHOR_4_3_2_1 );
+			Author authorCiderHouse = new Author( 2, AUTHOR_CIDER_HOUSE );
+			Author authorAvenueOfMysteries = new Author( 3, AUTHOR_AVENUE_OF_MYSTERIES );
+
+			Book book4321 = new Book( 1, TITLE_4_3_2_1 );
+			book4321.setAuthor( author4321 );
+			author4321.getBooks().add( book4321 );
+
+			Book bookCiderHouse = new Book( 2, TITLE_CIDER_HOUSE );
+			bookCiderHouse.setAuthor( authorCiderHouse );
+			authorCiderHouse.getBooks().add( bookCiderHouse );
+
+			Book bookAvenueOfMysteries = new Book( 3, TITLE_AVENUE_OF_MYSTERIES );
+			bookAvenueOfMysteries.setAuthor( authorAvenueOfMysteries );
+			authorAvenueOfMysteries.getBooks().add( bookAvenueOfMysteries );
+
+			session.persist( author4321 );
+			session.persist( authorCiderHouse );
+			session.persist( authorAvenueOfMysteries );
+			session.persist( book4321 );
+			session.persist( bookCiderHouse );
+			session.persist( bookAvenueOfMysteries );
+
+			backendMock.expectWorks( Book.NAME )
+					.add( "1", b -> b
+							.field( "title", TITLE_4_3_2_1 )
+							.objectField( "author", b2 -> b2
+									.field( "name", AUTHOR_4_3_2_1 )
+							)
+
+					)
+					.add( "2", b -> b
+							.field( "title", TITLE_CIDER_HOUSE )
+							.objectField( "author", b2 -> b2
+									.field( "name", AUTHOR_CIDER_HOUSE )
+							)
+					)
+					.add( "3", b -> b
+							.field( "title", TITLE_AVENUE_OF_MYSTERIES )
+							.objectField( "author", b2 -> b2
+									.field( "name", AUTHOR_CIDER_HOUSE )
+							)
+					);
+			backendMock.expectWorks( Author.NAME )
+					.add( "1", b -> b
+							.field( "name", AUTHOR_4_3_2_1 )
+					)
+					.add( "2", b -> b
+							.field( "name", AUTHOR_CIDER_HOUSE )
+					)
+					.add( "3", b -> b
+							.field( "name", AUTHOR_AVENUE_OF_MYSTERIES )
+					);
+		} );
 
 		backendMock.verifyExpectationsMet();
-
-		initData();
 	}
 
 	@Test
 	public void target_byClass_singleType() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Book> query = searchSession.search( Book.class )
@@ -125,7 +184,7 @@ public class SearchQueryBaseIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3896")
 	public void target_byClass_singleType_reuseQueryInstance() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Book> query = searchSession.search( Book.class )
@@ -157,7 +216,7 @@ public class SearchQueryBaseIT {
 
 	@Test
 	public void target_byClass_multipleTypes() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Object> query = searchSession.search( Arrays.asList( Book.class, Author.class ) )
@@ -183,7 +242,7 @@ public class SearchQueryBaseIT {
 
 	@Test
 	public void target_byClass_multipleTypes_entityLoadingTimeout_clientSideTimeout() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 			SlowerLoadingListener.registerSlowerLoadingListener( session, 100 );
 
@@ -210,7 +269,7 @@ public class SearchQueryBaseIT {
 
 	@Test
 	public void target_byClass_multipleTypes_entityLoadingTimeout_jdbcTimeout() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 			TimeoutLoadingListener.registerTimingOutLoadingListener( session );
 
@@ -237,7 +296,7 @@ public class SearchQueryBaseIT {
 
 	@Test
 	public void target_byClass_invalidClass() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			Class<?> invalidClass = String.class;
@@ -250,7 +309,7 @@ public class SearchQueryBaseIT {
 
 	@Test
 	public void target_byName_singleType() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Book> query = searchSession.search( searchSession.scope( Book.class, Book.NAME ) )
@@ -278,7 +337,7 @@ public class SearchQueryBaseIT {
 
 	@Test
 	public void target_byName_multipleTypes() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Object> query = searchSession.search( searchSession.scope(
@@ -306,7 +365,7 @@ public class SearchQueryBaseIT {
 
 	@Test
 	public void target_byName_invalidType() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			Class<?> invalidClass = String.class;
@@ -324,7 +383,7 @@ public class SearchQueryBaseIT {
 
 	@Test
 	public void target_byName_invalidName() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			String invalidName = "foo";
@@ -348,7 +407,7 @@ public class SearchQueryBaseIT {
 
 	@Test
 	public void selectEntity() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Book> query = searchSession.search( Book.class )
@@ -377,7 +436,7 @@ public class SearchQueryBaseIT {
 
 	@Test
 	public void select_searchProjection_single() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			SearchScope<Book> scope = searchSession.scope( Book.class );
@@ -410,7 +469,7 @@ public class SearchQueryBaseIT {
 
 	@Test
 	public void select_searchProjection_multiple() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			SearchScope<Book> scope = searchSession.scope( Book.class );
@@ -483,7 +542,7 @@ public class SearchQueryBaseIT {
 
 	@Test
 	public void select_lambda() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Book_Author_Score> query = searchSession.search( Book.class )
@@ -531,7 +590,7 @@ public class SearchQueryBaseIT {
 
 	@Test
 	public void select_compositeAndLoading() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Book_Author_Score> query = searchSession.search( Book.class )
@@ -583,7 +642,7 @@ public class SearchQueryBaseIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3671")
 	public void componentsFromMappingWithoutSession() {
-		SearchMapping mapping = Search.mapping( sessionFactory );
+		SearchMapping mapping = Search.mapping( setupHolder.sessionFactory() );
 		SearchScope<Book> scope = mapping.scope( Book.class );
 
 		/*
@@ -608,7 +667,7 @@ public class SearchQueryBaseIT {
 		 * so if a wrong object was passed, the whole query would fail.
 		 */
 		AggregationKey<Map<String, Long>> aggregationKey = AggregationKey.of( "titleAgg" );
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<EntityReference> query = searchSession.search( scope )
@@ -635,66 +694,6 @@ public class SearchQueryBaseIT {
 					EntityReferenceImpl.withName( Book.class, Book.NAME, 3 )
 			);
 		} );
-	}
-
-	private void initData() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			Author author4321 = new Author( 1, AUTHOR_4_3_2_1 );
-			Author authorCiderHouse = new Author( 2, AUTHOR_CIDER_HOUSE );
-			Author authorAvenueOfMysteries = new Author( 3, AUTHOR_AVENUE_OF_MYSTERIES );
-
-			Book book4321 = new Book( 1, TITLE_4_3_2_1 );
-			book4321.setAuthor( author4321 );
-			author4321.getBooks().add( book4321 );
-
-			Book bookCiderHouse = new Book( 2, TITLE_CIDER_HOUSE );
-			bookCiderHouse.setAuthor( authorCiderHouse );
-			authorCiderHouse.getBooks().add( bookCiderHouse );
-
-			Book bookAvenueOfMysteries = new Book( 3, TITLE_AVENUE_OF_MYSTERIES );
-			bookAvenueOfMysteries.setAuthor( authorAvenueOfMysteries );
-			authorAvenueOfMysteries.getBooks().add( bookAvenueOfMysteries );
-
-			session.persist( author4321 );
-			session.persist( authorCiderHouse );
-			session.persist( authorAvenueOfMysteries );
-			session.persist( book4321 );
-			session.persist( bookCiderHouse );
-			session.persist( bookAvenueOfMysteries );
-
-			backendMock.expectWorks( Book.NAME )
-					.add( "1", b -> b
-							.field( "title", TITLE_4_3_2_1 )
-							.objectField( "author", b2 -> b2
-									.field( "name", AUTHOR_4_3_2_1 )
-							)
-
-					)
-					.add( "2", b -> b
-							.field( "title", TITLE_CIDER_HOUSE )
-							.objectField( "author", b2 -> b2
-									.field( "name", AUTHOR_CIDER_HOUSE )
-							)
-					)
-					.add( "3", b -> b
-							.field( "title", TITLE_AVENUE_OF_MYSTERIES )
-							.objectField( "author", b2 -> b2
-									.field( "name", AUTHOR_CIDER_HOUSE )
-							)
-					);
-			backendMock.expectWorks( Author.NAME )
-					.add( "1", b -> b
-							.field( "name", AUTHOR_4_3_2_1 )
-					)
-					.add( "2", b -> b
-							.field( "name", AUTHOR_CIDER_HOUSE )
-					)
-					.add( "3", b -> b
-							.field( "name", AUTHOR_AVENUE_OF_MYSTERIES )
-					);
-		} );
-
-		backendMock.verifyExpectationsMet();
 	}
 
 	@Entity(name = Book.NAME)

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/AbstractSearchQueryEntityLoadingIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/AbstractSearchQueryEntityLoadingIT.java
@@ -28,18 +28,11 @@ import org.hibernate.search.mapper.orm.search.loading.dsl.SearchLoadingOptionsSt
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.common.rule.StubSearchWorkBehavior;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSoftAssertions;
-
-import org.junit.Rule;
 
 public abstract class AbstractSearchQueryEntityLoadingIT {
 
-	@Rule
-	public BackendMock backendMock = new BackendMock();
-
-	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+	protected abstract BackendMock backendMock();
 
 	protected abstract SessionFactory sessionFactory();
 
@@ -129,7 +122,7 @@ public abstract class AbstractSearchQueryEntityLoadingIT {
 
 	protected <T> List<T> getHits(List<String> targetIndexes, SearchQuery<T> query, List<DocumentReference> hitDocumentReferences,
 			Integer timeout, TimeUnit timeUnit) {
-		backendMock.expectSearchObjects(
+		backendMock().expectSearchObjects(
 				targetIndexes,
 				b -> {
 					if ( timeout != null && timeUnit != null ) {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/AbstractSearchQueryEntityLoadingSingleTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/AbstractSearchQueryEntityLoadingSingleTypeIT.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.search.loading;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -17,7 +19,6 @@ import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.sing
 import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.singletype.SingleTypeLoadingModel;
 import org.hibernate.search.mapper.orm.search.loading.dsl.SearchLoadingOptionsStep;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSoftAssertions;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 public abstract class AbstractSearchQueryEntityLoadingSingleTypeIT<T> extends AbstractSearchQueryEntityLoadingIT {
 
@@ -41,7 +42,7 @@ public abstract class AbstractSearchQueryEntityLoadingSingleTypeIT<T> extends Ab
 
 	protected final void persistThatManyEntities(int entityCount) {
 		// We don't care about what is indexed exactly, so use the lenient mode
-		backendMock.inLenientMode( () -> OrmUtils.withinTransaction( sessionFactory(), session -> {
+		backendMock().inLenientMode( () -> withinTransaction( sessionFactory(), session -> {
 			for ( int i = 0; i < entityCount; i++ ) {
 				session.persist( model.newIndexed( i, mapping ) );
 			}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingBaseIT.java
@@ -17,10 +17,13 @@ import org.hibernate.SessionFactory;
 import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.singletype.SingleTypeLoadingMapping;
 import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.singletype.SingleTypeLoadingModel;
 import org.hibernate.search.util.common.SearchTimeoutException;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.TimeoutLoadingListener;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -41,10 +44,25 @@ public class SearchQueryEntityLoadingBaseIT<T> extends AbstractSearchQueryEntity
 		return result;
 	}
 
+	@Rule
+	public BackendMock backendMock = new BackendMock();
+
+	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+
 	private SessionFactory sessionFactory;
 
 	public SearchQueryEntityLoadingBaseIT(SingleTypeLoadingModel<T> model, SingleTypeLoadingMapping mapping) {
 		super( model, mapping );
+	}
+
+	@Override
+	protected BackendMock backendMock() {
+		return backendMock;
+	}
+
+	@Override
+	protected SessionFactory sessionFactory() {
+		return sessionFactory;
 	}
 
 	@Before
@@ -166,11 +184,6 @@ public class SearchQueryEntityLoadingBaseIT<T> extends AbstractSearchQueryEntity
 				// Only one entity type means only one statement should be executed, even if there are multiple hits
 				c -> c.assertStatementExecutionCount().isEqualTo( 1 )
 		);
-	}
-
-	@Override
-	protected SessionFactory sessionFactory() {
-		return sessionFactory;
 	}
 
 }

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingCacheLookupIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingCacheLookupIT.java
@@ -22,6 +22,8 @@ import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.sing
 import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.singletype.SingleTypeLoadingModel;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.mapper.orm.search.loading.EntityLoadingCacheLookupStrategy;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 import org.hibernate.search.util.impl.test.rule.ExpectedLog4jLog;
 
@@ -53,6 +55,11 @@ public class SearchQueryEntityLoadingCacheLookupIT<T> extends AbstractSearchQuer
 	}
 
 	@Rule
+	public BackendMock backendMock = new BackendMock();
+
+	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+
+	@Rule
 	public final ExpectedLog4jLog logged = ExpectedLog4jLog.create();
 
 	private final EntityLoadingCacheLookupStrategy defaultCacheLookupStrategy;
@@ -63,6 +70,16 @@ public class SearchQueryEntityLoadingCacheLookupIT<T> extends AbstractSearchQuer
 			EntityLoadingCacheLookupStrategy defaultCacheLookupStrategy) {
 		super( model, mapping );
 		this.defaultCacheLookupStrategy = defaultCacheLookupStrategy;
+	}
+
+	@Override
+	protected BackendMock backendMock() {
+		return backendMock;
+	}
+
+	@Override
+	protected SessionFactory sessionFactory() {
+		return sessionFactory;
 	}
 
 	@Before
@@ -194,11 +211,6 @@ public class SearchQueryEntityLoadingCacheLookupIT<T> extends AbstractSearchQuer
 				// Expect no DB statement since everything has been loaded
 				false
 		);
-	}
-
-	@Override
-	protected SessionFactory sessionFactory() {
-		return sessionFactory;
 	}
 
 	private void testLoadingCacheLookupExpectingSkipCacheLookup(

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingFetchSizeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingFetchSizeIT.java
@@ -16,8 +16,11 @@ import org.hibernate.graph.GraphSemantic;
 import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.singletype.SingleTypeLoadingMapping;
 import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.singletype.SingleTypeLoadingModel;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -38,10 +41,25 @@ public class SearchQueryEntityLoadingFetchSizeIT<T> extends AbstractSearchQueryE
 		return result;
 	}
 
+	@Rule
+	public BackendMock backendMock = new BackendMock();
+
+	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+
 	private SessionFactory sessionFactory;
 
 	public SearchQueryEntityLoadingFetchSizeIT(SingleTypeLoadingModel<T> model, SingleTypeLoadingMapping mapping) {
 		super( model, mapping );
+	}
+
+	@Override
+	protected BackendMock backendMock() {
+		return backendMock;
+	}
+
+	@Override
+	protected SessionFactory sessionFactory() {
+		return sessionFactory;
 	}
 
 	@Test
@@ -142,11 +160,6 @@ public class SearchQueryEntityLoadingFetchSizeIT<T> extends AbstractSearchQueryE
 				// so as to always trigger a subselect for associations with FetchMode.SUBSELECT.
 				model.getEagerGraphName()
 		);
-	}
-
-	@Override
-	protected SessionFactory sessionFactory() {
-		return sessionFactory;
 	}
 
 	private void testLoadingFetchSize(Integer searchLoadingFetchSize, Integer overriddenFetchSize,

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingGraphIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingGraphIT.java
@@ -19,10 +19,13 @@ import org.hibernate.graph.RootGraph;
 import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.singletype.SingleTypeLoadingMapping;
 import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.singletype.SingleTypeLoadingModel;
 import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -43,10 +46,25 @@ public class SearchQueryEntityLoadingGraphIT<T> extends AbstractSearchQueryEntit
 		return result;
 	}
 
+	@Rule
+	public BackendMock backendMock = new BackendMock();
+
+	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+
 	private SessionFactory sessionFactory;
 
 	public SearchQueryEntityLoadingGraphIT(SingleTypeLoadingModel<T> model, SingleTypeLoadingMapping mapping) {
 		super( model, mapping );
+	}
+
+	@Override
+	protected BackendMock backendMock() {
+		return backendMock;
+	}
+
+	@Override
+	protected SessionFactory sessionFactory() {
+		return sessionFactory;
 	}
 
 	@Before
@@ -187,11 +205,6 @@ public class SearchQueryEntityLoadingGraphIT<T> extends AbstractSearchQueryEntit
 		} ) )
 				.isInstanceOf( IllegalArgumentException.class )
 				.hasMessageContaining( "'semantic' must not be null" );
-	}
-
-	@Override
-	protected SessionFactory sessionFactory() {
-		return sessionFactory;
 	}
 
 	private void testLoadingWithEntityGraph(String graphName, GraphSemantic graphSemantic,

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingMultipleTypesIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingMultipleTypesIT.java
@@ -49,12 +49,15 @@ import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.mult
 import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.multipletypes.Interface2;
 import org.hibernate.search.mapper.orm.search.loading.EntityLoadingCacheLookupStrategy;
 import org.hibernate.search.util.common.SearchTimeoutException;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSoftAssertions;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.SlowerLoadingListener;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -63,7 +66,22 @@ import org.junit.Test;
  */
 public class SearchQueryEntityLoadingMultipleTypesIT extends AbstractSearchQueryEntityLoadingIT {
 
+	@Rule
+	public BackendMock backendMock = new BackendMock();
+
+	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+
 	private SessionFactory sessionFactory;
+
+	@Override
+	protected BackendMock backendMock() {
+		return backendMock;
+	}
+
+	@Override
+	protected SessionFactory sessionFactory() {
+		return sessionFactory;
+	}
 
 	@Before
 	public void setup() {
@@ -468,11 +486,6 @@ public class SearchQueryEntityLoadingMultipleTypesIT extends AbstractSearchQuery
 							.isEqualTo( 0 );
 				}
 		);
-	}
-
-	@Override
-	protected SessionFactory sessionFactory() {
-		return sessionFactory;
 	}
 
 	protected <T> void testLoading(List<? extends Class<? extends T>> targetClasses,

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/model/singletype/BasicModel.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/model/singletype/BasicModel.java
@@ -68,6 +68,11 @@ final class BasicModel extends SingleTypeLoadingModel<BasicIndexedEntity> {
 	}
 
 	@Override
+	public void clearContainedEager(BasicIndexedEntity entity) {
+		entity.setContainedEager( null );
+	}
+
+	@Override
 	public List<?> getContainedLazy(BasicIndexedEntity entity) {
 		return entity.getContainedLazy();
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/model/singletype/FetchSubSelectModel.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/model/singletype/FetchSubSelectModel.java
@@ -68,6 +68,11 @@ final class FetchSubSelectModel extends SingleTypeLoadingModel<FetchSubSelectInd
 	}
 
 	@Override
+	public void clearContainedEager(FetchSubSelectIndexedEntity entity) {
+		entity.setContainedEager( null );
+	}
+
+	@Override
 	public List<?> getContainedLazy(FetchSubSelectIndexedEntity entity) {
 		return entity.getContainedLazy();
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/model/singletype/SingleTypeLoadingModel.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/model/singletype/SingleTypeLoadingModel.java
@@ -43,6 +43,8 @@ public abstract class SingleTypeLoadingModel<T> {
 
 	public abstract Object getContainedEager(T entity);
 
+	public abstract void clearContainedEager(T entity);
+
 	public abstract List<?> getContainedLazy(T entity);
 
 }

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchIndexingPlanNonEntityIdDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchIndexingPlanNonEntityIdDocumentIdIT.java
@@ -6,12 +6,9 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.session;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
-
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.mapper.orm.work.SearchIndexingPlan;
@@ -20,28 +17,40 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericFie
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
 
 /**
  * Test usage of the session indexing plan with an entity type whose document ID is not the entity ID.
  */
 public class SearchIndexingPlanNonEntityIdDocumentIdIT {
 
-	@Rule
-	public BackendMock backendMock = new BackendMock();
+	@ClassRule
+	public static BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
 
 	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
+
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext) {
+		backendMock.expectAnySchema( IndexedEntity.INDEX_NAME );
+
+		setupContext.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED, false )
+				.withAnnotatedTypes( IndexedEntity.class );
+	}
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3203")
 	public void simple() {
-		SessionFactory sessionFactory = setup();
-
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity( 1, 41, "number1" );
 			IndexedEntity entity2 = new IndexedEntity( 2, 42, "number2" );
 			IndexedEntity entity3 = new IndexedEntity( 3, 43, "number3" );
@@ -63,18 +72,6 @@ public class SearchIndexingPlanNonEntityIdDocumentIdIT {
 					.delete( "47" );
 		} );
 		backendMock.verifyExpectationsMet();
-	}
-
-	private SessionFactory setup() {
-		backendMock.expectAnySchema( IndexedEntity.INDEX_NAME );
-
-		SessionFactory sessionFactory = ormSetupHelper.start()
-				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED, false )
-				.setup( IndexedEntity.class );
-
-		backendMock.verifyExpectationsMet();
-
-		return sessionFactory;
 	}
 
 	@Entity(name = "indexed")

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/AnnotationMappingSmokeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/AnnotationMappingSmokeIT.java
@@ -26,7 +26,6 @@ import javax.persistence.ManyToOne;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.OneToMany;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.search.integrationtest.mapper.orm.smoke.bridge.CustomPropertyBinding;
 import org.hibernate.search.integrationtest.mapper.orm.smoke.bridge.CustomTypeBinding;
 import org.hibernate.search.integrationtest.mapper.orm.smoke.bridge.IntegerAsStringValueBridge;
@@ -45,28 +44,30 @@ import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.ValueBridgeRef
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.common.rule.StubSearchWorkBehavior;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 import org.hibernate.search.util.impl.test.rule.StaticCounters;
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
 
 
 public class AnnotationMappingSmokeIT {
 
-	@Rule
-	public BackendMock backendMock = new BackendMock();
+	@ClassRule
+	public static BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
 
 	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
 
 	@Rule
 	public StaticCounters counters = new StaticCounters();
 
-	private SessionFactory sessionFactory;
-
-	@Before
-	public void setup() {
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		backendMock.expectSchema( OtherIndexedEntity.NAME, b -> b
 				.field( "numeric", Integer.class )
 				.field( "numericAsString", String.class )
@@ -124,19 +125,17 @@ public class AnnotationMappingSmokeIT {
 				.field( "myLocalDateField", LocalDate.class )
 		);
 
-		sessionFactory = ormSetupHelper.start()
-				.setup(
-						IndexedEntity.class,
-						ParentIndexedEntity.class,
-						OtherIndexedEntity.class,
-						YetAnotherIndexedEntity.class
-				);
-		backendMock.verifyExpectationsMet();
+		setupContext.withAnnotatedTypes(
+				IndexedEntity.class,
+				ParentIndexedEntity.class,
+				OtherIndexedEntity.class,
+				YetAnotherIndexedEntity.class
+		);
 	}
 
 	@Test
 	public void index() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 			entity1.setText( "this is text (1)" );
@@ -293,7 +292,7 @@ public class AnnotationMappingSmokeIT {
 
 	@Test
 	public void search() {
-		backendMock.inLenientMode( () -> OrmUtils.withinTransaction( sessionFactory, session -> {
+		backendMock.inLenientMode( () -> setupHolder.runInTransaction( session -> {
 			IndexedEntity entity0 = new IndexedEntity();
 			entity0.setId( 0 );
 			session.persist( entity0 );
@@ -302,7 +301,7 @@ public class AnnotationMappingSmokeIT {
 			session.persist( entity1 );
 		} ) );
 
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 			SearchQuery<ParentIndexedEntity> query = searchSession.search(
 							Arrays.asList( IndexedEntity.class, YetAnotherIndexedEntity.class )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/ProgrammaticMappingSmokeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/ProgrammaticMappingSmokeIT.java
@@ -25,7 +25,6 @@ import javax.persistence.ManyToOne;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.OneToMany;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.mapper.orm.smoke.bridge.CustomPropertyBridge;
 import org.hibernate.search.integrationtest.mapper.orm.smoke.bridge.CustomTypeBridge;
@@ -42,29 +41,31 @@ import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMapp
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.common.rule.StubSearchWorkBehavior;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 import org.hibernate.search.util.impl.test.rule.StaticCounters;
 
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
 
 
 public class ProgrammaticMappingSmokeIT {
 
-	@Rule
-	public BackendMock backendMock = new BackendMock();
+	@ClassRule
+	public static BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
 
 	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
 
 	@Rule
 	public StaticCounters counters = new StaticCounters();
 
-	private SessionFactory sessionFactory;
-
-	@Before
-	public void setup() {
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		backendMock.expectSchema( OtherIndexedEntity.NAME, b -> b
 				.field( "numeric", Integer.class )
 				.field( "numericAsString", String.class )
@@ -122,20 +123,18 @@ public class ProgrammaticMappingSmokeIT {
 				.field( "myLocalDateField", LocalDate.class )
 		);
 
-		sessionFactory = ormSetupHelper.start()
-				.withProperty( HibernateOrmMapperSettings.MAPPING_CONFIGURER, new MyMappingConfigurer() )
-				.setup(
+		setupContext.withProperty( HibernateOrmMapperSettings.MAPPING_CONFIGURER, new MyMappingConfigurer() )
+				.withAnnotatedTypes(
 						IndexedEntity.class,
 						ParentIndexedEntity.class,
 						OtherIndexedEntity.class,
 						YetAnotherIndexedEntity.class
 				);
-		backendMock.verifyExpectationsMet();
 	}
 
 	@Test
 	public void index() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 			entity1.setText( "this is text (1)" );
@@ -292,7 +291,7 @@ public class ProgrammaticMappingSmokeIT {
 
 	@Test
 	public void search() {
-		backendMock.inLenientMode( () -> OrmUtils.withinTransaction( sessionFactory, session -> {
+		backendMock.inLenientMode( () -> setupHolder.runInTransaction( session -> {
 			IndexedEntity entity0 = new IndexedEntity();
 			entity0.setId( 0 );
 			session.persist( entity0 );
@@ -301,7 +300,7 @@ public class ProgrammaticMappingSmokeIT {
 			session.persist( entity1 );
 		} ) );
 
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 			SearchQuery<ParentIndexedEntity> query = searchSession.search(
 							Arrays.asList( IndexedEntity.class, YetAnotherIndexedEntity.class )

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateOrmListenerContextProvider.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateOrmListenerContextProvider.java
@@ -14,6 +14,8 @@ public interface HibernateOrmListenerContextProvider {
 
 	HibernateOrmListenerTypeContextProvider typeContextProvider();
 
+	boolean listenerEnabled();
+
 	PojoIndexingPlan currentIndexingPlan(SessionImplementor session, boolean createIfDoesNotExist);
 
 	ConfiguredAutomaticIndexingSynchronizationStrategy currentAutomaticIndexingSynchronizationStrategy(

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
@@ -86,28 +86,39 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 
 	@Override
 	public void onPostDelete(PostDeleteEvent event) {
+		if ( !contextProvider.listenerEnabled() ) {
+			return;
+		}
 		Object entity = event.getEntity();
 		HibernateOrmListenerTypeContext typeContext = getTypeContext( event.getPersister() );
-		if ( typeContext != null ) {
-			Object providedId = typeContext.toIndexingPlanProvidedId( event.getId() );
-			getCurrentIndexingPlan( event.getSession() )
-					.delete( typeContext.typeIdentifier(), providedId, null, entity );
+		if ( typeContext == null ) {
+			return;
 		}
+		Object providedId = typeContext.toIndexingPlanProvidedId( event.getId() );
+		getCurrentIndexingPlan( event.getSession() )
+				.delete( typeContext.typeIdentifier(), providedId, null, entity );
 	}
 
 	@Override
 	public void onPostInsert(PostInsertEvent event) {
+		if ( !contextProvider.listenerEnabled() ) {
+			return;
+		}
 		final Object entity = event.getEntity();
 		HibernateOrmListenerTypeContext typeContext = getTypeContext( event.getPersister() );
-		if ( typeContext != null ) {
-			Object providedId = typeContext.toIndexingPlanProvidedId( event.getId() );
-			getCurrentIndexingPlan( event.getSession() )
-					.add( typeContext.typeIdentifier(), providedId, null, entity );
+		if ( typeContext == null ) {
+			return;
 		}
+		Object providedId = typeContext.toIndexingPlanProvidedId( event.getId() );
+		getCurrentIndexingPlan( event.getSession() )
+				.add( typeContext.typeIdentifier(), providedId, null, entity );
 	}
 
 	@Override
 	public void onPostUpdate(PostUpdateEvent event) {
+		if ( !contextProvider.listenerEnabled() ) {
+			return;
+		}
 		final Object entity = event.getEntity();
 		HibernateOrmListenerTypeContext typeContext = getTypeContext( event.getPersister() );
 		if ( typeContext == null ) {
@@ -173,6 +184,9 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 	 */
 	@Override
 	public void onFlush(FlushEvent event) {
+		if ( !contextProvider.listenerEnabled() ) {
+			return;
+		}
 		EventSource session = event.getSession();
 
 		PojoIndexingPlan plan = getCurrentIndexingPlanIfExisting( session );
@@ -194,6 +208,9 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 
 	@Override
 	public void onAutoFlush(AutoFlushEvent event) throws HibernateException {
+		if ( !contextProvider.listenerEnabled() ) {
+			return;
+		}
 		if ( !event.isFlushRequired() ) {
 			/*
 			 * Auto-flush was disabled or there wasn't any entity/collection to flush.
@@ -208,6 +225,9 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 
 	@Override
 	public void onClear(ClearEvent event) {
+		if ( !contextProvider.listenerEnabled() ) {
+			return;
+		}
 		EventSource session = event.getSession();
 		PojoIndexingPlan plan = getCurrentIndexingPlanIfExisting( session );
 
@@ -231,6 +251,9 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 	}
 
 	private void processCollectionEvent(AbstractCollectionEvent event) {
+		if ( !contextProvider.listenerEnabled() ) {
+			return;
+		}
 		Object ownerEntity = event.getAffectedOwnerOrNull();
 		if ( ownerEntity == null ) {
 			//Hibernate cannot determine every single time the owner especially in case detached objects are involved

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapping.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapping.java
@@ -127,6 +127,8 @@ public class HibernateOrmMapping extends AbstractPojoMappingImplementor<Hibernat
 
 	private final SchemaManagementListener schemaManagementListener;
 
+	private volatile boolean listenerEnabled = true;
+
 	private HibernateOrmMapping(PojoMappingDelegate mappingDelegate,
 			HibernateOrmTypeContextContainer typeContextContainer,
 			SessionFactoryImplementor sessionFactory,
@@ -302,6 +304,16 @@ public class HibernateOrmMapping extends AbstractPojoMappingImplementor<Hibernat
 	@Override
 	public DetachedBackendSessionContext detachedBackendSessionContext(String tenantId) {
 		return DetachedBackendSessionContext.of( this, tenantId );
+	}
+
+	@Override
+	public boolean listenerEnabled() {
+		return listenerEnabled;
+	}
+
+	// For tests
+	public void listenerEnabled(boolean enabled) {
+		this.listenerEnabled = enabled;
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
@@ -49,11 +49,19 @@ public class BackendMock implements TestRule {
 				started = true;
 				try {
 					base.evaluate();
-					verifyExpectationsMet();
+					// Workaround for a problem in Hibernate ORM's CustomRunner
+					// (used by BytecodeEnhancerRunner in particular)
+					// which applies class rules twices, resulting in "started" being false
+					// when we get here in the outermost statement...
+					if ( started ) {
+						verifyExpectationsMet();
+					}
 				}
 				finally {
-					resetExpectations();
-					started = false;
+					if ( started ) {
+						resetExpectations();
+						started = false;
+					}
 				}
 			}
 		};

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
@@ -53,7 +53,6 @@ public class BackendMock implements TestRule {
 				}
 				finally {
 					resetExpectations();
-					indexingWorkExpectations = BackendIndexingWorkExpectations.sync();
 					started = false;
 				}
 			}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/MappingSetupHelper.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/MappingSetupHelper.java
@@ -85,6 +85,8 @@ public abstract class MappingSetupHelper<C extends MappingSetupHelper<C, B, R>.A
 
 		private final List<Configuration<B, R>> configurations = new ArrayList<>();
 
+		private boolean setupCalled;
+
 		protected AbstractSetupContext() {
 		}
 
@@ -150,6 +152,11 @@ public abstract class MappingSetupHelper<C extends MappingSetupHelper<C, B, R>.A
 		 * @return The result of setting up Hibernate Search.
 		 */
 		public final R setup() {
+			if ( setupCalled ) {
+				throw new IllegalStateException( "SetupContext#setup() was called multiple times on the same context" );
+			}
+			setupCalled = true;
+
 			B builder = createBuilder();
 
 			configurations.forEach( c -> c.beforeBuild( builder ) );

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/JPAPersistenceRunner.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/JPAPersistenceRunner.java
@@ -35,7 +35,7 @@ class JPAPersistenceRunner implements PersistenceRunner<EntityManager, EntityTra
 	}
 
 	@Override
-	public <R> R apply(BiFunction<? super EntityManager, ? super EntityTransaction, R> action) {
+	public <R> R applyInTransaction(BiFunction<? super EntityManager, ? super EntityTransaction, R> action) {
 		return applyNoTransaction( entityManager -> {
 			return OrmUtils.withinJPATransaction( entityManager, tx -> { return action.apply( entityManager, tx ); } );
 		} );

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/NativePersistenceRunner.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/NativePersistenceRunner.java
@@ -28,7 +28,7 @@ class NativePersistenceRunner implements PersistenceRunner<Session, Transaction>
 	}
 
 	@Override
-	public <R> R apply(BiFunction<? super Session, ? super Transaction, R> action) {
+	public <R> R applyInTransaction(BiFunction<? super Session, ? super Transaction, R> action) {
 		return applyNoTransaction( session -> {
 			return OrmUtils.withinTransaction( session, tx -> { return action.apply( session, tx ); } );
 		} );

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmSetupHelper.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmSetupHelper.java
@@ -158,9 +158,12 @@ public final class OrmSetupHelper
 			return thisAsC();
 		}
 
+		public SetupContext withAnnotatedTypes(Class<?> ... annotatedTypes) {
+			return withConfiguration( builder -> builder.addAnnotatedClasses( Arrays.asList( annotatedTypes ) ) );
+		}
+
 		public SessionFactory setup(Class<?> ... annotatedTypes) {
-			return withConfiguration( builder -> builder.addAnnotatedClasses( Arrays.asList( annotatedTypes ) ) )
-					.setup();
+			return withAnnotatedTypes( annotatedTypes ).setup();
 		}
 
 		@Override

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmUtils.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmUtils.java
@@ -38,11 +38,11 @@ public final class OrmUtils {
 	}
 
 	public static void withinTransaction(SessionFactory sessionFactory, Consumer<Session> action) {
-		with( sessionFactory ).run( action );
+		with( sessionFactory ).runInTransaction( action );
 	}
 
 	public static void withinJPATransaction(EntityManagerFactory entityManagerFactory, Consumer<EntityManager> action) {
-		with( entityManagerFactory ).run( action );
+		with( entityManagerFactory ).runInTransaction( action );
 	}
 
 	public static void withinTransaction(Session session, Consumer<Transaction> action) {

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/PersistenceRunner.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/PersistenceRunner.java
@@ -31,21 +31,21 @@ public interface PersistenceRunner<C, T> {
 		} );
 	}
 
-	default <R> R apply(Function<? super C, R> action) {
-		return apply( (c, t) -> action.apply( c ) );
+	default <R> R applyInTransaction(Function<? super C, R> action) {
+		return applyInTransaction( (c, t) -> action.apply( c ) );
 	}
 
-	<R> R apply(BiFunction<? super C, ? super T, R> action);
+	<R> R applyInTransaction(BiFunction<? super C, ? super T, R> action);
 
-	default void run(Consumer<? super C> action) {
-		apply( c -> {
+	default void runInTransaction(Consumer<? super C> action) {
+		applyInTransaction( c -> {
 			action.accept( c );
 			return null;
 		} );
 	}
 
-	default void run(BiConsumer<? super C, T> action) {
-		apply( (c, t) -> {
+	default void runInTransaction(BiConsumer<? super C, T> action) {
+		applyInTransaction( (c, t) -> {
 			action.accept( c, t );
 			return null;
 		} );

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/ReusableOrmSetupHolder.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/ReusableOrmSetupHolder.java
@@ -1,0 +1,558 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.integrationtest.mapper.orm;
+
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+import javax.persistence.metamodel.Attribute;
+import javax.persistence.metamodel.EmbeddableType;
+import javax.persistence.metamodel.EntityType;
+import javax.persistence.metamodel.ManagedType;
+import javax.persistence.metamodel.Metamodel;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.Query;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.mapping.impl.HibernateOrmMapping;
+import org.hibernate.search.util.common.impl.Closer;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+
+import org.hibernate.testing.junit4.CustomParameterized;
+import org.junit.rules.MethodRule;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+import org.jboss.logging.Logger;
+
+/**
+ * A test rule to create a {@link SessionFactory} and reuse it across test methods,
+ * automatically reinitializing data between test methods.
+ * <p>
+ * Useful for tests with many test methods, where recreating the {@link SessionFactory}
+ * before each method would take too much time, in particular when testing against some
+ * databases that are slow to create schemas (Oracle, DB2, ...).
+ * <p>
+ * Usage:
+ * <pre>{@code
+ * 	@ClassRule
+ * 	public static BackendMock backendMock = new BackendMock();
+ *
+ * 	@ClassRule
+ * 	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
+ *
+ * 	@Rule
+ * 	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
+ *
+ * 	@ReusableOrmSetupHolder.Setup
+ * 	public void setup(OrmSetupHelper.SetupContext setupContext, ReusableOrmSetupHolder.DataClearConfig dataClearConfig) {
+ * 	    // configure setupContext here, but do NOT call setupContext.setup(); the rule will do that.
+ * 		...
+ * 	}
+ * }</pre>
+ * </p>
+ */
+public class ReusableOrmSetupHolder implements TestRule {
+	private static final Logger log = Logger.getLogger( SimpleSessionFactoryBuilder.class.getName() );
+
+	/**
+	 * When applied to a public instance method in a test,
+	 * designates a setup method which must be called by {@link ReusableOrmSetupHolder}
+	 * when creating the session factory.
+	 * <p>
+	 * The method can get passed arguments of the following types:
+	 * <ul>
+	 *     <li>{@link org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper.SetupContext}</li>
+	 *     <li>{@link DataClearConfig}</li>
+	 * </ul>
+	 *
+	 * @see ReusableOrmSetupHolder
+	 */
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.METHOD)
+	public @interface Setup {
+
+	}
+
+	/**
+	 * When applied to a public instance method in a test,
+	 * designates a method which must be called by {@link ReusableOrmSetupHolder}
+	 * to inspect the parameters of the current test that could impact session factory setup.
+	 * <p>
+	 * Useful (and mandatory) when using {@link ReusableOrmSetupHolder}
+	 * in conjunction with the {@link org.junit.runners.Parameterized} runner,
+	 * so that the session factory can be recreated for each set of parameters,
+	 * but reused across test methods using the same parameters.
+	 * <p>
+	 * The method must return a {@code Collection<?>} and must not accept any parameter.
+	 *
+	 * @see ReusableOrmSetupHolder
+	 */
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.METHOD)
+	public @interface SetupParams {
+
+	}
+
+	public interface DataClearConfig {
+
+		DataClearConfig preClear(Consumer<Session> preClear);
+
+		<T> DataClearConfig preClear(Class<T> entityType, Consumer<T> preClear);
+
+		DataClearConfig clearOrder(Class<?>... entityClasses);
+
+	}
+
+	public static ReusableOrmSetupHolder withBackendMock(BackendMock backendMock) {
+		return new ReusableOrmSetupHolder( OrmSetupHelper.withBackendMock( backendMock ),
+				Collections.singletonList( backendMock ) );
+	}
+
+	public static ReusableOrmSetupHolder withBackendMocks(BackendMock defaultBackendMock,
+			Map<String, BackendMock> namedBackendMocks) {
+		List<BackendMock> allBackendMocks = new ArrayList<>();
+		allBackendMocks.add( defaultBackendMock );
+		allBackendMocks.addAll( namedBackendMocks.values() );
+		return new ReusableOrmSetupHolder( OrmSetupHelper.withBackendMocks( defaultBackendMock, namedBackendMocks ),
+				allBackendMocks );
+	}
+
+	private final OrmSetupHelper setupHelper;
+	private final List<BackendMock> allBackendMocks;
+
+	private boolean inClassStatement;
+	private boolean inMethodStatement;
+	private DataClearConfigImpl config;
+	private SessionFactory sessionFactory;
+	private Collection<?> testParamsForSessionFactory;
+
+	private ReusableOrmSetupHolder(OrmSetupHelper setupHelper, List<BackendMock> allBackendMocks) {
+		this.setupHelper = setupHelper;
+		this.allBackendMocks = allBackendMocks;
+	}
+
+	// We need the class rule and test rule to be two separate objects, unfortunately.
+	// See
+	public MethodRule methodRule() {
+		return new MethodRule() {
+			@Override
+			public Statement apply(Statement base, FrameworkMethod method, Object target) {
+				return methodStatement( base, target );
+			}
+		};
+	}
+
+	public ReusableOrmSetupHolder coordinationStrategy(CoordinationStrategyExpectations coordinationStrategyExpectations) {
+		setupHelper.coordinationStrategy( coordinationStrategyExpectations );
+		return this;
+	}
+
+	public boolean areEntitiesProcessedInSession() {
+		return setupHelper.areEntitiesProcessedInSession();
+	}
+
+	public EntityManagerFactory entityManagerFactory() {
+		return sessionFactory();
+	}
+
+	public SessionFactory sessionFactory() {
+		if ( !inMethodStatement ) {
+			throw new Error( "The session factory cannot be used outside of methods annotated with @Test, @Before, @After."
+					+ " In particular, you cannot use it in a method annotated with " + Setup.class.getName() + ";"
+					+ " use a @Before method instead." );
+		}
+		if ( sessionFactory == null ) {
+			throw new Error( "The session factory in " + getClass().getSimpleName() + " was not created."
+					+ " Did you use the rule as explained in the javadoc, with both a @ClassRule and a @Rule,"
+					+ " on two separate fields?" );
+		}
+		return sessionFactory;
+	}
+
+	public PersistenceRunner<Session, Transaction> with() {
+		return OrmUtils.with( sessionFactory() );
+	}
+
+	public void runInTransaction(Consumer<? super Session> action) {
+		with().runInTransaction( action );
+	}
+
+	public void runNoTransaction(Consumer<? super Session> action) {
+		with().runNoTransaction( action );
+	}
+
+	@Override
+	public Statement apply(Statement base, Description description) {
+		return classStatement( base, description );
+	}
+
+	private Statement classStatement(Statement base, Description description) {
+		Statement wrapped = new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				try ( Closer<Exception> closer = new Closer<>() ) {
+					try {
+						inClassStatement = true;
+						base.evaluate();
+					}
+					finally {
+						inClassStatement = false;
+						// Do this in the closer in order to preserve the original exception.
+						closer.push( ReusableOrmSetupHolder::tearDownSessionFactory, ReusableOrmSetupHolder.this );
+					}
+				}
+			}
+		};
+		return setupHelper.apply( wrapped, description );
+	}
+
+	private Statement methodStatement(Statement base, Object testInstance) {
+		return new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				try {
+					setupSessionFactory( testInstance );
+					inMethodStatement = true;
+					base.evaluate();
+					// Since BackendMock is used as a ClassRule,
+					// we must explicitly force the verify/reset after each test method.
+					for ( BackendMock backendMock : allBackendMocks ) {
+						backendMock.verifyExpectationsMet();
+					}
+				}
+				finally {
+					inMethodStatement = false;
+					for ( BackendMock backendMock : allBackendMocks ) {
+						backendMock.resetExpectations();
+					}
+				}
+			}
+		};
+	}
+
+	private void setupSessionFactory(Object testInstance) {
+		if ( !inClassStatement ) {
+			throw new Error( "This usage of " + getClass().getSimpleName() + " is invalid and may result"
+					+ " in the session factory not being closed."
+					+ " Did you use the rule as explained in the javadoc, with both a @ClassRule and a @Rule,"
+					+ " on two separate fields?" );
+		}
+
+		Collection<?> testParams = testParams( testInstance );
+
+		if ( sessionFactory != null ) {
+			if ( testParams.equals( testParamsForSessionFactory ) ) {
+				log.infof( "Test parameters did not change (%s vs %s). Clearing data and reusing the same session factory.",
+						testParamsForSessionFactory, testParams );
+				try {
+					clearAllData( sessionFactory );
+				}
+				catch (RuntimeException e) {
+					throw new Error( "Failed to clear data before test execution: " + e.getMessage(), e );
+				}
+				return;
+			}
+			else {
+				log.infof( "Test parameters changed (%s vs %s). Closing the current session factory and creating another one.",
+						testParamsForSessionFactory, testParams );
+				tearDownSessionFactory();
+			}
+		}
+
+		OrmSetupHelper.SetupContext setupContext = setupHelper.start();
+		config = new DataClearConfigImpl();
+		TestCustomSetup customSetup = new TestCustomSetup( testInstance );
+		customSetup.callSetupMethods( setupContext, config );
+		sessionFactory = setupContext.setup();
+		testParamsForSessionFactory = testParams;
+
+		// If any backend expectations where set during setup, verify them immediately.
+		for ( BackendMock backendMock : allBackendMocks ) {
+			backendMock.verifyExpectationsMet();
+		}
+	}
+
+	private void tearDownSessionFactory() {
+		try ( Closer<RuntimeException> closer = new Closer<>() ) {
+			closer.push( SessionFactory::close, sessionFactory );
+			sessionFactory = null;
+			config = null;
+		}
+	}
+
+	private Collection<?> testParams(Object testInstance) {
+		List<TestPluggableMethod<Collection>> setupParamsMethods = TestPluggableMethod.createAll( SetupParams.class,
+				testInstance.getClass(), Collection.class, Collections.emptyList() );
+		if ( setupParamsMethods.size() > 1 ) {
+			throw new Error( "Test class " + testInstance.getClass()
+					+ " must not declare more than one method annotated with " + SetupParams.class.getName() );
+		}
+		if ( setupParamsMethods.isEmpty() ) {
+			Class<?> runnerClass = runnerClass( testInstance.getClass() );
+			if ( Parameterized.class.equals( runnerClass ) || CustomParameterized.class.equals( runnerClass ) ) {
+				throw new Error( "Test class " + testInstance.getClass()
+						+ " must declare one method annotated with " + SetupParams.class.getName()
+						+ " because it uses runner " + runnerClass.getSimpleName() );
+			}
+			else {
+				return Collections.emptyList();
+			}
+		}
+		return setupParamsMethods.iterator().next().call( testInstance, Collections.emptyMap() );
+	}
+
+	private Class<?> runnerClass(Class<?> testClass) {
+		RunWith annotation = testClass.getAnnotation( RunWith.class );
+		return annotation == null ? null : annotation.value();
+	}
+
+	private void clearAllData(SessionFactory sessionFactory) {
+		HibernateOrmMapping mapping = ( (HibernateOrmMapping) Search.mapping( sessionFactory ) );
+
+		sessionFactory.getCache().evictAllRegions();
+
+		clearDatabase( sessionFactory, mapping );
+
+		// Must re-clear the caches as they may have been re-populated
+		// while executing queries in clearDatabase().
+		sessionFactory.getCache().evictAllRegions();
+	}
+
+	private void clearDatabase(SessionFactory sessionFactory, HibernateOrmMapping mapping) {
+		for ( Consumer<Session> preClear : config.preClear ) {
+			mapping.listenerEnabled( false );
+			withinTransaction( sessionFactory, preClear );
+			mapping.listenerEnabled( true );
+		}
+
+		Set<String> clearedEntityNames = new HashSet<>();
+		for ( Class<?> entityClass : config.entityClearOrder ) {
+			EntityType<?> entityType;
+			try {
+				entityType = sessionFactory.getMetamodel().entity( entityClass );
+			}
+			catch (IllegalArgumentException e) {
+				// When using annotatedTypes to infer the clear order,
+				// some annotated types may not be entities;
+				// this can be ignored.
+				continue;
+			}
+			if ( clearedEntityNames.add( entityType.getName() ) ) {
+				clearEntityInstances( sessionFactory, mapping, entityType );
+			}
+		}
+
+		// Just in case some entity types were not mentioned in entityClearOrder,
+		// we try to delete all remaining entity types.
+		// Note we're stabilizing the order, because ORM uses a HashSet internally
+		// and the order may change from one execution to the next.
+		List<EntityType<?>> sortedEntityTypes = sessionFactory.getMetamodel().getEntities().stream()
+				.sorted( Comparator.comparing( EntityType::getName ) )
+				.collect( Collectors.toList() );
+		for ( EntityType<?> entityType : sortedEntityTypes ) {
+			if ( clearedEntityNames.add( entityType.getName() ) ) {
+				clearEntityInstances( sessionFactory, mapping, entityType );
+			}
+		}
+	}
+
+	private static void clearEntityInstances(SessionFactory sessionFactory, HibernateOrmMapping mapping,
+			EntityType<?> entityType) {
+		if ( Modifier.isAbstract( entityType.getJavaType().getModifiers() ) ) {
+			// There are no instances of this specific class,
+			// only instances of subclasses, and those are handled separately.
+			return;
+		}
+		if (
+				// Workaround until https://hibernate.atlassian.net/browse/HHH-5529 gets implemented
+				hasPotentiallyJoinTable( sessionFactory, entityType )
+				// Workaround until https://hibernate.atlassian.net/browse/HHH-14814 gets fixed
+				|| hasEntitySubclass( sessionFactory, entityType )
+		) {
+			mapping.listenerEnabled( false );
+			try {
+				withinTransaction( sessionFactory, s -> {
+					Query<?> query = selectAllOfSpecificType( entityType, s );
+					try {
+						query.list().forEach( s::remove );
+					}
+					catch (RuntimeException e) {
+						throw new RuntimeException( "Failed to delete all entity instances returned by "
+								+ query.getQueryString() + " on type " + entityType + ": " + e.getMessage(), e );
+					}
+				} );
+			}
+			finally {
+				mapping.listenerEnabled( true );
+			}
+		}
+		else {
+			withinTransaction( sessionFactory, s -> {
+				Query<?> query = deleteAllOfSpecificType( entityType, s );
+				try {
+					query.executeUpdate();
+				}
+				catch (RuntimeException e) {
+					throw new RuntimeException( "Failed to execute " + query.getQueryString() + " on type " + entityType
+							+ ": " + e.getMessage(), e );
+				}
+			} );
+		}
+	}
+
+	private static Query<?> selectAllOfSpecificType(EntityType<?> entityType, Session session) {
+		return createSelectOrDeleteAllOfSpecificTypeQuery( entityType, session, "" );
+	}
+
+	private static Query<?> deleteAllOfSpecificType(EntityType<?> entityType, Session session) {
+		return createSelectOrDeleteAllOfSpecificTypeQuery( entityType, session, "delete " );
+	}
+
+	private static Query<?> createSelectOrDeleteAllOfSpecificTypeQuery(EntityType<?> entityType, Session session, String prefix) {
+		StringBuilder builder = new StringBuilder( prefix ).append( "from " ).append( entityType.getName() ).append( " e" );
+		Class<?> typeArg = null;
+		if ( hasEntitySubclass( session.getSessionFactory(), entityType ) ) {
+			// We must target the type explicitly, without polymorphism,
+			// because subtypes might have associations pointing to the supertype,
+			// in which case deleting subtypes and supertypes in the same query
+			// may fail or not, depending on processing order (supertype before subtype or subtype before supertype).
+			builder.append( " where type( e ) in (:type)" );
+			typeArg = entityType.getJavaType();
+		}
+		Query<?> query = session.createQuery( builder.toString() );
+		if ( typeArg != null ) {
+			query.setParameter( "type", typeArg );
+		}
+		return query;
+	}
+
+	private static boolean hasEntitySubclass(SessionFactory sessionFactory, EntityType<?> parentEntity) {
+		Metamodel metamodel = sessionFactory.unwrap( SessionFactoryImplementor.class ).getMetamodel();
+		for ( EntityType<?> entity : metamodel.getEntities() ) {
+			if ( parentEntity.equals( entity.getSupertype() ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean hasPotentiallyJoinTable(SessionFactory sessionFactory,
+			ManagedType<?> managedType) {
+		for ( Attribute<?, ?> attribute : managedType.getAttributes() ) {
+			switch ( attribute.getPersistentAttributeType() ) {
+				case MANY_TO_ONE:
+				case ONE_TO_ONE:
+				case BASIC:
+					break;
+				case MANY_TO_MANY:
+				case ONE_TO_MANY:
+				case ELEMENT_COLLECTION:
+					return true;
+				case EMBEDDED:
+					EmbeddableType<?> embeddable = sessionFactory.getMetamodel().embeddable( attribute.getJavaType() );
+					if ( hasPotentiallyJoinTable( sessionFactory, embeddable ) ) {
+						return true;
+					}
+					break;
+			}
+		}
+		return false;
+	}
+
+	private static class TestCustomSetup {
+
+		private static final TestPluggableMethod.ArgumentKey<OrmSetupHelper.SetupContext> SETUP_CONTEXT_KEY =
+				new TestPluggableMethod.ArgumentKey<>( OrmSetupHelper.SetupContext.class, "setupContext" );
+		private static final TestPluggableMethod.ArgumentKey<DataClearConfig> CONFIG_CONTEXT_KEY =
+				new TestPluggableMethod.ArgumentKey<>( DataClearConfig.class, "configContext" );
+		private static final List<TestPluggableMethod.ArgumentKey<?>> KEYS =
+				Arrays.asList( SETUP_CONTEXT_KEY, CONFIG_CONTEXT_KEY );
+
+		private final List<TestPluggableMethod<Void>> setupMethods;
+
+		private final Object testInstance;
+
+		TestCustomSetup(Object testInstance) {
+			this.testInstance = testInstance;
+			this.setupMethods = TestPluggableMethod.createAll( Setup.class, testInstance.getClass(), void.class, KEYS );
+		}
+
+		void callSetupMethods(OrmSetupHelper.SetupContext setupContext, DataClearConfig dataClearConfig) {
+			Map<TestPluggableMethod.ArgumentKey<?>, Object> context = new HashMap<>();
+			context.put( SETUP_CONTEXT_KEY, setupContext );
+			context.put( CONFIG_CONTEXT_KEY, dataClearConfig );
+
+			for ( TestPluggableMethod<Void> pluggableMethod : setupMethods ) {
+				pluggableMethod.call( testInstance, context );
+			}
+		}
+	}
+
+	private static class DataClearConfigImpl implements DataClearConfig {
+		private final List<Class<?>> entityClearOrder = new ArrayList<>();
+
+		private final List<Consumer<Session>> preClear = new ArrayList<>();
+
+		@Override
+		public DataClearConfig preClear(Consumer<Session> preClear) {
+			this.preClear.add( preClear );
+			return this;
+		}
+
+		@Override
+		public <T> DataClearConfig preClear(Class<T> entityType, Consumer<T> preClear) {
+			return preClear( session -> {
+				// We'll go through subtypes as well here,
+				// on contrary to selectAllOfSpecificType(),
+				// because we are performing updates only, not deletes.
+
+				CriteriaBuilder builder = session.getCriteriaBuilder();
+				CriteriaQuery<T> query = builder.createQuery( entityType );
+				Root<T> root = query.from( entityType );
+				query.select( root );
+				for ( T entity : session.createQuery( query ).list() ) {
+					preClear.accept( entity );
+				}
+			} );
+		}
+
+		@Override
+		public DataClearConfigImpl clearOrder(Class<?>... entityClasses) {
+			entityClearOrder.clear();
+			Collections.addAll( entityClearOrder, entityClasses );
+			return this;
+		}
+	}
+}

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/TestPluggableMethod.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/TestPluggableMethod.java
@@ -1,0 +1,155 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.integrationtest.mapper.orm;
+
+import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * A representation of a method defined in a test class in order to be called from test infrastructure
+ * (e.g. a {@link org.junit.rules.TestRule}).
+ */
+class TestPluggableMethod<T> {
+
+	public static <T> List<TestPluggableMethod<T>> createAll(Class<? extends Annotation> annotationClass,
+			Class<?> testClass, Class<T> expectedReturnType, List<ArgumentKey<?>> availableKeys) {
+		List<TestPluggableMethod<T>> result = new ArrayList<>();
+		MethodHandles.Lookup lookup = MethodHandles.lookup();
+		collectAllSetupMethods( lookup, annotationClass, result, testClass, expectedReturnType, availableKeys );
+		return result;
+	}
+
+	private static <T> void collectAllSetupMethods(MethodHandles.Lookup lookup, Class<? extends Annotation> annotationClass,
+			List<TestPluggableMethod<T>> collector, Class<?> testClass,
+			Class<T> expectedReturnType, List<ArgumentKey<?>> availableKeys) {
+		Class<?> superClass = testClass.getSuperclass();
+		if ( superClass != Object.class ) {
+			collectAllSetupMethods( lookup, annotationClass, collector, superClass, expectedReturnType, availableKeys );
+		}
+		for ( Method method : testClass.getDeclaredMethods() ) {
+			if ( method.isAnnotationPresent( annotationClass ) ) {
+				collector.add( create( lookup, annotationClass, method, expectedReturnType, availableKeys ) );
+			}
+		}
+	}
+
+	private static <T> TestPluggableMethod<T> create(MethodHandles.Lookup lookup, Class<? extends Annotation> annotationClass,
+			Method method, Class<T> expectedReturnType, List<ArgumentKey<?>> availableKeys) {
+		if ( !Modifier.isPublic( method.getModifiers() ) ) {
+			throw new IllegalStateException(
+					"Method " + method + ", annotated with " + annotationClass.getName() + ", must be public." );
+		}
+		if ( Modifier.isStatic( method.getModifiers() ) ) {
+			throw new IllegalStateException(
+					"Method " + method + ", annotated with " + annotationClass.getName() + ", must be non-static." );
+		}
+		if ( !expectedReturnType.isAssignableFrom( method.getReturnType() ) ) {
+			throw new IllegalStateException(
+					"Method " + method + ", annotated with " + annotationClass.getName() + ", must return type "
+							+ expectedReturnType );
+		}
+		MethodHandle setupMethod;
+		try {
+			setupMethod = lookup.unreflect( method );
+		}
+		catch (IllegalAccessException e) {
+			throw new IllegalStateException(
+					"Method " + method + ", annotated with " + annotationClass.getName() + ", must be accessible from " + lookup + ".",
+					e
+			);
+		}
+		List<ArgumentKey<?>> argumentKeys = new ArrayList<>();
+		for ( Class<?> parameterType : method.getParameterTypes() ) {
+			ArgumentKey<?> matchingKey = null;
+			for ( ArgumentKey<?> key : availableKeys ) {
+				if ( parameterType.isAssignableFrom( key.type ) ) {
+					matchingKey = key;
+					break;
+				}
+			}
+			if ( matchingKey == null ) {
+				throw new IllegalStateException(
+						"Method " + method + " has a parameter of type " + parameterType.getName() + ", which isn't supported."
+								+ " Supported parameter types: "
+								+ availableKeys.stream().map( k -> k.type.getName() ).collect( Collectors.toList() ) );
+			}
+			argumentKeys.add( matchingKey );
+		}
+		return new TestPluggableMethod<>( setupMethod, expectedReturnType, argumentKeys );
+	}
+
+	private final MethodHandle setupMethod;
+	private final Class<T> expectedReturnType;
+	private final List<ArgumentKey<?>> argumentKeys;
+
+	private TestPluggableMethod(MethodHandle setupMethod, Class<T> expectedReturnType,
+			List<ArgumentKey<?>> argumentKeys) {
+		this.setupMethod = setupMethod;
+		this.expectedReturnType = expectedReturnType;
+		this.argumentKeys = argumentKeys;
+	}
+
+	public T call(Object testInstance, Map<ArgumentKey<?>, Object> context) {
+		Object[] args = new Object[1 + argumentKeys.size()];
+		args[0] = testInstance;
+		int i = 1;
+		for ( ArgumentKey<?> argumentKey : argumentKeys ) {
+			args[i++] = context.get( argumentKey );
+		}
+		try {
+			return expectedReturnType.cast( setupMethod.invokeWithArguments( args ) );
+		}
+		catch (Throwable t) {
+			throw new Error(
+					"Failed to call " + setupMethod + " with arguments " + Arrays.toString( args )
+							+ ": " + t.getMessage(),
+					t
+			);
+		}
+	}
+
+	public static final class ArgumentKey<T> {
+		public final Class<T> type;
+		public final String name;
+
+		public ArgumentKey(Class<T> type, String name) {
+			this.type = type;
+			this.name = name;
+		}
+
+		@Override
+		public String toString() {
+			return name;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			ArgumentKey that = (ArgumentKey) o;
+			return Objects.equals( type, that.type ) && Objects.equals( name, that.name );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( type, name );
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4300

Also includes a few follow-up fixes for [HSEARCH-4303](https://hibernate.atlassian.net/browse/HSEARCH-4303), since we can now actually test on Oracle.

Some tests are down from 4+ minutes to ~10 seconds on DB2, because we do much fewer DDL operations. Hopefully that will be enough to bring test execution on DB2/Oracle back under 1 hour.