### PR TITLE
HSEARCH-4240 Separate artifacts for compatibility with Jakarta EE 9.1 (Jakarta Persistence 3)

### DIFF
--- a/build/config/pom.xml
+++ b/build/config/pom.xml
@@ -106,6 +106,14 @@
                                     <version>${version.javax.batch}</version>
                                     <outputDirectory>${tmpdir.dependencies-javadoc-packagelists}/batch-api</outputDirectory>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>jakarta.batch</groupId>
+                                    <artifactId>jakarta.batch-api</artifactId>
+                                    <classifier>javadoc</classifier>
+                                    <type>jar</type>
+                                    <version>${version.javax.batch}</version>
+                                    <outputDirectory>${tmpdir.dependencies-javadoc-packagelists}/batch-api</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                             <includes>package-list</includes>
                             <overWriteSnapshots>true</overWriteSnapshots>

--- a/build/config/src/main/resources/forbidden-runtime.txt
+++ b/build/config/src/main/resources/forbidden-runtime.txt
@@ -25,13 +25,15 @@ java.lang.StringBuffer @ Do not use java.lang.StringBuffer: use java.lang.String
 org.jboss.logging.processor.util.Objects @ Bad import, use java.util.Objects
 
 ################################################################################################################
-# Methods from Hibernate ORM :
+# Unsafe API/SPI from Hibernate ORM
 org.hibernate.SharedSessionContract#getTransaction() @ Using this method is often unsafe
 org.hibernate.SharedSessionContract#createCriteria(java.lang.Class) @ Native Criteria are deprecated
 org.hibernate.SharedSessionContract#createCriteria(java.lang.Class, java.lang.String) @ Native Criteria are deprecated
 org.hibernate.SharedSessionContract#createCriteria(java.lang.String) @ Native Criteria are deprecated
 org.hibernate.SharedSessionContract#createCriteria(java.lang.String, java.lang.String) @ Native Criteria are deprecated
 org.hibernate.criterion.** @ Native Criteria are deprecated
+org.hibernate.jpa.QueryHints @ Hibernate ORM's QueryHints constants may not be correct for Jakarta artifacts.
+org.hibernate.annotations.QueryHints @ Hibernate ORM's QueryHints constants may not be correct for Jakarta artifacts.
 
 ################################################################################################################
 # Use our Contracts class instead
@@ -54,7 +56,7 @@ java.time.ZonedDateTime#parse(java.lang.CharSequence)
 java.time.ZonedDateTime#parse(java.lang.CharSequence, java.time.format.DateTimeFormatter)
 
 ################################################################################################################
-@defaultMessage Avoid to use Hibernate ORM internals
+@defaultMessage Avoid using Hibernate ORM internals
 org.hibernate.internal.**
 org.hibernate.**.internal.**
 

--- a/build/config/src/main/resources/forbidden-tests.txt
+++ b/build/config/src/main/resources/forbidden-tests.txt
@@ -24,6 +24,11 @@ org.assertj.core.api.Assumptions @ Use JUnit's Assume instead of AssertJ's Assum
 org.skyscreamer.jsonassert.JSONAssert @ Use JsonHelper.assertJsonEquals to avoid the checked exception and get clearer assertion errors
 
 ################################################################################################################
+# Unsafe API/SPI from Hibernate ORM
+org.hibernate.jpa.QueryHints @ Hibernate ORM's QueryHints constants may not be correct for Jakarta artifacts.
+org.hibernate.annotations.QueryHints @ Hibernate ORM's QueryHints constants may not be correct for Jakarta artifacts.
+
+################################################################################################################
 # Various, from our own code.
 # This one needs to be handled with special care to avoid tests breaking out of their isolation (see exclusions):
 org.hibernate.search.spi.SearchIntegratorBuilder#buildSearchIntegrator()

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -319,6 +319,8 @@
                         <hibernateVersion>${version.org.hibernate}</hibernateVersion>
                         <hibernateDocUrl>${documentation.org.hibernate.url}</hibernateDocUrl>
                         <jpaVersion>${parsed-version.javax.persistence.majorVersion}.${parsed-version.javax.persistence.minorVersion}</jpaVersion>
+                        <jakartaUrl>https://jakarta.ee/</jakartaUrl>
+                        <jakartaPersistenceVersion>${parsed-version.jakarta.persistence.majorVersion}.${parsed-version.jakarta.persistence.minorVersion}</jakartaPersistenceVersion>
                         <luceneVersion>${version.org.apache.lucene}</luceneVersion>
                         <luceneUrl>https://lucene.apache.org</luceneUrl>
                         <luceneJavadocUrl>${javadoc.org.apache.lucene.core.url}</luceneJavadocUrl>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -110,12 +110,6 @@
     </dependencies>
 
     <build>
-        <testResources>
-            <testResource>
-                <filtering>false</filtering>
-                <directory>src/test/resources</directory>
-            </testResource>
-        </testResources>
         <plugins>
             <plugin>
                 <groupId>io.fabric8</groupId>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -125,7 +125,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <reportNameSuffix>${surefire.environment}-${surefire.executing-module}-lucene</reportNameSuffix>
+                            <reportNameSuffix>${surefire.environment}-${project.artifactId}-lucene</reportNameSuffix>
                             <classpathDependencyExcludes>
                                 <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-elasticsearch</classpathDependencyExclude>
                             </classpathDependencyExcludes>
@@ -143,7 +143,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <reportNameSuffix>${surefire.environment}-${surefire.executing-module}-elasticsearch</reportNameSuffix>
+                            <reportNameSuffix>${surefire.environment}-${project.artifactId}-elasticsearch</reportNameSuffix>
                             <classpathDependencyExcludes>
                                 <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-lucene</classpathDependencyExclude>
                             </classpathDependencyExcludes>

--- a/documentation/src/main/asciidoc/reference/getting-started.asciidoc
+++ b/documentation/src/main/asciidoc/reference/getting-started.asciidoc
@@ -9,23 +9,31 @@ to integrate Hibernate Search into your application.
 
 .Compatibility
 
-[cols="h,1", stripes=none]
+[cols="h,^1,1", stripes=none]
 |===============
+| h|Version h|Note
 |Java Runtime
-|Java *8* or greater.
+|8, 11 or 17
+|
 |Hibernate ORM (for the ORM mapper)
-|Hibernate ORM *{hibernateVersion}*.
-|JPA (for the ORM mapper)
-|JPA *{jpaVersion}*.
+|{hibernateVersion}
+|
+|JPA (Java EE) (for the ORM mapper)
+|{jpaVersion}
+|
+|Jakarta Persistence (for the ORM mapper)
+|{jakartaPersistenceVersion}
+|Need to use <<other-integrations-jakarta,different Maven artifacts>>.
 |Apache Lucene (for the Lucene backend)
-|Lucene *{luceneVersion}*.
+|{luceneVersion}
+|
 |Elasticsearch server (for the Elasticsearch backend)
-|Elasticsearch *{elasticsearchCompatibleVersions}*.
-Other minor versions (e.g. {elasticsearchOtherPotentiallyCompatibleVersions}) may work
+|{elasticsearchCompatibleVersions}
+|Other minor versions (e.g. {elasticsearchOtherPotentiallyCompatibleVersions}) may work
 but are not given priority for bugfixes and new features.
 |OpenSearch server (for the Elasticsearch backend)
-|OpenSearch *{openSearchCompatibleVersions}*.
-Other minor versions may work
+|{openSearchCompatibleVersions}
+|Other minor versions may work
 but are not given priority for bugfixes and new features.
 |===============
 

--- a/documentation/src/main/asciidoc/reference/index.asciidoc
+++ b/documentation/src/main/asciidoc/reference/index.asciidoc
@@ -39,6 +39,8 @@ include::backend-elasticsearch.asciidoc[]
 
 include::coordination.asciidoc[]
 
+include::integrations.asciidoc[]
+
 include::limitations.asciidoc[]
 
 include::troubleshooting.asciidoc[]

--- a/documentation/src/main/asciidoc/reference/integrations.asciidoc
+++ b/documentation/src/main/asciidoc/reference/integrations.asciidoc
@@ -1,0 +1,56 @@
+[[integrations]]
+= Standards and integrations
+
+[[other-integrations-jakarta]]
+== Jakarta EE
+
+include::components/incubating-warning.asciidoc[]
+
+Hibernate Search includes experimental support for link:{jakartaUrl}[Jakarta EE],
+and it requires only one small change:
+when declaring the dependencies of your project,
+you must add `-jakarta` to some artifact identifiers.
+
+For example, an application using Hibernate ORM and the Elasticsearch backend
+will need to update its dependencies as follows:
+
+[source, XML, subs="+attributes"]
+----
+<dependency>
+   <groupId>org.hibernate</groupId>
+   <artifactId>hibernate-core-jakarta</artifactId> <!--1-->
+   <version>{hibernateVersion}</version>
+</dependency>
+<dependency>
+   <groupId>org.hibernate.search</groupId>
+   <artifactId></artifactId>
+   <artifactId>hibernate-search-mapper-orm-jakarta</artifactId> <!--2-->
+   <version>{hibernateSearchVersion}</version>
+</dependency>
+<dependency>
+   <groupId>org.hibernate.search</groupId>
+   <artifactId>hibernate-search-backend-elasticsearch</artifactId> <!--3-->
+   <version>{hibernateSearchVersion}</version>
+</dependency>
+----
+<1> Replaces `hibernate-core`.
+<2> Replaces `hibernate-search-mapper-orm`.
+<3> No replacement necessary: this artifact does not rely on Java EE.
+
+All artifacts relying directly or indirectly on Java EE must be replaced with their Jakarta counterpart.
+This includes in particular:
+
+* https://in.relation.to/2021/06/04/hibernate-is-jakarta-jpa-2/#get-it[Hibernate ORM artifacts]
+* `hibernate-search-mapper-orm` => `hibernate-search-mapper-orm-jakarta`
+* `hibernate-search-mapper-orm-batch-jsr352-core` => `hibernate-search-mapper-orm-batch-jsr352-core-jakarta`
+* ...
+
+Artifacts that do not rely on Java EE at all, on the other hand,
+do not have a Jakarta counterpart and must not be replaced.
+These artifacts should be excluded from your replacements in particular:
+
+* `hibernate-search-engine`
+* `hibernate-search-backend-lucene`
+* `hibernate-search-backend-elasticsearch`
+* `hibernate-search-backend-elasticsearch-aws`
+* ...

--- a/integrationtest/backend/elasticsearch/pom.xml
+++ b/integrationtest/backend/elasticsearch/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <test.elasticsearch.run.skip>${test.elasticsearch.connection.uris.defined}</test.elasticsearch.run.skip>
 
-        <surefire.executing-module>it-elasticsearch</surefire.executing-module>
         <!-- By default we don't exclude tests because of the version, but profiles override this -->
         <failsafe.excludedGroups.elasticsearch.version />
         <!-- By default AWS is not enabled, which means we need to exclude these categories -->

--- a/integrationtest/backend/elasticsearch/pom.xml
+++ b/integrationtest/backend/elasticsearch/pom.xml
@@ -66,12 +66,6 @@
     </dependencies>
 
     <build>
-        <testResources>
-            <testResource>
-                <filtering>false</filtering>
-                <directory>src/test/resources</directory>
-            </testResource>
-        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/integrationtest/backend/lucene/pom.xml
+++ b/integrationtest/backend/lucene/pom.xml
@@ -43,7 +43,7 @@
     <build>
         <testResources>
             <testResource>
-                <filtering>true</filtering>
+                <filtering>false</filtering>
                 <directory>src/test/resources</directory>
             </testResource>
         </testResources>

--- a/integrationtest/backend/lucene/pom.xml
+++ b/integrationtest/backend/lucene/pom.xml
@@ -41,12 +41,6 @@
     </dependencies>
 
     <build>
-        <testResources>
-            <testResource>
-                <filtering>false</filtering>
-                <directory>src/test/resources</directory>
-            </testResource>
-        </testResources>
         <plugins>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/integrationtest/backend/lucene/pom.xml
+++ b/integrationtest/backend/lucene/pom.xml
@@ -12,10 +12,6 @@
     <name>Hibernate Search ITs - Backend - Lucene</name>
     <description>Hibernate Search integration tests for the Lucene backend, running the Backend TCK in particular</description>
 
-    <properties>
-        <surefire.executing-module>it-lucene</surefire.executing-module>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.hibernate.search</groupId>

--- a/integrationtest/jdk/java-modules/pom.xml
+++ b/integrationtest/jdk/java-modules/pom.xml
@@ -63,12 +63,6 @@
     </dependencies>
 
     <build>
-        <resources>
-            <resource>
-                <filtering>true</filtering>
-                <directory>src/main/resources</directory>
-            </resource>
-        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/integrationtest/jdk/java-modules/pom.xml
+++ b/integrationtest/jdk/java-modules/pom.xml
@@ -23,6 +23,17 @@
         <maven.compiler.release>11</maven.compiler.release>
         <!-- Override the default from the parent POM: here we really do want to use the modulepath -->
         <failsafe.useModulePath>true</failsafe.useModulePath>
+
+        <surefire.jvm.args.module>
+            -Dhibernate.search.backend.uris=${test.elasticsearch.connection.uris}
+            -Dhibernate.search.backend.username=${test.elasticsearch.connection.username}
+            -Dhibernate.search.backend.password=${test.elasticsearch.connection.password}
+            -Dhibernate.search.backend.aws.signing.enabled=${test.elasticsearch.connection.aws.signing.enabled}
+            -Dhibernate.search.backend.aws.region=${test.elasticsearch.connection.aws.region}
+            -Dhibernate.search.backend.aws.credentials.type=${test.elasticsearch.connection.aws.credentials.type}
+            -Dhibernate.search.backend.aws.credentials.access_key_id=${test.elasticsearch.connection.aws.credentials.access_key_id}
+            -Dhibernate.search.backend.aws.credentials.secret_access_key=${test.elasticsearch.connection.aws.credentials.secret_access_key}
+        </surefire.jvm.args.module>
     </properties>
 
     <dependencies>

--- a/integrationtest/jdk/java-modules/src/main/resources/hibernate.properties
+++ b/integrationtest/jdk/java-modules/src/main/resources/hibernate.properties
@@ -1,10 +1,5 @@
 # Hibernate ORM properties:
-hibernate.dialect = ${db.dialect}
-hibernate.connection.driver_class = ${jdbc.driver}
-hibernate.connection.url = ${jdbc.url}
-hibernate.connection.username = ${jdbc.user}
-hibernate.connection.password = ${jdbc.pass}
-hibernate.connection.isolation = ${jdbc.isolation}
+## Connection info: see integration-test parent POM
 hibernate.hbm2ddl.auto = create-drop
 hibernate.show_sql = true
 hibernate.format_sql = true
@@ -14,14 +9,7 @@ hibernate.max_fetch_depth = 5
 #hibernate.cache.region.factory_class = org.hibernate.testing.cache.CachingRegionFactory
 
 # Hibernate Search properties:
+## Connection info: see POM
 hibernate.search.automatic_indexing.synchronization.strategy = sync
-hibernate.search.backend.uris = ${test.elasticsearch.connection.uris}
-hibernate.search.backend.username = ${test.elasticsearch.connection.username}
-hibernate.search.backend.password = ${test.elasticsearch.connection.password}
-hibernate.search.backend.aws.signing.enabled = ${test.elasticsearch.connection.aws.signing.enabled}
-hibernate.search.backend.aws.region = ${test.elasticsearch.connection.aws.region}
-hibernate.search.backend.aws.credentials.type = ${test.elasticsearch.connection.aws.credentials.type}
-hibernate.search.backend.aws.credentials.access_key_id = ${test.elasticsearch.connection.aws.credentials.access_key_id}
-hibernate.search.backend.aws.credentials.secret_access_key = ${test.elasticsearch.connection.aws.credentials.secret_access_key}
 hibernate.search.backend.log.json_pretty_printing = true
 hibernate.search.backend.analysis.configurer = org.hibernate.search.integrationtest.java.module.config.MyElasticsearchAnalysisConfigurer

--- a/integrationtest/mapper/orm-batch-jsr352/pom.xml
+++ b/integrationtest/mapper/orm-batch-jsr352/pom.xml
@@ -118,7 +118,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <reportNameSuffix>${surefire.environment}-${surefire.executing-module}-lucene-jbatch</reportNameSuffix>
+                            <reportNameSuffix>${surefire.environment}-${project.artifactId}-lucene-jbatch</reportNameSuffix>
                             <classpathDependencyExcludes>
                                 <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-elasticsearch</classpathDependencyExclude>
                                 <classpathDependencyExclude>org.hibernate.search:hibernate-search-util-internal-integrationtest-jberet-se</classpathDependencyExclude>
@@ -137,7 +137,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <reportNameSuffix>${surefire.environment}-${surefire.executing-module}-lucene-jberet</reportNameSuffix>
+                            <reportNameSuffix>${surefire.environment}-${project.artifactId}-lucene-jberet</reportNameSuffix>
                             <classpathDependencyExcludes>
                                 <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-elasticsearch</classpathDependencyExclude>
                                 <classpathDependencyExclude>org.hibernate.search:hibernate-search-util-internal-integrationtest-jbatch-runtime</classpathDependencyExclude>
@@ -155,7 +155,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <reportNameSuffix>${surefire.environment}-${surefire.executing-module}-elasticsearch-jbatch</reportNameSuffix>
+                            <reportNameSuffix>${surefire.environment}-${project.artifactId}-elasticsearch-jbatch</reportNameSuffix>
                             <classpathDependencyExcludes>
                                 <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-lucene</classpathDependencyExclude>
                                 <classpathDependencyExclude>org.hibernate.search:hibernate-search-util-internal-integrationtest-jberet-se</classpathDependencyExclude>
@@ -174,7 +174,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <reportNameSuffix>${surefire.environment}-${surefire.executing-module}-elasticsearch-jberet</reportNameSuffix>
+                            <reportNameSuffix>${surefire.environment}-${project.artifactId}-elasticsearch-jberet</reportNameSuffix>
                             <classpathDependencyExcludes>
                                 <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-lucene</classpathDependencyExclude>
                                 <classpathDependencyExclude>org.hibernate.search:hibernate-search-util-internal-integrationtest-jbatch-runtime</classpathDependencyExclude>

--- a/integrationtest/mapper/orm-batch-jsr352/pom.xml
+++ b/integrationtest/mapper/orm-batch-jsr352/pom.xml
@@ -107,12 +107,6 @@
     </dependencies>
 
     <build>
-        <testResources>
-            <testResource>
-                <filtering>false</filtering>
-                <directory>src/test/resources</directory>
-            </testResource>
-        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/integrationtest/mapper/orm-batch-jsr352/pom.xml
+++ b/integrationtest/mapper/orm-batch-jsr352/pom.xml
@@ -14,7 +14,19 @@
 
     <properties>
         <test.elasticsearch.run.skip>${test.elasticsearch.connection.uris.defined}</test.elasticsearch.run.skip>
+
+        <surefire.jvm.args.module>
+            -Dhibernate.search.backend.uris=${test.elasticsearch.connection.uris}
+            -Dhibernate.search.backend.username=${test.elasticsearch.connection.username}
+            -Dhibernate.search.backend.password=${test.elasticsearch.connection.password}
+            -Dhibernate.search.backend.aws.signing.enabled=${test.elasticsearch.connection.aws.signing.enabled}
+            -Dhibernate.search.backend.aws.region=${test.elasticsearch.connection.aws.region}
+            -Dhibernate.search.backend.aws.credentials.type=${test.elasticsearch.connection.aws.credentials.type}
+            -Dhibernate.search.backend.aws.credentials.access_key_id=${test.elasticsearch.connection.aws.credentials.access_key_id}
+            -Dhibernate.search.backend.aws.credentials.secret_access_key=${test.elasticsearch.connection.aws.credentials.secret_access_key}
+        </surefire.jvm.args.module>
     </properties>
+
 
     <dependencyManagement>
         <dependencies>
@@ -97,7 +109,7 @@
     <build>
         <testResources>
             <testResource>
-                <filtering>true</filtering>
+                <filtering>false</filtering>
                 <directory>src/test/resources</directory>
             </testResource>
         </testResources>

--- a/integrationtest/mapper/orm-batch-jsr352/src/test/resources/META-INF/persistence.xml
+++ b/integrationtest/mapper/orm-batch-jsr352/src/test/resources/META-INF/persistence.xml
@@ -10,11 +10,6 @@
     <persistence-unit name="lucene_pu" transaction-type="RESOURCE_LOCAL">
         <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
         <properties>
-            <property name="hibernate.dialect" value="${db.dialect}" />
-            <property name="hibernate.connection.driver_class" value="${jdbc.driver}" />
-            <property name="hibernate.connection.url" value="${jdbc.url}" />
-            <property name="hibernate.connection.user" value="${jdbc.user}" />
-            <property name="hibernate.connection.password" value="${jdbc.pass}" />
             <property name="hibernate.hbm2ddl.auto" value="create-drop" />
             <property name="hibernate.session_factory_name" value="primary_session_factory" />
             <property name="hibernate.session_factory_name_is_jndi" value="false" />
@@ -27,11 +22,6 @@
     <persistence-unit name="elasticsearch_pu" transaction-type="RESOURCE_LOCAL">
         <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
         <properties>
-            <property name="hibernate.dialect" value="${db.dialect}" />
-            <property name="hibernate.connection.driver_class" value="${jdbc.driver}" />
-            <property name="hibernate.connection.url" value="${jdbc.url}" />
-            <property name="hibernate.connection.user" value="${jdbc.user}" />
-            <property name="hibernate.connection.password" value="${jdbc.pass}" />
             <property name="hibernate.hbm2ddl.auto" value="create-drop" />
             <property name="hibernate.session_factory_name" value="primary_session_factory" />
             <property name="hibernate.session_factory_name_is_jndi" value="false" />
@@ -39,14 +29,6 @@
             <property name="hibernate.search.automatic_indexing.enabled" value="false"/>
             <property name="hibernate.search.schema_management.strategy" value="drop-and-create-and-drop"/>
             <property name="hibernate.search.backend.type" value="elasticsearch" />
-            <property name="hibernate.search.backend.uris" value="${test.elasticsearch.connection.uris}" />
-            <property name="hibernate.search.backend.username" value="${test.elasticsearch.connection.username}" />
-            <property name="hibernate.search.backend.password" value="${test.elasticsearch.connection.password}" />
-            <property name="hibernate.search.backend.aws.signing.enabled" value="${test.elasticsearch.connection.aws.signing.enabled}" />
-            <property name="hibernate.search.backend.aws.region" value="${test.elasticsearch.connection.aws.region}" />
-            <property name="hibernate.search.backend.aws.credentials.type" value="${test.elasticsearch.connection.aws.credentials.type}" />
-            <property name="hibernate.search.backend.aws.credentials.access_key_id" value="${test.elasticsearch.connection.aws.credentials.access_key_id}" />
-            <property name="hibernate.search.backend.aws.credentials.secret_access_key" value="${test.elasticsearch.connection.aws.credentials.secret_access_key}" />
 
             <property name="hibernate.search.backend.log.json_pretty_printing" value="true" />
         </properties>
@@ -54,11 +36,6 @@
     <persistence-unit name="unused_pu" transaction-type="RESOURCE_LOCAL">
         <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
         <properties>
-            <property name="hibernate.dialect" value="${db.dialect}" />
-            <property name="hibernate.connection.driver_class" value="${jdbc.driver}" />
-            <property name="hibernate.connection.url" value="${jdbc.url}" />
-            <property name="hibernate.connection.user" value="${jdbc.user}" />
-            <property name="hibernate.connection.password" value="${jdbc.pass}" />
             <property name="hibernate.hbm2ddl.auto" value="create-drop" />
             <property name="hibernate.session_factory_name" value="unused_session_factory" />
             <property name="hibernate.session_factory_name_is_jndi" value="false" />

--- a/integrationtest/mapper/orm-realbackend/pom.xml
+++ b/integrationtest/mapper/orm-realbackend/pom.xml
@@ -94,7 +94,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <reportNameSuffix>${surefire.environment}-${surefire.executing-module}-lucene</reportNameSuffix>
+                            <reportNameSuffix>${surefire.environment}-${project.artifactId}-lucene</reportNameSuffix>
                             <classpathDependencyExcludes>
                                 <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-elasticsearch</classpathDependencyExclude>
                             </classpathDependencyExcludes>
@@ -112,7 +112,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <reportNameSuffix>${surefire.environment}-${surefire.executing-module}-elasticsearch</reportNameSuffix>
+                            <reportNameSuffix>${surefire.environment}-${project.artifactId}-elasticsearch</reportNameSuffix>
                             <classpathDependencyExcludes>
                                 <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-lucene</classpathDependencyExclude>
                             </classpathDependencyExcludes>
@@ -130,7 +130,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <reportNameSuffix>${surefire.environment}-${surefire.executing-module}-multiplebackends</reportNameSuffix>
+                            <reportNameSuffix>${surefire.environment}-${project.artifactId}-multiplebackends</reportNameSuffix>
                             <includes>
                                 <include>org.hibernate.search.integrationtest.mapper.orm.realbackend.bootstrap.BackendTypeAutoDetectMultipleBackendTypesInClasspathIT</include>
                             </includes>

--- a/integrationtest/showcase/library/pom.xml
+++ b/integrationtest/showcase/library/pom.xml
@@ -158,7 +158,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <reportNameSuffix>${surefire.environment}-${surefire.executing-module}-lucene</reportNameSuffix>
+                            <reportNameSuffix>${surefire.environment}-${project.artifactId}-lucene</reportNameSuffix>
                             <systemPropertyVariables>
                                 <!-- See TestActiveProfilesResolver -->
                                 <test.backend>lucene</test.backend>
@@ -171,7 +171,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <reportNameSuffix>${surefire.environment}-${surefire.executing-module}-elasticsearch</reportNameSuffix>
+                            <reportNameSuffix>${surefire.environment}-${project.artifactId}-elasticsearch</reportNameSuffix>
                             <systemPropertyVariables>
                                 <!-- See TestActiveProfilesResolver -->
                                 <test.backend>elasticsearch</test.backend>

--- a/integrationtest/v5migrationhelper/engine/pom.xml
+++ b/integrationtest/v5migrationhelper/engine/pom.xml
@@ -46,18 +46,8 @@
     <build>
         <testResources>
             <testResource>
-                <filtering>true</filtering>
-                <directory>src/test/resources</directory>
-                <excludes>
-                    <exclude>**/*.pdf</exclude>
-                </excludes>
-            </testResource>
-            <testResource>
                 <filtering>false</filtering>
                 <directory>src/test/resources</directory>
-                <includes>
-                    <include>**/*.pdf</include>
-                </includes>
             </testResource>
         </testResources>
         <plugins>

--- a/integrationtest/v5migrationhelper/engine/pom.xml
+++ b/integrationtest/v5migrationhelper/engine/pom.xml
@@ -44,12 +44,6 @@
     </dependencies>
 
     <build>
-        <testResources>
-            <testResource>
-                <filtering>false</filtering>
-                <directory>src/test/resources</directory>
-            </testResource>
-        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/integrationtest/v5migrationhelper/orm/pom.xml
+++ b/integrationtest/v5migrationhelper/orm/pom.xml
@@ -75,12 +75,6 @@
     </dependencies>
 
     <build>
-        <testResources>
-            <testResource>
-                <filtering>false</filtering>
-                <directory>src/test/resources</directory>
-            </testResource>
-        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/integrationtest/v5migrationhelper/orm/pom.xml
+++ b/integrationtest/v5migrationhelper/orm/pom.xml
@@ -77,20 +77,8 @@
     <build>
         <testResources>
             <testResource>
-                <filtering>true</filtering>
-                <directory>src/test/resources</directory>
-                <excludes>
-                    <exclude>**/*.pdf</exclude>
-                    <exclude>**/*.mp3</exclude>
-                </excludes>
-            </testResource>
-            <testResource>
                 <filtering>false</filtering>
                 <directory>src/test/resources</directory>
-                <includes>
-                    <include>**/*.pdf</include>
-                    <include>**/*.mp3</include>
-                </includes>
             </testResource>
         </testResources>
         <plugins>

--- a/jakarta/ant-copy-and-transform-sources.xml
+++ b/jakarta/ant-copy-and-transform-sources.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <target name="copy">
+        <!-- https://ant.apache.org/manual/Tasks/copy.html -->
+        <copy todir="${transform.output.root.path}" failonerror="false" overwrite="true">
+            <fileset dir="${transform.original.path}/src/"/>
+        </copy>
+    </target>
+    <target name="test-output-present">
+        <available file="${transform.output.root.path}" type="dir" property="output.present"/>
+    </target>
+    <target name="transform" depends="copy,test-output-present" if="output.present">
+        <!-- https://ant.apache.org/manual/Tasks/replace.html -->
+        <replace dir="${transform.output.root.path}">
+            <replacefilter token="javax.persistence" value="jakarta.persistence"/>
+            <replacefilter token="javax.transaction" value="jakarta.transaction"/>
+            <replacefilter token="javax.enterprise" value="jakarta.enterprise"/>
+            <replacefilter token="javax.annotation" value="jakarta.annotation"/>
+            <replacefilter token="javax.inject" value="jakarta.inject"/>
+            <replacefilter token="javax.batch" value="jakarta.batch"/>
+        </replace>
+        <replace dir="${transform.output.root.path}" includes="**/beans.xml">
+            <replacefilter token="http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd" value="https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"/>
+            <replacefilter token="https://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd" value="https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"/>
+            <replacefilter token="http://xmlns.jcp.org/xml/ns/javaee" value="https://jakarta.ee/xml/ns/jakartaee"/>
+            <replacefilter token="https://xmlns.jcp.org/xml/ns/javaee" value="https://jakarta.ee/xml/ns/jakartaee"/>
+            <replacefilter>
+                <replacetoken>version="1.2"</replacetoken>
+                <replacevalue>version="3.0"</replacevalue>
+            </replacefilter>
+            <replacefilter>
+                <replacetoken>version="2.0"</replacetoken>
+                <replacevalue>version="3.0"</replacevalue>
+            </replacefilter>
+        </replace>
+        <replace dir="${transform.output.root.path}" includes="**/persistence.xml">
+            <replacefilter token="http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd" value="https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"/>
+            <replacefilter token="https://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd" value="https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"/>
+            <replacefilter token="http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd" value="https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"/>
+            <replacefilter token="https://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd" value="https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"/>
+            <replacefilter token="http://xmlns.jcp.org/xml/ns/javaee" value="https://jakarta.ee/xml/ns/jakartaee"/>
+            <replacefilter token="https://xmlns.jcp.org/xml/ns/javaee" value="https://jakarta.ee/xml/ns/jakartaee"/>
+            <replacefilter token="http://xmlns.jcp.org/xml/ns/persistence" value="https://jakarta.ee/xml/ns/persistence"/>
+            <replacefilter token="https://xmlns.jcp.org/xml/ns/persistence" value="https://jakarta.ee/xml/ns/persistence"/>
+            <replacefilter token="http://java.sun.com/xml/ns/persistence" value="https://jakarta.ee/xml/ns/persistence"/>
+            <replacefilter token="https://java.sun.com/xml/ns/persistence" value="https://jakarta.ee/xml/ns/persistence"/>
+            <replacefilter>
+                <!-- Use trailing &gt; to avoid matching <?xml version="1.0 ...>
+                     We know our persistence.xml files always have a trailing &gt; after version="1.0" anyway. -->
+                <replacetoken>version="1.0"&gt;</replacetoken>
+                <replacevalue>version="3.0"&gt;</replacevalue>
+            </replacefilter>
+            <replacefilter>
+                <replacetoken>version="2.0"</replacetoken>
+                <replacevalue>version="3.0"</replacevalue>
+            </replacefilter>
+            <replacefilter>
+                <replacetoken>version="2.1"</replacetoken>
+                <replacevalue>version="3.0"</replacevalue>
+            </replacefilter>
+            <replacefilter>
+                <replacetoken>version="2.2"</replacetoken>
+                <replacevalue>version="3.0"</replacevalue>
+            </replacefilter>
+        </replace>
+        <replace dir="${transform.output.root.path}" includes="**/batch.xml,**/hibernate-search-mass-indexing.xml">
+            <replacefilter token="http://xmlns.jcp.org/xml/ns/javaee/jobXML_1_0.xsd" value="https://jakarta.ee/xml/ns/jakartaee/jobXML_2_0.xsd"/>
+            <replacefilter token="http://xmlns.jcp.org/xml/ns/javaee/jobXML_1_0.xsd" value="https://jakarta.ee/xml/ns/jakartaee/jobXML_2_0.xsd"/>
+            <replacefilter token="http://xmlns.jcp.org/xml/ns/javaee" value="https://jakarta.ee/xml/ns/jakartaee"/>
+            <replacefilter token="https://xmlns.jcp.org/xml/ns/javaee" value="https://jakarta.ee/xml/ns/jakartaee"/>
+            <replacefilter>
+                <!-- Use trailing &gt; to avoid matching <?xml version="1.0 ...>
+                     We know our job definition files always have a trailing &gt; after version="1.0" anyway. -->
+                <replacetoken>version="1.0"&gt;</replacetoken>
+                <replacevalue>version="2.0"&gt;</replacevalue>
+            </replacefilter>
+        </replace>
+    </target>
+</project>

--- a/jakarta/documentation/pom.xml
+++ b/jakarta/documentation/pom.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-parent-integrationtest-jakarta</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>../parents/integrationtest</relativePath>
+    </parent>
+    <artifactId>hibernate-search-documentation-jakarta</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Hibernate Search Documentation - Tests only - Jakarta EE</name>
+    <description>Re-execution of Hibernate Search reference documentation tests with Jakarta EE</description>
+
+    <properties>
+        <test.elasticsearch.run.skip>${test.elasticsearch.connection.uris.defined}</test.elasticsearch.run.skip>
+        <test.database.run.skip>false</test.database.run.skip>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${version.org.mockito}</version>
+                <exclusions>
+                    <!-- Bytebuddy is already imported by Hibernate ORM with a different version -->
+                    <exclusion>
+                        <groupId>net.bytebuddy</groupId>
+                        <artifactId>byte-buddy</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-mapper-orm-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-backend-lucene</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-backend-elasticsearch</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-backend-elasticsearch</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-backend-lucene</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-mapper-orm-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!--
+            Leave this dependency here, not in a utils module, so that we don't need to recompile
+            the utils to re-run the tests with a different database.
+         -->
+        <dependency>
+            <groupId>${jdbc.driver.groupId}</groupId>
+            <artifactId>${jdbc.driver.artifactId}</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- JSR-352 integration -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-mapper-orm-batch-jsr352-core-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-jbatch-runtime-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>it-lucene</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <reportNameSuffix>${surefire.environment}-${project.artifactId}-lucene</reportNameSuffix>
+                            <classpathDependencyExcludes>
+                                <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-elasticsearch</classpathDependencyExclude>
+                            </classpathDependencyExcludes>
+                            <systemPropertyVariables>
+                                <org.hibernate.search.integrationtest.backend.type>lucene</org.hibernate.search.integrationtest.backend.type>
+                            </systemPropertyVariables>
+                            <excludes>
+                                <exclude>**/Elasticsearch*IT</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>it-elasticsearch</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <reportNameSuffix>${surefire.environment}-${project.artifactId}-elasticsearch</reportNameSuffix>
+                            <classpathDependencyExcludes>
+                                <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-lucene</classpathDependencyExclude>
+                            </classpathDependencyExcludes>
+                            <systemPropertyVariables>
+                                <org.hibernate.search.integrationtest.backend.type>elasticsearch</org.hibernate.search.integrationtest.backend.type>
+                            </systemPropertyVariables>
+                            <excludes>
+                                <exclude>**/Lucene*IT</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>it-verify</id>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jakarta/integrationtest/jdk/java-modules/pom.xml
+++ b/jakarta/integrationtest/jdk/java-modules/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-integrationtest-jakarta</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>../../</relativePath>
+    </parent>
+    <artifactId>hibernate-search-integrationtest-java-modules-jakarta</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Hibernate Search ITs - JDK - Java modules - Jakarta EE</name>
+    <description>Hibernate Search integration tests for (JDK 11+) Java modules - Jakarta EE version</description>
+
+    <properties>
+        <transform.original.pathFromRoot>integrationtests/jdk/java-modules</transform.original.pathFromRoot>
+
+        <test.elasticsearch.run.skip>${test.elasticsearch.connection.uris.defined}</test.elasticsearch.run.skip>
+        <test.database.run.skip>false</test.database.run.skip>
+
+        <maven.compiler.release>11</maven.compiler.release>
+        <!-- Override the default from the parent POM: here we really do want to use the modulepath -->
+        <failsafe.useModulePath>true</failsafe.useModulePath>
+
+        <surefire.jvm.args.module>
+            -Dhibernate.search.backend.uris=${test.elasticsearch.connection.uris}
+            -Dhibernate.search.backend.username=${test.elasticsearch.connection.username}
+            -Dhibernate.search.backend.password=${test.elasticsearch.connection.password}
+            -Dhibernate.search.backend.aws.signing.enabled=${test.elasticsearch.connection.aws.signing.enabled}
+            -Dhibernate.search.backend.aws.region=${test.elasticsearch.connection.aws.region}
+            -Dhibernate.search.backend.aws.credentials.type=${test.elasticsearch.connection.aws.credentials.type}
+            -Dhibernate.search.backend.aws.credentials.access_key_id=${test.elasticsearch.connection.aws.credentials.access_key_id}
+            -Dhibernate.search.backend.aws.credentials.secret_access_key=${test.elasticsearch.connection.aws.credentials.secret_access_key}
+        </surefire.jvm.args.module>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm-jakarta</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-backend-elasticsearch</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${jdbc.driver.groupId}</groupId>
+            <artifactId>${jdbc.driver.artifactId}</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>it</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/jakarta/integrationtest/mapper/orm-batch-jsr352/pom.xml
+++ b/jakarta/integrationtest/mapper/orm-batch-jsr352/pom.xml
@@ -1,0 +1,229 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-integrationtest-jakarta</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-integrationtest-mapper-orm-batch-jsr352-jakarta</artifactId>
+
+    <name>Hibernate Search ITs - ORM - Batch JSR-352 - Jakarta EE</name>
+    <description>Hibernate Search integration tests for the Batch JSR-352 integration - Jakarta EE version</description>
+
+    <properties>
+        <transform.original.pathFromRoot>integrationtest/mapper/orm-batch-jsr352</transform.original.pathFromRoot>
+
+        <test.elasticsearch.run.skip>${test.elasticsearch.connection.uris.defined}</test.elasticsearch.run.skip>
+
+        <surefire.jvm.args.module>
+            -Dhibernate.search.backend.uris=${test.elasticsearch.connection.uris}
+            -Dhibernate.search.backend.username=${test.elasticsearch.connection.username}
+            -Dhibernate.search.backend.password=${test.elasticsearch.connection.password}
+            -Dhibernate.search.backend.aws.signing.enabled=${test.elasticsearch.connection.aws.signing.enabled}
+            -Dhibernate.search.backend.aws.region=${test.elasticsearch.connection.aws.region}
+            -Dhibernate.search.backend.aws.credentials.type=${test.elasticsearch.connection.aws.credentials.type}
+            -Dhibernate.search.backend.aws.credentials.access_key_id=${test.elasticsearch.connection.aws.credentials.access_key_id}
+            -Dhibernate.search.backend.aws.credentials.secret_access_key=${test.elasticsearch.connection.aws.credentials.secret_access_key}
+        </surefire.jvm.args.module>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${version.org.mockito}</version>
+                <exclusions>
+                    <!-- Bytebuddy is already imported by Hibernate ORM with a different version -->
+                    <exclusion>
+                        <groupId>net.bytebuddy</groupId>
+                        <artifactId>byte-buddy</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm-batch-jsr352-core-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm-batch-jsr352-jberet-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-mapper-orm-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-backend-lucene</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-backend-elasticsearch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-backend-lucene</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-backend-elasticsearch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-jbatch-runtime-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-jberet-se-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!--
+            Leave this dependency here, not in a utils module, so that we don't need to recompile
+            the utils to re-run the tests with a different database.
+         -->
+        <dependency>
+            <groupId>${jdbc.driver.groupId}</groupId>
+            <artifactId>${jdbc.driver.artifactId}</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>it-lucene-jbatch</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <reportNameSuffix>${surefire.environment}-${project.artifactId}-lucene-jbatch</reportNameSuffix>
+                            <classpathDependencyExcludes>
+                                <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-elasticsearch</classpathDependencyExclude>
+                                <classpathDependencyExclude>org.hibernate.search:hibernate-search-util-internal-integrationtest-jberet-se-jakarta</classpathDependencyExclude>
+                                <classpathDependencyExclude>org.jberet:jberet-core</classpathDependencyExclude>
+                                <classpathDependencyExclude>org.jberet:jberet-se</classpathDependencyExclude>
+                            </classpathDependencyExcludes>
+                            <systemPropertyVariables>
+                                <org.hibernate.search.integrationtest.backend.type>lucene</org.hibernate.search.integrationtest.backend.type>
+                                <org.hibernate.search.integrationtest.jsr352.type>jbatch</org.hibernate.search.integrationtest.jsr352.type>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>it-lucene-jberet</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <reportNameSuffix>${surefire.environment}-${project.artifactId}-lucene-jberet</reportNameSuffix>
+                            <classpathDependencyExcludes>
+                                <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-elasticsearch</classpathDependencyExclude>
+                                <classpathDependencyExclude>org.hibernate.search:hibernate-search-util-internal-integrationtest-jbatch-runtime-jakarta</classpathDependencyExclude>
+                                <classpathDependencyExclude>com.ibm.jbatch:com.ibm.jbatch.container</classpathDependencyExclude>
+                            </classpathDependencyExcludes>
+                            <systemPropertyVariables>
+                                <org.hibernate.search.integrationtest.backend.type>lucene</org.hibernate.search.integrationtest.backend.type>
+                                <org.hibernate.search.integrationtest.jsr352.type>jberet</org.hibernate.search.integrationtest.jsr352.type>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>it-elasticsearch-jbatch</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <reportNameSuffix>${surefire.environment}-${project.artifactId}-elasticsearch-jbatch</reportNameSuffix>
+                            <classpathDependencyExcludes>
+                                <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-lucene</classpathDependencyExclude>
+                                <classpathDependencyExclude>org.hibernate.search:hibernate-search-util-internal-integrationtest-jberet-se-jakarta</classpathDependencyExclude>
+                                <classpathDependencyExclude>org.jberet:jberet-core</classpathDependencyExclude>
+                                <classpathDependencyExclude>org.jberet:jberet-se</classpathDependencyExclude>
+                            </classpathDependencyExcludes>
+                            <systemPropertyVariables>
+                                <org.hibernate.search.integrationtest.backend.type>elasticsearch</org.hibernate.search.integrationtest.backend.type>
+                                <org.hibernate.search.integrationtest.jsr352.type>jbatch</org.hibernate.search.integrationtest.jsr352.type>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>it-elasticsearch-jberet</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <reportNameSuffix>${surefire.environment}-${project.artifactId}-elasticsearch-jberet</reportNameSuffix>
+                            <classpathDependencyExcludes>
+                                <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-lucene</classpathDependencyExclude>
+                                <classpathDependencyExclude>org.hibernate.search:hibernate-search-util-internal-integrationtest-jbatch-runtime-jakarta</classpathDependencyExclude>
+                                <classpathDependencyExclude>com.ibm.jbatch:com.ibm.jbatch.container</classpathDependencyExclude>
+                            </classpathDependencyExcludes>
+                            <systemPropertyVariables>
+                                <org.hibernate.search.integrationtest.backend.type>elasticsearch</org.hibernate.search.integrationtest.backend.type>
+                                <org.hibernate.search.integrationtest.jsr352.type>jberet</org.hibernate.search.integrationtest.jsr352.type>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>it-verify</id>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>testWithJdk11+</id>
+            <activation>
+                <property>
+                    <name>java-version.test.release</name>
+                    <value>!8</value>
+                </property>
+            </activation>
+            <properties>
+                <!-- Weld performs illegal accesses to java.base to generate proxies, so we need to allow them -->
+                <surefire.jvm.args.module>
+                    --add-opens java.base/java.security=ALL-UNNAMED
+                    --add-opens java.base/java.lang=ALL-UNNAMED
+                </surefire.jvm.args.module>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>
+

--- a/jakarta/integrationtest/mapper/orm-cdi/pom.xml
+++ b/jakarta/integrationtest/mapper/orm-cdi/pom.xml
@@ -1,0 +1,109 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-integrationtest-jakarta</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-integrationtest-mapper-orm-cdi-jakarta</artifactId>
+
+    <name>Hibernate Search ITs - ORM - CDI - Jakarta EE</name>
+    <description>Hibernate Search integration tests for the Hibernate ORM integration with CDI - Jakarta EE version</description>
+
+    <properties>
+        <transform.original.pathFromRoot>integrationtest/mapper/orm-cdi</transform.original.pathFromRoot>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${version.org.mockito}</version>
+                <exclusions>
+                    <!-- Bytebuddy is already imported by Hibernate ORM with a different version -->
+                    <exclusion>
+                        <groupId>net.bytebuddy</groupId>
+                        <artifactId>byte-buddy</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-mapper-orm-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-shaded</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!--
+            Leave this dependency here, not in a utils module, so that we don't need to recompile
+            the utils to re-run the tests with a different database.
+         -->
+        <dependency>
+            <groupId>${jdbc.driver.groupId}</groupId>
+            <artifactId>${jdbc.driver.artifactId}</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>it</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>testWithJdk11+</id>
+            <activation>
+                <property>
+                    <name>java-version.test.release</name>
+                    <value>!8</value>
+                </property>
+            </activation>
+            <properties>
+                <!-- Weld performs illegal accesses to java.base to generate proxies, so we need to allow them -->
+                <surefire.jvm.args.module>
+                    --add-opens java.base/java.security=ALL-UNNAMED
+                    --add-opens java.base/java.lang=ALL-UNNAMED
+                </surefire.jvm.args.module>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>
+

--- a/jakarta/integrationtest/mapper/orm-coordination-database-polling/pom.xml
+++ b/jakarta/integrationtest/mapper/orm-coordination-database-polling/pom.xml
@@ -1,0 +1,106 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-integrationtest-jakarta</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-integrationtest-mapper-orm-coordination-database-polling-jakarta</artifactId>
+
+    <name>Hibernate Search ITs - ORM - Coordination - Database Polling - Jakarta EE</name>
+    <description>Hibernate Search integration tests for the Hibernate ORM integration using database polling as coordination strategy - Jakarta EE version</description>
+
+    <properties>
+        <transform.original.pathFromRoot>integrationtest/mapper/orm-coordination-database-polling</transform.original.pathFromRoot>
+
+        <test.database.run.skip>false</test.database.run.skip>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${version.org.mockito}</version>
+                <exclusions>
+                    <!-- Bytebuddy is already imported by Hibernate ORM with a different version -->
+                    <exclusion>
+                        <groupId>net.bytebuddy</groupId>
+                        <artifactId>byte-buddy</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm-coordination-database-polling-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-mapper-orm-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-integrationtest-mapper-orm-jakarta</artifactId>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!--
+            Leave this dependency here, not in a utils module, so that we don't need to recompile
+            the utils to re-run the tests with a different database.
+         -->
+        <dependency>
+            <groupId>${jdbc.driver.groupId}</groupId>
+            <artifactId>${jdbc.driver.artifactId}</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.takari.junit</groupId>
+            <artifactId>takari-cpsuite</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>it</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/jakarta/integrationtest/mapper/orm-envers/pom.xml
+++ b/jakarta/integrationtest/mapper/orm-envers/pom.xml
@@ -1,0 +1,92 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-integrationtest-jakarta</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-integrationtest-mapper-orm-envers-jakarta</artifactId>
+
+    <name>Hibernate Search ITs - ORM - Envers - Jakarta EE</name>
+    <description>Hibernate Search integration tests for the Hibernate ORM integration with Envers - Jakarta EE version</description>
+
+    <properties>
+        <transform.original.pathFromRoot>integrationtest/mapper/orm-envers</transform.original.pathFromRoot>
+
+        <test.database.run.skip>false</test.database.run.skip>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${version.org.mockito}</version>
+                <exclusions>
+                    <!-- Bytebuddy is already imported by Hibernate ORM with a different version -->
+                    <exclusion>
+                        <groupId>net.bytebuddy</groupId>
+                        <artifactId>byte-buddy</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-envers-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-mapper-orm-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!--
+            Leave this dependency here, not in a utils module, so that we don't need to recompile
+            the utils to re-run the tests with a different database.
+         -->
+        <dependency>
+            <groupId>${jdbc.driver.groupId}</groupId>
+            <artifactId>${jdbc.driver.artifactId}</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>it</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+

--- a/jakarta/integrationtest/mapper/orm-realbackend/pom.xml
+++ b/jakarta/integrationtest/mapper/orm-realbackend/pom.xml
@@ -1,0 +1,160 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-integrationtest-jakarta</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-integrationtest-mapper-orm-realbackend-jakarta</artifactId>
+
+    <name>Hibernate Search ITs - ORM - Real backend - Jakarta EE</name>
+    <description>Hibernate Search integration tests for the Hibernate ORM mapper with a real (non-mock) backend - Jakarta EE version</description>
+
+    <properties>
+        <transform.original.pathFromRoot>integrationtest/mapper/orm-realbackend</transform.original.pathFromRoot>
+
+        <test.elasticsearch.run.skip>${test.elasticsearch.connection.uris.defined}</test.elasticsearch.run.skip>
+        <test.database.run.skip>false</test.database.run.skip>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${version.org.mockito}</version>
+                <exclusions>
+                    <!-- Bytebuddy is already imported by Hibernate ORM with a different version -->
+                    <exclusion>
+                        <groupId>net.bytebuddy</groupId>
+                        <artifactId>byte-buddy</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm-coordination-database-polling-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-backend-lucene</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-backend-elasticsearch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-mapper-orm-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-backend-lucene</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-backend-elasticsearch</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!--
+            Leave this dependency here, not in a utils module, so that we don't need to recompile
+            the utils to re-run the tests with a different database.
+         -->
+        <dependency>
+            <groupId>${jdbc.driver.groupId}</groupId>
+            <artifactId>${jdbc.driver.artifactId}</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>it-lucene</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <reportNameSuffix>${surefire.environment}-${project.artifactId}-lucene</reportNameSuffix>
+                            <classpathDependencyExcludes>
+                                <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-elasticsearch</classpathDependencyExclude>
+                            </classpathDependencyExcludes>
+                            <systemPropertyVariables>
+                                <org.hibernate.search.integrationtest.backend.type>lucene</org.hibernate.search.integrationtest.backend.type>
+                            </systemPropertyVariables>
+                            <excludes>
+                                <exclude>org.hibernate.search.integrationtest.mapper.orm.realbackend.bootstrap.BackendTypeAutoDetectMultipleBackendTypesInClasspathIT</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>it-elasticsearch</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <reportNameSuffix>${surefire.environment}-${project.artifactId}-elasticsearch</reportNameSuffix>
+                            <classpathDependencyExcludes>
+                                <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-lucene</classpathDependencyExclude>
+                            </classpathDependencyExcludes>
+                            <systemPropertyVariables>
+                                <org.hibernate.search.integrationtest.backend.type>elasticsearch</org.hibernate.search.integrationtest.backend.type>
+                            </systemPropertyVariables>
+                            <excludes>
+                                <exclude>org.hibernate.search.integrationtest.mapper.orm.realbackend.bootstrap.BackendTypeAutoDetectMultipleBackendTypesInClasspathIT</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>it-multiplebackends</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <reportNameSuffix>${surefire.environment}-${project.artifactId}-multiplebackends</reportNameSuffix>
+                            <includes>
+                                <include>org.hibernate.search.integrationtest.mapper.orm.realbackend.bootstrap.BackendTypeAutoDetectMultipleBackendTypesInClasspathIT</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>it-verify</id>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+

--- a/jakarta/integrationtest/mapper/orm/pom.xml
+++ b/jakarta/integrationtest/mapper/orm/pom.xml
@@ -1,0 +1,105 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-integrationtest-jakarta</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-integrationtest-mapper-orm-jakarta</artifactId>
+
+    <name>Hibernate Search ITs - ORM - Jakarta EE</name>
+    <description>Hibernate Search integration tests for the Hibernate ORM integration - Jakarta EE version</description>
+
+    <properties>
+        <transform.original.pathFromRoot>integrationtest/mapper/orm</transform.original.pathFromRoot>
+
+        <test.database.run.skip>false</test.database.run.skip>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${version.org.mockito}</version>
+                <exclusions>
+                    <!-- Bytebuddy is already imported by Hibernate ORM with a different version -->
+                    <exclusion>
+                        <groupId>net.bytebuddy</groupId>
+                        <artifactId>byte-buddy</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-mapper-orm-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!--
+            Leave this dependency here, not in a utils module, so that we don't need to recompile
+            the utils to re-run the tests with a different database.
+         -->
+        <dependency>
+            <groupId>${jdbc.driver.groupId}</groupId>
+            <artifactId>${jdbc.driver.artifactId}</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.takari.junit</groupId>
+            <artifactId>takari-cpsuite</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>it</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+

--- a/jakarta/integrationtest/pom.xml
+++ b/jakarta/integrationtest/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-parent-integrationtest-jakarta</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>../parents/integrationtest</relativePath>
+    </parent>
+    <artifactId>hibernate-search-integrationtest-jakarta</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Hibernate Search ITs - Jakarta EE - Aggregator POM</name>
+    <description>Aggregator POM of Hibernate Search Jakarta EE integration tests (except documentation)</description>
+
+    <modules>
+        <module>mapper/orm</module>
+        <module>mapper/orm-cdi</module>
+        <module>mapper/orm-envers</module>
+        <module>mapper/orm-realbackend</module>
+        <module>mapper/orm-coordination-database-polling</module>
+        <module>mapper/orm-batch-jsr352</module>
+        <module>v5migrationhelper/orm</module>
+    </modules>
+
+    <profiles>
+        <profile>
+            <id>javaModuleITs</id>
+            <activation>
+                <property>
+                    <name>java-version.test.release</name>
+                    <value>!8</value>
+                </property>
+            </activation>
+            <modules>
+                <module>jdk/java-modules</module>
+            </modules>
+        </profile>
+    </profiles>
+</project>
+

--- a/jakarta/integrationtest/v5migrationhelper/orm/pom.xml
+++ b/jakarta/integrationtest/v5migrationhelper/orm/pom.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-parent-integrationtest-jakarta</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>../../../parents/integrationtest/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>hibernate-search-integrationtest-v5migrationhelper-orm-jakarta</artifactId>
+
+    <name>Hibernate Search ITs - Migration Helper - ORM - Jakarta EE</name>
+    <description>Hibernate Search integration tests for the migration helper for Hibernate ORM - Jakarta EE version</description>
+
+    <properties>
+        <transform.original.pathFromRoot>integrationtests/v5migrationhelper/orm</transform.original.pathFromRoot>
+
+        <!-- This is based on legacy code and there are plenty of problems that we don't care to fix -->
+        <jqassistant.skip>true</jqassistant.skip>
+        <forbiddenapis.skip>true</forbiddenapis.skip>
+        <sonar.skip>true</sonar.skip>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${version.org.mockito}</version>
+                <exclusions>
+                    <!-- Bytebuddy is already imported by Hibernate ORM with a different version -->
+                    <exclusion>
+                        <groupId>net.bytebuddy</groupId>
+                        <artifactId>byte-buddy</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-v5migrationhelper-orm-jakarta</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-v5migrationhelper</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-mapper-orm-jakarta</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${jdbc.driver.groupId}</groupId>
+            <artifactId>${jdbc.driver.artifactId}</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-envers-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-testing-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- This is based on legacy code and there are plenty of warnings that we don't care to fix -->
+                    <failOnWarning>false</failOnWarning>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Tests are suffixed with *Test instead of *IT,
+                            but they really are integration tests: don't execute them with surefire -->
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>it</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/*IT.java</include>
+                                <!--
+                                    Warning: do not use a permissive wildcard such as '**/*.java',
+                                    as it would results in bugs such as HSEARCH-2481,
+                                    where Failsafe ended up loading every class from the classpath.
+                                    Here we use the default surefire patterns documented there:
+                                    http://maven.apache.org/surefire/maven-surefire-plugin/examples/inclusion-exclusion.html
+                                 -->
+                                <include>**/Test*.java</include>
+                                <include>**/*Test.java</include>
+                                <include>**/*Tests.java</include>
+                                <include>**/*TestCase.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jakarta/mapper/orm-batch-jsr352/core/pom.xml
+++ b/jakarta/mapper/orm-batch-jsr352/core/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-parent-public-jakarta</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>../../../parents/public/pom.xml</relativePath>
+    </parent>
+    <artifactId>hibernate-search-mapper-orm-batch-jsr352-core-jakarta</artifactId>
+
+    <name>Hibernate Search Batch JSR-352 Core - Jakarta EE</name>
+    <description>Core of the Hibernate Search Batch JSR-352 integration - Jakarta EE version</description>
+
+    <properties>
+        <transform.original.pathFromRoot>mapper/orm-batch-jsr352/core</transform.original.pathFromRoot>
+
+        <java.module.name>org.hibernate.search.batch.jsr352.core</java.module.name>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${version.org.mockito}</version>
+                <exclusions>
+                    <!-- Bytebuddy is already imported by Hibernate ORM with a different version -->
+                    <exclusion>
+                        <groupId>net.bytebuddy</groupId>
+                        <artifactId>byte-buddy</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm-jakarta</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.batch</groupId>
+            <artifactId>jakarta.batch-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jakarta/mapper/orm-batch-jsr352/jberet/pom.xml
+++ b/jakarta/mapper/orm-batch-jsr352/jberet/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-parent-public-jakarta</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>../../../parents/public/pom.xml</relativePath>
+    </parent>
+    <artifactId>hibernate-search-mapper-orm-batch-jsr352-jberet-jakarta</artifactId>
+    
+    <name>Hibernate Search Batch JSR-352 JBeret - Jakarta EE</name>
+    <description>Hibernate Search Batch JSR-352 integration - for JBeret - Jakarta EE version</description>
+
+    <properties>
+        <transform.original.pathFromRoot>mapper/orm-batch-jsr352/jberet</transform.original.pathFromRoot>
+
+        <java.module.name>org.hibernate.search.batch.jsr352.jberet</java.module.name>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${version.org.mockito}</version>
+                <exclusions>
+                    <!-- Bytebuddy is already imported by Hibernate ORM with a different version -->
+                    <exclusion>
+                        <groupId>net.bytebuddy</groupId>
+                        <artifactId>byte-buddy</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm-batch-jsr352-core-jakarta</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.batch</groupId>
+            <artifactId>jakarta.batch-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jberet</groupId>
+            <artifactId>jberet-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jakarta/mapper/orm-coordination-database-polling/pom.xml
+++ b/jakarta/mapper/orm-coordination-database-polling/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0"?>
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-parent-public-jakarta</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>../../parents/public</relativePath>
+    </parent>
+    <artifactId>hibernate-search-mapper-orm-coordination-database-polling-jakarta</artifactId>
+
+    <name>Hibernate Search ORM Integration - Coordination - Database Polling - Jakarta EE</name>
+    <description>Hibernate ORM integration using database polling as coordination strategy - Jakarta EE version</description>
+
+    <properties>
+        <transform.original.pathFromRoot>mapper/orm-coordination-database-polling</transform.original.pathFromRoot>
+
+        <java.module.name>org.hibernate.search.mapper.orm.coordination.databasepolling</java.module.name>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm-jakarta</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <!-- We use Avro-generated DTOs instead of GenericRecord,
+                       because that allows us to write type-safe code
+                       to convert between Hibernate Search objects and Avro objects (DTOs) -->
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>schema</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirectory>${transform.output.root.path}/main/avro/</sourceDirectory>
+                            <outputDirectory>${project.basedir}/target/generated-sources/avro/</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-generated-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>target/generated-sources/avro</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jakarta/mapper/orm/pom.xml
+++ b/jakarta/mapper/orm/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0"?>
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-parent-public-jakarta</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>../../parents/public</relativePath>
+    </parent>
+    <artifactId>hibernate-search-mapper-orm-jakarta</artifactId>
+
+    <name>Hibernate Search ORM Integration - Jakarta EE</name>
+    <description>Hibernate Search integration to Hibernate ORM - Jakarta EE version</description>
+
+    <properties>
+        <transform.original.pathFromRoot>mapper/orm</transform.original.pathFromRoot>
+
+        <java.module.name>org.hibernate.search.mapper.orm</java.module.name>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-pojo-base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core-jakarta</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.common</groupId>
+            <artifactId>hibernate-commons-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <!-- Bytebuddy is already imported by Hibernate ORM with a different version -->
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/jakarta/parents/integrationtest/pom.xml
+++ b/jakarta/parents/integrationtest/pom.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-parent-integrationtest</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>../../../parents/integrationtest</relativePath>
+    </parent>
+    <artifactId>hibernate-search-parent-integrationtest-jakarta</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Hibernate Search Parent POM for Integration Test Artifacts - Jakarta EE</name>
+    <description>Common build configuration for all Jakarta EE integration test artifacts (including documentation)</description>
+
+    <properties>
+        <!-- JQAssistant does not seem to work correctly on these artifacts for some reason -->
+        <jqassistant.skip>true</jqassistant.skip>
+        <!-- Prevent these modules from artificially affecting Sonar metrics -->
+        <sonar.skip>true</sonar.skip>
+
+        <!-- To be set by child modules -->
+        <transform.original.pathFromRoot></transform.original.pathFromRoot>
+        <transform.original.path>${rootProject.directory}/${transform.original.pathFromRoot}</transform.original.path>
+        <transform.output.root.path>${project.build.directory}/copied-sources/</transform.output.root.path>
+        <transform.output.main.sources.path>${transform.output.root.path}/main/java</transform.output.main.sources.path>
+        <transform.output.main.resources.path>${transform.output.root.path}/main/resources</transform.output.main.resources.path>
+        <transform.output.test.sources.path>${transform.output.root.path}/test/java</transform.output.test.sources.path>
+        <transform.output.test.resources.path>${transform.output.root.path}/test/resources</transform.output.test.resources.path>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.weld.se</groupId>
+                <artifactId>weld-se-shaded</artifactId>
+                <version>${version.org.jboss.weld.jakarta}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jberet</groupId>
+                <artifactId>jberet-core</artifactId>
+                <version>${version.org.jberet.jakarta}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jberet</groupId>
+                <artifactId>jberet-se</artifactId>
+                <version>${version.org.jberet.jakarta}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-mapper-orm-jakarta</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-v5migrationhelper-jakarta</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-jbatch-runtime-jakarta</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-jberet-se-jakarta</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>3.0.0</version>
+                    <executions>
+                        <execution>
+                            <id>copy-and-transform-sources</id>
+                            <phase>initialize</phase>
+                            <goals>
+                                <goal>run</goal>
+                            </goals>
+                            <configuration>
+                                <!-- WARNING: if you update this, make sure to update the "integrationtest" parent POM, too -->
+                                <target>
+                                    <ant dir="${rootProject.directory}/jakarta/" antfile="ant-copy-and-transform-sources.xml">
+                                        <target name="copy"/>
+                                        <target name="transform"/>
+                                    </ant>
+                                </target>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>replace-javax-with-jakarta</id>
+                            <phase>initialize</phase>
+                            <goals>
+                                <goal>run</goal>
+                            </goals>
+                            <configuration>
+                                <!-- WARNING: if you update this, make sure to update the "integrationtest" parent POM, too -->
+                                <target name="replace-javax" if="transform.output.present">
+                                    <!-- https://ant.apache.org/manual/Tasks/replace.html -->
+                                    <replace dir="${transform.output.root.path}" token="javax.persistence" value="jakarta.persistence" />
+                                    <replace dir="${transform.output.root.path}" token="javax.transaction" value="jakarta.transaction" />
+                                    <replace dir="${transform.output.root.path}" token="javax.enterprise" value="jakarta.enterprise" />
+                                </target>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-sources-copy</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${transform.output.main.sources.path}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-resources-copy</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${transform.output.main.resources.path}</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-test-sources-copy</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${transform.output.test.sources.path}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-test-resources-copy</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>add-test-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${transform.output.test.resources.path}</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/jakarta/parents/public/pom.xml
+++ b/jakarta/parents/public/pom.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-parent-public</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>../../../parents/public</relativePath>
+    </parent>
+    <artifactId>hibernate-search-parent-public-jakarta</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Hibernate Search Parent POM for Public Artifacts - Jakarta EE</name>
+    <description>Common build configuration for all Jakarta EE public artifacts</description>
+
+    <properties>
+        <!-- JQAssistant does not seem to work correctly on these artifacts for some reason -->
+        <jqassistant.skip>true</jqassistant.skip>
+        <!-- Prevent these modules from artificially affecting Sonar metrics -->
+        <sonar.skip>true</sonar.skip>
+
+        <!-- To be set by child modules -->
+        <transform.original.pathFromRoot></transform.original.pathFromRoot>
+        <transform.original.path>${rootProject.directory}/${transform.original.pathFromRoot}</transform.original.path>
+        <transform.output.root.path>${project.build.directory}/copied-sources</transform.output.root.path>
+        <transform.output.main.sources.path>${transform.output.root.path}/main/java</transform.output.main.sources.path>
+        <transform.output.main.resources.path>${transform.output.root.path}/main/resources</transform.output.main.resources.path>
+        <transform.output.test.sources.path>${transform.output.root.path}/test/java</transform.output.test.sources.path>
+        <transform.output.test.resources.path>${transform.output.root.path}/test/resources</transform.output.test.resources.path>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jberet</groupId>
+                <artifactId>jberet-core</artifactId>
+                <version>${version.org.jberet.jakarta}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>3.0.0</version>
+                    <executions>
+                        <execution>
+                            <id>copy-and-transform-sources</id>
+                            <phase>initialize</phase>
+                            <goals>
+                                <goal>run</goal>
+                            </goals>
+                            <configuration>
+                                <!-- WARNING: if you update this, make sure to update the "integrationtest" parent POM, too -->
+                                <target>
+                                    <ant dir="${rootProject.directory}/jakarta/" antfile="ant-copy-and-transform-sources.xml">
+                                        <target name="copy"/>
+                                        <target name="transform"/>
+                                    </ant>
+                                </target>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-sources-copy</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${transform.output.main.sources.path}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-resources-copy</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${transform.output.main.resources.path}</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-test-sources-copy</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${transform.output.test.sources.path}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-test-resources-copy</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>add-test-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${transform.output.test.resources.path}</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jakarta/pom.xml
+++ b/jakarta/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-parent</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-jakarta</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Hibernate Search Aggregator POM for Jakarta EE Artifacts</name>
+    <description>Hibernate Search Aggregator POM for Jakarta EE Artifacts</description>
+
+    <modules>
+        <module>parents/public</module>
+        <module>mapper/orm</module>
+        <module>mapper/orm-coordination-database-polling</module>
+        <module>mapper/orm-batch-jsr352/core</module>
+        <module>mapper/orm-batch-jsr352/jberet</module>
+        <module>v5migrationhelper/orm</module>
+        <module>util/internal/integrationtest</module>
+        <module>parents/integrationtest</module>
+        <module>integrationtest</module>
+        <module>documentation</module>
+    </modules>
+</project>
+

--- a/jakarta/util/internal/integrationtest/jbatch-runtime/pom.xml
+++ b/jakarta/util/internal/integrationtest/jbatch-runtime/pom.xml
@@ -1,0 +1,63 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-util-internal-integrationtest-jakarta</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-util-internal-integrationtest-jbatch-runtime-jakarta</artifactId>
+
+    <name>Hibernate Search Utils - Internal - ITs - JBatch Runtime - Jakarta EE</name>
+    <description>JBatch-runtime and runtime dependencies - Jakarta EE version</description>
+
+    <properties>
+        <transform.original.pathFromRoot>util/internal/integrationtest/jbatch-runtime</transform.original.pathFromRoot>
+    </properties>
+
+    <!--
+         This module is only necessary because the JBatch project takes the dubious approach
+         of defining most (all?) of its dependencies as provided.
+         So, we have to re-declare them all, with the right version.
+         Welcome to 1999.
+     -->
+    <dependencies>
+        <dependency>
+            <groupId>com.ibm.jbatch</groupId>
+            <artifactId>com.ibm.jbatch.container</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.batch</groupId>
+            <artifactId>jakarta.batch-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <!--
+            JBatch requires a database in order to work, and it seems it uses SQL that won't work with H2.
+            Anyway, it uses an embedded Derby instance by default, so we just put the Derby driver in the classpath
+            so it won't complain.
+         -->
+        <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derby</artifactId>
+            <version>${version.org.apache.derby}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+

--- a/jakarta/util/internal/integrationtest/jberet-se/pom.xml
+++ b/jakarta/util/internal/integrationtest/jberet-se/pom.xml
@@ -1,0 +1,101 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-util-internal-integrationtest-jakarta</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-util-internal-integrationtest-jberet-se-jakarta</artifactId>
+
+    <name>Hibernate Search Utils - Internal - ITs - JBeret SE - Jakarta EE</name>
+    <description>JBeret-SE and runtime dependencies - Jakarta EE version</description>
+
+    <properties>
+        <transform.original.pathFromRoot>util/internal/integrationtest/jberet-se</transform.original.pathFromRoot>
+    </properties>
+
+    <!--
+         This module is only necessary because the JBeret project takes the dubious approach
+         of defining some of its dependencies as provided.
+         So, we have to re-declare them all, with the right version.
+         Welcome to 1999.
+     -->
+    <dependencies>
+        <!-- JBeret-Core and dependencies -->
+        <dependency>
+            <groupId>org.jberet</groupId>
+            <artifactId>jberet-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.batch</groupId>
+            <artifactId>javax.batch-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.transaction</groupId>
+            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.marshalling</groupId>
+            <artifactId>jboss-marshalling</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-security-manager</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- JBeret-SE and additional dependencies -->
+        <dependency>
+            <groupId>org.jberet</groupId>
+            <artifactId>jberet-se</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-shaded</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${version.com.h2database}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+

--- a/jakarta/util/internal/integrationtest/mapper/orm/pom.xml
+++ b/jakarta/util/internal/integrationtest/mapper/orm/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-util-internal-integrationtest-jakarta</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-util-internal-integrationtest-mapper-orm-jakarta</artifactId>
+
+    <name>Hibernate Search Utils - Internal - ITs - ORM Mapper - Jakarta EE</name>
+    <description>Hibernate Search integration testing utilities for tests involving the Hibernate ORM Mapper - Jakarta EE version</description>
+
+    <properties>
+        <transform.original.pathFromRoot>util/internal/integrationtest/mapper/orm</transform.original.pathFromRoot>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${version.org.mockito}</version>
+                <exclusions>
+                    <!-- Bytebuddy is already imported by Hibernate ORM with a different version -->
+                    <exclusion>
+                        <groupId>net.bytebuddy</groupId>
+                        <artifactId>byte-buddy</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm-jakarta</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core-jakarta</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-testing-jakarta</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+

--- a/jakarta/util/internal/integrationtest/pom.xml
+++ b/jakarta/util/internal/integrationtest/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-parent-integrationtest-jakarta</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>../../../parents/integrationtest</relativePath>
+    </parent>
+    <artifactId>hibernate-search-util-internal-integrationtest-jakarta</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Hibernate Search Utils - Internal - ITs - Jakarta EE - Aggregator POM</name>
+    <description>Aggregator POM of Hibernate Search integration testing utilities</description>
+
+    <modules>
+        <module>mapper/orm</module>
+        <module>jbatch-runtime</module>
+        <module>jberet-se</module>
+    </modules>
+</project>
+

--- a/jakarta/v5migrationhelper/orm/pom.xml
+++ b/jakarta/v5migrationhelper/orm/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>hibernate-search-parent-public-jakarta</artifactId>
+        <groupId>org.hibernate.search</groupId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>../../parents/public/pom.xml</relativePath>
+    </parent>
+    <artifactId>hibernate-search-v5migrationhelper-orm-jakarta</artifactId>
+
+    <name>Hibernate Search 5 Migration Helper - ORM - Jakarta EE</name>
+    <description>Helper to migrate from Hibernate Search 5 to 6, providing partial support for Hibernate Search 5 ORM APIs on top of Hibernate Search 6 - with Jakarta EE</description>
+
+    <properties>
+        <transform.original.pathFromRoot>v5migrationhelper/orm</transform.original.pathFromRoot>
+
+        <java.module.name>org.hibernate.search.v5migrationhelper.orm</java.module.name>
+
+        <!-- This is based on legacy code and there are plenty of problems that we don't care to fix -->
+        <jqassistant.skip>true</jqassistant.skip>
+        <forbiddenapis.skip>true</forbiddenapis.skip>
+        <sonar.skip>true</sonar.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-v5migrationhelper-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm-jakarta</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- This is based on legacy code and there are plenty of warnings that we don't care to fix -->
+                    <failOnWarning>false</failOnWarning>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java
@@ -30,7 +30,6 @@ import org.hibernate.TypeMismatchException;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.RootGraph;
-import org.hibernate.jpa.QueryHints;
 import org.hibernate.query.Query;
 import org.hibernate.query.QueryParameter;
 import org.hibernate.query.internal.AbstractProducedQuery;
@@ -42,6 +41,7 @@ import org.hibernate.search.engine.search.query.spi.SearchQueryImplementor;
 import org.hibernate.search.mapper.orm.logging.impl.Log;
 import org.hibernate.search.mapper.orm.loading.impl.EntityGraphHint;
 import org.hibernate.search.mapper.orm.loading.impl.MutableEntityLoadingOptions;
+import org.hibernate.search.mapper.orm.search.query.spi.HibernateOrmSearchQueryHints;
 import org.hibernate.search.mapper.orm.search.query.spi.HibernateOrmSearchScrollableResultsAdapter;
 import org.hibernate.search.mapper.orm.search.query.spi.HibernateOrmSearchScrollableResultsAdapter.ScrollHitExtractor;
 import org.hibernate.search.util.common.SearchTimeoutException;
@@ -166,19 +166,18 @@ public final class HibernateOrmSearchQueryAdapter<R> extends AbstractProducedQue
 	}
 
 	@Override
-	@SuppressWarnings("deprecation")
 	public HibernateOrmSearchQueryAdapter<R> setHint(String hintName, Object value) {
 		switch ( hintName ) {
-			case QueryHints.SPEC_HINT_TIMEOUT:
+			case HibernateOrmSearchQueryHints.TIMEOUT_JPA:
 				delegate.failAfter( hintValueToLong( value ), TimeUnit.MILLISECONDS );
 				break;
-			case QueryHints.HINT_TIMEOUT:
+			case HibernateOrmSearchQueryHints.TIMEOUT_HIBERNATE:
 				setTimeout( hintValueToInteger( value ) );
 				break;
-			case "javax.persistence.fetchgraph":
+			case HibernateOrmSearchQueryHints.FETCHGRAPH:
 				applyGraph( hintValueToEntityGraph( value ), GraphSemantic.FETCH );
 				break;
-			case "javax.persistence.loadgraph":
+			case HibernateOrmSearchQueryHints.LOADGRAPH:
 				applyGraph( hintValueToEntityGraph( value ), GraphSemantic.LOAD );
 				break;
 			default:

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/query/spi/HibernateOrmSearchQueryHints.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/query/spi/HibernateOrmSearchQueryHints.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.orm.search.query.spi;
+
+/**
+ * Constants for query hints accepted by Hibernate Search.
+ * <p>
+ * We redefine the constants here instead of using those exposed by Hibernate ORM,
+ * because the constants from Hibernate ORM are not transformed currently
+ * in some versions of the Jakarta artifacts (they start with "javax.persistence." instead of "jakarta.persistence.").
+ * By defining the constants directly in our project, we can transform the constants correctly
+ * in our own Jakarta artifacts.
+ */
+public final class HibernateOrmSearchQueryHints {
+	private HibernateOrmSearchQueryHints() {
+	}
+
+	public static final String TIMEOUT_JPA = "javax.persistence.query.timeout";
+	public static final String TIMEOUT_HIBERNATE = "org.hibernate.timeout";
+	public static final String FETCHGRAPH = "javax.persistence.fetchgraph";
+	public static final String LOADGRAPH = "javax.persistence.loadgraph";
+}

--- a/parents/public/pom.xml
+++ b/parents/public/pom.xml
@@ -91,6 +91,11 @@
                                 <url>${javadoc.javaee.url}</url>
                                 <location>${javadoc.packagelists.directory}/batch-api</location>
                             </offlineLink>
+                            <!-- For jakarta.batch in the JSR 352 modules -->
+                            <offlineLink>
+                                <url>${javadoc.jakarta.batch.url}</url>
+                                <location>${javadoc.packagelists.directory}/batch-api</location>
+                            </offlineLink>
                         </offlineLinks>
                         <bottom>
                             <![CDATA[Copyright &copy; ${project.inceptionYear}-{currentYear} <a href="https://www.redhat.com/">Red Hat, Inc.</a> and others. Licensed under the GNU Lesser General Public License (LGPL), version 2.1 or later.]]>

--- a/pom.xml
+++ b/pom.xml
@@ -1413,6 +1413,16 @@
                             <versionString>${version.javax.persistence}</versionString>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>parse-jakarta-persistence-version</id>
+                        <goals>
+                            <goal>parse-version</goal>
+                        </goals>
+                        <configuration>
+                            <propertyPrefix>parsed-version.jakarta.persistence</propertyPrefix>
+                            <versionString>${version.jakarta.persistence}</versionString>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <!-- Skip the deploy plugin explicitly: we use nexus-staging-maven-plugin instead -->

--- a/pom.xml
+++ b/pom.xml
@@ -486,12 +486,6 @@
         <failsafe.spring.skip>${skipITs}</failsafe.spring.skip>
 
         <!--
-            Should be set by submodules.
-            Used by integration tests modules that execute tests from another module.
-            Allows to distinguish between multiple executions of the same test in test reports.
-         -->
-        <surefire.executing-module>default</surefire.executing-module>
-        <!--
             Should be set from the command line.
             Used by CI jobs that execute tests in multiple environments.
             Allows to distinguish between multiple executions of the same test in test reports.
@@ -1794,7 +1788,7 @@
                         </systemPropertyVariables>
                         <jvm>${java-version.test.launcher}</jvm>
                         <argLine>${surefire.jvm.args}</argLine>
-                        <reportNameSuffix>${surefire.environment}-${surefire.executing-module}</reportNameSuffix>
+                        <reportNameSuffix>${surefire.environment}-${project.artifactId}</reportNameSuffix>
                     </configuration>
                     <dependencies>
                         <!--
@@ -1843,7 +1837,7 @@
                         </systemPropertyVariables>
                         <jvm>${java-version.test.launcher}</jvm>
                         <argLine>${failsafe.jvm.args}</argLine>
-                        <reportNameSuffix>${surefire.environment}-${surefire.executing-module}</reportNameSuffix>
+                        <reportNameSuffix>${surefire.reportNameSuffix}</reportNameSuffix>
                     </configuration>
                     <dependencies>
                         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,7 @@
         <module>util/internal/integrationtest</module>
         <module>parents/integrationtest</module>
         <module>integrationtest</module>
+        <module>jakarta</module>
         <module>documentation</module>
     </modules>
 
@@ -253,19 +254,31 @@
         <documentation.org.hibernate.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.majorVersion}.${parsed-version.org.hibernate.minorVersion}/userguide/html_single/Hibernate_User_Guide.html</documentation.org.hibernate.url>
         <version.org.hibernate.commons.annotations>5.1.2.Final</version.org.hibernate.commons.annotations>
         <version.javax.persistence>2.2</version.javax.persistence>
+        <version.jakarta.persistence>3.0.0</version.jakarta.persistence>
 
         <!-- >>> JSR 352 -->
         <version.javax.batch>1.0.1</version.javax.batch>
+        <version.jakarta.batch>2.0.0</version.jakarta.batch>
         <version.org.jberet>1.4.0.Final</version.org.jberet>
+        <version.org.jberet.jakarta>2.0.2.Final</version.org.jberet.jakarta>
 
         <!-- >>> Java EE/Jakarta EE dependencies -->
         <!-- Used in the JSR352 integration in particular, but also in the ORM integration (?) and various tests -->
         <version.javax.inject>1</version.javax.inject>
+        <version.jakarta.inject-api>2.0.0</version.jakarta.inject-api>
         <version.javax.enterprise>2.0</version.javax.enterprise>
+        <version.jakarta.enterprise>3.0.0</version.jakarta.enterprise>
         <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>1.0.2.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>
+        <version.jakarta.annotation>2.0.0</version.jakarta.annotation>
         <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>1.1.1.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>
+        <!-- We need dependency management on these ones to avoid a dependency divergence created by Hibernate ORM
+             Ideally, we should remove this dependency management when Hibernate ORM fixes that dependency divergence.
+         -->
+        <version.jakarta.xml.bind>3.0.1</version.jakarta.xml.bind>
+        <version.jakarta.activation>2.0.1</version.jakarta.activation>
         <!-- This is used to generate a link to the Java EE javadoc -->
         <javadoc.javaee.url>https://javaee.github.io/javaee-spec/javadocs/</javadoc.javaee.url>
+        <javadoc.jakarta.batch.url>https://jakarta.ee/specifications/batch/2.0/apidocs/</javadoc.jakarta.batch.url>
 
         <!-- Test dependencies -->
 
@@ -285,12 +298,14 @@
         <version.org.apache.commons.math3>3.2</version.org.apache.commons.math3>
         <version.org.apache.avro>1.10.2</version.org.apache.avro>
         <version.org.jboss.weld>3.1.5.SP1</version.org.jboss.weld>
+        <version.org.jboss.weld.jakarta>4.0.2.Final</version.org.jboss.weld.jakarta>
 
         <!-- >>> Performance tests -->
         <version.org.openjdk.jmh>1.23</version.org.openjdk.jmh>
 
         <!-- >>> JSR 352: JBatch runtime -->
         <version.com.ibm.jbatch>1.0</version.com.ibm.jbatch>
+        <version.com.ibm.jbatch.jakarta>2.0.0</version.com.ibm.jbatch.jakarta>
         <version.org.apache.derby>10.13.1.1</version.org.apache.derby>
 
         <!-- >>> JSR 352: JBeret SE dependencies -->
@@ -667,6 +682,11 @@
             </dependency>
             <dependency>
                 <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-mapper-orm-jakarta</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-v5migrationhelper-engine</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -677,7 +697,17 @@
             </dependency>
             <dependency>
                 <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-v5migrationhelper-orm-jakarta</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-mapper-orm-batch-jsr352-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-mapper-orm-batch-jsr352-core-jakarta</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -687,7 +717,17 @@
             </dependency>
             <dependency>
                 <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-mapper-orm-batch-jsr352-jberet-jakarta</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-mapper-orm-coordination-database-polling</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-mapper-orm-coordination-database-polling-jakarta</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -774,7 +814,17 @@
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-core-jakarta</artifactId>
+                <version>${version.org.hibernate}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-envers</artifactId>
+                <version>${version.org.hibernate}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-envers-jakarta</artifactId>
                 <version>${version.org.hibernate}</version>
             </dependency>
             <dependency>
@@ -847,7 +897,11 @@
                 <groupId>javax.persistence</groupId>
                 <artifactId>javax.persistence-api</artifactId>
                 <version>${version.javax.persistence}</version>
-                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.persistence</groupId>
+                <artifactId>jakarta.persistence-api</artifactId>
+                <version>${version.jakarta.persistence}</version>
             </dependency>
             <dependency>
                 <groupId>javax.enterprise</groupId>
@@ -856,10 +910,19 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>${version.jakarta.enterprise}</version>
+            </dependency>
+            <dependency>
                 <groupId>javax.inject</groupId>
                 <artifactId>javax.inject</artifactId>
                 <version>${version.javax.inject}</version>
-                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
+                <version>${version.jakarta.inject-api}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.spec.javax.annotation</groupId>
@@ -878,6 +941,24 @@
                 <artifactId>javax.batch-api</artifactId>
                 <version>${version.javax.batch}</version>
                 <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.batch</groupId>
+                <artifactId>jakarta.batch-api</artifactId>
+                <version>${version.jakarta.batch}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- Fixes for dependency divergence in Hibernate ORM -->
+            <dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>${version.jakarta.xml.bind}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.activation</groupId>
+                <artifactId>jakarta.activation</artifactId>
+                <version>${version.jakarta.activation}</version>
             </dependency>
 
             <!-- Jackson: used by the Elasticsearch REST client and in tests (wiremock, ...) -->
@@ -1037,12 +1118,29 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-testing-jakarta</artifactId>
+                <version>${version.org.hibernate}</version>
+                <exclusions>
+                    <!-- we use Log4J 2 -->
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
 
             <!-- JBatch runtime -->
             <dependency>
                 <groupId>com.ibm.jbatch</groupId>
                 <artifactId>com.ibm.jbatch-runtime</artifactId>
                 <version>${version.com.ibm.jbatch}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.ibm.jbatch</groupId>
+                <artifactId>com.ibm.jbatch.container</artifactId>
+                <version>${version.com.ibm.jbatch.jakarta}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.derby</groupId>
@@ -1475,6 +1573,8 @@
                                 <!-- Disable usage of the @Generated annotation: too much trouble as requirements are different across JDK8 vs JDK9 -->
                                 <!-- See also: https://github.com/jboss-logging/jboss-logging-tools/pull/60#issuecomment-293088198 -->
                                 <compilerArguments>-Aorg.jboss.logging.tools.addGeneratedAnnotation=false</compilerArguments>
+                                <!-- Necessary for the Jakarta artifacts, where sources are copied from other modules -->
+                                <addCompileSourceRoots>true</addCompileSourceRoots>
                             </configuration>
                         </execution>
                     </executions>
@@ -1991,6 +2091,10 @@
                             <version>${version.org.codehaus.groovy-jsr223}</version> <!-- look for latest -->
                         </dependency>
                     </dependencies>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>3.0.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/util/internal/integrationtest/backend/elasticsearch/pom.xml
+++ b/util/internal/integrationtest/backend/elasticsearch/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.hibernate.search</groupId>
-        <artifactId>hibernate-search-util-internal-integrationtest-parent</artifactId>
+        <artifactId>hibernate-search-util-internal-integrationtest</artifactId>
         <version>6.1.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>

--- a/util/internal/integrationtest/backend/lucene/pom.xml
+++ b/util/internal/integrationtest/backend/lucene/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.hibernate.search</groupId>
-        <artifactId>hibernate-search-util-internal-integrationtest-parent</artifactId>
+        <artifactId>hibernate-search-util-internal-integrationtest</artifactId>
         <version>6.1.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>

--- a/util/internal/integrationtest/common/pom.xml
+++ b/util/internal/integrationtest/common/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.hibernate.search</groupId>
-        <artifactId>hibernate-search-util-internal-integrationtest-parent</artifactId>
+        <artifactId>hibernate-search-util-internal-integrationtest</artifactId>
         <version>6.1.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>

--- a/util/internal/integrationtest/jbatch-runtime/pom.xml
+++ b/util/internal/integrationtest/jbatch-runtime/pom.xml
@@ -22,7 +22,6 @@
         <dependency>
             <groupId>com.ibm.jbatch</groupId>
             <artifactId>com.ibm.jbatch-runtime</artifactId>
-            <version>${version.com.ibm.jbatch}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/util/internal/integrationtest/jbatch-runtime/pom.xml
+++ b/util/internal/integrationtest/jbatch-runtime/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.hibernate.search</groupId>
-        <artifactId>hibernate-search-util-internal-integrationtest-parent</artifactId>
+        <artifactId>hibernate-search-util-internal-integrationtest</artifactId>
         <version>6.1.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>

--- a/util/internal/integrationtest/jberet-se/pom.xml
+++ b/util/internal/integrationtest/jberet-se/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.hibernate.search</groupId>
-        <artifactId>hibernate-search-util-internal-integrationtest-parent</artifactId>
+        <artifactId>hibernate-search-util-internal-integrationtest</artifactId>
         <version>6.1.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>

--- a/util/internal/integrationtest/mapper/orm/pom.xml
+++ b/util/internal/integrationtest/mapper/orm/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.hibernate.search</groupId>
-        <artifactId>hibernate-search-util-internal-integrationtest-parent</artifactId>
+        <artifactId>hibernate-search-util-internal-integrationtest</artifactId>
         <version>6.1.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>

--- a/util/internal/integrationtest/mapper/orm/pom.xml
+++ b/util/internal/integrationtest/mapper/orm/pom.xml
@@ -56,14 +56,5 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <resources>
-            <resource>
-                <filtering>true</filtering>
-                <directory>src/main/resources</directory>
-            </resource>
-        </resources>
-    </build>
-
 </project>
 

--- a/util/internal/integrationtest/mapper/stub/pom.xml
+++ b/util/internal/integrationtest/mapper/stub/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.hibernate.search</groupId>
-        <artifactId>hibernate-search-util-internal-integrationtest-parent</artifactId>
+        <artifactId>hibernate-search-util-internal-integrationtest</artifactId>
         <version>6.1.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>

--- a/util/internal/integrationtest/pom.xml
+++ b/util/internal/integrationtest/pom.xml
@@ -3,28 +3,15 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.hibernate.search</groupId>
-        <artifactId>hibernate-search-parent</artifactId>
+        <artifactId>hibernate-search-parent-integrationtest</artifactId>
         <version>6.1.0-SNAPSHOT</version>
-        <relativePath>../../..</relativePath>
+        <relativePath>../../../parents/integrationtest</relativePath>
     </parent>
-    <artifactId>hibernate-search-util-internal-integrationtest-parent</artifactId>
+    <artifactId>hibernate-search-util-internal-integrationtest</artifactId>
     <packaging>pom</packaging>
 
-    <name>Hibernate Search Utils - Internal - ITs - Parent POM</name>
-    <description>Parent POM of Hibernate Search integration testing utilities</description>
-
-    <properties>
-        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-        <!-- Skip javadoc generation (forced by releases) -->
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-
-        <!--
-            Consider all sources as tests during Sonar analysis.
-            This is important because some analysis rules do not apply to test code.
-         -->
-        <sonar.sources>${rootProject.emptySubdirectory}</sonar.sources>
-        <sonar.tests>${project.basedir}/src</sonar.tests>
-    </properties>
+    <name>Hibernate Search Utils - Internal - ITs - Aggregator POM</name>
+    <description>Aggregator POM of Hibernate Search integration testing utilities</description>
 
     <modules>
         <module>common</module>
@@ -36,38 +23,5 @@
         <module>jbatch-runtime</module>
         <module>jberet-se</module>
     </modules>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>de.thetaphi</groupId>
-                    <artifactId>forbiddenapis</artifactId>
-                    <!-- Override the executions defined in the parent module -->
-                    <executions>
-                        <execution>
-                            <id>verify-forbidden-apis</id>
-                            <!-- Do not use the main rules at all in integration test utils, see below -->
-                            <phase>none</phase>
-                        </execution>
-                        <execution>
-                            <id>verify-forbidden-test-apis</id>
-                            <goals>
-                                <!-- Apply the test rules to all code in integration test utils, even to code from src/main -->
-                                <goal>check</goal>
-                                <goal>testCheck</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>
 

--- a/util/internal/integrationtest/v5migrationhelper/pom.xml
+++ b/util/internal/integrationtest/v5migrationhelper/pom.xml
@@ -71,12 +71,6 @@
     </dependencies>
 
     <build>
-        <resources>
-            <resource>
-                <filtering>true</filtering>
-                <directory>src/main/resources</directory>
-            </resource>
-        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/util/internal/integrationtest/v5migrationhelper/pom.xml
+++ b/util/internal/integrationtest/v5migrationhelper/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.hibernate.search</groupId>
-        <artifactId>hibernate-search-util-internal-integrationtest-parent</artifactId>
+        <artifactId>hibernate-search-util-internal-integrationtest</artifactId>
         <version>6.1.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>

--- a/v5migrationhelper/orm/src/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
+++ b/v5migrationhelper/orm/src/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
@@ -32,7 +32,6 @@ import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.RootGraph;
 import org.hibernate.hql.internal.QueryExecutionRequestException;
-import org.hibernate.jpa.QueryHints;
 import org.hibernate.query.QueryParameter;
 import org.hibernate.query.internal.AbstractProducedQuery;
 import org.hibernate.query.internal.ParameterMetadataImpl;
@@ -44,6 +43,7 @@ import org.hibernate.search.engine.search.query.SearchScroll;
 import org.hibernate.search.impl.V5MigrationOrmSearchIntegratorAdapter;
 import org.hibernate.search.mapper.orm.search.loading.EntityLoadingCacheLookupStrategy;
 import org.hibernate.search.mapper.orm.search.loading.dsl.SearchLoadingOptionsStep;
+import org.hibernate.search.mapper.orm.search.query.spi.HibernateOrmSearchQueryHints;
 import org.hibernate.search.mapper.orm.search.query.spi.HibernateOrmSearchScrollableResultsAdapter;
 import org.hibernate.search.mapper.orm.search.query.spi.HibernateOrmSearchScrollableResultsAdapter.ScrollHitExtractor;
 import org.hibernate.search.query.DatabaseRetrievalMethod;
@@ -257,16 +257,16 @@ public class FullTextQueryImpl extends AbstractProducedQuery implements FullText
 	public FullTextQuery setHint(String hintName, Object value) {
 		hints.put( hintName, value );
 		switch ( hintName ) {
-			case QueryHints.SPEC_HINT_TIMEOUT:
+			case HibernateOrmSearchQueryHints.TIMEOUT_JPA:
 				setTimeout( hintValueToInteger( value ), TimeUnit.MILLISECONDS );
 				break;
-			case QueryHints.HINT_TIMEOUT:
+			case HibernateOrmSearchQueryHints.TIMEOUT_HIBERNATE:
 				setTimeout( hintValueToInteger( value ) );
 				break;
-			case "javax.persistence.fetchgraph":
+			case HibernateOrmSearchQueryHints.FETCHGRAPH:
 				applyGraph( hintValueToEntityGraph( value ), GraphSemantic.FETCH );
 				break;
-			case "javax.persistence.loadgraph":
+			case HibernateOrmSearchQueryHints.LOADGRAPH:
 				applyGraph( hintValueToEntityGraph( value ), GraphSemantic.LOAD );
 				break;
 			default:


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4240

This creates additional Maven artifacts, which are copies of some of the current ones, except their artifact ID is appended with `-jakarta` (e.g. `hibernate-search-mapper-orm-jakarta`), and they use Jakarta APIs instead of Java EE APIs.

This is done through source transformation and recompilation. Dependencies of the new artifacts are different (pointing to Jakarta APIs instead of Java EE ones, as well as Hibernate ORM's `-jakarta` artifacts). References to `javax.` packages in the source code is replaced with references to `jakarta.` packages. Same for XML namespaces.

I used source transformation instead of bytecode transformation because:

1. It seems safer and easier to debug. If something is wrong, it likely won't compile, and then you just look at the generated source code to find out what's wrong exactly.
2. We don't need all the power that bytecode transformation provides, because we're don't have as much coupling to JPA as Hibernate ORM.
3. I hope to use the same solution for ORM6-specific artifacts, which will not only need replacements of packages (since ORM 6 will use Jakarta APIs), but also a few patches to address backwards incompatible SPIs or APIs. With source transformation, I could add patch files to the repository, and have the build apply these patches before compilation.

I also did the source transformation for integration tests, which guarantees that these new artifacts work correctly. To check that the source code actually uses Jakarta APIs, just run `mvn clean install -DskipTests`, then have a look at the code in `target/copied-sources`: this is the one that get compiled, then executed in tests.

Note that I did not add the new artifacts to the distribution ZIP, on purpose: it's too much hassle, and since this is an experimental feature anyway, it's unlikely to be needed by people who still don't use Maven in 2021.