### PR TITLE
HSEARCH-4366 Add context to exceptions thrown during processing of POJOs (for indexing or reindexing resolution)

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureCustomBackgroundFailureHandlerIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureCustomBackgroundFailureHandlerIT.java
@@ -117,13 +117,11 @@ public class MassIndexingFailureCustomBackgroundFailureHandlerIT extends Abstrac
 		EntityIndexingFailureContext context = entityFailureContextCapture.getValue();
 		assertThat( context.throwable() )
 				.isInstanceOf( SearchException.class )
-				.hasMessageContaining( "Exception while building document for entity '%s'", entityReferenceAsString )
-				.extracting( Throwable::getCause, InstanceOfAssertFactories.THROWABLE )
-				.isInstanceOf( SearchException.class )
-				.hasMessageContaining( "Exception while invoking" )
-				.extracting( Throwable::getCause, InstanceOfAssertFactories.THROWABLE )
-				.isInstanceOf( SimulatedFailure.class )
-				.hasMessageContaining( exceptionMessage );
+				.hasMessageContainingAll(
+						"Exception while building document for entity '" + entityReferenceAsString + "'",
+						"Exception while invoking",
+						exceptionMessage )
+				.hasRootCauseInstanceOf( SimulatedFailure.class );
 		assertThat( context.failingOperation() ).asString()
 				.isEqualTo( failingOperationAsString );
 		assertThat( context.entityReferences() )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureCustomMassIndexingFailureHandlerIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureCustomMassIndexingFailureHandlerIT.java
@@ -117,13 +117,11 @@ public class MassIndexingFailureCustomMassIndexingFailureHandlerIT extends Abstr
 		MassIndexingEntityFailureContext context = entityFailureContextCapture.getValue();
 		assertThat( context.throwable() )
 				.isInstanceOf( SearchException.class )
-				.hasMessageContaining( "Exception while building document for entity '%s'", entityReferenceAsString )
-				.extracting( Throwable::getCause, InstanceOfAssertFactories.THROWABLE )
-				.isInstanceOf( SearchException.class )
-				.hasMessageContaining( "Exception while invoking" )
-				.extracting( Throwable::getCause, InstanceOfAssertFactories.THROWABLE )
-				.isInstanceOf( SimulatedFailure.class )
-				.hasMessageContaining( exceptionMessage );
+				.hasMessageContainingAll(
+						"Exception while building document for entity '" + entityReferenceAsString + "'",
+						"Exception while invoking",
+						exceptionMessage )
+				.hasRootCauseInstanceOf( SimulatedFailure.class );
 		assertThat( context.failingOperation() ).asString()
 				.isEqualTo( failingOperationAsString );
 		assertThat( context.entityReferences() )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureDefaultBackgroundFailureHandlerIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureDefaultBackgroundFailureHandlerIT.java
@@ -82,10 +82,9 @@ public class MassIndexingFailureDefaultBackgroundFailureHandlerIT extends Abstra
 				Level.ERROR,
 				ExceptionMatcherBuilder.isException( SearchException.class )
 						.withMessage( "Exception while building document for entity '" + entityReferenceAsString + "'" )
-						.causedBy( SearchException.class )
 						.withMessage( "Exception while invoking" )
-						.causedBy( SimulatedFailure.class )
 						.withMessage( exceptionMessage )
+						.rootCause( SimulatedFailure.class )
 						.build(),
 				failingOperationAsString,
 				"Entities that could not be indexed correctly:",

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/IndexedEmbeddedBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/IndexedEmbeddedBaseIT.java
@@ -934,7 +934,7 @@ public class IndexedEmbeddedBaseIT {
 		} )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContaining( "Exception while building document for entity 'IndexedEntity#1'" )
-				.hasCauseInstanceOf( ClassCastException.class );
+				.hasRootCauseInstanceOf( ClassCastException.class );
 	}
 
 	@Test

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingFailureCustomBackgroundFailureHandlerIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingFailureCustomBackgroundFailureHandlerIT.java
@@ -117,13 +117,11 @@ public class MassIndexingFailureCustomBackgroundFailureHandlerIT extends Abstrac
 		EntityIndexingFailureContext context = entityFailureContextCapture.getValue();
 		assertThat( context.throwable() )
 				.isInstanceOf( SearchException.class )
-				.hasMessageContaining( "Exception while building document for entity '%s'", entityReferenceAsString )
-				.extracting( Throwable::getCause, InstanceOfAssertFactories.THROWABLE )
-				.isInstanceOf( SearchException.class )
-				.hasMessageContaining( "Exception while invoking" )
-				.extracting( Throwable::getCause, InstanceOfAssertFactories.THROWABLE )
-				.isInstanceOf( SimulatedFailure.class )
-				.hasMessageContaining( exceptionMessage );
+				.hasMessageContainingAll(
+						"Exception while building document for entity '" + entityReferenceAsString + "'",
+						"Exception while invoking",
+						exceptionMessage )
+				.hasRootCauseInstanceOf( SimulatedFailure.class );
 		assertThat( context.failingOperation() ).asString()
 				.isEqualTo( failingOperationAsString );
 		assertThat( context.entityReferences() )

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingFailureCustomMassIndexingFailureHandlerIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingFailureCustomMassIndexingFailureHandlerIT.java
@@ -117,13 +117,11 @@ public class MassIndexingFailureCustomMassIndexingFailureHandlerIT extends Abstr
 		MassIndexingEntityFailureContext context = entityFailureContextCapture.getValue();
 		assertThat( context.throwable() )
 				.isInstanceOf( SearchException.class )
-				.hasMessageContaining( "Exception while building document for entity '%s'", entityReferenceAsString )
-				.extracting( Throwable::getCause, InstanceOfAssertFactories.THROWABLE )
-				.isInstanceOf( SearchException.class )
-				.hasMessageContaining( "Exception while invoking" )
-				.extracting( Throwable::getCause, InstanceOfAssertFactories.THROWABLE )
-				.isInstanceOf( SimulatedFailure.class )
-				.hasMessageContaining( exceptionMessage );
+				.hasMessageContainingAll(
+						"Exception while building document for entity '" + entityReferenceAsString + "'",
+						"Exception while invoking",
+						exceptionMessage )
+				.hasRootCauseInstanceOf( SimulatedFailure.class );
 		assertThat( context.failingOperation() ).asString()
 				.isEqualTo( failingOperationAsString );
 		assertThat( context.entityReferences() )

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingFailureDefaultBackgroundFailureHandlerIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingFailureDefaultBackgroundFailureHandlerIT.java
@@ -82,10 +82,9 @@ public class MassIndexingFailureDefaultBackgroundFailureHandlerIT extends Abstra
 				Level.ERROR,
 				ExceptionMatcherBuilder.isException( SearchException.class )
 						.withMessage( "Exception while building document for entity '" + entityReferenceAsString + "'" )
-						.causedBy( SearchException.class )
 						.withMessage( "Exception while invoking" )
-						.causedBy( SimulatedFailure.class )
 						.withMessage( exceptionMessage )
+						.rootCause( SimulatedFailure.class )
 						.build(),
 				failingOperationAsString,
 				"Entities that could not be indexed correctly:",

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/AbstractPojoIndexingProcessorFailureIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/AbstractPojoIndexingProcessorFailureIT.java
@@ -1,0 +1,195 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.work.operations;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.lang.invoke.MethodHandles;
+import java.util.List;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.util.rule.JavaBeanMappingSetupHelper;
+import org.hibernate.search.mapper.javabean.mapping.SearchMapping;
+import org.hibernate.search.mapper.javabean.session.SearchSession;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.AssociationInverseSide;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyValue;
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+
+abstract class AbstractPojoIndexingProcessorFailureIT {
+
+	@Rule
+	public final BackendMock backendMock = new BackendMock();
+
+	@Rule
+	public final JavaBeanMappingSetupHelper setupHelper =
+			JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );
+
+	@Rule
+	public final MockitoRule mockito = MockitoJUnit.rule().strictness( Strictness.STRICT_STUBS );
+
+	protected SearchMapping mapping;
+
+	@Before
+	public void setup() {
+		backendMock.expectSchema( RootEntity.NAME, b -> b
+				.field( "value", String.class )
+				.objectField( "containedNoContainer", b2 -> b2
+						.field( "value", String.class )
+						.objectField( "containedNoContainer", b3 -> b3
+								.field( "value", String.class ) )
+						.objectField( "containedInContainer", b3 -> b3
+								.multiValued( true )
+								.field( "value", String.class ) ) )
+				.objectField( "containedInContainer", b2 -> b2
+						.multiValued( true )
+						.field( "value", String.class )
+						.objectField( "containedNoContainer", b3 -> b3
+								.field( "value", String.class ) )
+						.objectField( "containedInContainer", b3 -> b3
+								.multiValued( true )
+								.field( "value", String.class ) ) ) );
+
+		mapping = setupHelper.start().setup( RootEntity.class, NonRootEntity.class );
+
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void getter() {
+		RootEntity root = new RootEntity();
+		root.id = 1;
+
+		SimulatedFailure simulatedFailure = new SimulatedFailure();
+		root.exceptionOnGetterCall = simulatedFailure;
+
+		try ( SearchSession session = mapping.createSessionWithOptions().build() ) {
+			assertThatThrownBy( () -> process( session, root ) )
+					.isInstanceOf( SearchException.class )
+					.hasMessageContainingAll( SimulatedFailure.MESSAGE, ".containedNoContainer" )
+					.hasRootCause( simulatedFailure );
+		}
+	}
+
+	@Test
+	public void containerExtraction() {
+		RootEntity root = new RootEntity();
+		root.id = 1;
+		root.containedInContainer = Mockito.mock( List.class );
+
+		SimulatedFailure simulatedFailure = new SimulatedFailure();
+		when( root.containedInContainer.iterator() ).thenThrow( simulatedFailure );
+
+		try ( SearchSession session = mapping.createSessionWithOptions().build() ) {
+			assertThatThrownBy( () -> process( session, root ) )
+					.isInstanceOf( SearchException.class )
+					.hasMessageContainingAll( SimulatedFailure.MESSAGE, ".containedInContainer" )
+					.hasRootCause( simulatedFailure );
+		}
+	}
+
+	@Test
+	public void nested_getter() {
+		RootEntity root = new RootEntity();
+		root.id = 1;
+		NonRootEntity level1 = new NonRootEntity();
+		root.containedNoContainer = level1;
+
+		SimulatedFailure simulatedFailure = new SimulatedFailure();
+		level1.exceptionOnGetterCall = simulatedFailure;
+
+		try ( SearchSession session = mapping.createSessionWithOptions().build() ) {
+			assertThatThrownBy( () -> process( session, root ) )
+					.isInstanceOf( SearchException.class )
+					.hasMessageContainingAll( SimulatedFailure.MESSAGE,
+							".containedNoContainer<no value extractors>.containedNoContainer" )
+					.hasRootCause( simulatedFailure );
+		}
+	}
+
+	@Test
+	public void nested_containerExtraction() {
+		RootEntity root = new RootEntity();
+		root.id = 1;
+		NonRootEntity level1 = new NonRootEntity();
+		root.containedNoContainer = level1;
+		level1.containedInContainer = Mockito.mock( List.class );
+
+		SimulatedFailure simulatedFailure = new SimulatedFailure();
+		when( level1.containedInContainer.iterator() ).thenThrow( simulatedFailure );
+
+		try ( SearchSession session = mapping.createSessionWithOptions().build() ) {
+			assertThatThrownBy( () -> process( session, root ) )
+					.isInstanceOf( SearchException.class )
+					.hasMessageContainingAll( SimulatedFailure.MESSAGE,
+							".containedNoContainer<no value extractors>.containedInContainer" )
+					.hasRootCause( simulatedFailure );
+		}
+	}
+
+	protected abstract void process(SearchSession session, Object entity);
+
+	static class SimulatedFailure extends RuntimeException {
+		static final String MESSAGE = "Simulated failure";
+
+		SimulatedFailure() {
+			super( MESSAGE );
+		}
+	}
+
+	static class AbstractEntity {
+		@DocumentId
+		Integer id;
+
+		@GenericField
+		String value;
+
+		@IndexedEmbedded(includeDepth = 2)
+		@AssociationInverseSide(inversePath = @ObjectPath(@PropertyValue(propertyName = "containingNoContainer")))
+		NonRootEntity containedNoContainer;
+
+		@IndexedEmbedded(includeDepth = 2)
+		@AssociationInverseSide(inversePath = @ObjectPath(@PropertyValue(propertyName = "containingInContainer")))
+		List<NonRootEntity> containedInContainer;
+
+		RuntimeException exceptionOnGetterCall = null;
+
+		public NonRootEntity getContainedNoContainer() {
+			if ( exceptionOnGetterCall != null ) {
+				throw exceptionOnGetterCall;
+			}
+			return containedNoContainer;
+		}
+	}
+
+	@Indexed(index = RootEntity.NAME)
+	static class RootEntity extends AbstractEntity {
+		public static final String NAME = "RootEntity";
+	}
+
+	static class NonRootEntity extends AbstractEntity {
+		AbstractEntity containingNoContainer;
+
+		List<AbstractEntity> containingInContainer;
+	}
+
+
+}

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/AbstractPojoReindexingResolutionFailureIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/AbstractPojoReindexingResolutionFailureIT.java
@@ -1,0 +1,193 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.work.operations;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.lang.invoke.MethodHandles;
+import java.util.List;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.util.rule.JavaBeanMappingSetupHelper;
+import org.hibernate.search.mapper.javabean.mapping.SearchMapping;
+import org.hibernate.search.mapper.javabean.session.SearchSession;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.AssociationInverseSide;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyValue;
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+
+abstract class AbstractPojoReindexingResolutionFailureIT {
+
+	@Rule
+	public final BackendMock backendMock = new BackendMock();
+
+	@Rule
+	public final JavaBeanMappingSetupHelper setupHelper =
+			JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );
+
+	@Rule
+	public final MockitoRule mockito = MockitoJUnit.rule().strictness( Strictness.STRICT_STUBS );
+
+	protected SearchMapping mapping;
+
+	@Before
+	public void setup() {
+		backendMock.expectSchema( RootEntity.NAME, b -> b
+				.field( "value", String.class )
+				.objectField( "containedNoContainer", b2 -> b2
+						.field( "value", String.class )
+						.objectField( "containedNoContainer", b3 -> b3
+								.field( "value", String.class ) )
+						.objectField( "containedInContainer", b3 -> b3
+								.multiValued( true )
+								.field( "value", String.class ) ) )
+				.objectField( "containedInContainer", b2 -> b2
+						.multiValued( true )
+						.field( "value", String.class )
+						.objectField( "containedNoContainer", b3 -> b3
+								.field( "value", String.class ) )
+						.objectField( "containedInContainer", b3 -> b3
+								.multiValued( true )
+								.field( "value", String.class ) ) ) );
+
+		mapping = setupHelper.start().setup( RootEntity.class, NonRootEntity.class );
+
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void getter() {
+		NonRootEntity level1 = new NonRootEntity();
+
+		SimulatedFailure simulatedFailure = new SimulatedFailure();
+		level1.exceptionOnGetterCall = simulatedFailure;
+
+		try ( SearchSession session = mapping.createSessionWithOptions().build() ) {
+			assertThatThrownBy( () -> process( session, level1 ) )
+					.isInstanceOf( SearchException.class )
+					.hasMessageContainingAll( SimulatedFailure.MESSAGE, ".containingNoContainer" )
+					.hasRootCause( simulatedFailure );
+		}
+	}
+
+	@Test
+	public void containerExtraction() {
+		NonRootEntity level1 = new NonRootEntity();
+		level1.containingInContainer = Mockito.mock( List.class );
+
+		SimulatedFailure simulatedFailure = new SimulatedFailure();
+		when( level1.containingInContainer.iterator() ).thenThrow( simulatedFailure );
+
+		try ( SearchSession session = mapping.createSessionWithOptions().build() ) {
+			assertThatThrownBy( () -> process( session, level1 ) )
+					.isInstanceOf( SearchException.class )
+					.hasMessageContainingAll( SimulatedFailure.MESSAGE, ".containingInContainer" )
+					.hasRootCause( simulatedFailure );
+		}
+	}
+
+	@Test
+	public void nested_getter() {
+		NonRootEntity level1 = new NonRootEntity();
+
+		SimulatedFailure simulatedFailure = new SimulatedFailure();
+		level1.exceptionOnGetterCall = simulatedFailure;
+
+		NonRootEntity level2 = new NonRootEntity();
+		level2.containingNoContainer = level1;
+
+		try ( SearchSession session = mapping.createSessionWithOptions().build() ) {
+			assertThatThrownBy( () -> process( session, level2 ) )
+					.isInstanceOf( SearchException.class )
+					.hasMessageContainingAll( SimulatedFailure.MESSAGE,
+							".containingNoContainer<no value extractors>.containingNoContainer" )
+					.hasRootCause( simulatedFailure );
+		}
+	}
+
+	@Test
+	public void nested_containerExtraction() {
+		NonRootEntity level1 = new NonRootEntity();
+		level1.containingInContainer = Mockito.mock( List.class );
+
+		SimulatedFailure simulatedFailure = new SimulatedFailure();
+		when( level1.containingInContainer.iterator() ).thenThrow( simulatedFailure );
+
+		NonRootEntity level2 = new NonRootEntity();
+		level2.containingNoContainer = level1;
+
+		try ( SearchSession session = mapping.createSessionWithOptions().build() ) {
+			assertThatThrownBy( () -> process( session, level2 ) )
+					.isInstanceOf( SearchException.class )
+					.hasMessageContainingAll( SimulatedFailure.MESSAGE,
+							".containingNoContainer<no value extractors>.containingInContainer" )
+					.hasRootCause( simulatedFailure );
+		}
+	}
+
+	protected abstract void process(SearchSession session, Object entity);
+
+	static class SimulatedFailure extends RuntimeException {
+		static final String MESSAGE = "Simulated failure";
+
+		SimulatedFailure() {
+			super( MESSAGE );
+		}
+	}
+
+	static class AbstractEntity {
+		@DocumentId
+		Integer id;
+
+		@GenericField
+		String value;
+
+		@IndexedEmbedded(includeDepth = 2)
+		@AssociationInverseSide(inversePath = @ObjectPath(@PropertyValue(propertyName = "containingNoContainer")))
+		NonRootEntity containedNoContainer;
+
+		@IndexedEmbedded(includeDepth = 2)
+		@AssociationInverseSide(inversePath = @ObjectPath(@PropertyValue(propertyName = "containingInContainer")))
+		List<NonRootEntity> containedInContainer;
+	}
+
+	@Indexed(index = RootEntity.NAME)
+	static class RootEntity extends AbstractEntity {
+		public static final String NAME = "RootEntity";
+	}
+
+	static class NonRootEntity extends AbstractEntity {
+		AbstractEntity containingNoContainer;
+
+		List<AbstractEntity> containingInContainer;
+
+		RuntimeException exceptionOnGetterCall = null;
+
+		public AbstractEntity getContainingNoContainer() {
+			if ( exceptionOnGetterCall != null ) {
+				throw exceptionOnGetterCall;
+			}
+			return containingNoContainer;
+		}
+	}
+
+
+}

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/PojoIndexingAddIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/PojoIndexingAddIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.integrationtest.mapper.pojo.work.operations;
 
 import java.util.concurrent.CompletionStage;
 
+import org.hibernate.search.mapper.javabean.session.SearchSession;
 import org.hibernate.search.mapper.javabean.work.SearchIndexer;
 import org.hibernate.search.mapper.javabean.work.SearchIndexingPlan;
 import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
@@ -71,6 +72,13 @@ public class PojoIndexingAddIT {
 		}
 	}
 
+	public static class IndexerIndexingProcessorFailureIT extends AbstractPojoIndexingProcessorFailureIT {
+		@Override
+		protected void process(SearchSession session, Object entity) {
+			session.indexer().add( entity );
+		}
+	}
+
 	public static class IndexingPlanBaseIT extends AbstractPojoIndexingPlanOperationBaseIT {
 		@Override
 		protected PojoIndexingOperationScenario scenario() {
@@ -89,6 +97,22 @@ public class PojoIndexingAddIT {
 		@Override
 		protected PojoIndexingOperationScenario scenario() {
 			return SCENARIO;
+		}
+	}
+
+	public static class IndexingPlanIndexingProcessorFailureIT extends AbstractPojoIndexingProcessorFailureIT {
+		@Override
+		protected void process(SearchSession session, Object entity) {
+			session.indexingPlan().add( entity );
+			session.close();
+		}
+	}
+
+	public static class IndexingPlanReindexingResolutionFailureIT extends AbstractPojoReindexingResolutionFailureIT {
+		@Override
+		protected void process(SearchSession session, Object entity) {
+			session.indexingPlan().add( entity );
+			session.close();
 		}
 	}
 

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/PojoIndexingAddOrUpdateIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/PojoIndexingAddOrUpdateIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.integrationtest.mapper.pojo.work.operations;
 
 import java.util.concurrent.CompletionStage;
 
+import org.hibernate.search.mapper.javabean.session.SearchSession;
 import org.hibernate.search.mapper.javabean.work.SearchIndexer;
 import org.hibernate.search.mapper.javabean.work.SearchIndexingPlan;
 import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
@@ -72,6 +73,13 @@ public class PojoIndexingAddOrUpdateIT {
 		}
 	}
 
+	public static class IndexerIndexingProcessorFailureIT extends AbstractPojoIndexingProcessorFailureIT {
+		@Override
+		protected void process(SearchSession session, Object entity) {
+			session.indexer().addOrUpdate( entity );
+		}
+	}
+
 	public static class IndexingPlanBaseIT extends AbstractPojoIndexingPlanOperationBaseIT {
 		@Override
 		protected PojoIndexingOperationScenario scenario() {
@@ -93,5 +101,20 @@ public class PojoIndexingAddOrUpdateIT {
 		}
 	}
 
+	public static class IndexingPlanIndexingProcessorFailureIT extends AbstractPojoIndexingProcessorFailureIT {
+		@Override
+		protected void process(SearchSession session, Object entity) {
+			session.indexingPlan().addOrUpdate( entity );
+			session.close();
+		}
+	}
+
+	public static class IndexingPlanReindexingResolutionFailureIT extends AbstractPojoReindexingResolutionFailureIT {
+		@Override
+		protected void process(SearchSession session, Object entity) {
+			session.indexingPlan().addOrUpdate( entity );
+			session.close();
+		}
+	}
 
 }

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/PojoIndexingDeleteIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/PojoIndexingDeleteIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.integrationtest.mapper.pojo.work.operations;
 
 import java.util.concurrent.CompletionStage;
 
+import org.hibernate.search.mapper.javabean.session.SearchSession;
 import org.hibernate.search.mapper.javabean.work.SearchIndexer;
 import org.hibernate.search.mapper.javabean.work.SearchIndexingPlan;
 import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
@@ -90,6 +91,14 @@ public class PojoIndexingDeleteIT {
 		@Override
 		protected PojoIndexingOperationScenario scenario() {
 			return SCENARIO;
+		}
+	}
+
+	public static class IndexingPlanReindexingResolutionFailureIT extends AbstractPojoReindexingResolutionFailureIT {
+		@Override
+		protected void process(SearchSession session, Object entity) {
+			session.indexingPlan().delete( entity );
+			session.close();
 		}
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/PojoImplicitReindexingResolverPropertyNodeBuilder.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/PojoImplicitReindexingResolverPropertyNodeBuilder.java
@@ -130,7 +130,8 @@ class PojoImplicitReindexingResolverPropertyNodeBuilder<T, P>
 		}
 		else {
 			return Optional.of( new PojoImplicitReindexingResolverPropertyNode<>(
-					modelPath.getPropertyModel().handle(), createNested( immutableNestedNodes )
+					modelPath.getPropertyModel().handle(), createNested( immutableNestedNodes ),
+					modelPath.toUnboundPath()
 			) );
 		}
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/common/annotation/impl/SearchProcessingWithContextException.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/common/annotation/impl/SearchProcessingWithContextException.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.common.annotation.impl;
+
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.common.annotation.impl.SuppressForbiddenApis;
+import org.hibernate.search.util.common.reporting.EventContext;
+
+public class SearchProcessingWithContextException extends SearchException {
+	@SuppressForbiddenApis(reason = SEARCH_EXCEPTION_AND_SUBCLASSES_CAN_USE_CONSTRUCTOR)
+	public SearchProcessingWithContextException(String message, Throwable cause, EventContext context) {
+		super( message, cause, context );
+	}
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeOptionsStep;
+import org.hibernate.search.mapper.pojo.common.annotation.impl.SearchProcessingWithContextException;
 import org.hibernate.search.mapper.pojo.extractor.ContainerExtractor;
 import org.hibernate.search.mapper.pojo.logging.spi.PojoModelPathFormatter;
 import org.hibernate.search.mapper.pojo.logging.spi.PojoTypeModelFormatter;
@@ -640,5 +641,10 @@ public interface Log extends BasicLogger {
 			+ " First failure: %2$s")
 	SearchException massIndexingFirstFailure(long finalFailureCount, String firstFailureMessage,
 			@Cause Throwable firstFailure);
+
+	// Not using a message ID: this exception is just a simple wrapper
+	@Message(value = "%1$s")
+	SearchProcessingWithContextException searchProcessingFailure(@Cause Throwable cause, String causeMessage,
+			@Param EventContext context);
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexingProcessorPropertyNodeBuilder.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexingProcessorPropertyNodeBuilder.java
@@ -196,7 +196,8 @@ class PojoIndexingProcessorPropertyNodeBuilder<T, P> extends AbstractPojoProcess
 			else {
 				return Optional.of( new PojoIndexingProcessorPropertyNode<>(
 						modelPath.getPropertyModel().handle(),
-						createNested( nestedNodes )
+						createNested( nestedNodes ),
+						modelPath.toUnboundPath()
 				) );
 			}
 		}

--- a/util/common/src/main/java/org/hibernate/search/util/common/logging/impl/Log.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/logging/impl/Log.java
@@ -73,8 +73,9 @@ public interface Log extends BasicLogger {
 			value = "'%1$s' must not be null or empty.")
 	IllegalArgumentException arrayMustNotBeNullNorEmpty(String objectDescription);
 
-	@Message(id = ID_OFFSET + 5, value = "Exception while invoking '%1$s' on '%2$s'.")
-	SearchException errorInvokingMember(Member member, String componentAsString, @Cause Throwable e);
+	@Message(id = ID_OFFSET + 5, value = "Exception while invoking '%1$s' on '%2$s': %3$s.")
+	SearchException errorInvokingMember(Member member, String componentAsString,
+			@Cause Throwable cause, String causeMessage);
 
 	@Message(id = ID_OFFSET + 6,
 			value = "Requested type argument %3$s to type %2$s"

--- a/util/common/src/main/java/org/hibernate/search/util/common/reflect/impl/FieldValueReadHandle.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/reflect/impl/FieldValueReadHandle.java
@@ -35,7 +35,7 @@ public final class FieldValueReadHandle<T> implements ValueReadHandle<T> {
 			return (T) field.get( thiz );
 		}
 		catch (RuntimeException | IllegalAccessException e) {
-			throw log.errorInvokingMember( field, Throwables.safeToString( e, thiz ), e );
+			throw log.errorInvokingMember( field, Throwables.safeToString( e, thiz ), e, e.getMessage() );
 		}
 	}
 

--- a/util/common/src/main/java/org/hibernate/search/util/common/reflect/impl/MethodHandleValueReadHandle.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/reflect/impl/MethodHandleValueReadHandle.java
@@ -45,7 +45,7 @@ public final class MethodHandleValueReadHandle<T> implements ValueReadHandle<T> 
 			if ( e instanceof InterruptedException ) {
 				Thread.currentThread().interrupt();
 			}
-			throw log.errorInvokingMember( member, Throwables.safeToString( e, thiz ), e );
+			throw log.errorInvokingMember( member, Throwables.safeToString( e, thiz ), e, e.getMessage() );
 		}
 	}
 

--- a/util/common/src/main/java/org/hibernate/search/util/common/reflect/impl/MethodValueReadHandle.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/reflect/impl/MethodValueReadHandle.java
@@ -36,7 +36,7 @@ public final class MethodValueReadHandle<T> implements ValueReadHandle<T> {
 			return (T) method.invoke( thiz );
 		}
 		catch (RuntimeException | IllegalAccessException e) {
-			throw log.errorInvokingMember( method, Throwables.safeToString( e, thiz ), e );
+			throw log.errorInvokingMember( method, Throwables.safeToString( e, thiz ), e, e.getMessage() );
 		}
 		catch (InvocationTargetException e) {
 			Throwable thrown = e.getCause();
@@ -44,7 +44,7 @@ public final class MethodValueReadHandle<T> implements ValueReadHandle<T> {
 				throw (Error) thrown;
 			}
 			else {
-				throw log.errorInvokingMember( method, Throwables.safeToString( thrown, thiz ), thrown );
+				throw log.errorInvokingMember( method, Throwables.safeToString( thrown, thiz ), thrown, thrown.getMessage() );
 			}
 		}
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4366

This simply adds context to exception thrown during processing, i.e. like this:

```
org.hibernate.search.util.common.SearchException: HSEARCH700083: Exception while building document for entity 'RootEntity#1': Simulated failure
Context: path '.containedNoContainer<no value extractors>.containedInContainer'
```

The path representation is far from perfect, but that's a more general problem. I'd say it's better than nothing: at least it gives a general idea of where the problem is in user code.