### PR TITLE
HSEARCH-4372 Simplify sharding configuration and move it to hibernate.search.coordination.event_processor.* properties

### DIFF
--- a/documentation/src/main/asciidoc/reference/coordination.asciidoc
+++ b/documentation/src/main/asciidoc/reference/coordination.asciidoc
@@ -194,7 +194,7 @@ Indexing happens in a background thread::
 When a Hibernate ORM session is flushed,
 Hibernate Search will persist entity change events within the same Hibernate ORM session and the same transaction.
 +
-A <<coordination-outbox-polling-agents-event-processor,event processor>> polls the database for new entity change events,
+A <<coordination-outbox-polling-event-processor,event processor>> polls the database for new entity change events,
 and asynchronously performs reindexing of the appropriate entities when it finds new events
 (i.e. after the transaction is committed).
 +
@@ -248,7 +248,7 @@ This means these changes are safely stored to disk,
 but this does not mean a search query ran immediately when the thread resumes will take the changes into account:
 <<coordination-outbox-polling-indexing-background,indexing will happen at a later time, asynchronously, in a background processor>>.
 +
-You can <<coordination-outbox-polling-agents-event-processor,configure this event processor>> to run more often,
+You can <<coordination-outbox-polling-event-processor,configure this event processor>> to run more often,
 but it will remain asynchronous.
 
 [[coordination-outbox-polling-schema]]
@@ -284,13 +284,13 @@ In order to avoid unnecessarily indexing the same entity multiple times on diffe
 Hibernate Search partitions the entities in what it calls "shards":
 
 * Each entity belongs to exactly one shard.
-* Each application node involved in <<coordination-outbox-polling-agents-event-processor,event processing>>
+* Each application node involved in <<coordination-outbox-polling-event-processor,event processing>>
 is uniquely assigned one or more shards, and will only process events related to entities in these shards.
 
 In order to reliably assign shards,
 Hibernate Search <<coordination-outbox-polling-schema,adds an agent table to the database>>,
 and uses that table to register agents involved in indexing (most of the time, one application instance = one agent =
-the <<coordination-outbox-polling-agents-event-processor,event processor>>).
+the <<coordination-outbox-polling-event-processor,event processor>>).
 The registered agents form a cluster.
 
 To make sure that agents are always assigned one shard,
@@ -298,46 +298,40 @@ and that one shard is never assigned to more than one agent,
 each agent will periodically perform a "pulse",
 updating and inspecting the agent table.
 
-What happens during a pulse depends on the <<coordination-outbox-polling-agents,type of agent>>.
+What happens during a pulse depends on the type of agent.
 During a "pulse":
 
-* An event processor will:
+* An <<coordination-outbox-polling-event-processor,event processor>> will:
 ** update its own entry in the agent table, to let other agents knows it's still active;
 ** forcibly remove entries from other agents if it detects that these agents expired
    (did not update their entry for a long time);
 ** detect and report configuration mistakes
    if using <<coordination-outbox-polling-sharding-static,static sharding>>,
    e.g. two agents assigned to the same shard;
-** decide to suspend itself if a <<coordination-outbox-polling-agents-mass-indexer,mass indexer>> is running;
-** trigger rebalancing as necessary if using <<coordination-outbox-polling-agents-event-processor-sharding,dynamic sharding>>;
+** decide to suspend itself if a <<coordination-outbox-polling-mass-indexer,mass indexer>> is running;
+** trigger rebalancing as necessary if using <<coordination-outbox-polling-event-processor-sharding,dynamic sharding>>;
    e.g. when it detects that new agents recently joined the cluster,
    or that agents left the cluster (voluntarily or forcibly).
-* A mass indexer will:
+* A <<coordination-outbox-polling-mass-indexer,mass indexer>> will:
 ** update its own entry in the agent table, to let other agents knows it's still active;
 ** forcibly remove entries from other agents if it detects that these agents expired
    (did not update their entry for a long time);
 ** switch to active waiting mode (frequent polling) if it notices some
-   <<coordination-outbox-polling-agents-event-processor,event processors>> are still running;
+   <<coordination-outbox-polling-event-processor,event processors>> are still running;
 ** switch to pulse-only mode (infrequent polling) and give the green light for mass indexing to start
-  if it notices no <<coordination-outbox-polling-agents-event-processor,event processors>> are running anymore.
+  if it notices no <<coordination-outbox-polling-event-processor,event processors>> are running anymore.
 
 For more details about dynamic and static sharding, see the following sections.
 
-[[coordination-outbox-polling-agents]]
-=== [[coordination-database-polling-processors]] Agents
+[[coordination-outbox-polling-event-processor]]
+=== [[coordination-database-polling-processors]] Event processor
 
-The `outbox-polling` coordination strategy involves agents executing in the background.
+[[coordination-outbox-polling-event-processor-basics]]
+==== Basics
 
-The following subsections list those agents and detail their respective configuration options.
-
-[[coordination-outbox-polling-agents-event-processor]]
-==== Event processor
-
-[[coordination-outbox-polling-agents-event-processor-basics]]
-===== Basics
-
-The most important agent is the event processor,
-which polls the outbox table for events
+Among agents of the `outbox-polling` coordination strategy executing in the background,
+the most important one is the event processor:
+it polls the outbox table for events
 and then reindexes the corresponding entities when new events are found.
 
 The event processor can be configured using the following configuration properties:
@@ -414,17 +408,17 @@ as a <<configuration-property-types,positive integer value>> in seconds.
 Use the value `0` to reprocess the failed events as soon as possible, with no delay.
 The default for this property is `30`.
 Dynamic sharding does not require any specific configuration,
-but you may want to configure other properties of <<coordination-outbox-polling-agents-event-processor,the event processor>>.
+but you may want to configure other properties of <<coordination-outbox-polling-event-processor,the event processor>>.
 
-[[coordination-outbox-polling-agents-event-processor-sharding]]
-===== [[coordination-database-polling-sharding-dynamic]] [[coordination-database-polling-sharding-static]] Sharding
+[[coordination-outbox-polling-event-processor-sharding]]
+==== [[coordination-database-polling-sharding-dynamic]] [[coordination-database-polling-sharding-static]] Sharding
 
 By default, <<coordination-outbox-polling-sharding,sharding>> is dynamic:
 Hibernate Search registers each application instance in the database,
 and uses that information to dynamically assign a single, unique shard to each application instance,
 updating assignments as instances start or stop.
 Dynamic sharding does not accept any configuration beyond the
-<<coordination-outbox-polling-agents-event-processor-basics,basics>>.
+<<coordination-outbox-polling-event-processor-basics,basics>>.
 
 If you want to configure sharding explicitly, you can use static sharding
 by setting the following configuration properties:
@@ -497,11 +491,11 @@ hibernate.search.coordination.event_processor.enabled = false
 ----
 ====
 
-[[coordination-outbox-polling-agents-mass-indexer]]
-==== Mass indexer
+[[coordination-outbox-polling-mass-indexer]]
+=== Mass indexer
 
-[[coordination-outbox-polling-agents-mass-indexer-basics]]
-===== Basics
+[[coordination-outbox-polling-mass-indexer-basics]]
+==== Basics
 
 During <<mapper-orm-indexing-massindexer,mass indexing>>,
 an application instance will exceptionally bypass <<coordination-database-polling-sharding,sharding>>
@@ -576,8 +570,8 @@ If you use link:{hibernateDocUrl}#configurations-multi-tenancy[Hibernate ORM's m
 you will need to <<configuration-multi-tenancy,configure the list of all possible tenant identifiers>>.
 
 Failing to mention a tenant identifier in this configuration might result in
-events piling up in the outbox table without ever being <<coordination-outbox-polling-agents-event-processor,processed>>,
-or in exceptions being thrown upon <<coordination-outbox-polling-agents-mass-indexer,mass indexing>>
+events piling up in the outbox table without ever being <<coordination-outbox-polling-event-processor,processed>>,
+or in exceptions being thrown upon <<coordination-outbox-polling-mass-indexer,mass indexing>>
 due to incomplete configuration.
 
 Apart from that, multi-tenancy support should be fairly transparent:

--- a/documentation/src/main/asciidoc/reference/coordination.asciidoc
+++ b/documentation/src/main/asciidoc/reference/coordination.asciidoc
@@ -343,9 +343,9 @@ Sharding can be controlled explicitly by setting the following configuration pro
 
 [source]
 ----
-hibernate.search.coordination.shards.static = true
-hibernate.search.coordination.shards.total_count = 4
-hibernate.search.coordination.shards.assigned = 0
+hibernate.search.coordination.event_processor.shards.static = true
+hibernate.search.coordination.event_processor.shards.total_count = 4
+hibernate.search.coordination.event_processor.shards.assigned = 0
 ----
 
 * `shards.static` defines sharding as static.
@@ -388,18 +388,18 @@ and no shard at all to application nodes #2 and #3:
 ----
 # Node #0
 hibernate.search.coordination.strategy = outbox-polling
-hibernate.search.coordination.shards.static = true
-hibernate.search.coordination.shards.total_count = 2
-hibernate.search.coordination.shards.assigned = 0
+hibernate.search.coordination.event_processor.shards.static = true
+hibernate.search.coordination.event_processor.shards.total_count = 2
+hibernate.search.coordination.event_processor.shards.assigned = 0
 ----
 
 [source]
 ----
 # Node #1
 hibernate.search.coordination.strategy = outbox-polling
-hibernate.search.coordination.shards.static = true
-hibernate.search.coordination.shards.total_count = 2
-hibernate.search.coordination.shards.assigned = 1
+hibernate.search.coordination.event_processor.shards.static = true
+hibernate.search.coordination.event_processor.shards.total_count = 2
+hibernate.search.coordination.event_processor.shards.assigned = 1
 ----
 
 [source]

--- a/documentation/src/main/asciidoc/reference/coordination.asciidoc
+++ b/documentation/src/main/asciidoc/reference/coordination.asciidoc
@@ -261,7 +261,7 @@ This includes in particular an outbox table, to which one row (representing a ch
 in a way that requires reindexing.
 
 This also includes an agent table, where Hibernate Search registers every background event processor
-in order to <<coordination-outbox-polling-sharding-dynamic,dynamically assign shards>> to each application instance,
+in order to <<coordination-outbox-polling-sharding,dynamically assign shards>> to each application instance,
 or simply to check that <<coordination-outbox-polling-sharding-static,statically assigned shards>>
 are consistent.
 
@@ -278,10 +278,7 @@ in particular the Hibernate ORM properties `javax.persistence.schema-generation.
 and `javax.persistence.schema-generation.scripts.drop-target`.
 
 [[coordination-outbox-polling-sharding]]
-=== [[coordination-database-polling-sharding]] Sharding
-
-[[coordination-outbox-polling-sharding-basics]]
-==== [[coordination-database-polling-sharding-basics]] Basics
+=== [[coordination-database-polling-sharding]] [[coordination-outbox-polling-sharding-basics]] Sharding and pulse
 
 In order to avoid unnecessarily indexing the same entity multiple times on different application nodes,
 Hibernate Search partitions the entities in what it calls "shards":
@@ -312,7 +309,7 @@ During a "pulse":
    if using <<coordination-outbox-polling-sharding-static,static sharding>>,
    e.g. two agents assigned to the same shard;
 ** decide to suspend itself if a <<coordination-outbox-polling-agents-mass-indexer,mass indexer>> is running;
-** trigger rebalancing as necessary if using <<coordination-outbox-polling-sharding-dynamic,dynamic sharding>>;
+** trigger rebalancing as necessary if using <<coordination-outbox-polling-agents-event-processor-sharding,dynamic sharding>>;
    e.g. when it detects that new agents recently joined the cluster,
    or that agents left the cluster (voluntarily or forcibly).
 * A mass indexer will:
@@ -326,20 +323,111 @@ During a "pulse":
 
 For more details about dynamic and static sharding, see the following sections.
 
-[[coordination-outbox-polling-sharding-dynamic]]
-==== [[coordination-database-polling-sharding-dynamic]] Dynamic sharding
+[[coordination-outbox-polling-agents]]
+=== [[coordination-database-polling-processors]] Agents
 
-By default, sharding is dynamic: Hibernate Search registers each application instance in the database,
+The `outbox-polling` coordination strategy involves agents executing in the background.
+
+The following subsections list those agents and detail their respective configuration options.
+
+[[coordination-outbox-polling-agents-event-processor]]
+==== Event processor
+
+[[coordination-outbox-polling-agents-event-processor-basics]]
+===== Basics
+
+The most important agent is the event processor,
+which polls the outbox table for events
+and then reindexes the corresponding entities when new events are found.
+
+The event processor can be configured using the following configuration properties:
+
+[source]
+----
+hibernate.search.coordination.event_processor.enabled = true
+hibernate.search.coordination.event_processor.polling_interval = 100
+hibernate.search.coordination.event_processor.pulse_interval = 2000
+hibernate.search.coordination.event_processor.pulse_expiration = 30000
+hibernate.search.coordination.event_processor.batch_size = 50
+hibernate.search.coordination.event_processor.transaction_timeout = 10
+hibernate.search.coordination.event_processor.retry_delay = 15
+----
+
+* `event_processor.enabled` defines whether the event processor is enabled,
+as a <<configuration-property-types,boolean value>>.
+The default for this property is `true`, but it can be set to `false` to disable event processing on some application nodes,
+for example to dedicate some nodes to HTTP request processing and other nodes to event processing.
+* `event_processor.polling_interval` defines how long to wait for another query to the outbox events table
+after a query didn't return any event,
+as an <<configuration-property-types,integer value>> in milliseconds.
+The default for this property is `100`.
++
+Lower values will reduce the time it takes for a change to be reflected in the index,
+but will increase the stress on the database when there are no new events.
+* `event_processor.pulse_interval` defines how long the event processor can poll for events
+before it must perform a "pulse",
+as an <<configuration-property-types,integer value>> in milliseconds.
+The default for this property is `2000`.
++
+See <<coordination-outbox-polling-sharding-basics,the sharding basics>> for information about "pulses".
++
+The pulse interval must be set to a value between the polling interval (see above) and one third (1/3) of the expiration interval (see below).
++
+Low values (closer to the polling interval) mean a shorter delay before rebalancing
+when a node joins or leaves the cluster,
+and reduced risk of incorrectly considering an agent disconnected,
+but more stress on the database because of more frequent checks of the list of agents.
++
+High values (closer to the expiration interval) mean a longer delay before rebalancing
+when a node joins or leaves the cluster,
+and increased risk of incorrectly considering an agent disconnected,
+but less stress on the database because of less frequent checks of the list of agents.
+* `event_processor.pulse_expiration` defines how long an event processor "pulse" remains valid
+before considering the processor disconnected and forcibly removing it from the cluster,
+as an <<configuration-property-types,integer value>> in milliseconds.
+The default for this property is `30000`.
++
+See <<coordination-outbox-polling-sharding-basics,the sharding basics>> for information about "pulses".
++
+The expiration interval must be set to a value 3 times larger than the pulse interval (see above).
++
+Low values (closer to the pulse interval) mean a shorter delay before rebalancing
+when a node abruptly leaves the cluster due to a crash or network failure,
+but increased risk of incorrectly considering an event processor disconnected.
++
+High values (much larger than the pulse interval) mean a longer delay before rebalancing
+when a node abruptly leaves the cluster due to a crash or network failure,
+but reduced risk of incorrectly considering an event processor disconnected.
+* `event_processor.batch_size` defines how many outbox events, at most, are processed in a single transaction
+as an <<configuration-property-types,integer value>>.
+The default for this property is `50`.
++
+Higher values will reduce the number of transactions opened by the background process
+and may increase performance thanks to the first-level cache (persistence context),
+but will increase memory usage and in extreme cases may lead to `OutOfMemoryErrors`.
+* `event_processor.transaction_timeout` defines the timeout for transactions processing outbox events
+as an <<configuration-property-types,integer value>> in seconds.
+Only effective when a JTA transaction manager is configured.
+When using JTA and this property is not set, Hibernate Search will use whatever default transaction timeout is configured in the JTA transaction manager.
+* `event_processor.retry_delay` defines the time after which it is possible to process again an event that has gone into error.
+as a <<configuration-property-types,positive integer value>> in seconds.
+Use the value `0` to reprocess the failed events as soon as possible, with no delay.
+The default for this property is `30`.
+Dynamic sharding does not require any specific configuration,
+but you may want to configure other properties of <<coordination-outbox-polling-agents-event-processor,the event processor>>.
+
+[[coordination-outbox-polling-agents-event-processor-sharding]]
+===== [[coordination-database-polling-sharding-dynamic]] [[coordination-database-polling-sharding-static]] Sharding
+
+By default, <<coordination-outbox-polling-sharding,sharding>> is dynamic:
+Hibernate Search registers each application instance in the database,
 and uses that information to dynamically assign a single, unique shard to each application instance,
 updating assignments as instances start or stop.
+Dynamic sharding does not accept any configuration beyond the
+<<coordination-outbox-polling-agents-event-processor-basics,basics>>.
 
-Dynamic sharding does not require any specific configuration,
-but you may want to configure <<coordination-outbox-polling-agents-event-processor,the event processor>>.
-
-[[coordination-outbox-polling-sharding-static]]
-==== [[coordination-database-polling-sharding-static]] Static sharding
-
-Sharding can be controlled explicitly by setting the following configuration properties:
+If you want to configure sharding explicitly, you can use static sharding
+by setting the following configuration properties:
 
 [source]
 ----
@@ -429,96 +517,11 @@ then (once every node has processing disabled),
 restart nodes one by one with the new sharding settings and with processing re-enabled.
 ====
 
-[[coordination-outbox-polling-agents]]
-=== [[coordination-database-polling-processors]] Agents
-
-The `outbox-polling` coordination strategy involves agents executing in the background.
-
-The following subsections list those agents and detail their respective configuration options.
-
-[[coordination-outbox-polling-agents-event-processor]]
-==== Event processor
-
-The most important agent is the event processor,
-which polls the outbox table for events
-and then reindexes the corresponding entities when new events are found.
-
-The event processor can be configured using the following configuration properties:
-
-[source]
-----
-hibernate.search.coordination.event_processor.enabled = true
-hibernate.search.coordination.event_processor.polling_interval = 100
-hibernate.search.coordination.event_processor.pulse_interval = 2000
-hibernate.search.coordination.event_processor.pulse_expiration = 30000
-hibernate.search.coordination.event_processor.batch_size = 50
-hibernate.search.coordination.event_processor.transaction_timeout = 10
-hibernate.search.coordination.event_processor.retry_delay = 15
-----
-
-* `event_processor.enabled` defines whether the event processor is enabled,
-as a <<configuration-property-types,boolean value>>.
-The default for this property is `true`, but it can be set to `false` to disable event processing on some application nodes,
-for example to dedicate some nodes to HTTP request processing and other nodes to event processing.
-* `event_processor.polling_interval` defines how long to wait for another query to the outbox events table
-after a query didn't return any event,
-as an <<configuration-property-types,integer value>> in milliseconds.
-The default for this property is `100`.
-+
-Lower values will reduce the time it takes for a change to be reflected in the index,
-but will increase the stress on the database when there are no new events.
-* `event_processor.pulse_interval` defines how long the event processor can poll for events
-before it must perform a "pulse",
-as an <<configuration-property-types,integer value>> in milliseconds.
-The default for this property is `2000`.
-+
-See <<coordination-outbox-polling-sharding-basics,the sharding basics>> for information about "pulses".
-+
-The pulse interval must be set to a value between the polling interval (see above) and one third (1/3) of the expiration interval (see below).
-+
-Low values (closer to the polling interval) mean a shorter delay before rebalancing
-when a node joins or leaves the cluster,
-and reduced risk of incorrectly considering an agent disconnected,
-but more stress on the database because of more frequent checks of the list of agents.
-+
-High values (closer to the expiration interval) mean a longer delay before rebalancing
-when a node joins or leaves the cluster,
-and increased risk of incorrectly considering an agent disconnected,
-but less stress on the database because of less frequent checks of the list of agents.
-* `event_processor.pulse_expiration` defines how long an event processor "pulse" remains valid
-before considering the processor disconnected and forcibly removing it from the cluster,
-as an <<configuration-property-types,integer value>> in milliseconds.
-The default for this property is `30000`.
-+
-See <<coordination-outbox-polling-sharding-basics,the sharding basics>> for information about "pulses".
-+
-The expiration interval must be set to a value 3 times larger than the pulse interval (see above).
-+
-Low values (closer to the pulse interval) mean a shorter delay before rebalancing
-when a node abruptly leaves the cluster due to a crash or network failure,
-but increased risk of incorrectly considering an event processor disconnected.
-+
-High values (much larger than the pulse interval) mean a longer delay before rebalancing
-when a node abruptly leaves the cluster due to a crash or network failure,
-but reduced risk of incorrectly considering an event processor disconnected.
-* `event_processor.batch_size` defines how many outbox events, at most, are processed in a single transaction
-as an <<configuration-property-types,integer value>>.
-The default for this property is `50`.
-+
-Higher values will reduce the number of transactions opened by the background process
-and may increase performance thanks to the first-level cache (persistence context),
-but will increase memory usage and in extreme cases may lead to `OutOfMemoryErrors`.
-* `event_processor.transaction_timeout` defines the timeout for transactions processing outbox events
-as an <<configuration-property-types,integer value>> in seconds.
-Only effective when a JTA transaction manager is configured.
-When using JTA and this property is not set, Hibernate Search will use whatever default transaction timeout is configured in the JTA transaction manager.
-* `event_processor.retry_delay` defines the time after which it is possible to process again an event that has gone into error.
-as a <<configuration-property-types,positive integer value>> in seconds.
-Use the value `0` to reprocess the failed events as soon as possible, with no delay.
-The default for this property is `30`.
-
 [[coordination-outbox-polling-agents-mass-indexer]]
 ==== Mass indexer
+
+[[coordination-outbox-polling-agents-mass-indexer-basics]]
+===== Basics
 
 During <<mapper-orm-indexing-massindexer,mass indexing>>,
 an application instance will exceptionally bypass <<coordination-database-polling-sharding,sharding>>

--- a/documentation/src/main/asciidoc/reference/coordination.asciidoc
+++ b/documentation/src/main/asciidoc/reference/coordination.asciidoc
@@ -451,19 +451,11 @@ A given application node must be assigned at least one shard
 but may be assigned multiple shards by setting `shards.assigned` to a comma-separated list,
 e.g. `0,3`.
 
-[CAUTION]
+[NOTE]
 ====
-Each shard must be assigned to one and only one application node,
-but this is **not** checked automatically by Hibernate Search.
+Each shard must be assigned to one and only one application node.
 
-Failure to do so may result in poor performance,
-or event out-of-sync indexes.
-====
-
-[TIP]
-====
-Sharding settings are irrelevant, and thus ignored,
-when <<coordination-outbox-polling-agents-event-processor,event processing is disabled>>.
+Event processing simply won't start until every shard has exactly one node.
 ====
 
 .Example of static sharding settings
@@ -503,18 +495,6 @@ hibernate.search.coordination.event_processor.enabled = false
 hibernate.search.coordination.strategy = outbox-polling
 hibernate.search.coordination.event_processor.enabled = false
 ----
-====
-
-[TIP]
-====
-Sharding settings, even static, may change over the lifetime of an application,
-but must be consistent across all application nodes involved in processing at all times.
-
-If you cannot stop your whole application cluster,
-the only way to safely change sharding settings is to restart nodes one by one
-to disable <<coordination-outbox-polling-agents-event-processor,event processing>>,
-then (once every node has processing disabled),
-restart nodes one by one with the new sharding settings and with processing re-enabled.
 ====
 
 [[coordination-outbox-polling-agents-mass-indexer]]

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingShardingBaseIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingShardingBaseIT.java
@@ -105,9 +105,9 @@ public class OutboxPollingAutomaticIndexingShardingBaseIT {
 				.with( ctx -> {
 					if ( isStatic ) {
 						return ctx
-								.withProperty( "hibernate.search.coordination.shards.static", "true" )
-								.withProperty( "hibernate.search.coordination.shards.total_count", totalShardCount )
-								.withProperty( "hibernate.search.coordination.shards.assigned", String.valueOf( assignedShardIndex ) );
+								.withProperty( "hibernate.search.coordination.event_processor.shards.static", "true" )
+								.withProperty( "hibernate.search.coordination.event_processor.shards.total_count", totalShardCount )
+								.withProperty( "hibernate.search.coordination.event_processor.shards.assigned", String.valueOf( assignedShardIndex ) );
 					}
 					else {
 						return ctx;

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingShardingBaseIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingShardingBaseIT.java
@@ -105,7 +105,6 @@ public class OutboxPollingAutomaticIndexingShardingBaseIT {
 				.with( ctx -> {
 					if ( isStatic ) {
 						return ctx
-								.withProperty( "hibernate.search.coordination.event_processor.shards.static", "true" )
 								.withProperty( "hibernate.search.coordination.event_processor.shards.total_count", totalShardCount )
 								.withProperty( "hibernate.search.coordination.event_processor.shards.assigned", String.valueOf( assignedShardIndex ) );
 					}

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingStaticShardingIncompatibleConfigurationIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingStaticShardingIncompatibleConfigurationIT.java
@@ -51,7 +51,6 @@ public class OutboxPollingAutomaticIndexingStaticShardingIncompatibleConfigurati
 		OrmSetupHelper.SetupContext context = ormSetupHelper.start()
 				.withProperty( Environment.HBM2DDL_AUTO, hbm2ddlAction )
 				.withProperty( "hibernate.search.background_failure_handler", failureHandler )
-				.withProperty( "hibernate.search.coordination.event_processor.shards.static", "true" )
 				.withProperty( "hibernate.search.coordination.event_processor.shards.total_count", totalShardCount )
 				.withProperty( "hibernate.search.coordination.event_processor.shards.assigned", assignedShardIndices );
 

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingStaticShardingIncompatibleConfigurationIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingStaticShardingIncompatibleConfigurationIT.java
@@ -51,9 +51,9 @@ public class OutboxPollingAutomaticIndexingStaticShardingIncompatibleConfigurati
 		OrmSetupHelper.SetupContext context = ormSetupHelper.start()
 				.withProperty( Environment.HBM2DDL_AUTO, hbm2ddlAction )
 				.withProperty( "hibernate.search.background_failure_handler", failureHandler )
-				.withProperty( "hibernate.search.coordination.shards.static", "true" )
-				.withProperty( "hibernate.search.coordination.shards.total_count", totalShardCount )
-				.withProperty( "hibernate.search.coordination.shards.assigned", assignedShardIndices );
+				.withProperty( "hibernate.search.coordination.event_processor.shards.static", "true" )
+				.withProperty( "hibernate.search.coordination.event_processor.shards.total_count", totalShardCount )
+				.withProperty( "hibernate.search.coordination.event_processor.shards.assigned", assignedShardIndices );
 
 		context.setup( IndexedEntity.class );
 	}

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingStaticShardingInvalidConfigurationIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingStaticShardingInvalidConfigurationIT.java
@@ -40,7 +40,7 @@ public class OutboxPollingAutomaticIndexingStaticShardingInvalidConfigurationIT 
 		assertThatThrownBy( () -> setup( context -> context ) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.failure( "Invalid value for configuration property 'hibernate.search.coordination.shards.total_count'",
+						.failure( "Invalid value for configuration property 'hibernate.search.coordination.event_processor.shards.total_count'",
 								"''", "When using static sharding, this property must be set" )
 						.build() );
 	}
@@ -48,10 +48,10 @@ public class OutboxPollingAutomaticIndexingStaticShardingInvalidConfigurationIT 
 	@Test
 	public void totalCount_zero() {
 		assertThatThrownBy( () -> setup( context -> context
-				.withProperty( "hibernate.search.coordination.shards.total_count", "0" ) ) )
+				.withProperty( "hibernate.search.coordination.event_processor.shards.total_count", "0" ) ) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.failure( "Invalid value for configuration property 'hibernate.search.coordination.shards.total_count'",
+						.failure( "Invalid value for configuration property 'hibernate.search.coordination.event_processor.shards.total_count'",
 								"'0'", "'value' must be strictly positive" )
 						.build() );
 	}
@@ -59,10 +59,10 @@ public class OutboxPollingAutomaticIndexingStaticShardingInvalidConfigurationIT 
 	@Test
 	public void totalCount_negative() {
 		assertThatThrownBy( () -> setup( context -> context
-				.withProperty( "hibernate.search.coordination.shards.total_count", "-1" ) ) )
+				.withProperty( "hibernate.search.coordination.event_processor.shards.total_count", "-1" ) ) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.failure( "Invalid value for configuration property 'hibernate.search.coordination.shards.total_count'",
+						.failure( "Invalid value for configuration property 'hibernate.search.coordination.event_processor.shards.total_count'",
 								"'-1'", "'value' must be strictly positive" )
 						.build() );
 	}
@@ -70,10 +70,10 @@ public class OutboxPollingAutomaticIndexingStaticShardingInvalidConfigurationIT 
 	@Test
 	public void assigned_missing() {
 		assertThatThrownBy( () -> setup( context -> context
-				.withProperty( "hibernate.search.coordination.shards.total_count", "10" ) ) )
+				.withProperty( "hibernate.search.coordination.event_processor.shards.total_count", "10" ) ) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.failure( "Invalid value for configuration property 'hibernate.search.coordination.shards.assigned'",
+						.failure( "Invalid value for configuration property 'hibernate.search.coordination.event_processor.shards.assigned'",
 								"''", "When using static sharding, this property must be set" )
 						.build() );
 	}
@@ -81,11 +81,11 @@ public class OutboxPollingAutomaticIndexingStaticShardingInvalidConfigurationIT 
 	@Test
 	public void assigned_negative() {
 		assertThatThrownBy( () -> setup( context -> context
-				.withProperty( "hibernate.search.coordination.shards.total_count", "10" )
-				.withProperty( "hibernate.search.coordination.shards.assigned", "-1" ) ) )
+				.withProperty( "hibernate.search.coordination.event_processor.shards.total_count", "10" )
+				.withProperty( "hibernate.search.coordination.event_processor.shards.assigned", "-1" ) ) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.failure( "Invalid value for configuration property 'hibernate.search.coordination.shards.assigned'",
+						.failure( "Invalid value for configuration property 'hibernate.search.coordination.event_processor.shards.assigned'",
 								"'-1'",
 								"'value' must be positive or zero" )
 						.build() );
@@ -94,28 +94,28 @@ public class OutboxPollingAutomaticIndexingStaticShardingInvalidConfigurationIT 
 	@Test
 	public void assigned_equalToTotalCount() {
 		assertThatThrownBy( () -> setup( context -> context
-				.withProperty( "hibernate.search.coordination.shards.total_count", "10" )
-				.withProperty( "hibernate.search.coordination.shards.assigned", "10" ) ) )
+				.withProperty( "hibernate.search.coordination.event_processor.shards.total_count", "10" )
+				.withProperty( "hibernate.search.coordination.event_processor.shards.assigned", "10" ) ) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.failure( "Invalid value for configuration property 'hibernate.search.coordination.shards.assigned'",
+						.failure( "Invalid value for configuration property 'hibernate.search.coordination.event_processor.shards.assigned'",
 								"'10'",
 								"Shard indices must be between 0 (inclusive) and 10 (exclusive,"
-										+ " set by 'hibernate.search.coordination.shards.total_count')" )
+										+ " set by 'hibernate.search.coordination.event_processor.shards.total_count')" )
 						.build() );
 	}
 
 	@Test
 	public void assigned_greaterThanTotalCount() {
 		assertThatThrownBy( () -> setup( context -> context
-				.withProperty( "hibernate.search.coordination.shards.total_count", "10" )
-				.withProperty( "hibernate.search.coordination.shards.assigned", "11" ) ) )
+				.withProperty( "hibernate.search.coordination.event_processor.shards.total_count", "10" )
+				.withProperty( "hibernate.search.coordination.event_processor.shards.assigned", "11" ) ) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.failure( "Invalid value for configuration property 'hibernate.search.coordination.shards.assigned'",
+						.failure( "Invalid value for configuration property 'hibernate.search.coordination.event_processor.shards.assigned'",
 								"'11'",
 								"Shard indices must be between 0 (inclusive) and 10 (exclusive,"
-										+ " set by 'hibernate.search.coordination.shards.total_count')" )
+										+ " set by 'hibernate.search.coordination.event_processor.shards.total_count')" )
 						.build() );
 	}
 
@@ -123,7 +123,7 @@ public class OutboxPollingAutomaticIndexingStaticShardingInvalidConfigurationIT 
 		backendMock.expectSchema( IndexedEntity.NAME, b -> b
 				.field( "text", String.class, f -> f.analyzerName( AnalyzerNames.DEFAULT ) ) );
 		ormSetupHelper.start()
-				.withProperty( "hibernate.search.coordination.shards.static", "true" )
+				.withProperty( "hibernate.search.coordination.event_processor.shards.static", "true" )
 				.with( config )
 				.setup( IndexedEntity.class );
 	}

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingStaticShardingInvalidConfigurationIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingStaticShardingInvalidConfigurationIT.java
@@ -37,11 +37,12 @@ public class OutboxPollingAutomaticIndexingStaticShardingInvalidConfigurationIT 
 
 	@Test
 	public void totalCount_missing() {
-		assertThatThrownBy( () -> setup( context -> context ) )
+		assertThatThrownBy( () -> setup( context -> context
+				.withProperty( "hibernate.search.coordination.event_processor.shards.assigned", "0" ) ) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
 						.failure( "Invalid value for configuration property 'hibernate.search.coordination.event_processor.shards.total_count'",
-								"''", "When using static sharding, this property must be set" )
+								"''", "This property must be set when 'hibernate.search.coordination.event_processor.shards.assigned' is set" )
 						.build() );
 	}
 
@@ -74,7 +75,7 @@ public class OutboxPollingAutomaticIndexingStaticShardingInvalidConfigurationIT 
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
 						.failure( "Invalid value for configuration property 'hibernate.search.coordination.event_processor.shards.assigned'",
-								"''", "When using static sharding, this property must be set" )
+								"''", "This property must be set when 'hibernate.search.coordination.event_processor.shards.total_count' is set" )
 						.build() );
 	}
 
@@ -123,7 +124,6 @@ public class OutboxPollingAutomaticIndexingStaticShardingInvalidConfigurationIT 
 		backendMock.expectSchema( IndexedEntity.NAME, b -> b
 				.field( "text", String.class, f -> f.analyzerName( AnalyzerNames.DEFAULT ) ) );
 		ormSetupHelper.start()
-				.withProperty( "hibernate.search.coordination.event_processor.shards.static", "true" )
 				.with( config )
 				.setup( IndexedEntity.class );
 	}

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingStaticShardingUnevenShardsIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingStaticShardingUnevenShardsIT.java
@@ -88,8 +88,7 @@ public class OutboxPollingAutomaticIndexingStaticShardingUnevenShardsIT {
 				.with( indexingCountHelper::bind );
 
 		if ( processingEnabled ) {
-			context = context.withProperty( "hibernate.search.coordination.event_processor.shards.static", "true" )
-					.withProperty( "hibernate.search.coordination.event_processor.shards.total_count", TOTAL_SHARD_COUNT )
+			context = context.withProperty( "hibernate.search.coordination.event_processor.shards.total_count", TOTAL_SHARD_COUNT )
 					.withProperty( "hibernate.search.coordination.event_processor.shards.assigned", assignedShardIndices );
 		}
 		else {

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingStaticShardingUnevenShardsIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingStaticShardingUnevenShardsIT.java
@@ -88,9 +88,9 @@ public class OutboxPollingAutomaticIndexingStaticShardingUnevenShardsIT {
 				.with( indexingCountHelper::bind );
 
 		if ( processingEnabled ) {
-			context = context.withProperty( "hibernate.search.coordination.shards.static", "true" )
-					.withProperty( "hibernate.search.coordination.shards.total_count", TOTAL_SHARD_COUNT )
-					.withProperty( "hibernate.search.coordination.shards.assigned", assignedShardIndices );
+			context = context.withProperty( "hibernate.search.coordination.event_processor.shards.static", "true" )
+					.withProperty( "hibernate.search.coordination.event_processor.shards.total_count", TOTAL_SHARD_COUNT )
+					.withProperty( "hibernate.search.coordination.event_processor.shards.assigned", assignedShardIndices );
 		}
 		else {
 			// If processing is disabled, sharding is irrelevant: we don't need to configure it.

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/HibernateOrmMapperOutboxPollingSettings.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/HibernateOrmMapperOutboxPollingSettings.java
@@ -45,64 +45,6 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	public static final String COORDINATION_TENANTS = PREFIX + Radicals.COORDINATION_TENANTS;
 
 	/**
-	 * Whether shards are static, i.e. configured explicitly for each node, with a fixed number of shards/nodes.
-	 * <p>
-	 * <strong>WARNING:</strong> This property must have the same value for all application nodes,
-	 * and must never change unless all application nodes are stopped, then restarted.
-	 * Failing that, some events may not be processed or may be processed twice or in the wrong order,
-	 * resulting in errors and/or out-of-sync indexes.
-	 * <p>
-	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
-	 * {@value #COORDINATION_STRATEGY_NAME}.
-	 * <p>
-	 * Expects a Boolean value such as {@code true} or {@code false},
-	 * or a string that can be parsed to such Boolean value.
-	 * <p>
-	 * Defaults to {@link Defaults#COORDINATION_SHARDS_STATIC}.
-	 */
-	public static final String COORDINATION_SHARDS_STATIC = PREFIX + Radicals.COORDINATION_SHARDS_STATIC;
-
-	/**
-	 * The total number of shards across all application nodes.
-	 * <p>
-	 * <strong>WARNING:</strong> This property must have the same value for all application nodes,
-	 * and must never change unless all application nodes are stopped, then restarted.
-	 * Failing that, some events may not be processed or may be processed twice or in the wrong order,
-	 * resulting in errors and/or out-of-sync indexes.
-	 * <p>
-	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
-	 * {@value #COORDINATION_STRATEGY_NAME}
-	 * and {@link #COORDINATION_SHARDS_STATIC} is {@code true}.
-	 * <p>
-	 * Expects an Integer value of at least {@code 2},
-	 * or a String that can be parsed into such Integer value.
-	 * <p>
-	 * No default: must be provided when static sharding is enabled.
-	 */
-	public static final String COORDINATION_SHARDS_TOTAL_COUNT = PREFIX + Radicals.COORDINATION_SHARDS_TOTAL_COUNT;
-
-	/**
-	 * The indices of shards assigned to this application node.
-	 * <p>
-	 * <strong>WARNING:</strong> shards must be uniquely assigned to one and only one application nodes.
-	 * Failing that, some events may not be processed or may be processed twice or in the wrong order,
-	 * resulting in errors and/or out-of-sync indexes.
-	 * <p>
-	 * Only available when {@link HibernateOrmMapperSettings#AUTOMATIC_INDEXING_STRATEGY} is
-	 * {@value #COORDINATION_STRATEGY_NAME}
-	 * and {@link #COORDINATION_SHARDS_STATIC} is {@code true}.
-	 * <p>
-	 * Expects a shard index, i.e. an Integer value between {@code 0} (inclusive) and the
-	 * {@link #COORDINATION_SHARDS_TOTAL_COUNT total shard count} (exclusive),
-	 * or a String that can be parsed into such shard index,
-	 * or a String containing multiple such shard index strings separated by commas,
-	 * or a {@code Collection<Integer>} containing such shard indices.
-	 * <p>
-	 * No default: must be provided when static sharding is enabled.
-	 */
-	public static final String COORDINATION_SHARDS_ASSIGNED = PREFIX + Radicals.COORDINATION_SHARDS_ASSIGNED;
-
-	/**
 	 * Whether the application will process entity change events.
 	 * <p>
 	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
@@ -119,6 +61,65 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	 */
 	public static final String COORDINATION_EVENT_PROCESSOR_ENABLED =
 			PREFIX + Radicals.COORDINATION_EVENT_PROCESSOR_ENABLED;
+
+	/**
+	 * Whether shards configured for event processing are static,
+	 * i.e. configured explicitly for each node, with a fixed number of shards/nodes.
+	 * <p>
+	 * <strong>WARNING:</strong> This property must have the same value for all application nodes,
+	 * and must never change unless all application nodes are stopped, then restarted.
+	 * Failing that, some events may not be processed or may be processed twice or in the wrong order,
+	 * resulting in errors and/or out-of-sync indexes.
+	 * <p>
+	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * {@value #COORDINATION_STRATEGY_NAME}.
+	 * <p>
+	 * Expects a Boolean value such as {@code true} or {@code false},
+	 * or a string that can be parsed to such Boolean value.
+	 * <p>
+	 * Defaults to {@link Defaults#COORDINATION_EVENT_PROCESSOR_SHARDS_STATIC}.
+	 */
+	public static final String COORDINATION_EVENT_PROCESSOR_SHARDS_STATIC = PREFIX + Radicals.COORDINATION_EVENT_PROCESSOR_SHARDS_STATIC;
+
+	/**
+	 * The total number of shards across all application nodes for event processing.
+	 * <p>
+	 * <strong>WARNING:</strong> This property must have the same value for all application nodes,
+	 * and must never change unless all application nodes are stopped, then restarted.
+	 * Failing that, some events may not be processed or may be processed twice or in the wrong order,
+	 * resulting in errors and/or out-of-sync indexes.
+	 * <p>
+	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * {@value #COORDINATION_STRATEGY_NAME}
+	 * and {@link #COORDINATION_EVENT_PROCESSOR_SHARDS_STATIC} is {@code true}.
+	 * <p>
+	 * Expects an Integer value of at least {@code 2},
+	 * or a String that can be parsed into such Integer value.
+	 * <p>
+	 * No default: must be provided when static sharding is enabled.
+	 */
+	public static final String COORDINATION_EVENT_PROCESSOR_SHARDS_TOTAL_COUNT = PREFIX + Radicals.COORDINATION_EVENT_PROCESSOR_SHARDS_TOTAL_COUNT;
+
+	/**
+	 * The indices of shards assigned to this application node for event processing.
+	 * <p>
+	 * <strong>WARNING:</strong> shards must be uniquely assigned to one and only one application nodes.
+	 * Failing that, some events may not be processed or may be processed twice or in the wrong order,
+	 * resulting in errors and/or out-of-sync indexes.
+	 * <p>
+	 * Only available when {@link HibernateOrmMapperSettings#AUTOMATIC_INDEXING_STRATEGY} is
+	 * {@value #COORDINATION_STRATEGY_NAME}
+	 * and {@link #COORDINATION_EVENT_PROCESSOR_SHARDS_STATIC} is {@code true}.
+	 * <p>
+	 * Expects a shard index, i.e. an Integer value between {@code 0} (inclusive) and the
+	 * {@link #COORDINATION_EVENT_PROCESSOR_SHARDS_TOTAL_COUNT total shard count} (exclusive),
+	 * or a String that can be parsed into such shard index,
+	 * or a String containing multiple such shard index strings separated by commas,
+	 * or a {@code Collection<Integer>} containing such shard indices.
+	 * <p>
+	 * No default: must be provided when static sharding is enabled.
+	 */
+	public static final String COORDINATION_EVENT_PROCESSOR_SHARDS_ASSIGNED = PREFIX + Radicals.COORDINATION_EVENT_PROCESSOR_SHARDS_ASSIGNED;
 
 	/**
 	 * In the event processor, how long to wait for another query to the outbox events table
@@ -365,10 +366,10 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 
 		public static final String COORDINATION_PREFIX = HibernateOrmMapperSettings.Radicals.COORDINATION_PREFIX;
 		public static final String COORDINATION_TENANTS = COORDINATION_PREFIX + CoordinationRadicals.TENANTS;
-		public static final String COORDINATION_SHARDS_STATIC = COORDINATION_PREFIX + CoordinationRadicals.SHARDS_STATIC;
-		public static final String COORDINATION_SHARDS_TOTAL_COUNT = COORDINATION_PREFIX + CoordinationRadicals.SHARDS_TOTAL_COUNT;
-		public static final String COORDINATION_SHARDS_ASSIGNED = COORDINATION_PREFIX + CoordinationRadicals.SHARDS_ASSIGNED;
 		public static final String COORDINATION_EVENT_PROCESSOR_ENABLED = COORDINATION_PREFIX + CoordinationRadicals.EVENT_PROCESSOR_ENABLED;
+		public static final String COORDINATION_EVENT_PROCESSOR_SHARDS_STATIC = COORDINATION_PREFIX + CoordinationRadicals.EVENT_PROCESSOR_SHARDS_STATIC;
+		public static final String COORDINATION_EVENT_PROCESSOR_SHARDS_TOTAL_COUNT = COORDINATION_PREFIX + CoordinationRadicals.EVENT_PROCESSOR_SHARDS_TOTAL_COUNT;
+		public static final String COORDINATION_EVENT_PROCESSOR_SHARDS_ASSIGNED = COORDINATION_PREFIX + CoordinationRadicals.EVENT_PROCESSOR_SHARDS_ASSIGNED;
 		public static final String COORDINATION_EVENT_PROCESSOR_POLLING_INTERVAL = COORDINATION_PREFIX + CoordinationRadicals.EVENT_PROCESSOR_POLLING_INTERVAL;
 		public static final String COORDINATION_EVENT_PROCESSOR_PULSE_INTERVAL = COORDINATION_PREFIX + CoordinationRadicals.EVENT_PROCESSOR_PULSE_INTERVAL;
 		public static final String COORDINATION_EVENT_PROCESSOR_PULSE_EXPIRATION = COORDINATION_PREFIX + CoordinationRadicals.EVENT_PROCESSOR_PULSE_EXPIRATION;
@@ -389,11 +390,11 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 		}
 
 		public static final String TENANTS = "tenants";
-		public static final String SHARDS_STATIC = "shards.static";
-		public static final String SHARDS_TOTAL_COUNT = "shards.total_count";
-		public static final String SHARDS_ASSIGNED = "shards.assigned";
 		public static final String EVENT_PROCESSOR_PREFIX = "event_processor.";
 		public static final String EVENT_PROCESSOR_ENABLED = EVENT_PROCESSOR_PREFIX + "enabled";
+		public static final String EVENT_PROCESSOR_SHARDS_STATIC = EVENT_PROCESSOR_PREFIX + "shards.static";
+		public static final String EVENT_PROCESSOR_SHARDS_TOTAL_COUNT = EVENT_PROCESSOR_PREFIX + "shards.total_count";
+		public static final String EVENT_PROCESSOR_SHARDS_ASSIGNED = EVENT_PROCESSOR_PREFIX + "shards.assigned";
 		public static final String EVENT_PROCESSOR_POLLING_INTERVAL = EVENT_PROCESSOR_PREFIX + "polling_interval";
 		public static final String EVENT_PROCESSOR_PULSE_INTERVAL = EVENT_PROCESSOR_PREFIX + "pulse_interval";
 		public static final String EVENT_PROCESSOR_PULSE_EXPIRATION = EVENT_PROCESSOR_PREFIX + "pulse_expiration";
@@ -414,8 +415,8 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 		private Defaults() {
 		}
 
-		public static final boolean COORDINATION_SHARDS_STATIC = false;
 		public static final boolean COORDINATION_EVENT_PROCESSOR_ENABLED = true;
+		public static final boolean COORDINATION_EVENT_PROCESSOR_SHARDS_STATIC = false;
 		public static final int COORDINATION_EVENT_PROCESSOR_POLLING_INTERVAL = 100;
 		public static final int COORDINATION_EVENT_PROCESSOR_PULSE_INTERVAL = 2000;
 		public static final int COORDINATION_EVENT_PROCESSOR_PULSE_EXPIRATION = 30000;

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/HibernateOrmMapperOutboxPollingSettings.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/HibernateOrmMapperOutboxPollingSettings.java
@@ -63,8 +63,7 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 			PREFIX + Radicals.COORDINATION_EVENT_PROCESSOR_ENABLED;
 
 	/**
-	 * Whether shards configured for event processing are static,
-	 * i.e. configured explicitly for each node, with a fixed number of shards/nodes.
+	 * The total number of shards across all application nodes for event processing.
 	 * <p>
 	 * <strong>WARNING:</strong> This property must have the same value for all application nodes,
 	 * and must never change unless all application nodes are stopped, then restarted.
@@ -74,24 +73,7 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value #COORDINATION_STRATEGY_NAME}.
 	 * <p>
-	 * Expects a Boolean value such as {@code true} or {@code false},
-	 * or a string that can be parsed to such Boolean value.
-	 * <p>
-	 * Defaults to {@link Defaults#COORDINATION_EVENT_PROCESSOR_SHARDS_STATIC}.
-	 */
-	public static final String COORDINATION_EVENT_PROCESSOR_SHARDS_STATIC = PREFIX + Radicals.COORDINATION_EVENT_PROCESSOR_SHARDS_STATIC;
-
-	/**
-	 * The total number of shards across all application nodes for event processing.
-	 * <p>
-	 * <strong>WARNING:</strong> This property must have the same value for all application nodes,
-	 * and must never change unless all application nodes are stopped, then restarted.
-	 * Failing that, some events may not be processed or may be processed twice or in the wrong order,
-	 * resulting in errors and/or out-of-sync indexes.
-	 * <p>
-	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
-	 * {@value #COORDINATION_STRATEGY_NAME}
-	 * and {@link #COORDINATION_EVENT_PROCESSOR_SHARDS_STATIC} is {@code true}.
+	 * When this property is set, {@value #COORDINATION_EVENT_PROCESSOR_SHARDS_ASSIGNED} must also be set.
 	 * <p>
 	 * Expects an Integer value of at least {@code 2},
 	 * or a String that can be parsed into such Integer value.
@@ -108,8 +90,9 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	 * resulting in errors and/or out-of-sync indexes.
 	 * <p>
 	 * Only available when {@link HibernateOrmMapperSettings#AUTOMATIC_INDEXING_STRATEGY} is
-	 * {@value #COORDINATION_STRATEGY_NAME}
-	 * and {@link #COORDINATION_EVENT_PROCESSOR_SHARDS_STATIC} is {@code true}.
+	 * {@value #COORDINATION_STRATEGY_NAME}.
+	 * <p>
+	 * When this property is set, {@value #COORDINATION_EVENT_PROCESSOR_SHARDS_TOTAL_COUNT} must also be set.
 	 * <p>
 	 * Expects a shard index, i.e. an Integer value between {@code 0} (inclusive) and the
 	 * {@link #COORDINATION_EVENT_PROCESSOR_SHARDS_TOTAL_COUNT total shard count} (exclusive),
@@ -367,7 +350,6 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 		public static final String COORDINATION_PREFIX = HibernateOrmMapperSettings.Radicals.COORDINATION_PREFIX;
 		public static final String COORDINATION_TENANTS = COORDINATION_PREFIX + CoordinationRadicals.TENANTS;
 		public static final String COORDINATION_EVENT_PROCESSOR_ENABLED = COORDINATION_PREFIX + CoordinationRadicals.EVENT_PROCESSOR_ENABLED;
-		public static final String COORDINATION_EVENT_PROCESSOR_SHARDS_STATIC = COORDINATION_PREFIX + CoordinationRadicals.EVENT_PROCESSOR_SHARDS_STATIC;
 		public static final String COORDINATION_EVENT_PROCESSOR_SHARDS_TOTAL_COUNT = COORDINATION_PREFIX + CoordinationRadicals.EVENT_PROCESSOR_SHARDS_TOTAL_COUNT;
 		public static final String COORDINATION_EVENT_PROCESSOR_SHARDS_ASSIGNED = COORDINATION_PREFIX + CoordinationRadicals.EVENT_PROCESSOR_SHARDS_ASSIGNED;
 		public static final String COORDINATION_EVENT_PROCESSOR_POLLING_INTERVAL = COORDINATION_PREFIX + CoordinationRadicals.EVENT_PROCESSOR_POLLING_INTERVAL;
@@ -392,7 +374,6 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 		public static final String TENANTS = "tenants";
 		public static final String EVENT_PROCESSOR_PREFIX = "event_processor.";
 		public static final String EVENT_PROCESSOR_ENABLED = EVENT_PROCESSOR_PREFIX + "enabled";
-		public static final String EVENT_PROCESSOR_SHARDS_STATIC = EVENT_PROCESSOR_PREFIX + "shards.static";
 		public static final String EVENT_PROCESSOR_SHARDS_TOTAL_COUNT = EVENT_PROCESSOR_PREFIX + "shards.total_count";
 		public static final String EVENT_PROCESSOR_SHARDS_ASSIGNED = EVENT_PROCESSOR_PREFIX + "shards.assigned";
 		public static final String EVENT_PROCESSOR_POLLING_INTERVAL = EVENT_PROCESSOR_PREFIX + "polling_interval";
@@ -416,7 +397,6 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 		}
 
 		public static final boolean COORDINATION_EVENT_PROCESSOR_ENABLED = true;
-		public static final boolean COORDINATION_EVENT_PROCESSOR_SHARDS_STATIC = false;
 		public static final int COORDINATION_EVENT_PROCESSOR_POLLING_INTERVAL = 100;
 		public static final int COORDINATION_EVENT_PROCESSOR_PULSE_INTERVAL = 2000;
 		public static final int COORDINATION_EVENT_PROCESSOR_PULSE_EXPIRATION = 30000;

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/logging/impl/Log.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/logging/impl/Log.java
@@ -65,9 +65,9 @@ public interface Log extends BasicLogger {
 	SearchException invalidShardIndex(int totalShardCount, String totalShardCountPropertyKey);
 
 	@Message(id = ID_OFFSET + 9,
-			value = "When using static sharding, this property must be set."
+			value = "This property must be set when '%s' is set."
 	)
-	SearchException missingPropertyForStaticSharding();
+	SearchException missingPropertyForStaticSharding(String otherPropertyKey);
 
 	@LogMessage(level = DEBUG)
 	@Message(id = ID_OFFSET + 10, value = "The outbox event processor is disabled for tenant '%s'. "


### PR DESCRIPTION
* [HSEARCH-4372](https://hibernate.atlassian.net/browse/HSEARCH-4372): Simplify sharding configuration and move it to hibernate.search.coordination.event_processor.* properties

Based on #2713 , which should be merged first.

