### PR TITLE
HSEARCH-4360 Use conflict-free entity names for entities added by the database-polling coordination strategy

### DIFF
--- a/integrationtest/mapper/orm-coordination-database-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/databasepolling/FilteringOutboxEventFinder.java
+++ b/integrationtest/mapper/orm-coordination-database-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/databasepolling/FilteringOutboxEventFinder.java
@@ -8,6 +8,7 @@ package org.hibernate.search.integrationtest.mapper.orm.coordination.databasepol
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.hibernate.search.mapper.orm.coordination.databasepolling.event.impl.DatabasePollingOutboxEventAdditionalJaxbMappingProducer.ENTITY_NAME;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import java.util.HashSet;
@@ -97,7 +98,7 @@ public class FilteringOutboxEventFinder {
 	public List<OutboxEvent> findOutboxEventsNoFilter(Session session) {
 		checkFiltering();
 		Query<OutboxEvent> query = session.createQuery(
-				"select e from OutboxEvent e order by e.id", OutboxEvent.class );
+				"select e from " + ENTITY_NAME + " e order by e.id", OutboxEvent.class );
 		avoidLockingConflicts( query );
 		return query.list();
 	}
@@ -106,7 +107,7 @@ public class FilteringOutboxEventFinder {
 	public List<OutboxEvent> findOutboxEventsNoFilterOrderById(Session session) {
 		checkFiltering();
 		Query<OutboxEvent> query = session.createQuery(
-				"select e from OutboxEvent e order by e.id", OutboxEvent.class );
+				"select e from " + ENTITY_NAME + " e order by e.id", OutboxEvent.class );
 		avoidLockingConflicts( query );
 		return query.list();
 	}
@@ -114,7 +115,7 @@ public class FilteringOutboxEventFinder {
 	public List<Long> findOutboxEventIdsNoFilter(Session session) {
 		checkFiltering();
 		Query<Long> query = session.createQuery(
-				"select e.id from OutboxEvent e order by e.id", Long.class );
+				"select e.id from " + ENTITY_NAME + " e order by e.id", Long.class );
 		return query.list();
 	}
 

--- a/mapper/orm-coordination-database-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/databasepolling/cluster/impl/DatabasePollingAgentAdditionalJaxbMappingProducer.java
+++ b/mapper/orm-coordination-database-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/databasepolling/cluster/impl/DatabasePollingAgentAdditionalJaxbMappingProducer.java
@@ -34,14 +34,23 @@ public class DatabasePollingAgentAdditionalJaxbMappingProducer
 
 	// WARNING: Always use this prefix for all tables added by Hibernate Search:
 	// we guarantee that in the documentation.
-	public static final String HSEARCH_TABLE_NAME_PREFIX = "HSEARCH_";
+	public static final String HSEARCH_PREFIX = "HSEARCH_";
 
 	// Must not be longer than 20 characters, so that the generator does not exceed the 30 characters for Oracle11g
-	private static final String TABLE_NAME = HSEARCH_TABLE_NAME_PREFIX + "AGENT";
+	private static final String TABLE_NAME = HSEARCH_PREFIX + "AGENT";
+
+	private static final String CLASS_NAME = Agent.class.getName();
+
+	// Setting both the JPA entity name and the native entity name to the FQCN so that:
+	// 1. We don't pollute the namespace of JPA entity names with something like
+	// "Agent" that could potentially conflict with user-defined entities.
+	// 2. We can still use session methods (persist, ...) without passing the entity name,
+	// because our override actually matches the default for the native entity name.
+	public static final String ENTITY_NAME = CLASS_NAME;
 
 	private static final String ENTITY_DEFINITION = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
 			"<hibernate-mapping>\n" +
-			"    <class name=\"" + Agent.class.getName() + "\" table=\"" + TABLE_NAME + "\">\n" +
+			"    <class name=\"" + CLASS_NAME + "\" entity-name=\"" + ENTITY_NAME + "\" table=\"" + TABLE_NAME + "\">\n" +
 			"        <id name=\"id\">\n" +
 			"            <generator class=\"org.hibernate.id.enhanced.SequenceStyleGenerator\">\n" +
 			"                <param name=\"sequence_name\">" + TABLE_NAME + "_GENERATOR</param>\n" +

--- a/mapper/orm-coordination-database-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/databasepolling/cluster/impl/DefaultAgentRepository.java
+++ b/mapper/orm-coordination-database-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/databasepolling/cluster/impl/DefaultAgentRepository.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.mapper.orm.coordination.databasepolling.cluster.impl;
 
+import static org.hibernate.search.mapper.orm.coordination.databasepolling.cluster.impl.DatabasePollingAgentAdditionalJaxbMappingProducer.ENTITY_NAME;
+
 import java.util.List;
 
 import org.hibernate.Session;
@@ -31,7 +33,7 @@ public class DefaultAgentRepository implements AgentRepository {
 
 	@Override
 	public List<Agent> findAllOrderById() {
-		return session.createQuery( "select a from Agent a order by id", Agent.class ).list();
+		return session.createQuery( "select a from " + ENTITY_NAME + " a order by id", Agent.class ).list();
 	}
 
 	@Override

--- a/mapper/orm-coordination-database-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/databasepolling/event/impl/DatabasePollingOutboxEventAdditionalJaxbMappingProducer.java
+++ b/mapper/orm-coordination-database-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/databasepolling/event/impl/DatabasePollingOutboxEventAdditionalJaxbMappingProducer.java
@@ -33,14 +33,23 @@ public final class DatabasePollingOutboxEventAdditionalJaxbMappingProducer
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private static final String HSEARCH_TABLE_NAME_PREFIX = DatabasePollingAgentAdditionalJaxbMappingProducer.HSEARCH_TABLE_NAME_PREFIX;
+	private static final String HSEARCH_PREFIX = DatabasePollingAgentAdditionalJaxbMappingProducer.HSEARCH_PREFIX;
 
 	// Must not be longer than 20 characters, so that the generator does not exceed the 30 characters for Oracle11g
-	private static final String TABLE_NAME = HSEARCH_TABLE_NAME_PREFIX + "OUTBOX_EVENT";
+	private static final String TABLE_NAME = HSEARCH_PREFIX + "OUTBOX_EVENT";
+
+	private static final String CLASS_NAME = OutboxEvent.class.getName();
+
+	// Setting both the JPA entity name and the native entity name to the FQCN so that:
+	// 1. We don't pollute the namespace of JPA entity names with something like
+	// "OutboxEvent" that could potentially conflict with user-defined entities.
+	// 2. We can still use session methods (persist, ...) without passing the entity name,
+	// because our override actually matches the default for the native entity name.
+	public static final String ENTITY_NAME = CLASS_NAME;
 
 	private static final String ENTITY_DEFINITION = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
 			"<hibernate-mapping>\n" +
-			"    <class name=\"" + OutboxEvent.class.getName() + "\" table=\"" + TABLE_NAME + "\">\n" +
+			"    <class name=\"" + CLASS_NAME + "\" entity-name=\"" + ENTITY_NAME + "\" table=\"" + TABLE_NAME + "\">\n" +
 			"        <id name=\"id\" type=\"long\">\n" +
 			"            <generator class=\"org.hibernate.id.enhanced.SequenceStyleGenerator\">\n" +
 			"                <param name=\"sequence_name\">" + TABLE_NAME + "_GENERATOR</param>\n" +

--- a/mapper/orm-coordination-database-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/databasepolling/event/impl/DefaultOutboxEventFinder.java
+++ b/mapper/orm-coordination-database-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/databasepolling/event/impl/DefaultOutboxEventFinder.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.mapper.orm.coordination.databasepolling.event.impl;
 
+import static org.hibernate.search.mapper.orm.coordination.databasepolling.event.impl.DatabasePollingOutboxEventAdditionalJaxbMappingProducer.ENTITY_NAME;
+
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -27,7 +29,7 @@ public final class DefaultOutboxEventFinder implements OutboxEventFinder {
 				OutboxEventAndPredicate.of( predicate.get(), processAfterFilter ) :
 				processAfterFilter;
 
-		return "select e from OutboxEvent e where " + combined.queryPart( "e" ) + " order by e.id";
+		return "select e from " + ENTITY_NAME + " e where " + combined.queryPart( "e" ) + " order by e.id";
 	}
 
 	public static Query<OutboxEvent> createQuery(Session session, int maxResults,


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4360
