### PR TITLE
HSEARCH-4240 Follow-up: fix testing on JDK8

### DIFF
--- a/jakarta/parents/internal/pom.xml
+++ b/jakarta/parents/internal/pom.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-parent-internal</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>../../../parents/internal</relativePath>
+    </parent>
+    <artifactId>hibernate-search-parent-internal-jakarta</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Hibernate Search Parent POM for Internal Artifacts - Jakarta EE</name>
+    <description>Common build configuration for all internal (non-published) artifacts - Jakarta EE version</description>
+
+    <properties>
+        <!-- JQAssistant does not seem to work correctly on these artifacts for some reason -->
+        <jqassistant.skip>true</jqassistant.skip>
+        <!-- Prevent these modules from artificially affecting Sonar metrics -->
+        <sonar.skip>true</sonar.skip>
+
+        <!-- To be set by child modules -->
+        <transform.original.pathFromRoot></transform.original.pathFromRoot>
+        <transform.original.path>${rootProject.directory}/${transform.original.pathFromRoot}</transform.original.path>
+        <transform.output.root.path>${project.build.directory}/copied-sources/</transform.output.root.path>
+        <transform.output.main.sources.path>${transform.output.root.path}/main/java</transform.output.main.sources.path>
+        <transform.output.main.resources.path>${transform.output.root.path}/main/resources</transform.output.main.resources.path>
+        <transform.output.test.sources.path>${transform.output.root.path}/test/java</transform.output.test.sources.path>
+        <transform.output.test.resources.path>${transform.output.root.path}/test/resources</transform.output.test.resources.path>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.weld.se</groupId>
+                <artifactId>weld-se-shaded</artifactId>
+                <version>${version.org.jboss.weld.jakarta}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jberet</groupId>
+                <artifactId>jberet-core</artifactId>
+                <version>${version.org.jberet.jakarta}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jberet</groupId>
+                <artifactId>jberet-se</artifactId>
+                <version>${version.org.jberet.jakarta}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-mapper-orm-jakarta</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-v5migrationhelper-jakarta</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-jbatch-runtime-jakarta</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-jberet-se-jakarta</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>3.0.0</version>
+                    <executions>
+                        <execution>
+                            <id>copy-and-transform-sources</id>
+                            <phase>initialize</phase>
+                            <goals>
+                                <goal>run</goal>
+                            </goals>
+                            <configuration>
+                                <!-- WARNING: if you update this, make sure to update the "integrationtest" parent POM, too -->
+                                <target>
+                                    <ant dir="${rootProject.directory}/jakarta/" antfile="ant-copy-and-transform-sources.xml">
+                                        <target name="copy"/>
+                                        <target name="transform"/>
+                                    </ant>
+                                </target>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>replace-javax-with-jakarta</id>
+                            <phase>initialize</phase>
+                            <goals>
+                                <goal>run</goal>
+                            </goals>
+                            <configuration>
+                                <!-- WARNING: if you update this, make sure to update the "integrationtest" parent POM, too -->
+                                <target name="replace-javax" if="transform.output.present">
+                                    <!-- https://ant.apache.org/manual/Tasks/replace.html -->
+                                    <replace dir="${transform.output.root.path}" token="javax.persistence" value="jakarta.persistence" />
+                                    <replace dir="${transform.output.root.path}" token="javax.transaction" value="jakarta.transaction" />
+                                    <replace dir="${transform.output.root.path}" token="javax.enterprise" value="jakarta.enterprise" />
+                                </target>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-sources-copy</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${transform.output.main.sources.path}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-resources-copy</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${transform.output.main.resources.path}</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-test-sources-copy</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${transform.output.test.sources.path}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-test-resources-copy</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>add-test-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${transform.output.test.resources.path}</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/jakarta/pom.xml
+++ b/jakarta/pom.xml
@@ -22,6 +22,7 @@
 
     <modules>
         <module>parents/public</module>
+        <module>parents/internal</module>
         <module>mapper/orm</module>
         <module>mapper/orm-coordination-database-polling</module>
         <module>mapper/orm-batch-jsr352/core</module>

--- a/jakarta/util/internal/integrationtest/pom.xml
+++ b/jakarta/util/internal/integrationtest/pom.xml
@@ -3,15 +3,25 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.hibernate.search</groupId>
-        <artifactId>hibernate-search-parent-integrationtest-jakarta</artifactId>
+        <artifactId>hibernate-search-parent-internal-jakarta</artifactId>
         <version>6.1.0-SNAPSHOT</version>
-        <relativePath>../../../parents/integrationtest</relativePath>
+        <relativePath>../../../parents/internal</relativePath>
     </parent>
     <artifactId>hibernate-search-util-internal-integrationtest-jakarta</artifactId>
     <packaging>pom</packaging>
 
     <name>Hibernate Search Utils - Internal - ITs - Jakarta EE - Aggregator POM</name>
     <description>Aggregator POM of Hibernate Search integration testing utilities</description>
+
+    <properties>
+        <!-- Apply the main JDK release settings to all code in integration tests utils, even code in src/main
+             That way, we can reuse utils compiled in with JDK 11 when running tests against JDK 8,
+             like we do for main artifacts (engine, ...).
+         -->
+        <java-version.main.release>${java-version.test.release}</java-version.main.release>
+        <java-version.main.compiler.java_home>${java-version.test.compiler.java_home}</java-version.main.compiler.java_home>
+        <java-version.main.compiler>${java-version.test.compiler}</java-version.main.compiler>
+    </properties>
 
     <modules>
         <module>mapper/orm</module>

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -10,9 +10,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.hibernate.search</groupId>
-        <artifactId>hibernate-search-parent</artifactId>
+        <artifactId>hibernate-search-parent-internal</artifactId>
         <version>6.1.0-SNAPSHOT</version>
-        <relativePath>../..</relativePath>
+        <relativePath>../internal</relativePath>
     </parent>
     <artifactId>hibernate-search-parent-integrationtest</artifactId>
     <packaging>pom</packaging>
@@ -21,10 +21,6 @@
     <description>Common build configuration for all integration test artifacts (including documentation)</description>
 
     <properties>
-        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-        <!-- Skip javadoc generation (forced by releases) -->
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-
         <!-- Apply the test JDK release settings to all code in integration tests, even code in src/main -->
         <java-version.main.release>${java-version.test.release}</java-version.main.release>
         <java-version.main.compiler.java_home>${java-version.test.compiler.java_home}</java-version.main.compiler.java_home>
@@ -43,13 +39,6 @@
             -Dhibernate.connection.isolation=${jdbc.isolation}
         </failsafe.jvm.args.hibernate-orm>
 
-        <!--
-            Consider all sources as tests during Sonar analysis.
-            This is important because some analysis rules do not apply to test code.
-         -->
-        <sonar.sources>${rootProject.emptySubdirectory}</sonar.sources>
-        <sonar.tests>${project.basedir}/src</sonar.tests>
-
         <!-- For some reason, the failsafe plugin uses the modulepath
              even when we didn't define a module-info.java,
              and many things fail because of the modulepath.
@@ -67,47 +56,6 @@
                 <version>${project.version}</version>
             </dependency>
 
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-util-internal-integrationtest-common</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-util-internal-integrationtest-backend-elasticsearch</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-util-internal-integrationtest-backend-lucene</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-util-internal-integrationtest-mapper-stub</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-util-internal-integrationtest-mapper-orm</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-util-internal-integrationtest-v5migrationhelper</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-util-internal-integrationtest-jbatch-runtime</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-util-internal-integrationtest-jberet-se</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
             <!-- JDBC drivers -->
             <!-- Profile-specific driver, used in most database-sensitive integration tests -->
             <dependency>
@@ -121,26 +69,6 @@
     <build>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>de.thetaphi</groupId>
-                    <artifactId>forbiddenapis</artifactId>
-                    <!-- Override the executions defined in the parent module -->
-                    <executions>
-                        <execution>
-                            <id>verify-forbidden-apis</id>
-                            <!-- Do not use the main rules at all in integration tests, see below -->
-                            <phase>none</phase>
-                        </execution>
-                        <execution>
-                            <id>verify-forbidden-test-apis</id>
-                            <goals>
-                                <!-- Apply the test rules to all code in integration tests, even code in src/main -->
-                                <goal>check</goal>
-                                <goal>testCheck</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
@@ -419,16 +347,6 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-        </plugins>
     </build>
 
     <profiles>

--- a/parents/internal/pom.xml
+++ b/parents/internal/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-parent</artifactId>
+        <version>6.1.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-parent-internal</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Hibernate Search Parent POM for Internal Artifacts</name>
+    <description>Common build configuration for all internal (non-published) artifacts</description>
+
+    <properties>
+        <!-- Do not publish internal modules -->
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+        <!--
+             Skip javadoc generation for internal modules: we don't want to publish them.
+             Note this shouldn't be necessary because we don't even use the maven-javadoc-plugin
+             in these modules.
+             However, the maven-javadoc-plugin sometimes invokes the javadoc goal on these modules explicitly
+             from other (published) modules; probably because it tries to generate the javadoc of dependencies,
+             even test dependencies.
+             Whatever the reason, this triggers errors, so we better just disable the plugin explicitly.
+         -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+
+        <!--
+            In all internal modules, especially but not only test modules,
+            consider all sources as tests during Sonar analysis.
+            This is important because some analysis rules do not apply to test code.
+         -->
+        <sonar.sources>${rootProject.emptySubdirectory}</sonar.sources>
+        <sonar.tests>${project.basedir}/src</sonar.tests>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-backend-elasticsearch</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-backend-lucene</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-mapper-stub</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-mapper-orm</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-v5migrationhelper</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-jbatch-runtime</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-jberet-se</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>de.thetaphi</groupId>
+                    <artifactId>forbiddenapis</artifactId>
+                    <!-- Override the executions defined in the parent module -->
+                    <executions>
+                        <execution>
+                            <id>verify-forbidden-apis</id>
+                            <!-- Do not use the main rules at all in internal modules, see below -->
+                            <phase>none</phase>
+                        </execution>
+                        <execution>
+                            <id>verify-forbidden-test-apis</id>
+                            <goals>
+                                <!-- Apply the test rules to all code in internal modules, even code in src/main -->
+                                <goal>check</goal>
+                                <goal>testCheck</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/pom.xml
+++ b/pom.xml
@@ -153,9 +153,10 @@
     <modules>
         <module>build/config</module>
         <module>build/surefire-extension</module>
+        <module>parents/internal</module>
+        <module>util/internal/test</module>
         <module>parents/public</module>
         <module>util/common</module>
-        <module>util/internal/test</module>
         <module>engine</module>
         <module>backend/lucene</module>
         <module>backend/elasticsearch</module>

--- a/util/internal/integrationtest/pom.xml
+++ b/util/internal/integrationtest/pom.xml
@@ -3,9 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.hibernate.search</groupId>
-        <artifactId>hibernate-search-parent-integrationtest</artifactId>
+        <artifactId>hibernate-search-parent-internal</artifactId>
         <version>6.1.0-SNAPSHOT</version>
-        <relativePath>../../../parents/integrationtest</relativePath>
+        <relativePath>../../../parents/internal</relativePath>
     </parent>
     <artifactId>hibernate-search-util-internal-integrationtest</artifactId>
     <packaging>pom</packaging>

--- a/util/internal/test/pom.xml
+++ b/util/internal/test/pom.xml
@@ -3,35 +3,14 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.hibernate.search</groupId>
-        <artifactId>hibernate-search-parent</artifactId>
+        <artifactId>hibernate-search-parent-internal</artifactId>
         <version>6.1.0-SNAPSHOT</version>
-        <relativePath>../../..</relativePath>
+        <relativePath>../../../parents/internal</relativePath>
     </parent>
     <artifactId>hibernate-search-util-internal-test</artifactId>
 
     <name>Hibernate Search Utils - Internal - Test</name>
     <description>Hibernate Search common test utilities</description>
-
-    <properties>
-        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-        <!--
-             Skip javadoc generation for this module: we don't want to publish it.
-             Note this shouldn't be necessary because we don't even use the maven-javadoc-plugin
-             in this module.
-             However, the maven-javadoc-plugin sometimes invokes the javadoc goal on this module explicitly
-             from other (published) modules; probably because it tries to generate the javadoc of dependencies,
-             even test dependencies.
-             Whatever the reason, this triggers errors, so we better just disable the plugin explicitly.
-         -->
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-
-        <!--
-            Consider all sources as tests during Sonar analysis.
-            This is important because some analysis rules do not apply to test code.
-         -->
-        <sonar.sources>${rootProject.emptySubdirectory}</sonar.sources>
-        <sonar.tests>${project.basedir}/src</sonar.tests>
-    </properties>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4240

This creates a separate parent POM for internal, non-integration-test artifacts.

This is needed for internal util modules, in particular:
those modules share a lot of characteristics with integration test
modules, but they definitely should be compiled with -release 8
so that we can freely reuse them when testing against JDK 8.
Integration tests, on the other hand, may be compiled with -release 11.