### PR TITLE
HSEARCH-4348 Check ORM declared property fields by the ORM member name

### DIFF
--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmClassRawTypeModel.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmClassRawTypeModel.java
@@ -114,7 +114,10 @@ public class HibernateOrmClassRawTypeModel<T>
 				return findInSelfOrParents( t -> t.declaredPropertyGetters( propertyName ) );
 			}
 			else if ( memberFromHibernateOrmMetamodel instanceof Field ) {
-				Member field = findInSelfOrParents( t -> t.declaredPropertyField( propertyName ) );
+				// The field name may be different from the property name,
+				// in particular with Grails when using Groovy traits (see HSEARCH-4348)
+				String memberName = memberFromHibernateOrmMetamodel.getName();
+				Member field = findInSelfOrParents( t -> t.declaredPropertyField( memberName ) );
 				return field == null ? null : Collections.singletonList( field );
 			}
 			else {


### PR DESCRIPTION
HSEARCH-4348 Check ORM declared property fields by the ORM member name if not found by the propertyname

When using groovy traits the propertyName will not match with the ORM member name.
This addition will try to find the Member using the propertyName but if it cant then it will try by 
using the ORM metamodel property name.

https://hibernate.atlassian.net/browse/HSEARCH-4348
