### PR TITLE
Backport HSEARCH-4348 to branch 6.0 - Mapping does not work when the properties are defined inside Groovy Traits

### DIFF
--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmClassRawTypeModel.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmClassRawTypeModel.java
@@ -114,7 +114,10 @@ public class HibernateOrmClassRawTypeModel<T>
 				return findInSelfOrParents( t -> t.declaredPropertyGetters( propertyName ) );
 			}
 			else if ( memberFromHibernateOrmMetamodel instanceof Field ) {
-				Member field = findInSelfOrParents( t -> t.declaredPropertyField( propertyName ) );
+				// The field name may be different from the property name,
+				// in particular with Grails when using Groovy traits (see HSEARCH-4348)
+				String memberName = memberFromHibernateOrmMetamodel.getName();
+				Member field = findInSelfOrParents( t -> t.declaredPropertyField( memberName ) );
 				return field == null ? null : Collections.singletonList( field );
 			}
 			else {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4348

Backport of #2686