### PR TITLE
HSEARCH-4339 Upgrade to Elasticsearch client 7.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,8 +202,8 @@
 
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently from the version of the remote cluster -->
-        <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 7.11+ -->
-        <version.org.elasticsearch.client>7.13.4</version.org.elasticsearch.client>
+        <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 7.15+ -->
+        <version.org.elasticsearch.client>7.15.0</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links and as the default when testing.
              We're trying to stick to a fully-OSS version as the default, so don't upgrade to 7.11 here. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4339

We can't (easily) upgrade tests to ES 7.15 yet, because of bugs in Elasticsearch; see https://hibernate.atlassian.net/browse/HSEARCH-4327.