### PR TITLE
HSEARCH-4307 Hibernate Search version detection doesn't work on native images

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -36,4 +36,34 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jboss.maven.plugins</groupId>
+                <artifactId>maven-injection-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>bytecode</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <bytecodeInjections>
+                        <bytecodeInjection>
+                            <expression>${project.version}</expression>
+                            <targetMembers>
+                                <methodBodyReturn>
+                                    <className>org.hibernate.search.engine.Version</className>
+                                    <methodName>versionString</methodName>
+                                </methodBodyReturn>
+                            </targetMembers>
+                        </bytecodeInjection>
+                    </bytecodeInjections>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/engine/src/main/java/org/hibernate/search/engine/Version.java
+++ b/engine/src/main/java/org/hibernate/search/engine/Version.java
@@ -22,7 +22,8 @@ public final class Version {
 	 * @return A string representation of the version of Hibernate Search.
 	 */
 	public static String versionString() {
-		return Version.class.getPackage().getImplementationVersion();
+		// This implementation is replaced during the build with another one that returns the correct value.
+		return "UNKNOWN";
 	}
 
 	/**

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/BootstrapLogsIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/BootstrapLogsIT.java
@@ -61,7 +61,8 @@ public class BootstrapLogsIT {
 
 	@Test
 	public void noSuspiciousLogEvents() {
-		logged.expectEvent( suspiciousLogEventMatcher() ).never(); // Also fails if a higher severity event (e.g. error) is logged
+		logged.expectEvent( suspiciousLogEventMatcher() )
+				.never(); // Also fails if a higher severity event (e.g. error) is logged
 
 		backendMock.expectAnySchema( IndexedEntity.NAME );
 
@@ -72,6 +73,13 @@ public class BootstrapLogsIT {
 	@Test
 	@SuppressWarnings("deprecation")
 	public void version() {
+		if ( Version.versionString().equals( "UNKNOWN" ) ) {
+			throw new IllegalStateException( "Tests seem to be running from an IDE,"
+					+ " or the code was compiled by an IDE."
+					+ " This test won't work, because it requires Version.java to be injected with some bytecode"
+					+ " through a Maven plugin that IDEs don't know about." );
+		}
+
 		String propertyKey = "org.hibernate.search.version";
 		String expectedHibernateSearchVersion = System.getProperty( propertyKey );
 		if ( expectedHibernateSearchVersion == null ) {
@@ -80,7 +88,8 @@ public class BootstrapLogsIT {
 		}
 
 		logged.expectMessage( "HSEARCH000034",
-				"Hibernate Search version", expectedHibernateSearchVersion ).once();
+				"Hibernate Search version", expectedHibernateSearchVersion
+		).once();
 
 		backendMock.expectAnySchema( IndexedEntity.NAME );
 
@@ -95,11 +104,13 @@ public class BootstrapLogsIT {
 	private static Matcher<? extends LogEvent> suspiciousLogEventMatcher() {
 		return new TypeSafeMatcher<LogEvent>() {
 			private final Level level = Level.WARN;
+
 			@Override
 			public void describeTo(Description description) {
 				description.appendText( "a LogEvent with " ).appendValue( level ).appendText( " level or higher" )
 						.appendText( " (ignoring known test-only warnings)" );
 			}
+
 			@Override
 			protected boolean matchesSafely(LogEvent item) {
 				return item.getLevel().isMoreSpecificThan( level )

--- a/pom.xml
+++ b/pom.xml
@@ -1811,6 +1811,7 @@
                         <trimStackTrace>false</trimStackTrace>
                         <systemPropertyVariables>
                             <com.sun.management.jmxremote>true</com.sun.management.jmxremote>
+                            <org.hibernate.search.version>${project.version}</org.hibernate.search.version>
                             <org.hibernate.search.enable_performance_tests>${org.hibernate.search.enable_performance_tests}</org.hibernate.search.enable_performance_tests>
                             <org.hibernate.search.fail_on_unreleased_service>true</org.hibernate.search.fail_on_unreleased_service>
                             <org.hibernate.search.integrationtest.backend.elasticsearch.testdialect>${test.elasticsearch.testdialect}</org.hibernate.search.integrationtest.backend.elasticsearch.testdialect>

--- a/pom.xml
+++ b/pom.xml
@@ -1744,6 +1744,11 @@
                     <artifactId>moditect-maven-plugin</artifactId>
                     <version>${version.moditect.plugin}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.jboss.maven.plugins</groupId>
+                    <artifactId>maven-injection-plugin</artifactId>
+                    <version>1.0.2</version>
+                </plugin>
 
                 <!--
                     Test configuration


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4307

Backport to 6.0: #2657