### PR TITLE
Backport HSEARCH-4300 + HSEARCH-4303 to branch 6.0 - Fix build timeout after 1 hour when testing against DB2

### DIFF
--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/limitations/ConcurrentEmbeddedUpdateLimitationIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/limitations/ConcurrentEmbeddedUpdateLimitationIT.java
@@ -58,7 +58,7 @@ public class ConcurrentEmbeddedUpdateLimitationIT {
 
 	@Test
 	public void reproducer() {
-		with( sessionFactory ).run( session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			Book book = new Book();
 			book.setTitle( "The Caves Of Steel" );
 
@@ -133,7 +133,7 @@ public class ConcurrentEmbeddedUpdateLimitationIT {
 	}
 
 	long countByEditionAndAuthor(String editionLabel, String authorName) {
-		return with( sessionFactory ).apply( session -> {
+		return with( sessionFactory ).applyInTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			return searchSession.search( Book.class )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingConcurrentModificationInSameTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingConcurrentModificationInSameTypeIT.java
@@ -11,7 +11,6 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.OneToOne;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.mapper.orm.Search;
@@ -23,24 +22,27 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
 
 public class AutomaticIndexingConcurrentModificationInSameTypeIT {
-	@Rule
-	public BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
 
 	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
 
-	private SessionFactory sessionFactory;
-
-	@Before
-	public void setup() {
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		backendMock.expectSchema( IndexedEntity.INDEX, b -> b
 				.field( "firstName", String.class )
 				.field( "name", String.class )
@@ -50,12 +52,9 @@ public class AutomaticIndexingConcurrentModificationInSameTypeIT {
 				)
 		);
 
-		sessionFactory = ormSetupHelper.start().withProperty(
-				HibernateOrmMapperSettings.AUTOMATIC_INDEXING_STRATEGY,
-				AutomaticIndexingStrategyName.NONE
-		).setup( IndexedEntity.class );
-
-		backendMock.verifyExpectationsMet();
+		setupContext.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_STRATEGY,
+						AutomaticIndexingStrategyName.NONE )
+				.withAnnotatedTypes( IndexedEntity.class );
 	}
 
 	@Test
@@ -80,7 +79,7 @@ public class AutomaticIndexingConcurrentModificationInSameTypeIT {
 		entity1.setParent( entity2 );
 
 		// First transaction
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			session.persist( entity1 );
 			session.persist( entity2 );
 			session.persist( entity3 );
@@ -89,7 +88,7 @@ public class AutomaticIndexingConcurrentModificationInSameTypeIT {
 		} );
 
 		// Second transaction
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			SearchIndexingPlan indexingPlan = Search.session( session ).indexingPlan();
 			indexingPlan.addOrUpdate( session.load( IndexedEntity.class, 1 ) );
 			// Add another entity to the indexing plan so that we're not done iterating over all entities

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingNonEntityIdDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingNonEntityIdDocumentIdIT.java
@@ -14,18 +14,18 @@ import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
 
 /**
  * Test automatic indexing of an entity type whose document ID is not the entity ID.
@@ -34,30 +34,29 @@ import org.junit.Test;
  */
 public class AutomaticIndexingNonEntityIdDocumentIdIT {
 
-	@Rule
-	public BackendMock backendMock = new BackendMock();
+	@ClassRule
+	public static BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
 
 	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
 
-	private SessionFactory sessionFactory;
-
-	@Before
-	public void setup() {
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		backendMock.expectSchema( IndexedEntity.INDEX, b -> b
 				.field( "indexedField", String.class )
 				.field( "indexedElementCollectionField", String.class, b2 -> b2.multiValued( true ) )
 		);
 
-		sessionFactory = ormSetupHelper.start()
-				.setup( IndexedEntity.class );
-		backendMock.verifyExpectationsMet();
+		setupContext.withAnnotatedTypes( IndexedEntity.class );
 	}
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3203")
 	public void directPersistUpdateDelete() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 			entity1.setDocumentId( 42 );
@@ -77,7 +76,7 @@ public class AutomaticIndexingNonEntityIdDocumentIdIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
 			entity1.setIndexedField( "updatedValue" );
 
@@ -92,7 +91,7 @@ public class AutomaticIndexingNonEntityIdDocumentIdIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
 
 			session.delete( entity1 );
@@ -106,7 +105,7 @@ public class AutomaticIndexingNonEntityIdDocumentIdIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3203")
 	public void directValueUpdate_indexedElementCollectionField() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 			entity1.setDocumentId( 42 );
@@ -126,7 +125,7 @@ public class AutomaticIndexingNonEntityIdDocumentIdIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
 			entity1.getIndexedElementCollectionField().add( "secondValue" );
 
@@ -143,7 +142,7 @@ public class AutomaticIndexingNonEntityIdDocumentIdIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
 			entity1.getIndexedElementCollectionField().remove( 1 );
 
@@ -169,7 +168,7 @@ public class AutomaticIndexingNonEntityIdDocumentIdIT {
 	@Test
 	@TestForIssue(jiraKey = { "HSEARCH-3199", "HSEARCH-3203" })
 	public void directValueReplace_indexedElementCollectionField() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 			entity1.setDocumentId( 42 );
@@ -188,7 +187,7 @@ public class AutomaticIndexingNonEntityIdDocumentIdIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
 			entity1.setIndexedElementCollectionField( new ArrayList<>( Arrays.asList(
 					"newFirstValue", "newSecondValue"

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingAssociationDeletionBytecodeEnhancementIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingAssociationDeletionBytecodeEnhancementIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.associ
 
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
@@ -24,11 +25,10 @@ import org.junit.runner.RunWith;
 public class AutomaticIndexingAssociationDeletionBytecodeEnhancementIT
 		extends AutomaticIndexingAssociationDeletionIT {
 
-	@Override
-	protected OrmSetupHelper.SetupContext configure(OrmSetupHelper.SetupContext ctx) {
-		return ctx
-				// Necessary for BytecodeEnhancerRunner, see BytecodeEnhancementIT.setup
-				.withTcclLookupPrecedenceBefore()
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext) {
+		// Necessary for BytecodeEnhancerRunner, see BytecodeEnhancementIT.setup
+		setupContext.withTcclLookupPrecedenceBefore()
 				// So that we can have lazy *ToOne associations
 				.withProperty( AvailableSettings.ALLOW_ENHANCEMENT_AS_PROXY, "true" );
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingAssociationDeletionIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingAssociationDeletionIT.java
@@ -550,6 +550,7 @@ public class AutomaticIndexingAssociationDeletionIT {
 
 		@IndexedEmbedded(includePaths = {"basic", "elementCollection"})
 		@ManyToMany(mappedBy = "manyToMany")
+		@OrderBy("id")
 		private List<AssociationOwner> manyToMany = new ArrayList<>();
 
 		AssociationNonOwner() {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingGenericPolymorphicAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingGenericPolymorphicAssociationIT.java
@@ -63,7 +63,8 @@ public class AutomaticIndexingGenericPolymorphicAssociationIT {
 				ContainedEntity.class
 		);
 
-		dataClearConfig.clearOrder( IndexedEntity.class, ContainingEntity.class, ContainedEntity.class );
+		dataClearConfig.clearOrder( IndexedEntity.class, ContainingEntity.class, MiddleContainingEntity.class,
+				UnrelatedContainingEntity.class, ContainedEntity.class );
 	}
 
 	@Test

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingPolymorphicInverseSideAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingPolymorphicInverseSideAssociationIT.java
@@ -66,7 +66,8 @@ public class AutomaticIndexingPolymorphicInverseSideAssociationIT {
 				ContainedEntity.class
 		);
 
-		dataClearConfig.clearOrder( IndexedEntity.class, ContainingEntity.class, ContainedEntity.class );
+		dataClearConfig.clearOrder( IndexedEntity.class, ContainingEntity.class, UnrelatedContainingEntity.class,
+				FirstMiddleContainingEntity.class, SecondMiddleContainingEntity.class, ContainedEntity.class );
 	}
 
 	/**

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingPolymorphicInverseSideAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingPolymorphicInverseSideAssociationIT.java
@@ -19,17 +19,17 @@ import javax.persistence.OneToOne;
 import javax.persistence.OrderBy;
 import javax.persistence.Transient;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
 
 /**
  * Test automatic indexing based on Hibernate ORM entity events
@@ -37,16 +37,17 @@ import org.junit.Test;
  */
 public class AutomaticIndexingPolymorphicInverseSideAssociationIT {
 
-	@Rule
-	public BackendMock backendMock = new BackendMock();
+	@ClassRule
+	public static BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
 
 	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
 
-	private SessionFactory sessionFactory;
-
-	@Before
-	public void setup() {
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext, ReusableOrmSetupHolder.DataClearConfig dataClearConfig) {
 		backendMock.expectSchema( IndexedEntity.INDEX, b -> b
 				.objectField( "child", b3 -> b3
 						.objectField( "containedSingle", b2 -> b2
@@ -55,17 +56,17 @@ public class AutomaticIndexingPolymorphicInverseSideAssociationIT {
 				)
 		);
 
-		sessionFactory = ormSetupHelper.start()
-				.setup(
-						IndexedEntity.class,
-						ContainingEntity.class,
-						UnrelatedContainingEntity.class,
-						AbstractMiddleContainingEntity.class,
-						FirstMiddleContainingEntity.class,
-						SecondMiddleContainingEntity.class,
-						ContainedEntity.class
-				);
-		backendMock.verifyExpectationsMet();
+		setupContext.withAnnotatedTypes(
+				IndexedEntity.class,
+				ContainingEntity.class,
+				UnrelatedContainingEntity.class,
+				AbstractMiddleContainingEntity.class,
+				FirstMiddleContainingEntity.class,
+				SecondMiddleContainingEntity.class,
+				ContainedEntity.class
+		);
+
+		dataClearConfig.clearOrder( IndexedEntity.class, ContainingEntity.class, ContainedEntity.class );
 	}
 
 	/**
@@ -75,7 +76,7 @@ public class AutomaticIndexingPolymorphicInverseSideAssociationIT {
 	 */
 	@Test
 	public void inversePathIgnoresUnrelatedTypes() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity indexedEntity = new IndexedEntity();
 			indexedEntity.setId( 1 );
 
@@ -117,7 +118,7 @@ public class AutomaticIndexingPolymorphicInverseSideAssociationIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating the value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 5 );
 			containedEntity.setIncludedInSingle( "updatedValue" );
 
@@ -142,7 +143,7 @@ public class AutomaticIndexingPolymorphicInverseSideAssociationIT {
 	 */
 	@Test
 	public void inversePathDependsOnConcreteType() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity indexedEntity1 = new IndexedEntity();
 			indexedEntity1.setId( 1 );
 
@@ -200,7 +201,7 @@ public class AutomaticIndexingPolymorphicInverseSideAssociationIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating the value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 5 );
 			containedEntity.setIncludedInSingle( "updatedValue" );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingPolymorphicOriginalSideAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingPolymorphicOriginalSideAssociationIT.java
@@ -18,17 +18,17 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.OrderBy;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
 
 /**
  * Test automatic indexing based on Hibernate ORM entity events
@@ -36,16 +36,17 @@ import org.junit.Test;
  */
 public class AutomaticIndexingPolymorphicOriginalSideAssociationIT {
 
-	@Rule
-	public BackendMock backendMock = new BackendMock();
+	@ClassRule
+	public static BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
 
 	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
 
-	private SessionFactory sessionFactory;
-
-	@Before
-	public void setup() {
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		backendMock.expectSchema( IndexedEntity.INDEX, b -> b
 				.objectField( "child", b3 -> b3
 						.objectField( "containedSingle", b2 -> b2
@@ -54,15 +55,13 @@ public class AutomaticIndexingPolymorphicOriginalSideAssociationIT {
 				)
 		);
 
-		sessionFactory = ormSetupHelper.start()
-				.setup(
-						IndexedEntity.class,
-						ContainingEntity.class,
-						FirstMiddleContainingEntity.class,
-						SecondMiddleContainingEntity.class,
-						ContainedEntity.class
-				);
-		backendMock.verifyExpectationsMet();
+		setupContext.withAnnotatedTypes(
+				IndexedEntity.class,
+				ContainingEntity.class,
+				FirstMiddleContainingEntity.class,
+				SecondMiddleContainingEntity.class,
+				ContainedEntity.class
+		);
 	}
 
 	/**
@@ -75,7 +74,7 @@ public class AutomaticIndexingPolymorphicOriginalSideAssociationIT {
 	 */
 	@Test
 	public void inversePathDependsOnConcreteType() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity indexedEntity1 = new IndexedEntity();
 			indexedEntity1.setId( 1 );
 
@@ -135,7 +134,7 @@ public class AutomaticIndexingPolymorphicOriginalSideAssociationIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating the value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 5 );
 			containedEntity.setIncludedInSingle( "updatedValue" );
 
@@ -188,7 +187,8 @@ public class AutomaticIndexingPolymorphicOriginalSideAssociationIT {
 	}
 
 	@Entity(name = "containing")
-	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS) // Necessary because subtypes declare columns with identical names
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	// Necessary because subtypes declare columns with identical names
 	public abstract static class ContainingEntity {
 		@Id
 		private Integer id;

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/AbstractAutomaticIndexingAssociationBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/AbstractAutomaticIndexingAssociationBaseIT.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.association.bytype;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 import static org.junit.Assume.assumeTrue;
 
 import java.util.ArrayList;
@@ -18,15 +17,16 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.document.model.StubIndexSchemaNode;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
 
 /**
  * Abstract base for tests of automatic indexing caused by association updates
@@ -140,13 +140,14 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 				TIndexed extends TContaining, TContaining, TContained
 		> {
 
-	@Rule
-	public BackendMock backendMock = new BackendMock();
+	@ClassRule
+	public static BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
 
 	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
-
-	protected SessionFactory sessionFactory;
+	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
 
 	private final ModelPrimitives<TIndexed, TContaining, TContained> primitives;
 
@@ -155,8 +156,8 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		this.primitives = primitives;
 	}
 
-	@Before
-	public void setup() {
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext, ReusableOrmSetupHolder.DataClearConfig dataClearConfig) {
 		Consumer<StubIndexSchemaNode.Builder> associationFieldContributor = b -> {
 			if ( primitives.isMultiValuedAssociation() ) {
 				b.multiValued( true );
@@ -221,20 +222,23 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 				)
 		);
 
-		sessionFactory = ormSetupHelper.start()
-				.with( this::configure )
-				.setup( primitives.getIndexedClass(), primitives.getContainedClass() );
-		backendMock.verifyExpectationsMet();
-	}
+		setupContext.withAnnotatedTypes( primitives.getIndexedClass(), primitives.getContainingClass(),
+				primitives.getContainedClass() );
 
-	protected OrmSetupHelper.SetupContext configure(OrmSetupHelper.SetupContext setupContext) {
-		return setupContext;
+		if ( primitives.isAssociationOwnedByContainedSide() ) {
+			dataClearConfig.clearOrder( primitives.getContainedClass(), primitives.getContainingClass(),
+					primitives.getIndexedClass() );
+		}
+		else {
+			dataClearConfig.clearOrder( primitives.getContainingClass(), primitives.getIndexedClass(),
+					primitives.getContainedClass() );
+		}
 	}
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-4305")
 	public void directAssociationUpdate_indexedEmbedded() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			session.persist( entity1 );
@@ -245,7 +249,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained containedEntity = primitives.newContained( 2 );
@@ -266,7 +270,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained containedEntity = primitives.newContained( 3 );
@@ -288,7 +292,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			primitives.containingAsIndexedEmbedded().clear( primitives.containedIndexedEmbedded().get( entity1 ) );
@@ -308,7 +312,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3199")
 	public final void directAssociationUpdate_nonIndexedEmbedded() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			session.persist( entity1 );
@@ -319,7 +323,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained containedEntity = primitives.newContained( 2 );
@@ -335,7 +339,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained containedEntity = primitives.newContained( 3 );
@@ -352,7 +356,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			primitives.containingAsNonIndexedEmbedded().clear( primitives.containedNonIndexedEmbedded().get( entity1 ) );
@@ -371,7 +375,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = { "HSEARCH-4001", "HSEARCH-4305" })
 	public void directAssociationUpdate_indexedEmbeddedShallowReindexOnUpdate() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			session.persist( entity1 );
@@ -382,7 +386,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained containedEntity = primitives.newContained( 2 );
@@ -403,7 +407,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained containedEntity = primitives.newContained( 3 );
@@ -426,7 +430,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 			TContained containedEntity = session.get( primitives.getContainedClass(), 3 );
 
@@ -447,7 +451,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3206")
 	public final void directAssociationUpdate_indexedEmbeddedNoReindexOnUpdate() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			session.persist( entity1 );
@@ -458,7 +462,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained containedEntity = primitives.newContained( 2 );
@@ -474,7 +478,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained containedEntity = primitives.newContained( 3 );
@@ -492,7 +496,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 			TContained containedEntity = session.get( primitives.getContainedClass(), 3 );
 
@@ -525,7 +529,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 						+ " https://discourse.hibernate.org/t/hs6-not-indexing-add-or-delete-only-update-with-onetomany-indexedembedded/5638/6",
 				primitives.isAssociationLazyOnContainingSide() );
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			session.persist( entity1 );
@@ -535,7 +539,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained containedEntity = primitives.newContained( 2 );
@@ -579,7 +583,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 						+ " https://discourse.hibernate.org/t/hs6-not-indexing-add-or-delete-only-update-with-onetomany-indexedembedded/5638/6",
 				primitives.isAssociationLazyOnContainingSide() );
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 			TContained containedEntity = primitives.newContained( 2 );
 			primitives.indexedField().set( containedEntity, "initialValue" );
@@ -598,7 +602,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained containedEntity = session.get( primitives.getContainedClass(), 2 );
 
 			// Do NOT update the association on either side; that's on purpose.
@@ -618,7 +622,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-4305")
 	public void indirectAssociationUpdate_indexedEmbedded() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -641,7 +645,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained containedEntity = primitives.newContained( 4 );
@@ -664,7 +668,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained containedEntity = primitives.newContained( 5 );
@@ -688,7 +692,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining deeplyNestedContainingEntity1 = session.get( primitives.getContainingClass(), 3 );
 
 			TContained containedEntity = primitives.newContained( 6 );
@@ -704,7 +708,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			primitives.containingAsIndexedEmbedded().clear( primitives.containedIndexedEmbedded().get( containingEntity1 ) );
@@ -726,7 +730,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3199")
 	public final void indirectAssociationUpdate_nonIndexedEmbedded() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -744,7 +748,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained containedEntity = primitives.newContained( 4 );
@@ -760,7 +764,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained containedEntity = primitives.newContained( 5 );
@@ -777,7 +781,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			primitives.containingAsNonIndexedEmbedded().clear( primitives.containedNonIndexedEmbedded().get( containingEntity1 ) );
@@ -797,7 +801,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = { "HSEARCH-4001", "HSEARCH-4305" })
 	public void indirectAssociationUpdate_indexedEmbeddedShallowReindexOnUpdate() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -815,7 +819,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained containedEntity = primitives.newContained( 4 );
@@ -838,7 +842,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained containedEntity = primitives.newContained( 5 );
@@ -863,7 +867,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 			TContained containedEntity = session.get( primitives.getContainedClass(), 5 );
 
@@ -887,7 +891,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3206")
 	public final void indirectAssociationUpdate_indexedEmbeddedNoReindexOnUpdate() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -905,7 +909,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained containedEntity = primitives.newContained( 4 );
@@ -921,7 +925,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained containedEntity = primitives.newContained( 5 );
@@ -939,7 +943,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 			TContained containedEntity = session.get( primitives.getContainedClass(), 5 );
 
@@ -959,7 +963,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-4305")
 	public void indirectAssociationUpdate_usedInCrossEntityDerivedProperty() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -982,7 +986,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained containedEntity = primitives.newContained( 4 );
@@ -1007,7 +1011,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained containedEntity = primitives.newContained( 5 );
@@ -1033,7 +1037,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value that is too deeply nested to matter (it's out of the path)
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining deeplyNestedContainingEntity1 = session.get( primitives.getContainingClass(), 3 );
 
 			TContained containedEntity = primitives.newContained( 6 );
@@ -1050,7 +1054,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			primitives.containingAsUsedInCrossEntityDerivedProperty()
@@ -1079,7 +1083,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 						+ " https://discourse.hibernate.org/t/hs6-not-indexing-add-or-delete-only-update-with-onetomany-indexedembedded/5638/6",
 				primitives.isAssociationLazyOnContainingSide() );
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -1095,7 +1099,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained containedEntity = primitives.newContained( 2 );
@@ -1131,7 +1135,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 						+ " https://discourse.hibernate.org/t/hs6-not-indexing-add-or-delete-only-update-with-onetomany-indexedembedded/5638/6",
 				primitives.isAssociationLazyOnContainingSide() );
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 			TContaining containingEntity1 = primitives.newContaining( 2 );
 			primitives.child().set( entity1, containingEntity1 );
@@ -1155,7 +1159,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained containedEntity = session.get( primitives.getContainedClass(), 2 );
 
 			// Do NOT update the association on either side; that's on purpose.
@@ -1175,7 +1179,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 
 	@Test
 	public void indirectValueUpdate_indexedEmbedded_singleValue_indexed() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -1214,7 +1218,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating the value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
 			primitives.indexedField().set( contained, "updatedValue" );
 
@@ -1230,7 +1234,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 5 );
 			primitives.indexedField().set( contained, "updatedOutOfScopeValue" );
 
@@ -1242,7 +1246,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-4137")
 	public void directValueUpdate_nonIndexed_then_indirectValueUpdate_indexedEmbedded_singleValue_indexed() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 			primitives.containingEntityNonIndexedField().set( entity1, "initialValue" );
 
@@ -1271,7 +1275,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value in the indexed entity, then in the same transaction updating a value in a contained entity
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed indexed = session.get( primitives.getIndexedClass(), 1 );
 			primitives.containingEntityNonIndexedField().set( indexed, "updatedValue" );
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
@@ -1297,7 +1301,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3199")
 	public void indirectValueUpdate_indexedEmbedded_singleValue_nonIndexed() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -1325,7 +1329,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating the value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
 			primitives.nonIndexedField().set( contained, "updatedValue" );
 
@@ -1336,7 +1340,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 
 	@Test
 	public void indirectValueUpdate_indexedEmbedded_elementCollectionValue_indexed() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -1379,7 +1383,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
 			primitives.indexedElementCollectionField().add( contained, "secondValue" );
 
@@ -1399,7 +1403,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
 			primitives.indexedElementCollectionField().remove( contained, "firstValue" );
 
@@ -1419,7 +1423,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 5 );
 			primitives.indexedElementCollectionField().add( contained, "secondOutOfScopeValue" );
 
@@ -1439,7 +1443,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3199")
 	public void indirectValueReplace_indexedEmbedded_elementCollectionValue_indexed() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -1482,7 +1486,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test replacing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
 			primitives.indexedElementCollectionField().setContainer( contained, new ArrayList<>( Arrays.asList(
 					"newFirstValue", "newSecondValue"
@@ -1504,7 +1508,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test replacing a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 5 );
 			primitives.indexedElementCollectionField().setContainer( contained, new ArrayList<>( Arrays.asList(
 					"newFirstOutOfScopeValue", "newSecondOutOfScopeValue"
@@ -1523,7 +1527,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3199")
 	public void indirectValueUpdate_indexedEmbedded_elementCollectionValue_nonIndexed() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -1551,7 +1555,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
 			primitives.nonIndexedElementCollectionField().add( contained, "secondValue" );
 
@@ -1560,7 +1564,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
 			primitives.nonIndexedElementCollectionField().remove( contained, "firstValue" );
 
@@ -1580,7 +1584,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3204")
 	public void indirectValueReplace_indexedEmbedded_elementCollectionValue_nonIndexed() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -1608,7 +1612,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test replacing the values
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
 			primitives.nonIndexedElementCollectionField().setContainer( contained, new ArrayList<>( Arrays.asList(
 					"newFirstValue", "newSecondValue"
@@ -1629,7 +1633,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 
 	@Test
 	public void indirectValueUpdate_indexedEmbedded_containedDerivedValue_indexed() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -1663,7 +1667,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating one value the field depends on
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
 			primitives.fieldUsedInContainedDerivedField1().set( contained, "field1_updatedValue" );
 
@@ -1683,7 +1687,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating the other value the field depends on
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
 			primitives.fieldUsedInContainedDerivedField2().set( contained, "field2_updatedValue" );
 
@@ -1710,7 +1714,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 	 */
 	@Test
 	public void indirectValueUpdate_usedInCrossEntityDerivedProperty_crossEntityDerivedValue_indexed() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -1740,7 +1744,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating one value the field depends on
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
 			primitives.fieldUsedInCrossEntityDerivedField1().set( contained, "field1_updatedValue" );
 
@@ -1757,7 +1761,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating the other value the field depends on
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
 			primitives.fieldUsedInCrossEntityDerivedField2().set( contained, "field2_updatedValue" );
 
@@ -1777,7 +1781,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-4001")
 	public void indirectValueUpdate_indexedEmbeddedShallowReindexOnUpdate_singleValue_indexed() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -1805,7 +1809,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating the value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
 			primitives.indexedField().set( contained, "updatedValue" );
 
@@ -1823,7 +1827,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-4001")
 	public void indirectValueUpdate_indexedEmbeddedShallowReindexOnUpdate_elementCollectionValue_indexed() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -1855,7 +1859,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
 			primitives.indexedElementCollectionField().add( contained, "secondValue" );
 
@@ -1864,7 +1868,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
 			primitives.indexedElementCollectionField().remove( contained, "firstValue" );
 
@@ -1885,7 +1889,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-4001")
 	public void indirectValueReplace_indexedEmbeddedShallowReindexOnUpdate_elementCollectionValue_indexed() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -1917,7 +1921,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test replacing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
 			primitives.indexedElementCollectionField().setContainer( contained, new ArrayList<>( Arrays.asList(
 					"newFirstValue", "newSecondValue"
@@ -1931,7 +1935,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3206")
 	public void indirectValueUpdate_indexedEmbeddedNoReindexOnUpdate_singleValue_indexed() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -1959,7 +1963,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating the value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
 			primitives.indexedField().set( contained, "updatedValue" );
 
@@ -1977,7 +1981,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3206")
 	public void indirectValueUpdate_indexedEmbeddedNoReindexOnUpdate_elementCollectionValue_indexed() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -2009,7 +2013,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
 			primitives.indexedElementCollectionField().add( contained, "secondValue" );
 
@@ -2018,7 +2022,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
 			primitives.indexedElementCollectionField().remove( contained, "firstValue" );
 
@@ -2039,7 +2043,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3206")
 	public void indirectValueReplace_indexedEmbeddedNoReindexOnUpdate_elementCollectionValue_indexed() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -2071,7 +2075,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test replacing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
 			primitives.indexedElementCollectionField().setContainer( contained, new ArrayList<>( Arrays.asList(
 					"newFirstValue", "newSecondValue"
@@ -2085,7 +2089,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3072")
 	public void indirectValueUpdate_indexedEmbeddedWithCast_singleValue() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -2124,7 +2128,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating the value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
 			primitives.indexedField().set( contained, "updatedValue" );
 
@@ -2140,7 +2144,7 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContained contained = session.get( primitives.getContainedClass(), 5 );
 			primitives.indexedField().set( contained, "updatedOutOfScopeValue" );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/AbstractAutomaticIndexingMultiValuedAssociationBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/AbstractAutomaticIndexingMultiValuedAssociationBaseIT.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.association.bytype;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
-
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Test;
@@ -41,7 +39,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 
 	@Test
 	public void directMultiValuedAssociationUpdate_indexedEmbedded() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			session.persist( entity1 );
@@ -52,7 +50,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 2 );
@@ -73,7 +71,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a second value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 3 );
@@ -97,7 +95,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = session.get( primitives.getContainedClass(), 2 );
@@ -125,7 +123,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3199")
 	public void directMultiValuedAssociationReplace_indexedEmbedded() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContained contained = primitives.newContained( 2 );
@@ -146,7 +144,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 3 );
@@ -182,7 +180,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3199")
 	public void directMultiValuedAssociationMultiValuedUpdate_nonIndexedEmbedded() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			session.persist( entity1 );
@@ -193,7 +191,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 2 );
@@ -209,7 +207,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a second value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 3 );
@@ -225,7 +223,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = session.get( primitives.getContainedClass(), 2 );
@@ -249,7 +247,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3204")
 	public void directMultiValuedAssociationReplace_nonIndexedEmbedded() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContained contained = primitives.newContained( 2 );
@@ -266,7 +264,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 3 );
@@ -296,7 +294,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-4001")
 	public void directMultiValuedAssociationUpdate_indexedEmbeddedShallowReindexOnUpdate() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			session.persist( entity1 );
@@ -307,7 +305,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 2 );
@@ -328,7 +326,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a second value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 3 );
@@ -352,7 +350,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = session.get( primitives.getContainedClass(), 2 );
@@ -381,7 +379,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-4001")
 	public void directMultiValuedAssociationReplace_indexedEmbeddedShallowReindexOnUpdate() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContained contained = primitives.newContained( 2 );
@@ -402,7 +400,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 3 );
@@ -438,7 +436,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3206")
 	public void directMultiValuedAssociationUpdate_indexedEmbeddedNoReindexOnUpdate() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			session.persist( entity1 );
@@ -449,7 +447,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 2 );
@@ -465,7 +463,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a second value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 3 );
@@ -481,7 +479,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = session.get( primitives.getContainedClass(), 2 );
@@ -505,7 +503,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3204")
 	public void directMultiValuedAssociationReplace_indexedEmbeddedNoReindexOnUpdate() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContained contained = primitives.newContained( 2 );
@@ -526,7 +524,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
 
 			TContained contained = primitives.newContained( 3 );
@@ -557,7 +555,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 
 	@Test
 	public void indirectMultiValuedAssociationUpdate_indexedEmbedded() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -580,7 +578,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 4 );
@@ -603,7 +601,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding another value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 5 );
@@ -629,7 +627,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining deeplyNestedContainingEntity1 = session.get( primitives.getContainingClass(), 3 );
 
 			TContained contained = primitives.newContained( 6 );
@@ -645,7 +643,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
@@ -676,7 +674,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3199")
 	public void indirectMultiValuedAssociationReplace_indexedEmbedded() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -703,7 +701,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 4 );
@@ -741,7 +739,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3199")
 	public void indirectMultiValuedAssociationUpdate_nonIndexedEmbedded() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -759,7 +757,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 4 );
@@ -775,7 +773,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding another value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 5 );
@@ -791,7 +789,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
@@ -815,7 +813,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3204")
 	public void indirectMultiValuedAssociationReplace_nonIndexedEmbedded() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -838,7 +836,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 4 );
@@ -871,7 +869,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-4001")
 	public void indirectMultiValuedAssociationUpdate_indexedEmbeddedShallowReindexOnUpdate() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -889,7 +887,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 4 );
@@ -912,7 +910,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding another value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 5 );
@@ -938,7 +936,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
@@ -972,7 +970,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-4001")
 	public void indirectMultiValuedAssociationReplace_indexedEmbeddedShallowReindexOnUpdate() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -999,7 +997,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 4 );
@@ -1038,7 +1036,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3206")
 	public void indirectMultiValuedAssociationUpdate_indexedEmbeddedNoReindexOnUpdate() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -1056,7 +1054,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 4 );
@@ -1072,7 +1070,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test adding another value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 5 );
@@ -1088,7 +1086,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = session.get( primitives.getContainedClass(), 4 );
@@ -1113,7 +1111,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3204")
 	public void indirectMultiValuedAssociationReplace_indexedEmbeddedNoReindexOnUpdate() {
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
 			TContaining containingEntity1 = primitives.newContaining( 2 );
@@ -1140,7 +1138,7 @@ public abstract class AbstractAutomaticIndexingMultiValuedAssociationBaseIT<
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
 
 			TContained contained = primitives.newContained( 4 );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontained/AutomaticIndexingManyToManyOwnedByContainedListBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontained/AutomaticIndexingManyToManyOwnedByContainedListBaseIT.java
@@ -273,26 +273,32 @@ public class AutomaticIndexingManyToManyOwnedByContainedListBaseIT
 		private ContainingEntity child;
 
 		@ManyToMany(mappedBy = "containingAsIndexedEmbedded")
+		@OrderBy("id asc") // Make sure the iteration order is predictable
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		private List<ContainedEntity> containedIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany(mappedBy = "containingAsNonIndexedEmbedded")
+		@OrderBy("id asc") // Make sure the iteration order is predictable
 		private List<ContainedEntity> containedNonIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany(mappedBy = "containingAsIndexedEmbeddedShallowReindexOnUpdate")
+		@OrderBy("id asc") // Make sure the iteration order is predictable
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 		private List<ContainedEntity> containedIndexedEmbeddedShallowReindexOnUpdate = new ArrayList<>();
 
 		@ManyToMany(mappedBy = "containingAsIndexedEmbeddedNoReindexOnUpdate")
+		@OrderBy("id asc") // Make sure the iteration order is predictable
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.NO)
 		private List<ContainedEntity> containedIndexedEmbeddedNoReindexOnUpdate = new ArrayList<>();
 
 		@ManyToMany(mappedBy = "containingAsUsedInCrossEntityDerivedProperty")
+		@OrderBy("id asc") // Make sure the iteration order is predictable
 		private List<ContainedEntity> containedUsedInCrossEntityDerivedProperty = new ArrayList<>();
 
 		@ManyToMany(mappedBy = "containingAsIndexedEmbeddedWithCast", targetEntity = ContainedEntity.class)
+		@OrderBy("id asc") // Make sure the iteration order is predictable
 		@IndexedEmbedded(includePaths = "indexedField", targetType = ContainedEntity.class)
 		private List<Object> containedIndexedEmbeddedWithCast = new ArrayList<>();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontained/AutomaticIndexingManyToManyOwnedByContainedListBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontained/AutomaticIndexingManyToManyOwnedByContainedListBaseIT.java
@@ -412,37 +412,44 @@ public class AutomaticIndexingManyToManyOwnedByContainedListBaseIT
 		private Integer id;
 
 		@ManyToMany
-		@JoinTable(name = "i_containedIndexedEmbedded")
+		@JoinTable(name = "i_containedIndexedEmbedded",
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		private List<ContainingEntity> containingAsIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany
-		@JoinTable(name = "i_containedNonIndexedEmbedded", joinColumns = @JoinColumn(name = "containedNonIndexedEmbedded"),
-				inverseJoinColumns = @JoinColumn(name = "containingNonIndexedEmbedded"))
+		@JoinTable(name = "i_containedNonIndexedEmbedded",
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		private List<ContainingEntity> containingAsNonIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany
 		@JoinTable(name = "i_indexedEmbeddedShallow",
-				joinColumns = @JoinColumn(name = "indexedEmbeddedShallow"))
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		private List<ContainingEntity> containingAsIndexedEmbeddedShallowReindexOnUpdate = new ArrayList<>();
 
 		@ManyToMany
 		@JoinTable(name = "i_indexedEmbeddedNoReindex",
-				joinColumns = @JoinColumn(name = "indexedEmbeddedNoReindex"))
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		private List<ContainingEntity> containingAsIndexedEmbeddedNoReindexOnUpdate = new ArrayList<>();
 
 		@ManyToMany
-		@JoinTable(name = "i_containedCrossEntityDP", joinColumns = @JoinColumn(name = "containedCrossEntityDP"),
-				inverseJoinColumns = @JoinColumn(name = "containingCrossEntityDP"))
+		@JoinTable(name = "i_containedCrossEntityDP",
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		private List<ContainingEntity> containingAsUsedInCrossEntityDerivedProperty = new ArrayList<>();
 
 		@ManyToMany(targetEntity = ContainingEntity.class)
-		@JoinTable(name = "i_containedIndexedEmbeddedCast", joinColumns = @JoinColumn(name = "containedIndexedEmbeddedCast"),
-				inverseJoinColumns = @JoinColumn(name = "containingIndexedEmbeddedCast"))
+		@JoinTable(name = "i_containedIndexedEmbeddedCast",
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		private List<Object> containingAsIndexedEmbeddedWithCast = new ArrayList<>();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingListBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingListBaseIT.java
@@ -14,6 +14,7 @@ import javax.persistence.Basic;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.OneToOne;
@@ -270,32 +271,44 @@ public class AutomaticIndexingManyToManyOwnedByContainingListBaseIT
 		private ContainingEntity child;
 
 		@ManyToMany
-		@JoinTable(name = "indexed_containedIndexedEmbedded")
+		@JoinTable(name = "indexed_containedIndexedEmbedded",
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		private List<ContainedEntity> containedIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany
-		@JoinTable(name = "indexed_containedNonIndexedEmbedded")
+		@JoinTable(name = "i_containedNonIndexedEmbedded",
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		private List<ContainedEntity> containedNonIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany
-		@JoinTable(name = "indexed_indexedEmbeddedShallowReindexOnUpdateContained")
+		@JoinTable(name = "i_indexedEmbeddedShallow",
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 		private List<ContainedEntity> containedIndexedEmbeddedShallowReindexOnUpdate = new ArrayList<>();
 
 		@ManyToMany
-		@JoinTable(name = "indexed_indexedEmbeddedNoReindexOnUpdateContained")
+		@JoinTable(name = "i_indexedEmbeddedNoReindex",
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.NO)
 		private List<ContainedEntity> containedIndexedEmbeddedNoReindexOnUpdate = new ArrayList<>();
 
 		@ManyToMany
-		@JoinTable(name = "indexed_containedUsedInCrossEntityDerivedProperty")
+		@JoinTable(name = "i_containedCrossEntityDP",
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		private List<ContainedEntity> containedUsedInCrossEntityDerivedProperty = new ArrayList<>();
 
 		@ManyToMany(targetEntity = ContainedEntity.class)
-		@JoinTable(name = "indexed_containedIndexedEmbeddedWithCast")
+		@JoinTable(name = "i_containedIndexedEmbeddedCast",
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		@IndexedEmbedded(includePaths = "indexedField", targetType = ContainedEntity.class)
 		private List<Object> containedIndexedEmbeddedWithCast = new ArrayList<>();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT.java
@@ -286,11 +286,11 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 		@ElementCollection
 		@JoinTable(
 				name = "indexed_containedIndexedEmbedded",
-				joinColumns = @JoinColumn(name = "mapHolder")
+				joinColumns = @JoinColumn(name = "containing")
 		)
-		@MapKeyJoinColumn(name = "map_key")
+		@MapKeyJoinColumn(name = "contained")
 		@Column(name = "value")
-		@OrderBy("map_key asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
+		@OrderBy("contained asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
 		@IndexedEmbedded(
 				includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" },
 				extraction = @ContainerExtraction(BuiltinContainerExtractors.MAP_KEY)
@@ -300,21 +300,21 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 		@ElementCollection
 		@JoinTable(
 				name = "indexed_containedNonIndexedEmbedded",
-				joinColumns = @JoinColumn(name = "mapHolder")
+				joinColumns = @JoinColumn(name = "containing")
 		)
-		@MapKeyJoinColumn(name = "map_key")
+		@MapKeyJoinColumn(name = "contained")
 		@Column(name = "value")
-		@OrderBy("map_key asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
+		@OrderBy("contained asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
 		private Map<ContainedEntity, String> containedNonIndexedEmbedded = new LinkedHashMap<>();
 
 		@ElementCollection
 		@JoinTable(
 				name = "indexed_containedIndexedEmbeddedShallowReindexOnUpdate",
-				joinColumns = @JoinColumn(name = "mapHolder")
+				joinColumns = @JoinColumn(name = "containing")
 		)
-		@MapKeyJoinColumn(name = "map_key")
+		@MapKeyJoinColumn(name = "contained")
 		@Column(name = "value")
-		@OrderBy("map_key asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
+		@OrderBy("contained asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
 		@IndexedEmbedded(
 				includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" },
 				extraction = @ContainerExtraction(BuiltinContainerExtractors.MAP_KEY)
@@ -328,11 +328,11 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 		@ElementCollection
 		@JoinTable(
 				name = "indexed_containedIndexedEmbeddedNoReindexOnUpdate",
-				joinColumns = @JoinColumn(name = "mapHolder")
+				joinColumns = @JoinColumn(name = "containing")
 		)
-		@MapKeyJoinColumn(name = "map_key")
+		@MapKeyJoinColumn(name = "contained")
 		@Column(name = "value")
-		@OrderBy("map_key asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
+		@OrderBy("contained asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
 		@IndexedEmbedded(
 				includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" },
 				extraction = @ContainerExtraction(BuiltinContainerExtractors.MAP_KEY)
@@ -346,22 +346,22 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 		@ElementCollection
 		@JoinTable(
 				name = "indexed_containedUsedInCrossEntityDerivedProperty",
-				joinColumns = @JoinColumn(name = "mapHolder")
+				joinColumns = @JoinColumn(name = "containing")
 		)
-		@MapKeyJoinColumn(name = "map_key")
+		@MapKeyJoinColumn(name = "contained")
 		@Column(name = "value")
-		@OrderBy("map_key asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
+		@OrderBy("contained asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
 		private Map<ContainedEntity, String> containedUsedInCrossEntityDerivedProperty = new LinkedHashMap<>();
 
 		@ElementCollection
 		@JoinTable(
 				name = "indexed_containedIndexedEmbeddedWithCast",
-				joinColumns = @JoinColumn(name = "mapHolder")
+				joinColumns = @JoinColumn(name = "containing")
 		)
 		@MapKeyClass(ContainedEntity.class)
-		@MapKeyJoinColumn(name = "map_key")
+		@MapKeyJoinColumn(name = "contained")
 		@Column(name = "value")
-		@OrderBy("map_key asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
+		@OrderBy("contained asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
 		@IndexedEmbedded(
 				includePaths = { "indexedField" },
 				extraction = @ContainerExtraction(BuiltinContainerExtractors.MAP_KEY),
@@ -491,7 +491,9 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 		 * and ends up adding all kind of wrong foreign keys.
 		 */
 		@ManyToMany
-		@JoinTable(name = "contained_mapHolder")
+		@JoinTable(name = "contained_indEmd",
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		@AssociationInverseSide(
 				inversePath = @ObjectPath(
@@ -507,7 +509,9 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 		 * No mappedBy here, same reasons as above.
 		 */
 		@ManyToMany
-		@JoinTable(name = "contained_nonIndexedMapHolder")
+		@JoinTable(name = "contained_nonIndEmd",
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		private List<ContainingEntity> containingAsNonIndexedEmbedded = new ArrayList<>();
 
@@ -515,8 +519,9 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 		 * No mappedBy here, same reasons as above.
 		 */
 		@ManyToMany
-		@JoinTable(name = "contained_indexedShallowMapHolder",
-				inverseJoinColumns = @JoinColumn(name = "containingIndexedShallow"))
+		@JoinTable(name = "contained_indEmdShallow",
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		@AssociationInverseSide(
 				inversePath = @ObjectPath(
@@ -532,8 +537,9 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 		 * No mappedBy here, same reasons as above.
 		 */
 		@ManyToMany
-		@JoinTable(name = "contained_indexedNoReindexMapHolder",
-				inverseJoinColumns = @JoinColumn(name = "containingIndexedNoReindex"))
+		@JoinTable(name = "contained_indEmdNoReindex",
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		@AssociationInverseSide(
 				inversePath = @ObjectPath(
@@ -549,6 +555,9 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 		 * No mappedBy here, same reasons as above.
 		 */
 		@ManyToMany
+		@JoinTable(name = "contained_usedInCEDP",
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		@AssociationInverseSide(
 				inversePath = @ObjectPath(
@@ -566,7 +575,9 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 		 * and ends up adding all kind of wrong foreign keys.
 		 */
 		@ManyToMany(targetEntity = ContainingEntity.class)
-		@JoinTable(name = "contained_withCastMapHolder")
+		@JoinTable(name = "contained_indEmdWithCast",
+				joinColumns = @JoinColumn(name = "contained"),
+				inverseJoinColumns = @JoinColumn(name = "containing"))
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		@AssociationInverseSide(
 				inversePath = @ObjectPath(

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT.java
@@ -41,6 +41,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmb
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyValue;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 
 
 /**
@@ -59,6 +60,18 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 
 	public AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT() {
 		super( new ModelPrimitivesImpl() );
+	}
+
+	@ReusableOrmSetupHolder.Setup
+	public void setup(ReusableOrmSetupHolder.DataClearConfig dataClearConfig) {
+		dataClearConfig.preClear( ContainedEntity.class, contained -> {
+			contained.getContainingAsIndexedEmbedded().clear();
+			contained.getContainingAsNonIndexedEmbedded().clear();
+			contained.getContainingAsIndexedEmbeddedShallowReindexOnUpdate().clear();
+			contained.getContainingAsIndexedEmbeddedNoReindexOnUpdate().clear();
+			contained.getContainingAsUsedInCrossEntityDerivedProperty().clear();
+			contained.getContainingAsIndexedEmbeddedWithCast().clear();
+		} );
 	}
 
 	private static class ModelPrimitivesImpl

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingMapValuesBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingMapValuesBaseIT.java
@@ -285,8 +285,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapValuesBaseIT
 		@ManyToMany
 		@JoinTable(
 				name = "indexed_containedIndexedEmbedded",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
@@ -296,8 +296,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapValuesBaseIT
 		@ManyToMany
 		@JoinTable(
 				name = "indexed_containedNonIndexedEmbedded",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@OrderBy("id asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
@@ -306,8 +306,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapValuesBaseIT
 		@ManyToMany
 		@JoinTable(
 				name = "indexed_containedIndexedEmbeddedShallowReindexOnUpdate",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
@@ -318,8 +318,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapValuesBaseIT
 		@ManyToMany
 		@JoinTable(
 				name = "indexed_containedIndexedEmbeddedNoReindexOnUpdate",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
@@ -330,8 +330,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapValuesBaseIT
 		@ManyToMany
 		@JoinTable(
 				name = "indexed_containedUsedInCrossEntityDerivedProperty",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@OrderBy("id asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
@@ -340,8 +340,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapValuesBaseIT
 		@ManyToMany(targetEntity = ContainedEntity.class)
 		@JoinTable(
 				name = "indexed_containedIndexedEmbeddedWithCast",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@IndexedEmbedded(includePaths = "indexedField", targetType = ContainedEntity.class)

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingSortedMapValuesBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingSortedMapValuesBaseIT.java
@@ -288,8 +288,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingSortedMapValuesBaseIT
 		@ManyToMany
 		@JoinTable(
 				name = "indexed_containedIndexedEmbedded",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
@@ -299,8 +299,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingSortedMapValuesBaseIT
 		@ManyToMany
 		@JoinTable(
 				name = "indexed_containedNonIndexedEmbedded",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@SortNatural
@@ -309,8 +309,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingSortedMapValuesBaseIT
 		@ManyToMany
 		@JoinTable(
 				name = "indexed_containedIndexedEmbeddedShallowReindexOnUpdate",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
@@ -321,8 +321,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingSortedMapValuesBaseIT
 		@ManyToMany
 		@JoinTable(
 				name = "indexed_containedIndexedEmbeddedNoReindexOnUpdate",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
@@ -333,8 +333,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingSortedMapValuesBaseIT
 		@ManyToMany
 		@JoinTable(
 				name = "indexed_containedUsedInCrossEntityDerivedProperty",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@SortNatural
@@ -343,8 +343,8 @@ public class AutomaticIndexingManyToManyOwnedByContainingSortedMapValuesBaseIT
 		@ManyToMany(targetEntity = ContainedEntity.class)
 		@JoinTable(
 				name = "indexed_containedIndexedEmbeddedWithCast",
-				joinColumns = @JoinColumn(name = "mapHolder"),
-				inverseJoinColumns = @JoinColumn(name = "value")
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained")
 		)
 		@MapKeyColumn(name = "map_key")
 		@IndexedEmbedded(includePaths = "indexedField", targetType = ContainedEntity.class)

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingSortedSetBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingSortedSetBaseIT.java
@@ -16,6 +16,7 @@ import javax.persistence.Basic;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.OneToOne;
@@ -274,37 +275,49 @@ public class AutomaticIndexingManyToManyOwnedByContainingSortedSetBaseIT
 		private ContainingEntity child;
 
 		@ManyToMany
-		@JoinTable(name = "indexed_containedIndexedEmbedded")
+		@JoinTable(name = "indexed_containedIndexedEmbedded",
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@SortNatural
 		private SortedSet<ContainedEntity> containedIndexedEmbedded = new TreeSet<>();
 
 		@ManyToMany
-		@JoinTable(name = "indexed_containedNonIndexedEmbedded")
+		@JoinTable(name = "i_containedNonIndexedEmbedded",
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		@SortNatural
 		private SortedSet<ContainedEntity> containedNonIndexedEmbedded = new TreeSet<>();
 
 		@ManyToMany
-		@JoinTable(name = "indexed_indexedEmbeddedShallowReindexOnUpdateContained")
+		@JoinTable(name = "i_indexedEmbeddedShallow",
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 		@SortNatural
 		private SortedSet<ContainedEntity> containedIndexedEmbeddedShallowReindexOnUpdate = new TreeSet<>();
 
 		@ManyToMany
-		@JoinTable(name = "indexed_indexedEmbeddedNoReindexOnUpdateContained")
+		@JoinTable(name = "i_indexedEmbeddedNoReindex",
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.NO)
 		@SortNatural
 		private SortedSet<ContainedEntity> containedIndexedEmbeddedNoReindexOnUpdate = new TreeSet<>();
 
 		@ManyToMany
-		@JoinTable(name = "indexed_containedUsedInCrossEntityDerivedProperty")
+		@JoinTable(name = "i_containedCrossEntityDP",
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		@SortNatural
 		private SortedSet<ContainedEntity> containedUsedInCrossEntityDerivedProperty = new TreeSet<>();
 
 		@ManyToMany(targetEntity = ContainedEntity.class)
-		@JoinTable(name = "indexed_containedIndexedEmbeddedWithCast")
+		@JoinTable(name = "i_containedIndexedEmbeddedCast",
+				joinColumns = @JoinColumn(name = "containing"),
+				inverseJoinColumns = @JoinColumn(name = "contained"))
 		@IndexedEmbedded(includePaths = "indexedField", targetType = ContainedEntity.class)
 		@SortNatural
 		private SortedSet<Object> containedIndexedEmbeddedWithCast = new TreeSet<>();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedBaseIT.java
@@ -303,23 +303,19 @@ public class AutomaticIndexingOneToOneOwnedByContainedBaseIT
 		private ContainedEntity containedNonIndexedEmbedded;
 
 		@OneToOne(mappedBy = "containingAsIndexedEmbeddedShallowReindexOnUpdate")
-		@JoinColumn(name = "CIndexedEmbeddedSROU")
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 		private ContainedEntity containedIndexedEmbeddedShallowReindexOnUpdate;
 
 		@OneToOne(mappedBy = "containingAsIndexedEmbeddedNoReindexOnUpdate")
-		@JoinColumn(name = "CIndexedEmbeddedNROU")
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.NO)
 		private ContainedEntity containedIndexedEmbeddedNoReindexOnUpdate;
 
 		@OneToOne(mappedBy = "containingAsUsedInCrossEntityDerivedProperty")
-		@JoinColumn(name = "CCrossEntityDerived")
 		private ContainedEntity containedUsedInCrossEntityDerivedProperty;
 
 		@OneToOne(mappedBy = "containingAsIndexedEmbeddedWithCast", targetEntity = ContainedEntity.class)
-		@JoinColumn(name = "CIndexedEmbeddedCast")
 		@IndexedEmbedded(includePaths = { "indexedField" }, targetType = ContainedEntity.class)
 		private Object containedIndexedEmbeddedWithCast;
 
@@ -442,21 +438,27 @@ public class AutomaticIndexingOneToOneOwnedByContainedBaseIT
 		private Integer id;
 
 		@OneToOne
+		@JoinColumn(name = "CIndexedEmbedded")
 		private ContainingEntity containingAsIndexedEmbedded;
 
 		@OneToOne
+		@JoinColumn(name = "CNonIndexedEmbedded")
 		private ContainingEntity containingAsNonIndexedEmbedded;
 
 		@OneToOne
+		@JoinColumn(name = "CIndexedEmbeddedSROU")
 		private ContainingEntity containingAsIndexedEmbeddedShallowReindexOnUpdate;
 
 		@OneToOne
+		@JoinColumn(name = "CIndexedEmbeddedNROU")
 		private ContainingEntity containingAsIndexedEmbeddedNoReindexOnUpdate;
 
 		@OneToOne
+		@JoinColumn(name = "CCrossEntityDerived")
 		private ContainingEntity containingAsUsedInCrossEntityDerivedProperty;
 
 		@OneToOne(targetEntity = ContainingEntity.class)
+		@JoinColumn(name = "CIndexedEmbeddedCast")
 		private Object containingAsIndexedEmbeddedWithCast;
 
 		@Basic

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedLazyOnContainingSideBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedLazyOnContainingSideBaseIT.java
@@ -324,26 +324,22 @@ public class AutomaticIndexingOneToOneOwnedByContainedLazyOnContainingSideBaseIT
 
 		@OneToOne(mappedBy = "containingAsIndexedEmbeddedShallowReindexOnUpdate", fetch = FetchType.LAZY)
 		@LazyToOne(LazyToOneOption.NO_PROXY) // Work around for HHH-13658 (which was only fixed in 5.5+)
-		@JoinColumn(name = "CIndexedEmbeddedSROU")
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 		private ContainedEntity containedIndexedEmbeddedShallowReindexOnUpdate;
 
 		@OneToOne(mappedBy = "containingAsIndexedEmbeddedNoReindexOnUpdate", fetch = FetchType.LAZY)
 		@LazyToOne(LazyToOneOption.NO_PROXY) // Work around for HHH-13658 (which was only fixed in 5.5+)
-		@JoinColumn(name = "CIndexedEmbeddedNROU")
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.NO)
 		private ContainedEntity containedIndexedEmbeddedNoReindexOnUpdate;
 
 		@OneToOne(mappedBy = "containingAsUsedInCrossEntityDerivedProperty", fetch = FetchType.LAZY)
 		@LazyToOne(LazyToOneOption.NO_PROXY) // Work around for HHH-13658 (which was only fixed in 5.5+)
-		@JoinColumn(name = "CCrossEntityDerived")
 		private ContainedEntity containedUsedInCrossEntityDerivedProperty;
 
 		@OneToOne(mappedBy = "containingAsIndexedEmbeddedWithCast", targetEntity = ContainedEntity.class, fetch = FetchType.LAZY)
 		@LazyToOne(LazyToOneOption.NO_PROXY) // Work around for HHH-13658 (which was only fixed in 5.5+)
-		@JoinColumn(name = "CIndexedEmbeddedCast")
 		@IndexedEmbedded(includePaths = { "indexedField" }, targetType = ContainedEntity.class)
 		private Object containedIndexedEmbeddedWithCast;
 
@@ -466,21 +462,27 @@ public class AutomaticIndexingOneToOneOwnedByContainedLazyOnContainingSideBaseIT
 		private Integer id;
 
 		@OneToOne
+		@JoinColumn(name = "CIndexedEmbedded")
 		private ContainingEntity containingAsIndexedEmbedded;
 
 		@OneToOne
+		@JoinColumn(name = "CNonIndexedEmbedded")
 		private ContainingEntity containingAsNonIndexedEmbedded;
 
 		@OneToOne
+		@JoinColumn(name = "CIndexedEmbeddedSROU")
 		private ContainingEntity containingAsIndexedEmbeddedShallowReindexOnUpdate;
 
 		@OneToOne
+		@JoinColumn(name = "CIndexedEmbeddedNROU")
 		private ContainingEntity containingAsIndexedEmbeddedNoReindexOnUpdate;
 
 		@OneToOne
+		@JoinColumn(name = "CCrossEntityDerived")
 		private ContainingEntity containingAsUsedInCrossEntityDerivedProperty;
 
 		@OneToOne(targetEntity = ContainingEntity.class)
+		@JoinColumn(name = "CIndexedEmbeddedCast")
 		private Object containingAsIndexedEmbeddedWithCast;
 
 		@Basic

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedLazyOnContainingSideBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedLazyOnContainingSideBaseIT.java
@@ -38,6 +38,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDe
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyValue;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
@@ -64,11 +65,10 @@ public class AutomaticIndexingOneToOneOwnedByContainedLazyOnContainingSideBaseIT
 		super( new ModelPrimitivesImpl() );
 	}
 
-	@Override
-	protected OrmSetupHelper.SetupContext configure(OrmSetupHelper.SetupContext setupContext) {
-		return super.configure( setupContext )
-				// Necessary for BytecodeEnhancerRunner, see BytecodeEnhancementIT.setup
-				.withTcclLookupPrecedenceBefore();
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext) {
+		// Necessary for BytecodeEnhancerRunner, see BytecodeEnhancementIT.setup
+		setupContext.withTcclLookupPrecedenceBefore();
 	}
 
 	@Override

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingBaseIT.java
@@ -14,7 +14,6 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 
 import org.hibernate.Session;
-import org.hibernate.SessionFactory;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.mapper.orm.Search;
@@ -29,11 +28,13 @@ import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.StubSchemaManagementWork;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
 
 /**
  * Very basic test to probe an use of {@link MassIndexer} api.
@@ -47,30 +48,36 @@ public class MassIndexingBaseIT {
 	public static final String TITLE_3 = "Frankenstein";
 	public static final String AUTHOR_3 = "Mary Shelley";
 
-	@Rule
-	public BackendMock backendMock = new BackendMock();
+	@ClassRule
+	public static BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
 
 	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
 
-	private SessionFactory sessionFactory;
-
-	@Before
-	public void setup() {
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		backendMock.expectAnySchema( Book.INDEX );
 
-		sessionFactory = ormSetupHelper.start()
-				.withPropertyRadical( HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_STRATEGY, AutomaticIndexingStrategyName.NONE )
-				.setup( Book.class );
+		setupContext.withPropertyRadical( HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_STRATEGY,
+						AutomaticIndexingStrategyName.NONE )
+				.withAnnotatedTypes( Book.class );
+	}
 
-		backendMock.verifyExpectationsMet();
-
-		initData();
+	@Before
+	public void initData() {
+		setupHolder.runInTransaction( session -> {
+			session.persist( new Book( 1, TITLE_1, AUTHOR_1 ) );
+			session.persist( new Book( 2, TITLE_2, AUTHOR_2 ) );
+			session.persist( new Book( 3, TITLE_3, AUTHOR_3 ) );
+		} );
 	}
 
 	@Test
 	public void defaultMassIndexerStartAndWait() throws Exception {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer();
 
@@ -114,7 +121,7 @@ public class MassIndexingBaseIT {
 
 	@Test
 	public void dropAndCreateSchemaOnStart() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer().dropAndCreateSchemaOnStart( true );
 
@@ -161,7 +168,7 @@ public class MassIndexingBaseIT {
 
 	@Test
 	public void mergeSegmentsOnFinish() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer().mergeSegmentsOnFinish( true );
 
@@ -207,7 +214,7 @@ public class MassIndexingBaseIT {
 
 	@Test
 	public void fromMappingWithoutSession() throws Exception {
-		SearchMapping searchMapping = Search.mapping( sessionFactory );
+		SearchMapping searchMapping = Search.mapping( setupHolder.sessionFactory() );
 		MassIndexer indexer = searchMapping.scope( Object.class ).massIndexer();
 
 		// add operations on indexes can follow any random order,
@@ -248,7 +255,7 @@ public class MassIndexingBaseIT {
 
 	@Test
 	public void reuseSearchSessionAfterOrmSessionIsClosed_createMassIndexer() {
-		Session session = sessionFactory.openSession();
+		Session session = setupHolder.sessionFactory().openSession();
 		SearchSession searchSession = Search.session( session );
 		// a SearchSession instance is created lazily,
 		// so we need to use it to have an instance of it
@@ -264,7 +271,7 @@ public class MassIndexingBaseIT {
 
 	@Test
 	public void lazyCreateSearchSessionAfterOrmSessionIsClosed_createMassIndexer() {
-		Session session = sessionFactory.openSession();
+		Session session = setupHolder.sessionFactory().openSession();
 		// Search session is not created, since we don't use it
 		SearchSession searchSession = Search.session( session );
 		session.close();
@@ -274,14 +281,6 @@ public class MassIndexingBaseIT {
 		} )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll( "Unable to access Hibernate ORM session", "is closed" );
-	}
-
-	private void initData() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			session.persist( new Book( 1, TITLE_1, AUTHOR_1 ) );
-			session.persist( new Book( 2, TITLE_2, AUTHOR_2 ) );
-			session.persist( new Book( 3, TITLE_3, AUTHOR_3 ) );
-		} );
 	}
 
 	@Entity

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingComplexHierarchyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingComplexHierarchyIT.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Fail.fail;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.mapper.orm.Search;
@@ -23,11 +22,13 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericFie
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
 
 /**
  * Test that the {@link MassIndexer} correctly indexes even complex entity hierarchies
@@ -35,34 +36,35 @@ import org.junit.Test;
  */
 public class MassIndexingComplexHierarchyIT {
 
-	@Rule
-	public BackendMock backendMock = new BackendMock();
+	@ClassRule
+	public static BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
 
 	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
 
-	private SessionFactory sessionFactory;
-
-	@Before
-	public void setup() {
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		backendMock.expectAnySchema( H1_B_Indexed.NAME );
 		backendMock.expectAnySchema( H2_Root_Indexed.NAME );
 		backendMock.expectAnySchema( H2_A_C_Indexed.NAME );
 		backendMock.expectAnySchema( H2_B_Indexed.NAME );
 
-		sessionFactory = ormSetupHelper.start()
-				.withPropertyRadical( HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_STRATEGY,
+		setupContext.withPropertyRadical( HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_STRATEGY,
 						AutomaticIndexingStrategyName.NONE )
-				.setup(
+				.withAnnotatedTypes(
 						H1_Root_NotIndexed.class, H1_A_NotIndexed.class, H1_B_Indexed.class,
 						H2_Root_Indexed.class,
 						H2_A_NotIndexed.class, H2_A_C_Indexed.class,
 						H2_B_Indexed.class, H2_B_D_NotIndexed.class
 				);
+	}
 
-		backendMock.verifyExpectationsMet();
-
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+	@Before
+	public void initData() {
+		setupHolder.runInTransaction( session -> {
 			session.persist( new H1_Root_NotIndexed( 1 ) );
 			session.persist( new H1_A_NotIndexed( 2 ) );
 			session.persist( new H1_B_Indexed( 3 ) );
@@ -76,7 +78,7 @@ public class MassIndexingComplexHierarchyIT {
 
 	@Test
 	public void rootNotIndexed_someSubclassesIndexed_requestMassIndexingOnRoot() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer( H1_Root_NotIndexed.class );
 
@@ -103,7 +105,7 @@ public class MassIndexingComplexHierarchyIT {
 
 	@Test
 	public void rootNotIndexed_someSubclassesIndexed_requestMassIndexingOnIndexedSubclass() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer( H1_B_Indexed.class );
 
@@ -130,7 +132,7 @@ public class MassIndexingComplexHierarchyIT {
 
 	@Test
 	public void rootIndexed_someSubclassesIndexed_requestMassIndexingOnRoot() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer( H2_Root_Indexed.class );
 
@@ -173,7 +175,7 @@ public class MassIndexingComplexHierarchyIT {
 
 	@Test
 	public void rootIndexed_someSubclassesIndexed_requestMassIndexingOnIndexedSubclass() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer( H2_B_Indexed.class );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/ReindexingResolverProxiedAssociatedEntityIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/ReindexingResolverProxiedAssociatedEntityIT.java
@@ -19,19 +19,19 @@ import javax.persistence.ManyToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Transient;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
 
 /**
  * Test that Hibernate Search correctly unproxies entities before accessing entity fields to resolve entities to reindex,
@@ -41,30 +41,31 @@ import org.junit.Test;
 @TestForIssue(jiraKey = "HSEARCH-3643")
 public class ReindexingResolverProxiedAssociatedEntityIT {
 
-	@Rule
-	public BackendMock backendMock = new BackendMock();
+	@ClassRule
+	public static BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
 
 	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
 
-	private SessionFactory sessionFactory;
-
-	@Before
-	public void setup() {
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext, ReusableOrmSetupHolder.DataClearConfig dataClearConfig) {
 		backendMock.expectAnySchema( IndexedEntity.NAME );
 
-		sessionFactory = ormSetupHelper.start()
-				.setup(
-						IndexedEntity.class,
-						ContainedLevel1Entity.class,
-						ContainedLevel2Entity.class
-				);
-		backendMock.verifyExpectationsMet();
+		setupContext.withAnnotatedTypes(
+				IndexedEntity.class,
+				ContainedLevel1Entity.class,
+				ContainedLevel2Entity.class
+		);
+
+		dataClearConfig.clearOrder( IndexedEntity.class, ContainedLevel2Entity.class, ContainedLevel1Entity.class );
 	}
 
 	@Test
 	public void toOne() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity indexed1 = new IndexedEntity( 1 );
 
 			ContainedLevel1Entity contained1 = new ContainedLevel1Entity( 2 );
@@ -90,7 +91,7 @@ public class ReindexingResolverProxiedAssociatedEntityIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			ContainedLevel2Entity contained2 = session.load( ContainedLevel2Entity.class, 3 );
 
 			// The contained entity should be a proxy, otherwise the test doesn't make sense
@@ -112,7 +113,7 @@ public class ReindexingResolverProxiedAssociatedEntityIT {
 
 	@Test
 	public void toMany() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity indexed1 = new IndexedEntity( 1 );
 
 			ContainedLevel1Entity contained1 = new ContainedLevel1Entity( 2 );
@@ -142,7 +143,7 @@ public class ReindexingResolverProxiedAssociatedEntityIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			// Create a proxy for contained1, so that the "containingList" list in contained2 is populated with that proxy.
 			// The proxy will be initialized, but that's irrelevant to our test.
 			@SuppressWarnings("unused") // Keep a reference to the proxy so that it's not garbage collected, which would prevent the above from happening.

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/schema/management/manager/AbstractSearchSchemaManagerValidatingSimpleOperationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/schema/management/manager/AbstractSearchSchemaManagerValidatingSimpleOperationIT.java
@@ -22,7 +22,7 @@ public abstract class AbstractSearchSchemaManagerValidatingSimpleOperationIT
 
 	@Test
 	public void failure_single() {
-		SearchSchemaManager manager = Search.mapping( sessionFactory )
+		SearchSchemaManager manager = Search.mapping( setupHolder.sessionFactory() )
 				.scope( Object.class )
 				.schemaManager();
 
@@ -42,7 +42,7 @@ public abstract class AbstractSearchSchemaManagerValidatingSimpleOperationIT
 
 	@Test
 	public void failure_multiple() {
-		SearchSchemaManager manager = Search.mapping( sessionFactory )
+		SearchSchemaManager manager = Search.mapping( setupHolder.sessionFactory() )
 				.scope( Object.class )
 				.schemaManager();
 
@@ -67,7 +67,7 @@ public abstract class AbstractSearchSchemaManagerValidatingSimpleOperationIT
 
 	@Test
 	public void failure_exception() {
-		SearchSchemaManager manager = Search.mapping( sessionFactory )
+		SearchSchemaManager manager = Search.mapping( setupHolder.sessionFactory() )
 				.scope( Object.class )
 				.schemaManager();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/AbstractSearchQueryEntityLoadingIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/AbstractSearchQueryEntityLoadingIT.java
@@ -28,18 +28,11 @@ import org.hibernate.search.mapper.orm.search.loading.dsl.SearchLoadingOptionsSt
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.common.rule.StubSearchWorkBehavior;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSoftAssertions;
-
-import org.junit.Rule;
 
 public abstract class AbstractSearchQueryEntityLoadingIT {
 
-	@Rule
-	public BackendMock backendMock = new BackendMock();
-
-	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+	protected abstract BackendMock backendMock();
 
 	protected abstract SessionFactory sessionFactory();
 
@@ -129,7 +122,7 @@ public abstract class AbstractSearchQueryEntityLoadingIT {
 
 	protected <T> List<T> getHits(List<String> targetIndexes, SearchQuery<T> query, List<DocumentReference> hitDocumentReferences,
 			Integer timeout, TimeUnit timeUnit) {
-		backendMock.expectSearchObjects(
+		backendMock().expectSearchObjects(
 				targetIndexes,
 				b -> {
 					if ( timeout != null && timeUnit != null ) {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/AbstractSearchQueryEntityLoadingSingleTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/AbstractSearchQueryEntityLoadingSingleTypeIT.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.search.loading;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -17,7 +19,6 @@ import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.sing
 import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.singletype.SingleTypeLoadingModel;
 import org.hibernate.search.mapper.orm.search.loading.dsl.SearchLoadingOptionsStep;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSoftAssertions;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 public abstract class AbstractSearchQueryEntityLoadingSingleTypeIT<T> extends AbstractSearchQueryEntityLoadingIT {
 
@@ -41,7 +42,7 @@ public abstract class AbstractSearchQueryEntityLoadingSingleTypeIT<T> extends Ab
 
 	protected final void persistThatManyEntities(int entityCount) {
 		// We don't care about what is indexed exactly, so use the lenient mode
-		backendMock.inLenientMode( () -> OrmUtils.withinTransaction( sessionFactory(), session -> {
+		backendMock().inLenientMode( () -> withinTransaction( sessionFactory(), session -> {
 			for ( int i = 0; i < entityCount; i++ ) {
 				session.persist( model.newIndexed( i, mapping ) );
 			}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingBaseIT.java
@@ -17,10 +17,13 @@ import org.hibernate.SessionFactory;
 import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.singletype.SingleTypeLoadingMapping;
 import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.singletype.SingleTypeLoadingModel;
 import org.hibernate.search.util.common.SearchTimeoutException;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.TimeoutLoadingListener;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -41,10 +44,25 @@ public class SearchQueryEntityLoadingBaseIT<T> extends AbstractSearchQueryEntity
 		return result;
 	}
 
+	@Rule
+	public BackendMock backendMock = new BackendMock();
+
+	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+
 	private SessionFactory sessionFactory;
 
 	public SearchQueryEntityLoadingBaseIT(SingleTypeLoadingModel<T> model, SingleTypeLoadingMapping mapping) {
 		super( model, mapping );
+	}
+
+	@Override
+	protected BackendMock backendMock() {
+		return backendMock;
+	}
+
+	@Override
+	protected SessionFactory sessionFactory() {
+		return sessionFactory;
 	}
 
 	@Before
@@ -166,11 +184,6 @@ public class SearchQueryEntityLoadingBaseIT<T> extends AbstractSearchQueryEntity
 				// Only one entity type means only one statement should be executed, even if there are multiple hits
 				c -> c.assertStatementExecutionCount().isEqualTo( 1 )
 		);
-	}
-
-	@Override
-	protected SessionFactory sessionFactory() {
-		return sessionFactory;
 	}
 
 }

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingCacheLookupIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingCacheLookupIT.java
@@ -22,6 +22,8 @@ import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.sing
 import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.singletype.SingleTypeLoadingModel;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.mapper.orm.search.loading.EntityLoadingCacheLookupStrategy;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 import org.hibernate.search.util.impl.test.rule.ExpectedLog4jLog;
 
@@ -53,6 +55,11 @@ public class SearchQueryEntityLoadingCacheLookupIT<T> extends AbstractSearchQuer
 	}
 
 	@Rule
+	public BackendMock backendMock = new BackendMock();
+
+	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+
+	@Rule
 	public final ExpectedLog4jLog logged = ExpectedLog4jLog.create();
 
 	private final EntityLoadingCacheLookupStrategy defaultCacheLookupStrategy;
@@ -63,6 +70,16 @@ public class SearchQueryEntityLoadingCacheLookupIT<T> extends AbstractSearchQuer
 			EntityLoadingCacheLookupStrategy defaultCacheLookupStrategy) {
 		super( model, mapping );
 		this.defaultCacheLookupStrategy = defaultCacheLookupStrategy;
+	}
+
+	@Override
+	protected BackendMock backendMock() {
+		return backendMock;
+	}
+
+	@Override
+	protected SessionFactory sessionFactory() {
+		return sessionFactory;
 	}
 
 	@Before
@@ -194,11 +211,6 @@ public class SearchQueryEntityLoadingCacheLookupIT<T> extends AbstractSearchQuer
 				// Expect no DB statement since everything has been loaded
 				false
 		);
-	}
-
-	@Override
-	protected SessionFactory sessionFactory() {
-		return sessionFactory;
 	}
 
 	private void testLoadingCacheLookupExpectingSkipCacheLookup(

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingFetchSizeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingFetchSizeIT.java
@@ -16,8 +16,11 @@ import org.hibernate.graph.GraphSemantic;
 import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.singletype.SingleTypeLoadingMapping;
 import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.singletype.SingleTypeLoadingModel;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -38,10 +41,25 @@ public class SearchQueryEntityLoadingFetchSizeIT<T> extends AbstractSearchQueryE
 		return result;
 	}
 
+	@Rule
+	public BackendMock backendMock = new BackendMock();
+
+	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+
 	private SessionFactory sessionFactory;
 
 	public SearchQueryEntityLoadingFetchSizeIT(SingleTypeLoadingModel<T> model, SingleTypeLoadingMapping mapping) {
 		super( model, mapping );
+	}
+
+	@Override
+	protected BackendMock backendMock() {
+		return backendMock;
+	}
+
+	@Override
+	protected SessionFactory sessionFactory() {
+		return sessionFactory;
 	}
 
 	@Test
@@ -142,11 +160,6 @@ public class SearchQueryEntityLoadingFetchSizeIT<T> extends AbstractSearchQueryE
 				// so as to always trigger a subselect for associations with FetchMode.SUBSELECT.
 				model.getEagerGraphName()
 		);
-	}
-
-	@Override
-	protected SessionFactory sessionFactory() {
-		return sessionFactory;
 	}
 
 	private void testLoadingFetchSize(Integer searchLoadingFetchSize, Integer overriddenFetchSize,

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingGraphIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingGraphIT.java
@@ -19,10 +19,13 @@ import org.hibernate.graph.RootGraph;
 import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.singletype.SingleTypeLoadingMapping;
 import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.singletype.SingleTypeLoadingModel;
 import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -43,10 +46,25 @@ public class SearchQueryEntityLoadingGraphIT<T> extends AbstractSearchQueryEntit
 		return result;
 	}
 
+	@Rule
+	public BackendMock backendMock = new BackendMock();
+
+	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+
 	private SessionFactory sessionFactory;
 
 	public SearchQueryEntityLoadingGraphIT(SingleTypeLoadingModel<T> model, SingleTypeLoadingMapping mapping) {
 		super( model, mapping );
+	}
+
+	@Override
+	protected BackendMock backendMock() {
+		return backendMock;
+	}
+
+	@Override
+	protected SessionFactory sessionFactory() {
+		return sessionFactory;
 	}
 
 	@Before
@@ -187,11 +205,6 @@ public class SearchQueryEntityLoadingGraphIT<T> extends AbstractSearchQueryEntit
 		} ) )
 				.isInstanceOf( IllegalArgumentException.class )
 				.hasMessageContaining( "'semantic' must not be null" );
-	}
-
-	@Override
-	protected SessionFactory sessionFactory() {
-		return sessionFactory;
 	}
 
 	private void testLoadingWithEntityGraph(String graphName, GraphSemantic graphSemantic,

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingMultipleTypesIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingMultipleTypesIT.java
@@ -49,12 +49,15 @@ import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.mult
 import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.multipletypes.Interface2;
 import org.hibernate.search.mapper.orm.search.loading.EntityLoadingCacheLookupStrategy;
 import org.hibernate.search.util.common.SearchTimeoutException;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSoftAssertions;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.SlowerLoadingListener;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -63,7 +66,22 @@ import org.junit.Test;
  */
 public class SearchQueryEntityLoadingMultipleTypesIT extends AbstractSearchQueryEntityLoadingIT {
 
+	@Rule
+	public BackendMock backendMock = new BackendMock();
+
+	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+
 	private SessionFactory sessionFactory;
+
+	@Override
+	protected BackendMock backendMock() {
+		return backendMock;
+	}
+
+	@Override
+	protected SessionFactory sessionFactory() {
+		return sessionFactory;
+	}
 
 	@Before
 	public void setup() {
@@ -468,11 +486,6 @@ public class SearchQueryEntityLoadingMultipleTypesIT extends AbstractSearchQuery
 							.isEqualTo( 0 );
 				}
 		);
-	}
-
-	@Override
-	protected SessionFactory sessionFactory() {
-		return sessionFactory;
 	}
 
 	protected <T> void testLoading(List<? extends Class<? extends T>> targetClasses,

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/model/singletype/BasicModel.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/model/singletype/BasicModel.java
@@ -68,6 +68,11 @@ final class BasicModel extends SingleTypeLoadingModel<BasicIndexedEntity> {
 	}
 
 	@Override
+	public void clearContainedEager(BasicIndexedEntity entity) {
+		entity.setContainedEager( null );
+	}
+
+	@Override
 	public List<?> getContainedLazy(BasicIndexedEntity entity) {
 		return entity.getContainedLazy();
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/model/singletype/FetchSubSelectModel.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/model/singletype/FetchSubSelectModel.java
@@ -68,6 +68,11 @@ final class FetchSubSelectModel extends SingleTypeLoadingModel<FetchSubSelectInd
 	}
 
 	@Override
+	public void clearContainedEager(FetchSubSelectIndexedEntity entity) {
+		entity.setContainedEager( null );
+	}
+
+	@Override
 	public List<?> getContainedLazy(FetchSubSelectIndexedEntity entity) {
 		return entity.getContainedLazy();
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/model/singletype/SingleTypeLoadingModel.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/model/singletype/SingleTypeLoadingModel.java
@@ -43,6 +43,8 @@ public abstract class SingleTypeLoadingModel<T> {
 
 	public abstract Object getContainedEager(T entity);
 
+	public abstract void clearContainedEager(T entity);
+
 	public abstract List<?> getContainedLazy(T entity);
 
 }

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/AnnotationMappingSmokeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/AnnotationMappingSmokeIT.java
@@ -25,7 +25,6 @@ import javax.persistence.ManyToOne;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.OneToMany;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.search.integrationtest.mapper.orm.smoke.bridge.CustomPropertyBinding;
 import org.hibernate.search.integrationtest.mapper.orm.smoke.bridge.CustomTypeBinding;
 import org.hibernate.search.integrationtest.mapper.orm.smoke.bridge.IntegerAsStringValueBridge;
@@ -44,28 +43,30 @@ import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.ValueBridgeRef
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.common.rule.StubSearchWorkBehavior;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 import org.hibernate.search.util.impl.test.rule.StaticCounters;
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.MethodRule;
 
 
 public class AnnotationMappingSmokeIT {
 
-	@Rule
-	public BackendMock backendMock = new BackendMock();
+	@ClassRule
+	public static BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
 
 	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
 
 	@Rule
 	public StaticCounters counters = new StaticCounters();
 
-	private SessionFactory sessionFactory;
-
-	@Before
-	public void setup() {
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		backendMock.expectSchema( OtherIndexedEntity.NAME, b -> b
 				.field( "numeric", Integer.class )
 				.field( "numericAsString", String.class )
@@ -123,19 +124,17 @@ public class AnnotationMappingSmokeIT {
 				.field( "myLocalDateField", LocalDate.class )
 		);
 
-		sessionFactory = ormSetupHelper.start()
-				.setup(
-						IndexedEntity.class,
-						ParentIndexedEntity.class,
-						OtherIndexedEntity.class,
-						YetAnotherIndexedEntity.class
-				);
-		backendMock.verifyExpectationsMet();
+		setupContext.withAnnotatedTypes(
+				IndexedEntity.class,
+				ParentIndexedEntity.class,
+				OtherIndexedEntity.class,
+				YetAnotherIndexedEntity.class
+		);
 	}
 
 	@Test
 	public void index() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 			entity1.setText( "this is text (1)" );
@@ -292,7 +291,7 @@ public class AnnotationMappingSmokeIT {
 
 	@Test
 	public void search() {
-		backendMock.inLenientMode( () -> OrmUtils.withinTransaction( sessionFactory, session -> {
+		backendMock.inLenientMode( () -> setupHolder.runInTransaction( session -> {
 			IndexedEntity entity0 = new IndexedEntity();
 			entity0.setId( 0 );
 			session.persist( entity0 );
@@ -301,7 +300,7 @@ public class AnnotationMappingSmokeIT {
 			session.persist( entity1 );
 		} ) );
 
-		OrmUtils.withinSession( sessionFactory, session -> {
+		setupHolder.runInTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 			SearchQuery<ParentIndexedEntity> query = searchSession.search(
 							Arrays.asList( IndexedEntity.class, YetAnotherIndexedEntity.class )

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateOrmListenerContextProvider.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateOrmListenerContextProvider.java
@@ -15,6 +15,8 @@ public interface HibernateOrmListenerContextProvider {
 
 	HibernateOrmListenerTypeContextProvider typeContextProvider();
 
+	boolean listenerEnabled();
+
 	PojoIndexingPlan<EntityReference> currentIndexingPlan(SessionImplementor session, boolean createIfDoesNotExist);
 
 	ConfiguredAutomaticIndexingSynchronizationStrategy currentAutomaticIndexingSynchronizationStrategy(

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
@@ -71,30 +71,41 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 	@Override
 	public void onPostDelete(PostDeleteEvent event) {
 		HibernateOrmListenerContextProvider contextProvider = state.getContextProvider();
+		if ( !contextProvider.listenerEnabled() ) {
+			return;
+		}
 		Object entity = event.getEntity();
 		HibernateOrmListenerTypeContext typeContext = getTypeContext( contextProvider, event.getPersister() );
-		if ( typeContext != null ) {
-			Object providedId = typeContext.toIndexingPlanProvidedId( event.getId() );
-			getCurrentIndexingPlan( contextProvider, event.getSession() )
-					.delete( typeContext.typeIdentifier(), providedId, null, entity );
+		if ( typeContext == null ) {
+			return;
 		}
+		Object providedId = typeContext.toIndexingPlanProvidedId( event.getId() );
+		getCurrentIndexingPlan( contextProvider, event.getSession() )
+				.delete( typeContext.typeIdentifier(), providedId, null, entity );
 	}
 
 	@Override
 	public void onPostInsert(PostInsertEvent event) {
 		HibernateOrmListenerContextProvider contextProvider = state.getContextProvider();
+		if ( !contextProvider.listenerEnabled() ) {
+			return;
+		}
 		final Object entity = event.getEntity();
 		HibernateOrmListenerTypeContext typeContext = getTypeContext( contextProvider, event.getPersister() );
-		if ( typeContext != null ) {
-			Object providedId = typeContext.toIndexingPlanProvidedId( event.getId() );
-			getCurrentIndexingPlan( contextProvider, event.getSession() )
-					.add( typeContext.typeIdentifier(), providedId, null, entity );
+		if ( typeContext == null ) {
+			return;
 		}
+		Object providedId = typeContext.toIndexingPlanProvidedId( event.getId() );
+		getCurrentIndexingPlan( contextProvider, event.getSession() )
+				.add( typeContext.typeIdentifier(), providedId, null, entity );
 	}
 
 	@Override
 	public void onPostUpdate(PostUpdateEvent event) {
 		HibernateOrmListenerContextProvider contextProvider = state.getContextProvider();
+		if ( !contextProvider.listenerEnabled() ) {
+			return;
+		}
 		final Object entity = event.getEntity();
 		HibernateOrmListenerTypeContext typeContext = getTypeContext( contextProvider, event.getPersister() );
 		if ( typeContext != null ) {
@@ -131,6 +142,9 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 	@Override
 	public void onFlush(FlushEvent event) {
 		HibernateOrmListenerContextProvider contextProvider = state.getContextProvider();
+		if ( !contextProvider.listenerEnabled() ) {
+			return;
+		}
 		EventSource session = event.getSession();
 
 		PojoIndexingPlan<EntityReference> plan = getCurrentIndexingPlanIfExisting( contextProvider, session );
@@ -161,13 +175,21 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 			 */
 			return;
 		}
-		getCurrentIndexingPlan( state.getContextProvider(), event.getSession() ).process();
+		HibernateOrmListenerContextProvider contextProvider = state.getContextProvider();
+		if ( !contextProvider.listenerEnabled() ) {
+			return;
+		}
+		getCurrentIndexingPlan( contextProvider, event.getSession() ).process();
 	}
 
 	@Override
 	public void onClear(ClearEvent event) {
+		HibernateOrmListenerContextProvider contextProvider = state.getContextProvider();
+		if ( !contextProvider.listenerEnabled() ) {
+			return;
+		}
 		EventSource session = event.getSession();
-		PojoIndexingPlan<?> plan = getCurrentIndexingPlanIfExisting( state.getContextProvider(), session );
+		PojoIndexingPlan<?> plan = getCurrentIndexingPlanIfExisting( contextProvider, session );
 
 		// skip the clearNotPrepared operation in case there has been no one to clear
 		if ( plan != null ) {
@@ -201,6 +223,9 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 
 	private void processCollectionEvent(AbstractCollectionEvent event) {
 		HibernateOrmListenerContextProvider contextProvider = state.getContextProvider();
+		if ( !contextProvider.listenerEnabled() ) {
+			return;
+		}
 		Object ownerEntity = event.getAffectedOwnerOrNull();
 		if ( ownerEntity == null ) {
 			//Hibernate cannot determine every single time the owner especially in case detached objects are involved

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapping.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapping.java
@@ -134,6 +134,8 @@ public class HibernateOrmMapping extends AbstractPojoMappingImplementor<Hibernat
 
 	private final SchemaManagementListener schemaManagementListener;
 
+	private volatile boolean listenerEnabled = true;
+
 	private HibernateOrmMapping(PojoMappingDelegate mappingDelegate,
 			HibernateOrmTypeContextContainer typeContextContainer,
 			SessionFactoryImplementor sessionFactory,
@@ -277,6 +279,16 @@ public class HibernateOrmMapping extends AbstractPojoMappingImplementor<Hibernat
 	@Override
 	public DetachedBackendSessionContext detachedBackendSessionContext(String tenantId) {
 		return DetachedBackendSessionContext.of( this, tenantId );
+	}
+
+	@Override
+	public boolean listenerEnabled() {
+		return listenerEnabled;
+	}
+
+	// For tests
+	public void listenerEnabled(boolean enabled) {
+		this.listenerEnabled = enabled;
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
@@ -51,11 +51,19 @@ public class BackendMock implements TestRule {
 				started = true;
 				try {
 					base.evaluate();
-					verifyExpectationsMet();
+					// Workaround for a problem in Hibernate ORM's CustomRunner
+					// (used by BytecodeEnhancerRunner in particular)
+					// which applies class rules twices, resulting in "started" being false
+					// when we get here in the outermost statement...
+					if ( started ) {
+						verifyExpectationsMet();
+					}
 				}
 				finally {
-					resetExpectations();
-					started = false;
+					if ( started ) {
+						resetExpectations();
+						started = false;
+					}
 				}
 			}
 		};

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/MappingSetupHelper.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/MappingSetupHelper.java
@@ -74,6 +74,8 @@ public abstract class MappingSetupHelper<C extends MappingSetupHelper<C, B, R>.A
 
 		private final List<Configuration<B, R>> configurations = new ArrayList<>();
 
+		private boolean setupCalled;
+
 		protected AbstractSetupContext() {
 		}
 
@@ -139,6 +141,11 @@ public abstract class MappingSetupHelper<C extends MappingSetupHelper<C, B, R>.A
 		 * @return The result of setting up Hibernate Search.
 		 */
 		public final R setup() {
+			if ( setupCalled ) {
+				throw new IllegalStateException( "SetupContext#setup() was called multiple times on the same context" );
+			}
+			setupCalled = true;
+
 			B builder = createBuilder();
 
 			configurations.forEach( c -> c.beforeBuild( builder ) );

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/JPAPersistenceRunner.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/JPAPersistenceRunner.java
@@ -35,7 +35,7 @@ class JPAPersistenceRunner implements PersistenceRunner<EntityManager, EntityTra
 	}
 
 	@Override
-	public <R> R apply(BiFunction<? super EntityManager, ? super EntityTransaction, R> action) {
+	public <R> R applyInTransaction(BiFunction<? super EntityManager, ? super EntityTransaction, R> action) {
 		return applyNoTransaction( entityManager -> {
 			return OrmUtils.withinJPATransaction( entityManager, tx -> { return action.apply( entityManager, tx ); } );
 		} );

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/NativePersistenceRunner.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/NativePersistenceRunner.java
@@ -28,7 +28,7 @@ class NativePersistenceRunner implements PersistenceRunner<Session, Transaction>
 	}
 
 	@Override
-	public <R> R apply(BiFunction<? super Session, ? super Transaction, R> action) {
+	public <R> R applyInTransaction(BiFunction<? super Session, ? super Transaction, R> action) {
 		return applyNoTransaction( session -> {
 			return OrmUtils.withinTransaction( session, tx -> { return action.apply( session, tx ); } );
 		} );

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmSetupHelper.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmSetupHelper.java
@@ -106,9 +106,12 @@ public final class OrmSetupHelper
 			return thisAsC();
 		}
 
+		public SetupContext withAnnotatedTypes(Class<?> ... annotatedTypes) {
+			return withConfiguration( builder -> builder.addAnnotatedClasses( Arrays.asList( annotatedTypes ) ) );
+		}
+
 		public SessionFactory setup(Class<?> ... annotatedTypes) {
-			return withConfiguration( builder -> builder.addAnnotatedClasses( Arrays.asList( annotatedTypes ) ) )
-					.setup();
+			return withAnnotatedTypes( annotatedTypes ).setup();
 		}
 
 		@Override

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmUtils.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmUtils.java
@@ -38,11 +38,11 @@ public final class OrmUtils {
 	}
 
 	public static void withinTransaction(SessionFactory sessionFactory, Consumer<Session> action) {
-		with( sessionFactory ).run( action );
+		with( sessionFactory ).runInTransaction( action );
 	}
 
 	public static void withinJPATransaction(EntityManagerFactory entityManagerFactory, Consumer<EntityManager> action) {
-		with( entityManagerFactory ).run( action );
+		with( entityManagerFactory ).runInTransaction( action );
 	}
 
 	public static void withinTransaction(Session session, Consumer<Transaction> action) {

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/PersistenceRunner.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/PersistenceRunner.java
@@ -31,21 +31,21 @@ public interface PersistenceRunner<C, T> {
 		} );
 	}
 
-	default <R> R apply(Function<? super C, R> action) {
-		return apply( (c, t) -> action.apply( c ) );
+	default <R> R applyInTransaction(Function<? super C, R> action) {
+		return applyInTransaction( (c, t) -> action.apply( c ) );
 	}
 
-	<R> R apply(BiFunction<? super C, ? super T, R> action);
+	<R> R applyInTransaction(BiFunction<? super C, ? super T, R> action);
 
-	default void run(Consumer<? super C> action) {
-		apply( c -> {
+	default void runInTransaction(Consumer<? super C> action) {
+		applyInTransaction( c -> {
 			action.accept( c );
 			return null;
 		} );
 	}
 
-	default void run(BiConsumer<? super C, T> action) {
-		apply( (c, t) -> {
+	default void runInTransaction(BiConsumer<? super C, T> action) {
+		applyInTransaction( (c, t) -> {
 			action.accept( c, t );
 			return null;
 		} );

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/ReusableOrmSetupHolder.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/ReusableOrmSetupHolder.java
@@ -84,7 +84,7 @@ import org.jboss.logging.Logger;
  * </p>
  */
 public class ReusableOrmSetupHolder implements TestRule {
-	private static final Logger log = Logger.getLogger( SimpleSessionFactoryBuilder.class.getName() );
+	private static final Logger log = Logger.getLogger( ReusableOrmSetupHolder.class.getName() );
 
 	/**
 	 * When applied to a public instance method in a test,

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/ReusableOrmSetupHolder.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/ReusableOrmSetupHolder.java
@@ -1,0 +1,549 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.integrationtest.mapper.orm;
+
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+import javax.persistence.metamodel.Attribute;
+import javax.persistence.metamodel.EmbeddableType;
+import javax.persistence.metamodel.EntityType;
+import javax.persistence.metamodel.ManagedType;
+import javax.persistence.metamodel.Metamodel;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.Query;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.mapping.impl.HibernateOrmMapping;
+import org.hibernate.search.util.common.impl.Closer;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+
+import org.hibernate.testing.junit4.CustomParameterized;
+import org.junit.rules.MethodRule;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+import org.jboss.logging.Logger;
+
+/**
+ * A test rule to create a {@link SessionFactory} and reuse it across test methods,
+ * automatically reinitializing data between test methods.
+ * <p>
+ * Useful for tests with many test methods, where recreating the {@link SessionFactory}
+ * before each method would take too much time, in particular when testing against some
+ * databases that are slow to create schemas (Oracle, DB2, ...).
+ * <p>
+ * Usage:
+ * <pre>{@code
+ * 	@ClassRule
+ * 	public static BackendMock backendMock = new BackendMock();
+ *
+ * 	@ClassRule
+ * 	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
+ *
+ * 	@Rule
+ * 	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
+ *
+ * 	@ReusableOrmSetupHolder.Setup
+ * 	public void setup(OrmSetupHelper.SetupContext setupContext, ReusableOrmSetupHolder.DataClearConfig dataClearConfig) {
+ * 	    // configure setupContext here, but do NOT call setupContext.setup(); the rule will do that.
+ * 		...
+ * 	}
+ * }</pre>
+ * </p>
+ */
+public class ReusableOrmSetupHolder implements TestRule {
+	private static final Logger log = Logger.getLogger( SimpleSessionFactoryBuilder.class.getName() );
+
+	/**
+	 * When applied to a public instance method in a test,
+	 * designates a setup method which must be called by {@link ReusableOrmSetupHolder}
+	 * when creating the session factory.
+	 * <p>
+	 * The method can get passed arguments of the following types:
+	 * <ul>
+	 *     <li>{@link org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper.SetupContext}</li>
+	 *     <li>{@link DataClearConfig}</li>
+	 * </ul>
+	 *
+	 * @see ReusableOrmSetupHolder
+	 */
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.METHOD)
+	public @interface Setup {
+
+	}
+
+	/**
+	 * When applied to a public instance method in a test,
+	 * designates a method which must be called by {@link ReusableOrmSetupHolder}
+	 * to inspect the parameters of the current test that could impact session factory setup.
+	 * <p>
+	 * Useful (and mandatory) when using {@link ReusableOrmSetupHolder}
+	 * in conjunction with the {@link org.junit.runners.Parameterized} runner,
+	 * so that the session factory can be recreated for each set of parameters,
+	 * but reused across test methods using the same parameters.
+	 * <p>
+	 * The method must return a {@code Collection<?>} and must not accept any parameter.
+	 *
+	 * @see ReusableOrmSetupHolder
+	 */
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.METHOD)
+	public @interface SetupParams {
+
+	}
+
+	public interface DataClearConfig {
+
+		DataClearConfig preClear(Consumer<Session> preClear);
+
+		<T> DataClearConfig preClear(Class<T> entityType, Consumer<T> preClear);
+
+		DataClearConfig clearOrder(Class<?>... entityClasses);
+
+	}
+
+	public static ReusableOrmSetupHolder withBackendMock(BackendMock backendMock) {
+		return new ReusableOrmSetupHolder( OrmSetupHelper.withBackendMock( backendMock ),
+				Collections.singletonList( backendMock ) );
+	}
+
+	public static ReusableOrmSetupHolder withBackendMocks(BackendMock defaultBackendMock,
+			Map<String, BackendMock> namedBackendMocks) {
+		List<BackendMock> allBackendMocks = new ArrayList<>();
+		allBackendMocks.add( defaultBackendMock );
+		allBackendMocks.addAll( namedBackendMocks.values() );
+		return new ReusableOrmSetupHolder( OrmSetupHelper.withBackendMocks( defaultBackendMock, namedBackendMocks ),
+				allBackendMocks );
+	}
+
+	private final OrmSetupHelper setupHelper;
+	private final List<BackendMock> allBackendMocks;
+
+	private boolean inClassStatement;
+	private boolean inMethodStatement;
+	private DataClearConfigImpl config;
+	private SessionFactory sessionFactory;
+	private Collection<?> testParamsForSessionFactory;
+
+	private ReusableOrmSetupHolder(OrmSetupHelper setupHelper, List<BackendMock> allBackendMocks) {
+		this.setupHelper = setupHelper;
+		this.allBackendMocks = allBackendMocks;
+	}
+
+	// We need the class rule and test rule to be two separate objects, unfortunately.
+	// See
+	public MethodRule methodRule() {
+		return new MethodRule() {
+			@Override
+			public Statement apply(Statement base, FrameworkMethod method, Object target) {
+				return methodStatement( base, target );
+			}
+		};
+	}
+
+	public EntityManagerFactory entityManagerFactory() {
+		return sessionFactory();
+	}
+
+	public SessionFactory sessionFactory() {
+		if ( !inMethodStatement ) {
+			throw new Error( "The session factory cannot be used outside of methods annotated with @Test, @Before, @After."
+					+ " In particular, you cannot use it in a method annotated with " + Setup.class.getName() + ";"
+					+ " use a @Before method instead." );
+		}
+		if ( sessionFactory == null ) {
+			throw new Error( "The session factory in " + getClass().getSimpleName() + " was not created."
+					+ " Did you use the rule as explained in the javadoc, with both a @ClassRule and a @Rule,"
+					+ " on two separate fields?" );
+		}
+		return sessionFactory;
+	}
+
+	public PersistenceRunner<Session, Transaction> with() {
+		return OrmUtils.with( sessionFactory() );
+	}
+
+	public void runInTransaction(Consumer<? super Session> action) {
+		with().runInTransaction( action );
+	}
+
+	public void runNoTransaction(Consumer<? super Session> action) {
+		with().runNoTransaction( action );
+	}
+
+	@Override
+	public Statement apply(Statement base, Description description) {
+		return classStatement( base, description );
+	}
+
+	private Statement classStatement(Statement base, Description description) {
+		Statement wrapped = new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				try ( Closer<Exception> closer = new Closer<>() ) {
+					try {
+						inClassStatement = true;
+						base.evaluate();
+					}
+					finally {
+						inClassStatement = false;
+						// Do this in the closer in order to preserve the original exception.
+						closer.push( ReusableOrmSetupHolder::tearDownSessionFactory, ReusableOrmSetupHolder.this );
+					}
+				}
+			}
+		};
+		return setupHelper.apply( wrapped, description );
+	}
+
+	private Statement methodStatement(Statement base, Object testInstance) {
+		return new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				try {
+					setupSessionFactory( testInstance );
+					inMethodStatement = true;
+					base.evaluate();
+					// Since BackendMock is used as a ClassRule,
+					// we must explicitly force the verify/reset after each test method.
+					for ( BackendMock backendMock : allBackendMocks ) {
+						backendMock.verifyExpectationsMet();
+					}
+				}
+				finally {
+					inMethodStatement = false;
+					for ( BackendMock backendMock : allBackendMocks ) {
+						backendMock.resetExpectations();
+					}
+				}
+			}
+		};
+	}
+
+	private void setupSessionFactory(Object testInstance) {
+		if ( !inClassStatement ) {
+			throw new Error( "This usage of " + getClass().getSimpleName() + " is invalid and may result"
+					+ " in the session factory not being closed."
+					+ " Did you use the rule as explained in the javadoc, with both a @ClassRule and a @Rule,"
+					+ " on two separate fields?" );
+		}
+
+		Collection<?> testParams = testParams( testInstance );
+
+		if ( sessionFactory != null ) {
+			if ( testParams.equals( testParamsForSessionFactory ) ) {
+				log.infof( "Test parameters did not change (%s vs %s). Clearing data and reusing the same session factory.",
+						testParamsForSessionFactory, testParams );
+				try {
+					clearAllData( sessionFactory );
+				}
+				catch (RuntimeException e) {
+					throw new Error( "Failed to clear data before test execution: " + e.getMessage(), e );
+				}
+				return;
+			}
+			else {
+				log.infof( "Test parameters changed (%s vs %s). Closing the current session factory and creating another one.",
+						testParamsForSessionFactory, testParams );
+				tearDownSessionFactory();
+			}
+		}
+
+		OrmSetupHelper.SetupContext setupContext = setupHelper.start();
+		config = new DataClearConfigImpl();
+		TestCustomSetup customSetup = new TestCustomSetup( testInstance );
+		customSetup.callSetupMethods( setupContext, config );
+		sessionFactory = setupContext.setup();
+		testParamsForSessionFactory = testParams;
+
+		// If any backend expectations where set during setup, verify them immediately.
+		for ( BackendMock backendMock : allBackendMocks ) {
+			backendMock.verifyExpectationsMet();
+		}
+	}
+
+	private void tearDownSessionFactory() {
+		try ( Closer<RuntimeException> closer = new Closer<>() ) {
+			closer.push( SessionFactory::close, sessionFactory );
+			sessionFactory = null;
+			config = null;
+		}
+	}
+
+	private Collection<?> testParams(Object testInstance) {
+		List<TestPluggableMethod<Collection>> setupParamsMethods = TestPluggableMethod.createAll( SetupParams.class,
+				testInstance.getClass(), Collection.class, Collections.emptyList() );
+		if ( setupParamsMethods.size() > 1 ) {
+			throw new Error( "Test class " + testInstance.getClass()
+					+ " must not declare more than one method annotated with " + SetupParams.class.getName() );
+		}
+		if ( setupParamsMethods.isEmpty() ) {
+			Class<?> runnerClass = runnerClass( testInstance.getClass() );
+			if ( Parameterized.class.equals( runnerClass ) || CustomParameterized.class.equals( runnerClass ) ) {
+				throw new Error( "Test class " + testInstance.getClass()
+						+ " must declare one method annotated with " + SetupParams.class.getName()
+						+ " because it uses runner " + runnerClass.getSimpleName() );
+			}
+			else {
+				return Collections.emptyList();
+			}
+		}
+		return setupParamsMethods.iterator().next().call( testInstance, Collections.emptyMap() );
+	}
+
+	private Class<?> runnerClass(Class<?> testClass) {
+		RunWith annotation = testClass.getAnnotation( RunWith.class );
+		return annotation == null ? null : annotation.value();
+	}
+
+	private void clearAllData(SessionFactory sessionFactory) {
+		HibernateOrmMapping mapping = ( (HibernateOrmMapping) Search.mapping( sessionFactory ) );
+
+		sessionFactory.getCache().evictAllRegions();
+
+		clearDatabase( sessionFactory, mapping );
+
+		// Must re-clear the caches as they may have been re-populated
+		// while executing queries in clearDatabase().
+		sessionFactory.getCache().evictAllRegions();
+	}
+
+	private void clearDatabase(SessionFactory sessionFactory, HibernateOrmMapping mapping) {
+		for ( Consumer<Session> preClear : config.preClear ) {
+			mapping.listenerEnabled( false );
+			withinTransaction( sessionFactory, preClear );
+			mapping.listenerEnabled( true );
+		}
+
+		Set<String> clearedEntityNames = new HashSet<>();
+		for ( Class<?> entityClass : config.entityClearOrder ) {
+			EntityType<?> entityType;
+			try {
+				entityType = sessionFactory.getMetamodel().entity( entityClass );
+			}
+			catch (IllegalArgumentException e) {
+				// When using annotatedTypes to infer the clear order,
+				// some annotated types may not be entities;
+				// this can be ignored.
+				continue;
+			}
+			if ( clearedEntityNames.add( entityType.getName() ) ) {
+				clearEntityInstances( sessionFactory, mapping, entityType );
+			}
+		}
+
+		// Just in case some entity types were not mentioned in entityClearOrder,
+		// we try to delete all remaining entity types.
+		// Note we're stabilizing the order, because ORM uses a HashSet internally
+		// and the order may change from one execution to the next.
+		List<EntityType<?>> sortedEntityTypes = sessionFactory.getMetamodel().getEntities().stream()
+				.sorted( Comparator.comparing( EntityType::getName ) )
+				.collect( Collectors.toList() );
+		for ( EntityType<?> entityType : sortedEntityTypes ) {
+			if ( clearedEntityNames.add( entityType.getName() ) ) {
+				clearEntityInstances( sessionFactory, mapping, entityType );
+			}
+		}
+	}
+
+	private static void clearEntityInstances(SessionFactory sessionFactory, HibernateOrmMapping mapping,
+			EntityType<?> entityType) {
+		if ( Modifier.isAbstract( entityType.getJavaType().getModifiers() ) ) {
+			// There are no instances of this specific class,
+			// only instances of subclasses, and those are handled separately.
+			return;
+		}
+		if (
+				// Workaround until https://hibernate.atlassian.net/browse/HHH-5529 gets implemented
+				hasPotentiallyJoinTable( sessionFactory, entityType )
+				// Workaround until https://hibernate.atlassian.net/browse/HHH-14814 gets fixed
+				|| hasEntitySubclass( sessionFactory, entityType )
+		) {
+			mapping.listenerEnabled( false );
+			try {
+				withinTransaction( sessionFactory, s -> {
+					Query<?> query = selectAllOfSpecificType( entityType, s );
+					try {
+						query.list().forEach( s::remove );
+					}
+					catch (RuntimeException e) {
+						throw new RuntimeException( "Failed to delete all entity instances returned by "
+								+ query.getQueryString() + " on type " + entityType + ": " + e.getMessage(), e );
+					}
+				} );
+			}
+			finally {
+				mapping.listenerEnabled( true );
+			}
+		}
+		else {
+			withinTransaction( sessionFactory, s -> {
+				Query<?> query = deleteAllOfSpecificType( entityType, s );
+				try {
+					query.executeUpdate();
+				}
+				catch (RuntimeException e) {
+					throw new RuntimeException( "Failed to execute " + query.getQueryString() + " on type " + entityType
+							+ ": " + e.getMessage(), e );
+				}
+			} );
+		}
+	}
+
+	private static Query<?> selectAllOfSpecificType(EntityType<?> entityType, Session session) {
+		return createSelectOrDeleteAllOfSpecificTypeQuery( entityType, session, "" );
+	}
+
+	private static Query<?> deleteAllOfSpecificType(EntityType<?> entityType, Session session) {
+		return createSelectOrDeleteAllOfSpecificTypeQuery( entityType, session, "delete " );
+	}
+
+	private static Query<?> createSelectOrDeleteAllOfSpecificTypeQuery(EntityType<?> entityType, Session session, String prefix) {
+		StringBuilder builder = new StringBuilder( prefix ).append( "from " ).append( entityType.getName() ).append( " e" );
+		Class<?> typeArg = null;
+		if ( hasEntitySubclass( session.getSessionFactory(), entityType ) ) {
+			// We must target the type explicitly, without polymorphism,
+			// because subtypes might have associations pointing to the supertype,
+			// in which case deleting subtypes and supertypes in the same query
+			// may fail or not, depending on processing order (supertype before subtype or subtype before supertype).
+			builder.append( " where type( e ) in (:type)" );
+			typeArg = entityType.getJavaType();
+		}
+		Query<?> query = session.createQuery( builder.toString() );
+		if ( typeArg != null ) {
+			query.setParameter( "type", typeArg );
+		}
+		return query;
+	}
+
+	private static boolean hasEntitySubclass(SessionFactory sessionFactory, EntityType<?> parentEntity) {
+		Metamodel metamodel = sessionFactory.unwrap( SessionFactoryImplementor.class ).getMetamodel();
+		for ( EntityType<?> entity : metamodel.getEntities() ) {
+			if ( parentEntity.equals( entity.getSupertype() ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean hasPotentiallyJoinTable(SessionFactory sessionFactory,
+			ManagedType<?> managedType) {
+		for ( Attribute<?, ?> attribute : managedType.getAttributes() ) {
+			switch ( attribute.getPersistentAttributeType() ) {
+				case MANY_TO_ONE:
+				case ONE_TO_ONE:
+				case BASIC:
+					break;
+				case MANY_TO_MANY:
+				case ONE_TO_MANY:
+				case ELEMENT_COLLECTION:
+					return true;
+				case EMBEDDED:
+					EmbeddableType<?> embeddable = sessionFactory.getMetamodel().embeddable( attribute.getJavaType() );
+					if ( hasPotentiallyJoinTable( sessionFactory, embeddable ) ) {
+						return true;
+					}
+					break;
+			}
+		}
+		return false;
+	}
+
+	private static class TestCustomSetup {
+
+		private static final TestPluggableMethod.ArgumentKey<OrmSetupHelper.SetupContext> SETUP_CONTEXT_KEY =
+				new TestPluggableMethod.ArgumentKey<>( OrmSetupHelper.SetupContext.class, "setupContext" );
+		private static final TestPluggableMethod.ArgumentKey<DataClearConfig> CONFIG_CONTEXT_KEY =
+				new TestPluggableMethod.ArgumentKey<>( DataClearConfig.class, "configContext" );
+		private static final List<TestPluggableMethod.ArgumentKey<?>> KEYS =
+				Arrays.asList( SETUP_CONTEXT_KEY, CONFIG_CONTEXT_KEY );
+
+		private final List<TestPluggableMethod<Void>> setupMethods;
+
+		private final Object testInstance;
+
+		TestCustomSetup(Object testInstance) {
+			this.testInstance = testInstance;
+			this.setupMethods = TestPluggableMethod.createAll( Setup.class, testInstance.getClass(), void.class, KEYS );
+		}
+
+		void callSetupMethods(OrmSetupHelper.SetupContext setupContext, DataClearConfig dataClearConfig) {
+			Map<TestPluggableMethod.ArgumentKey<?>, Object> context = new HashMap<>();
+			context.put( SETUP_CONTEXT_KEY, setupContext );
+			context.put( CONFIG_CONTEXT_KEY, dataClearConfig );
+
+			for ( TestPluggableMethod<Void> pluggableMethod : setupMethods ) {
+				pluggableMethod.call( testInstance, context );
+			}
+		}
+	}
+
+	private static class DataClearConfigImpl implements DataClearConfig {
+		private final List<Class<?>> entityClearOrder = new ArrayList<>();
+
+		private final List<Consumer<Session>> preClear = new ArrayList<>();
+
+		@Override
+		public DataClearConfig preClear(Consumer<Session> preClear) {
+			this.preClear.add( preClear );
+			return this;
+		}
+
+		@Override
+		public <T> DataClearConfig preClear(Class<T> entityType, Consumer<T> preClear) {
+			return preClear( session -> {
+				// We'll go through subtypes as well here,
+				// on contrary to selectAllOfSpecificType(),
+				// because we are performing updates only, not deletes.
+
+				CriteriaBuilder builder = session.getCriteriaBuilder();
+				CriteriaQuery<T> query = builder.createQuery( entityType );
+				Root<T> root = query.from( entityType );
+				query.select( root );
+				for ( T entity : session.createQuery( query ).list() ) {
+					preClear.accept( entity );
+				}
+			} );
+		}
+
+		@Override
+		public DataClearConfigImpl clearOrder(Class<?>... entityClasses) {
+			entityClearOrder.clear();
+			Collections.addAll( entityClearOrder, entityClasses );
+			return this;
+		}
+	}
+}

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/TestPluggableMethod.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/TestPluggableMethod.java
@@ -1,0 +1,155 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.integrationtest.mapper.orm;
+
+import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * A representation of a method defined in a test class in order to be called from test infrastructure
+ * (e.g. a {@link org.junit.rules.TestRule}).
+ */
+class TestPluggableMethod<T> {
+
+	public static <T> List<TestPluggableMethod<T>> createAll(Class<? extends Annotation> annotationClass,
+			Class<?> testClass, Class<T> expectedReturnType, List<ArgumentKey<?>> availableKeys) {
+		List<TestPluggableMethod<T>> result = new ArrayList<>();
+		MethodHandles.Lookup lookup = MethodHandles.lookup();
+		collectAllSetupMethods( lookup, annotationClass, result, testClass, expectedReturnType, availableKeys );
+		return result;
+	}
+
+	private static <T> void collectAllSetupMethods(MethodHandles.Lookup lookup, Class<? extends Annotation> annotationClass,
+			List<TestPluggableMethod<T>> collector, Class<?> testClass,
+			Class<T> expectedReturnType, List<ArgumentKey<?>> availableKeys) {
+		Class<?> superClass = testClass.getSuperclass();
+		if ( superClass != Object.class ) {
+			collectAllSetupMethods( lookup, annotationClass, collector, superClass, expectedReturnType, availableKeys );
+		}
+		for ( Method method : testClass.getDeclaredMethods() ) {
+			if ( method.isAnnotationPresent( annotationClass ) ) {
+				collector.add( create( lookup, annotationClass, method, expectedReturnType, availableKeys ) );
+			}
+		}
+	}
+
+	private static <T> TestPluggableMethod<T> create(MethodHandles.Lookup lookup, Class<? extends Annotation> annotationClass,
+			Method method, Class<T> expectedReturnType, List<ArgumentKey<?>> availableKeys) {
+		if ( !Modifier.isPublic( method.getModifiers() ) ) {
+			throw new IllegalStateException(
+					"Method " + method + ", annotated with " + annotationClass.getName() + ", must be public." );
+		}
+		if ( Modifier.isStatic( method.getModifiers() ) ) {
+			throw new IllegalStateException(
+					"Method " + method + ", annotated with " + annotationClass.getName() + ", must be non-static." );
+		}
+		if ( !expectedReturnType.isAssignableFrom( method.getReturnType() ) ) {
+			throw new IllegalStateException(
+					"Method " + method + ", annotated with " + annotationClass.getName() + ", must return type "
+							+ expectedReturnType );
+		}
+		MethodHandle setupMethod;
+		try {
+			setupMethod = lookup.unreflect( method );
+		}
+		catch (IllegalAccessException e) {
+			throw new IllegalStateException(
+					"Method " + method + ", annotated with " + annotationClass.getName() + ", must be accessible from " + lookup + ".",
+					e
+			);
+		}
+		List<ArgumentKey<?>> argumentKeys = new ArrayList<>();
+		for ( Class<?> parameterType : method.getParameterTypes() ) {
+			ArgumentKey<?> matchingKey = null;
+			for ( ArgumentKey<?> key : availableKeys ) {
+				if ( parameterType.isAssignableFrom( key.type ) ) {
+					matchingKey = key;
+					break;
+				}
+			}
+			if ( matchingKey == null ) {
+				throw new IllegalStateException(
+						"Method " + method + " has a parameter of type " + parameterType.getName() + ", which isn't supported."
+								+ " Supported parameter types: "
+								+ availableKeys.stream().map( k -> k.type.getName() ).collect( Collectors.toList() ) );
+			}
+			argumentKeys.add( matchingKey );
+		}
+		return new TestPluggableMethod<>( setupMethod, expectedReturnType, argumentKeys );
+	}
+
+	private final MethodHandle setupMethod;
+	private final Class<T> expectedReturnType;
+	private final List<ArgumentKey<?>> argumentKeys;
+
+	private TestPluggableMethod(MethodHandle setupMethod, Class<T> expectedReturnType,
+			List<ArgumentKey<?>> argumentKeys) {
+		this.setupMethod = setupMethod;
+		this.expectedReturnType = expectedReturnType;
+		this.argumentKeys = argumentKeys;
+	}
+
+	public T call(Object testInstance, Map<ArgumentKey<?>, Object> context) {
+		Object[] args = new Object[1 + argumentKeys.size()];
+		args[0] = testInstance;
+		int i = 1;
+		for ( ArgumentKey<?> argumentKey : argumentKeys ) {
+			args[i++] = context.get( argumentKey );
+		}
+		try {
+			return expectedReturnType.cast( setupMethod.invokeWithArguments( args ) );
+		}
+		catch (Throwable t) {
+			throw new Error(
+					"Failed to call " + setupMethod + " with arguments " + Arrays.toString( args )
+							+ ": " + t.getMessage(),
+					t
+			);
+		}
+	}
+
+	public static final class ArgumentKey<T> {
+		public final Class<T> type;
+		public final String name;
+
+		public ArgumentKey(Class<T> type, String name) {
+			this.type = type;
+			this.name = name;
+		}
+
+		@Override
+		public String toString() {
+			return name;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			ArgumentKey that = (ArgumentKey) o;
+			return Objects.equals( type, that.type ) && Objects.equals( name, that.name );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( type, name );
+		}
+	}
+}


### PR DESCRIPTION
* [HSEARCH-4300](https://hibernate.atlassian.net/browse/HSEARCH-4300): Fix build timeout after 1 hour when testing against DB2

Also includes a few follow-up fixes for [HSEARCH-4303](https://hibernate.atlassian.net/browse/HSEARCH-4303).

Backport of #2649. Backporting mainly to ease future backports, since this changes the testing framework.
