### PR TITLE
HSEARCH-4387 Address compilation warnings, in particular unchecked type conversions

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/scope/model/impl/ElasticsearchSearchIndexScopeImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/scope/model/impl/ElasticsearchSearchIndexScopeImpl.java
@@ -249,7 +249,7 @@ public final class ElasticsearchSearchIndexScopeImpl
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	protected ElasticsearchSearchIndexNodeContext createMultiIndexSearchValueFieldContext(String absolutePath,
 			List<ElasticsearchSearchIndexNodeContext> fieldForEachIndex) {
 		return new ElasticsearchMultiIndexSearchIndexValueFieldContext<>( this, absolutePath,
@@ -257,7 +257,7 @@ public final class ElasticsearchSearchIndexScopeImpl
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	protected ElasticsearchSearchIndexNodeContext createMultiIndexSearchObjectFieldContext(String absolutePath,
 			List<ElasticsearchSearchIndexNodeContext> fieldForEachIndex) {
 		return new ElasticsearchMultiIndexSearchIndexCompositeNodeContext( this, absolutePath,

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchEntityReferenceProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchEntityReferenceProjection.java
@@ -42,6 +42,7 @@ public class ElasticsearchEntityReferenceProjection<R> extends AbstractElasticse
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public R transform(LoadingResult<?, ?> loadingResult, DocumentReference extractedData,
 			SearchProjectionTransformContext context) {
 		return (R) loadingResult.convertReference( extractedData );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSearchProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSearchProjection.java
@@ -65,6 +65,7 @@ public interface ElasticsearchSearchProjection<E, P> extends SearchProjection<P>
 		if ( !( projection instanceof ElasticsearchSearchProjection ) ) {
 			throw log.cannotMixElasticsearchSearchQueryWithOtherProjections( projection );
 		}
+		@SuppressWarnings("unchecked") // Necessary for ecj (Eclipse compiler)
 		ElasticsearchSearchProjection<?, P> casted = (ElasticsearchSearchProjection<?, P>) projection;
 		if ( !scope.hibernateSearchIndexNames().equals( casted.indexNames() ) ) {
 			throw log.projectionDefinedOnDifferentIndexes( projection, casted.indexNames(),

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/util/impl/SloppyMath.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/util/impl/SloppyMath.java
@@ -154,7 +154,6 @@ public class SloppyMath {
 
 	// Earth's mean radius, in meters and kilometers; see http://earth-info.nga.mil/GandG/publications/tr8350.2/wgs84fin.pdf
 	private static final double TO_METERS = 6_371_008.7714D; // equatorial radius
-	private static final double TO_KILOMETERS = 6_371.0087714D; // equatorial radius
 
 	// cos/asin
 	private static final double ONE_DIV_F2 = 1 / 2.0;
@@ -218,7 +217,7 @@ public class SloppyMath {
 	private static final double ASIN_QS4 = Double.longBitsToDouble(
 			0x3fb3b8c5b12e9282L ); //  7.70381505559019352791e-02
 
-	/** Initializes look-up tables. */
+	/* Initializes look-up tables. */
 	static {
 		// sin and cos
 		final int SIN_COS_PI_INDEX = ( SIN_COS_TABS_SIZE - 1 ) / 2;

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/AbstractElasticsearchJavaTimeFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/AbstractElasticsearchJavaTimeFieldCodec.java
@@ -68,7 +68,7 @@ public abstract class AbstractElasticsearchJavaTimeFieldCodec<T extends Temporal
 			return false;
 		}
 
-		AbstractElasticsearchJavaTimeFieldCodec other = (AbstractElasticsearchJavaTimeFieldCodec) obj;
+		AbstractElasticsearchJavaTimeFieldCodec<?> other = (AbstractElasticsearchJavaTimeFieldCodec<?>) obj;
 		return formatter.equals( other.formatter );
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/ElasticsearchIndexIndexingPlanExecution.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/ElasticsearchIndexIndexingPlanExecution.java
@@ -28,6 +28,7 @@ class ElasticsearchIndexIndexingPlanExecution<R> {
 	private final List<SingleDocumentIndexingWork> works;
 	private final CompletableFuture<Void>[] futures;
 
+	@SuppressWarnings("unchecked")
 	ElasticsearchIndexIndexingPlanExecution(ElasticsearchSerialWorkOrchestrator orchestrator,
 			EntityReferenceFactory<R> entityReferenceFactory,
 			List<SingleDocumentIndexingWork> works) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/AbstractSingleDocumentIndexingWork.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/AbstractSingleDocumentIndexingWork.java
@@ -103,6 +103,7 @@ public abstract class AbstractSingleDocumentIndexingWork
 			this.documentIdentifier = documentIdentifier;
 		}
 
+		@SuppressWarnings("unchecked")
 		public B refresh(DocumentRefreshStrategy refreshStrategy) {
 			this.refreshStrategy = refreshStrategy;
 			return (B) this;

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/client/impl/GsonHttpEntityTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/client/impl/GsonHttpEntityTest.java
@@ -52,14 +52,14 @@ public class GsonHttpEntityTest {
 		JsonObject bodyPart3 = JsonParser.parseString( "{ \"obj1\": " + bodyPart1.toString()
 				+ ", \"obj2\": " + bodyPart2.toString() + "}" ).getAsJsonObject();
 
-		for ( @SuppressWarnings("unchecked") List<JsonObject> jsonObjects: new List[] {
+		for ( List<JsonObject> jsonObjects: Arrays.<List<JsonObject>>asList(
 				Collections.emptyList(),
 				Collections.singletonList( bodyPart1 ),
 				Collections.singletonList( bodyPart2 ),
 				Collections.singletonList( bodyPart3 ),
 				Arrays.asList( bodyPart1, bodyPart2, bodyPart3 ),
 				Arrays.asList( bodyPart3, bodyPart2, bodyPart1 )
-		} ) {
+		) ) {
 			params.add( new Object[] { jsonObjects.toString(), jsonObjects } );
 		}
 		params.add( new Object[] {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/directory/impl/FileSystemAccessStrategy.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/directory/impl/FileSystemAccessStrategy.java
@@ -49,6 +49,7 @@ enum FileSystemAccessStrategy {
 
 	public abstract FSDirectory createDirectory(Path indexDir, LockFactory factory) throws IOException;
 
+	@SuppressWarnings("deprecation")
 	public static FileSystemAccessStrategy get(FileSystemAccessStrategyName name) {
 		switch ( name ) {
 			case AUTO:

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/writer/impl/IndexWriterSettings.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/writer/impl/IndexWriterSettings.java
@@ -100,19 +100,19 @@ public final class IndexWriterSettings implements Serializable {
 
 	private static final class Extractor<T, R> {
 
-		static <T> Extractor fromInteger(String propertyKey,
-				Function<Integer, T> processor,
-				BiConsumer<IndexWriterConfig, T> writerSettingApplier,
-				BiConsumer<LogByteSizeMergePolicy, T> mergePolicySettingApplier) {
+		static <R> Extractor<Integer, R> fromInteger(String propertyKey,
+				Function<Integer, R> processor,
+				BiConsumer<IndexWriterConfig, R> writerSettingApplier,
+				BiConsumer<LogByteSizeMergePolicy, R> mergePolicySettingApplier) {
 			OptionalConfigurationProperty<Integer> property = ConfigurationProperty.forKey( propertyKey )
 					.asIntegerPositiveOrZeroOrNegative().build();
 			return new Extractor<>( propertyKey, property, processor, writerSettingApplier, mergePolicySettingApplier );
 		}
 
-		static <T> Extractor fromBoolean(String propertyKey,
-				Function<Boolean, T> processor,
-				BiConsumer<IndexWriterConfig, T> writerSettingApplier,
-				BiConsumer<LogByteSizeMergePolicy, T> mergePolicySettingApplier) {
+		static <R> Extractor<Boolean, R> fromBoolean(String propertyKey,
+				Function<Boolean, R> processor,
+				BiConsumer<IndexWriterConfig, R> writerSettingApplier,
+				BiConsumer<LogByteSizeMergePolicy, R> mergePolicySettingApplier) {
 			OptionalConfigurationProperty<Boolean> property = ConfigurationProperty.forKey( propertyKey )
 					.asBoolean().build();
 			return new Extractor<>( propertyKey, property, processor, writerSettingApplier, mergePolicySettingApplier );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/scope/model/impl/LuceneSearchIndexScopeImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/scope/model/impl/LuceneSearchIndexScopeImpl.java
@@ -226,7 +226,7 @@ public final class LuceneSearchIndexScopeImpl
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	protected LuceneSearchIndexNodeContext createMultiIndexSearchValueFieldContext(String absolutePath,
 			List<LuceneSearchIndexNodeContext> fieldForEachIndex) {
 		return new LuceneMultiIndexSearchIndexValueFieldContext<>( this, absolutePath,
@@ -234,7 +234,7 @@ public final class LuceneSearchIndexScopeImpl
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	protected LuceneSearchIndexNodeContext createMultiIndexSearchObjectFieldContext(String absolutePath,
 			List<LuceneSearchIndexNodeContext> fieldForEachIndex) {
 		return new LuceneMultiIndexSearchIndexCompositeNodeContext( this, absolutePath,

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/aggregation/impl/LuceneSearchAggregationBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/aggregation/impl/LuceneSearchAggregationBuilderFactory.java
@@ -12,10 +12,8 @@ import org.hibernate.search.engine.search.aggregation.spi.SearchAggregationBuild
 public class LuceneSearchAggregationBuilderFactory
 		implements SearchAggregationBuilderFactory {
 
-	private final LuceneSearchIndexScope<?> scope;
-
+	@SuppressWarnings("unused")
 	public LuceneSearchAggregationBuilderFactory(LuceneSearchIndexScope<?> scope) {
-		this.scope = scope;
 	}
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneEntityReferenceProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneEntityReferenceProjection.java
@@ -39,6 +39,7 @@ public class LuceneEntityReferenceProjection<R> extends AbstractLuceneProjection
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public R transform(LoadingResult<?, ?> loadingResult, DocumentReference extractedData,
 			SearchProjectionTransformContext context) {
 		return (R) loadingResult.convertReference( extractedData );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneSearchProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneSearchProjection.java
@@ -67,6 +67,7 @@ public interface LuceneSearchProjection<E, P> extends SearchProjection<P> {
 		if ( !( projection instanceof LuceneSearchProjection ) ) {
 			throw log.cannotMixLuceneSearchQueryWithOtherProjections( projection );
 		}
+		@SuppressWarnings("unchecked") // Necessary for ecj (Eclipse compiler)
 		LuceneSearchProjection<?, P> casted = (LuceneSearchProjection<?, P>) projection;
 		if ( !scope.hibernateSearchIndexNames().equals( casted.indexNames() ) ) {
 			throw log.projectionDefinedOnDifferentIndexes( projection, casted.indexNames(),

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/LuceneStandardFieldSort.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/LuceneStandardFieldSort.java
@@ -34,7 +34,7 @@ public class LuceneStandardFieldSort extends AbstractLuceneDocumentValueSort {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private LuceneStandardFieldSort(AbstractBuilder builder) {
+	private LuceneStandardFieldSort(AbstractBuilder<?, ?, ?> builder) {
 		super( builder );
 	}
 
@@ -139,6 +139,7 @@ public class LuceneStandardFieldSort extends AbstractLuceneDocumentValueSort {
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		protected LuceneFieldComparatorSource toFieldComparatorSource() {
 			return new LuceneNumericFieldComparatorSource<>( nestedDocumentPath, codec.getDomain(),
 					(E) getEffectiveMissingValue(), getMultiValueMode(), getNestedFilter() );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/LuceneIndexIndexingPlanExecution.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/LuceneIndexIndexingPlanExecution.java
@@ -32,6 +32,7 @@ class LuceneIndexIndexingPlanExecution<R> {
 	private final List<SingleDocumentIndexingWork> works;
 	private final CompletableFuture<Long>[] futures;
 
+	@SuppressWarnings("unchecked")
 	LuceneIndexIndexingPlanExecution(LuceneSerialWorkOrchestrator orchestrator,
 			EntityReferenceFactory<R> entityReferenceFactory,
 			DocumentCommitStrategy commitStrategy,

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/containers/property/BookEditionsForSalePropertyBinder.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/containers/property/BookEditionsForSalePropertyBinder.java
@@ -34,6 +34,7 @@ public class BookEditionsForSalePropertyBinder implements PropertyBinder {
 		context.bridge( Map.class, new Bridge( editionsForSaleField ) );
 	}
 
+	@SuppressWarnings("rawtypes")
 	private static class Bridge implements PropertyBridge<Map> {
 
 		private final IndexFieldReference<String> editionsForSaleField;
@@ -43,8 +44,8 @@ public class BookEditionsForSalePropertyBinder implements PropertyBinder {
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public void write(DocumentElement target, Map bridgedElement, PropertyBridgeWriteContext context) {
+			@SuppressWarnings("unchecked")
 			Map<BookEdition, ?> priceByEdition = (Map<BookEdition, ?>) bridgedElement;
 
 			for ( BookEdition edition : priceByEdition.keySet() ) { // <3>

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/dynamic/MultiTypeUserMetadataBinder.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/dynamic/MultiTypeUserMetadataBinder.java
@@ -50,6 +50,7 @@ public class MultiTypeUserMetadataBinder implements PropertyBinder {
 	//end::bind[]
 
 	//tag::write[]
+	@SuppressWarnings("rawtypes")
 	private static class Bridge implements PropertyBridge<Map> {
 
 		private final IndexObjectFieldReference userMetadataFieldReference;
@@ -60,6 +61,7 @@ public class MultiTypeUserMetadataBinder implements PropertyBinder {
 
 		@Override
 		public void write(DocumentElement target, Map bridgedElement, PropertyBridgeWriteContext context) {
+			@SuppressWarnings("unchecked")
 			Map<String, Object> userMetadata = (Map<String, Object>) bridgedElement;
 
 			DocumentElement indexedUserMetadata = target.addObject( userMetadataFieldReference ); // <1>

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/dynamic/UserMetadataBinder.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/dynamic/UserMetadataBinder.java
@@ -43,6 +43,7 @@ public class UserMetadataBinder implements PropertyBinder {
 	//end::bind[]
 
 	//tag::write[]
+	@SuppressWarnings("rawtypes")
 	private static class UserMetadataBridge implements PropertyBridge<Map> {
 
 		private final IndexObjectFieldReference userMetadataFieldReference;
@@ -53,6 +54,7 @@ public class UserMetadataBinder implements PropertyBinder {
 
 		@Override
 		public void write(DocumentElement target, Map bridgedElement, PropertyBridgeWriteContext context) {
+			@SuppressWarnings("unchecked")
 			Map<String, String> userMetadata = (Map<String, String>) bridgedElement;
 
 			DocumentElement indexedUserMetadata = target.addObject( userMetadataFieldReference ); // <1>

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/object/InvoiceLineItemsDetailBinder.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/object/InvoiceLineItemsDetailBinder.java
@@ -51,6 +51,7 @@ public class InvoiceLineItemsDetailBinder implements PropertyBinder {
 	}
 	//end::bind[]
 
+	@SuppressWarnings("rawtypes")
 	private static class Bridge implements PropertyBridge<List> {
 
 		private final IndexObjectFieldReference lineItemsField;
@@ -66,8 +67,8 @@ public class InvoiceLineItemsDetailBinder implements PropertyBinder {
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public void write(DocumentElement target, List bridgedElement, PropertyBridgeWriteContext context) {
+			@SuppressWarnings("unchecked")
 			List<InvoiceLineItem> lineItems = (List<InvoiceLineItem>) bridgedElement;
 
 			for ( InvoiceLineItem lineItem : lineItems ) {

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/object/InvoiceLineItemsSummaryBinder.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/object/InvoiceLineItemsSummaryBinder.java
@@ -53,6 +53,7 @@ public class InvoiceLineItemsSummaryBinder implements PropertyBinder {
 	}
 	//end::bind[]
 
+	@SuppressWarnings("rawtypes")
 	private static class Bridge implements PropertyBridge<List> {
 
 		private final IndexObjectFieldReference summaryField;
@@ -72,8 +73,8 @@ public class InvoiceLineItemsSummaryBinder implements PropertyBinder {
 
 		//tag::write[]
 		@Override
-		@SuppressWarnings("unchecked")
 		public void write(DocumentElement target, List bridgedElement, PropertyBridgeWriteContext context) {
+			@SuppressWarnings("unchecked")
 			List<InvoiceLineItem> lineItems = (List<InvoiceLineItem>) bridgedElement;
 
 			BigDecimal total = BigDecimal.ZERO;

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/bridgedelement/InvoiceLineItemsSummaryBinder.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/bridgedelement/InvoiceLineItemsSummaryBinder.java
@@ -46,6 +46,7 @@ public class InvoiceLineItemsSummaryBinder implements PropertyBinder {
 		) );
 	}
 
+	@SuppressWarnings("rawtypes")
 	private static class Bridge implements PropertyBridge<List> {
 
 		/* ... same implementation as before ... */
@@ -67,8 +68,8 @@ public class InvoiceLineItemsSummaryBinder implements PropertyBinder {
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public void write(DocumentElement target, List bridgedElement, PropertyBridgeWriteContext context) {
+			@SuppressWarnings("unchecked")
 			List<InvoiceLineItem> lineItems = (List<InvoiceLineItem>) bridgedElement;
 
 			BigDecimal total = BigDecimal.ZERO;

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/param/InvoiceLineItemsSummaryBinder.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/param/InvoiceLineItemsSummaryBinder.java
@@ -49,6 +49,7 @@ public class InvoiceLineItemsSummaryBinder implements PropertyBinder {
 		) );
 	}
 
+	@SuppressWarnings("rawtypes")
 	private static class Bridge implements PropertyBridge<List> {
 
 		/* ... same implementation as before ... */
@@ -70,8 +71,8 @@ public class InvoiceLineItemsSummaryBinder implements PropertyBinder {
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public void write(DocumentElement target, List bridgedElement, PropertyBridgeWriteContext context) {
+			@SuppressWarnings("unchecked")
 			List<InvoiceLineItem> lineItems = (List<InvoiceLineItem>) bridgedElement;
 
 			BigDecimal total = BigDecimal.ZERO;

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/param/context/InvoiceLineItemsSummaryBinder.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/param/context/InvoiceLineItemsSummaryBinder.java
@@ -45,6 +45,7 @@ public class InvoiceLineItemsSummaryBinder implements PropertyBinder {
 		) );
 	}
 
+	@SuppressWarnings("rawtypes")
 	private static class Bridge implements PropertyBridge<List> {
 
 		/* ... same implementation as before ... */
@@ -66,8 +67,8 @@ public class InvoiceLineItemsSummaryBinder implements PropertyBinder {
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public void write(DocumentElement target, List bridgedElement, PropertyBridgeWriteContext context) {
+			@SuppressWarnings("unchecked")
 			List<InvoiceLineItem> lineItems = (List<InvoiceLineItem>) bridgedElement;
 
 			BigDecimal total = BigDecimal.ZERO;

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/simple/InvoiceLineItemsSummaryBinder.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/simple/InvoiceLineItemsSummaryBinder.java
@@ -47,6 +47,7 @@ public class InvoiceLineItemsSummaryBinder implements PropertyBinder { // <1>
 	//tag::bridge[]
 	// ... class InvoiceLineItemsSummaryBinder (continued)
 
+	@SuppressWarnings("rawtypes")
 	private static class Bridge implements PropertyBridge<List> { // <1>
 
 		private final IndexObjectFieldReference summaryField;
@@ -65,8 +66,8 @@ public class InvoiceLineItemsSummaryBinder implements PropertyBinder { // <1>
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public void write(DocumentElement target, List bridgedElement, PropertyBridgeWriteContext context) { // <3>
+			@SuppressWarnings("unchecked")
 			List<InvoiceLineItem> lineItems = (List<InvoiceLineItem>) bridgedElement;
 
 			BigDecimal total = BigDecimal.ZERO;

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/resolver/EnumLabelService.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/resolver/EnumLabelService.java
@@ -21,9 +21,9 @@ public class EnumLabelService {
 		if ( Genre.class.equals( enumType ) ) {
 			switch ( value ) {
 				case "science-fiction":
-					return (T) Genre.SCIFI;
+					return enumType.cast( Genre.SCIFI );
 				case "crime-fiction":
-					return (T) Genre.CRIME;
+					return enumType.cast( Genre.CRIME );
 			}
 		}
 

--- a/engine/src/main/java/org/hibernate/search/engine/backend/scope/spi/AbstractSearchIndexScope.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/scope/spi/AbstractSearchIndexScope.java
@@ -157,7 +157,7 @@ public abstract class AbstractSearchIndexScope<
 		return fieldInternal( parent.absolutePath( name ) );
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"}) // We check types using reflection
+	@SuppressWarnings("unchecked")
 	private N createMultiIndexFieldContext(String absoluteFieldPath) {
 		List<N> fieldForEachIndex = new ArrayList<>();
 		M modelOfFirstField = null;

--- a/engine/src/main/java/org/hibernate/search/engine/environment/bean/impl/BeanConfigurationContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/environment/bean/impl/BeanConfigurationContextImpl.java
@@ -39,6 +39,6 @@ final class BeanConfigurationContextImpl implements BeanConfigurationContext {
 	@SuppressWarnings("unchecked")
 	private <T> BeanReferenceRegistryForType<T> configuredBeans(Class<T> exposedType) {
 		return (BeanReferenceRegistryForType<T>) configuredBeans.computeIfAbsent( exposedType,
-				ignored -> new BeanReferenceRegistryForType( exposedType ) );
+				ignored -> new BeanReferenceRegistryForType<>( exposedType ) );
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
@@ -227,7 +227,7 @@ public interface Log extends BasicLogger {
 			String causeMessage, @Cause Exception cause);
 
 	@Message(id = ID_OFFSET + 60, value = "Invalid value for enum '%2$s': '%1$s'.")
-	SearchException invalidStringForEnum(String value, @FormatWith(ClassFormatter.class) Class<? extends Enum> enumType, @Cause Exception cause);
+	SearchException invalidStringForEnum(String value, @FormatWith(ClassFormatter.class) Class<? extends Enum<?>> enumType, @Cause Exception cause);
 
 	@Message(id = ID_OFFSET + 61, value = "Multiple hits when a single hit was expected.")
 	SearchException nonSingleHit();

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/spi/ListProjectionAccumulator.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/spi/ListProjectionAccumulator.java
@@ -21,6 +21,7 @@ import org.hibernate.search.engine.backend.types.converter.spi.ProjectionConvert
  */
 public final class ListProjectionAccumulator<F, V> implements ProjectionAccumulator<F, V, List<F>, List<V>> {
 
+	@SuppressWarnings("rawtypes")
 	private static final Provider PROVIDER = new Provider() {
 		private final ListProjectionAccumulator instance = new ListProjectionAccumulator();
 		@Override
@@ -58,7 +59,7 @@ public final class ListProjectionAccumulator<F, V> implements ProjectionAccumula
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public List<V> finish(List<F> accumulated, ProjectionConverter<? super F, ? extends V> converter,
 			FromDocumentValueConvertContext context) {
 		// Hack to avoid instantiating another list: we convert a List<F> into a List<V> just by replacing its elements.

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/spi/SingleValuedProjectionAccumulator.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/spi/SingleValuedProjectionAccumulator.java
@@ -23,6 +23,7 @@ public final class SingleValuedProjectionAccumulator<F, V> implements Projection
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
+	@SuppressWarnings("rawtypes")
 	private static final ProjectionAccumulator.Provider PROVIDER = new ProjectionAccumulator.Provider() {
 		private final SingleValuedProjectionAccumulator instance = new SingleValuedProjectionAccumulator();
 		@Override

--- a/engine/src/test/java/org/hibernate/search/engine/backend/orchestration/spi/SingletonTaskTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/backend/orchestration/spi/SingletonTaskTest.java
@@ -50,7 +50,7 @@ public class SingletonTaskTest {
 
 	private static final class TestWorker implements SingletonTask.Worker {
 
-		private final CompletableFuture<Void> future = new CompletableFuture();
+		private final CompletableFuture<Void> future = new CompletableFuture<>();
 		private volatile boolean started = false;
 
 		@Override

--- a/engine/src/test/java/org/hibernate/search/engine/common/dsl/impl/DslExtensionStateTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/common/dsl/impl/DslExtensionStateTest.java
@@ -256,6 +256,7 @@ public class DslExtensionStateTest {
 		verifyNoOtherInteractionsAndReset();
 	}
 
+	@SuppressWarnings("unchecked")
 	private void verifyNoOtherInteractionsAndReset() {
 		verifyNoMoreInteractions( contextFunction );
 		reset( contextFunction );

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -813,6 +813,7 @@ public class ElasticsearchExtensionIT {
 	}
 
 	@Test
+	@SuppressWarnings("rawtypes")
 	public void projection_nativeField_withProjectionConverters_enabled() {
 		StubMappingScope scope = mainIndex.createScope();
 

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerDynamicMappingIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerDynamicMappingIT.java
@@ -134,6 +134,7 @@ public class ElasticsearchIndexSchemaManagerDynamicMappingIT {
 	}
 
 	private void verifyDynamicMapping(String mapping, DynamicMapping dynamicMapping) {
+		@SuppressWarnings("unchecked") // Workaround for assertThat(Map) not taking wildcard type into account like assertThat(Collection) does
 		Map<String, Object> map = gson.fromJson( mapping, Map.class );
 		assertThat( map ).extractingByKey( "dynamic" )
 				.isEqualTo( dynamicMapping.externalRepresentation() );

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
@@ -630,6 +630,7 @@ public class LuceneExtensionIT {
 	}
 
 	@Test
+	@SuppressWarnings("rawtypes")
 	public void projection_nativeField_withProjectionConverters_enabled() {
 		StubMappingScope scope = mainIndex.createScope();
 

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/CustomDirectoryIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/CustomDirectoryIT.java
@@ -92,13 +92,14 @@ public class CustomDirectoryIT extends AbstractDirectoryIT {
 		}
 
 		@Override
+		@SuppressWarnings("unchecked") // Workaround for assertThat(Optional) not taking wildcard type into account like assertThat(Collection) does
 		public DirectoryHolder createDirectoryHolder(DirectoryCreationContext context) {
 			StaticCounters.get().increment( CREATE_DIRECTORY_COUNTER_KEY );
 			assertThat( context ).isNotNull();
 			assertThat( context.indexName() ).isEqualTo( index.name() );
 			Optional<?> actualConfigurationPropertyValue = context.configurationPropertySource()
 					.get( CONFIGURATION_PROPERTY_KEY_RADICAL );
-			assertThat( (Optional) actualConfigurationPropertyValue )
+			assertThat( (Optional<Object>) actualConfigurationPropertyValue )
 					.contains( CONFIGURATION_PROPERTY_EXPECTED_VALUE );
 			return new DirectoryHolder() {
 				Directory directory;

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchTopDocsMergeFieldSortIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchTopDocsMergeFieldSortIT.java
@@ -213,7 +213,7 @@ public class LuceneSearchTopDocsMergeFieldSortIT<F> {
 		}
 	}
 
-	private TopFieldDocs[] retrieveTopDocs(LuceneSearchQuery<?> query, LuceneSearchResult ... results) {
+	private TopFieldDocs[] retrieveTopDocs(LuceneSearchQuery<?> query, LuceneSearchResult<?> ... results) {
 		Sort sort = query.luceneSort();
 		TopFieldDocs[] allTopDocs = new TopFieldDocs[results.length];
 		for ( int i = 0; i < results.length; i++ ) {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/metamodel/IndexFieldDescriptorIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/metamodel/IndexFieldDescriptorIT.java
@@ -40,6 +40,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import org.assertj.core.api.Assertions;
+
 /**
  * Tests for field descriptor features.
  * <p>
@@ -172,8 +174,10 @@ public class IndexFieldDescriptorIT {
 		// Static children
 		Collection<? extends IndexFieldDescriptor> children = fieldDescriptor.staticChildren();
 		Map<String, ? extends IndexFieldDescriptor> childrenByName = fieldDescriptor.staticChildrenByName();
-		assertThat( (Collection<IndexFieldDescriptor>) children ).contains( childFieldDescriptor );
-		assertThat( (Map<String, IndexFieldDescriptor>) childrenByName )
+		Assertions.<IndexFieldDescriptor>assertThat( children ).contains( childFieldDescriptor );
+		@SuppressWarnings("unchecked") // Workaround for assertThat(Map) not taking wildcard type into account like assertThat(Collection) does
+		Map<String, IndexFieldDescriptor> castChildrenByName = (Map<String, IndexFieldDescriptor>) childrenByName;
+		assertThat( castChildrenByName )
 				.contains( entry( getRelativeFieldName(), childFieldDescriptor ) );
 
 		switch ( fieldStructure.location ) {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/TermsAggregationSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/TermsAggregationSpecificsIT.java
@@ -642,7 +642,6 @@ public class TermsAggregationSpecificsIT<F> {
 
 		private void init() {
 			BulkIndexer indexer = index.bulkIndexer();
-			int documentCount = 0;
 			for ( Map.Entry<F, List<String>> entry : documentIdPerTerm.entrySet() ) {
 				F value = entry.getKey();
 				for ( String documentId : entry.getValue() ) {
@@ -650,11 +649,9 @@ public class TermsAggregationSpecificsIT<F> {
 						document.addValue( index.binding().fieldModels.get( fieldType ).reference, value );
 						document.addValue( index.binding().fieldWithConverterModels.get( fieldType ).reference, value );
 					} );
-					++documentCount;
 				}
 			}
 			indexer.add( name + "_document_empty", name, document -> { } );
-			++documentCount;
 			indexer.join();
 		}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AbstractPredicateTypeCheckingNoConversionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AbstractPredicateTypeCheckingNoConversionIT.java
@@ -178,6 +178,7 @@ public abstract class AbstractPredicateTypeCheckingNoConversionIT<V extends Abst
 	}
 
 	// These DSL converters should not be used, since no conversion takes place.
+	@SuppressWarnings("rawtypes")
 	private static <T> ToDocumentValueConverter<ValueWrapper, T> unusedDslConverter() {
 		return new ToDocumentValueConverter<ValueWrapper, T>() {
 			@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchPredicateFuzzyIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchPredicateFuzzyIT.java
@@ -33,7 +33,6 @@ import org.hibernate.search.util.common.impl.CollectionHelper;
 import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
-import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.annotation.PortedFromSearch5;
 
 import org.junit.BeforeClass;
@@ -321,7 +320,6 @@ public class MatchPredicateFuzzyIT {
 
 	@Test
 	public void skipAnalysis() {
-		StubMappingScope scope = index.createScope();
 		String absoluteFieldPath = index.binding().whitespaceLowercaseAnalyzedField.relativeFieldName;
 
 		assertThatQuery( index.query()

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/TermsPredicateMultivaluedIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/TermsPredicateMultivaluedIT.java
@@ -64,7 +64,7 @@ public class TermsPredicateMultivaluedIT<F> {
 		setupHelper.start().withIndexes( index ).setup();
 		BulkIndexer indexer = index.bulkIndexer();
 		indexer.add( DOC_ID, doc -> {
-			for ( TypeValues typeValues : typeValuesSet ) {
+			for ( TypeValues<?> typeValues : typeValuesSet ) {
 				typeValues.contribute( doc );
 			}
 		} );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/IdentifierSearchProjectionBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/IdentifierSearchProjectionBaseIT.java
@@ -46,6 +46,7 @@ public class IdentifierSearchProjectionBaseIT {
 
 	private final String[] ids = new String[7];
 	private final String[] names = new String[7];
+	@SuppressWarnings("unchecked")
 	private final List<String>[] duplicates = new List[7];
 
 	private final String[] compatibleIndexIds = new String[3];

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryScrollResultLoadingIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryScrollResultLoadingIT.java
@@ -68,8 +68,11 @@ public class SearchQueryScrollResultLoadingIT {
 
 	@Test
 	public void resultLoadingOnScrolling() {
-		SearchLoadingContext<StubTransformedReference, StubLoadedObject> loadingContextMock = mock( SearchLoadingContext.class );
-		DocumentReferenceConverter<StubTransformedReference> documentReferenceConverterMock = mock( StubDocumentReferenceConverter.class );
+		@SuppressWarnings("unchecked")
+		SearchLoadingContext<StubTransformedReference, StubLoadedObject> loadingContextMock =
+				mock( SearchLoadingContext.class );
+		DocumentReferenceConverter<StubTransformedReference> documentReferenceConverterMock =
+				mock( StubDocumentReferenceConverter.class );
 
 		GenericStubMappingScope<StubTransformedReference, StubLoadedObject> scope = index.createGenericScope();
 		SearchQuery<StubLoadedObject> objectsQuery = scope.query( loadingContextMock )
@@ -83,8 +86,11 @@ public class SearchQueryScrollResultLoadingIT {
 
 	@Test
 	public void resultLoadingOnScrolling_entityLoadingTimeout() {
-		SearchLoadingContext<StubTransformedReference, StubLoadedObject> loadingContextMock = mock( SearchLoadingContext.class );
-		DocumentReferenceConverter<StubTransformedReference> documentReferenceConverterMock = mock( StubDocumentReferenceConverter.class );
+		@SuppressWarnings("unchecked")
+		SearchLoadingContext<StubTransformedReference, StubLoadedObject> loadingContextMock =
+				mock( SearchLoadingContext.class );
+		DocumentReferenceConverter<StubTransformedReference> documentReferenceConverterMock =
+				mock( StubDocumentReferenceConverter.class );
 
 		GenericStubMappingScope<StubTransformedReference, StubLoadedObject> scope = index.createGenericScope();
 		SearchQuery<StubLoadedObject> objectsQuery = scope.query( loadingContextMock )
@@ -99,8 +105,11 @@ public class SearchQueryScrollResultLoadingIT {
 
 	@Test
 	public void resultLoadingOnScrolling_softTimeout() {
-		SearchLoadingContext<StubTransformedReference, StubLoadedObject> loadingContextMock = mock( SearchLoadingContext.class );
-		DocumentReferenceConverter<StubTransformedReference> documentReferenceConverterMock = mock( StubDocumentReferenceConverter.class );
+		@SuppressWarnings("unchecked")
+		SearchLoadingContext<StubTransformedReference, StubLoadedObject> loadingContextMock =
+				mock( SearchLoadingContext.class );
+		DocumentReferenceConverter<StubTransformedReference> documentReferenceConverterMock =
+				mock( StubDocumentReferenceConverter.class );
 
 		GenericStubMappingScope<StubTransformedReference, StubLoadedObject> scope = index.createGenericScope();
 		SearchQuery<StubLoadedObject> objectsQuery = scope.query( loadingContextMock )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortBaseIT.java
@@ -404,7 +404,7 @@ public class FieldSearchSortBaseIT<F> {
 		assumeTrue( "This test is only relevant when the field is located on an object field",
 				parentObjectBinding.absolutePath != null );
 
-		DataSet dataSet = dataSetForAsc;
+		DataSet<F> dataSet = dataSetForAsc;
 		assertThatQuery( index.query()
 				.where( f -> f.matchAll().except( f.id().matchingAny( Arrays.asList(
 								dataSet.emptyDoc1Id, dataSet.emptyDoc2Id, dataSet.emptyDoc3Id, dataSet.emptyDoc4Id

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/BooleanFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/BooleanFieldTypeDescriptor.java
@@ -72,7 +72,7 @@ public class BooleanFieldTypeDescriptor extends FieldTypeDescriptor<Boolean> {
 
 	@Override
 	protected List<Boolean> createNonMatchingValues() {
-		return Collections.EMPTY_LIST;
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/SimpleFieldModelsByType.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/SimpleFieldModelsByType.java
@@ -20,7 +20,7 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldT
 public class SimpleFieldModelsByType {
 	public static SimpleFieldModelsByType mapAll(Collection<? extends FieldTypeDescriptor<?>> typeDescriptors,
 			IndexSchemaElement parent, String prefix) {
-		return mapAll( typeDescriptors.stream(), parent, prefix, new Consumer[0] );
+		return mapAll( typeDescriptors.stream(), parent, prefix );
 	}
 
 	@SafeVarargs

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/StandardFieldMapper.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/StandardFieldMapper.java
@@ -72,6 +72,7 @@ public final class StandardFieldMapper<F, M> {
 		return map( parent, name, true, additionalConfigurations );
 	}
 
+	@SafeVarargs
 	private M map(IndexSchemaElement parent, String name, boolean multiValued,
 			Consumer<? super StandardIndexFieldTypeOptionsStep<?, F>>... additionalConfigurations) {
 		IndexSchemaFieldOptionsStep<?, IndexFieldReference<F>> fieldContext = parent

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TypeAssertionHelper.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TypeAssertionHelper.java
@@ -31,6 +31,7 @@ public abstract class TypeAssertionHelper<F, T> {
 		};
 	}
 
+	@SuppressWarnings("rawtypes")
 	public static <F> TypeAssertionHelper<F, ValueWrapper> wrapper(FieldTypeDescriptor<F> typeDescriptor) {
 		return new TypeAssertionHelper<F, ValueWrapper>() {
 			@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/ValueWrapper.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/ValueWrapper.java
@@ -22,6 +22,7 @@ import org.hibernate.search.util.impl.integrationtest.common.NormalizationUtils;
  * and {@link IndexFieldTypeConverterStep#projectionConverter(Class, FromDocumentValueConverter)  projection converters}.
  */
 public final class ValueWrapper<T> implements Normalizable<ValueWrapper<T>> {
+	@SuppressWarnings("rawtypes")
 	public static <T> ToDocumentValueConverter<ValueWrapper, T> toDocumentValueConverter() {
 		return new ToDocumentValueConverter<ValueWrapper, T>() {
 			@Override
@@ -37,6 +38,7 @@ public final class ValueWrapper<T> implements Normalizable<ValueWrapper<T>> {
 		};
 	}
 
+	@SuppressWarnings("rawtypes")
 	public static <T> FromDocumentValueConverter<T, ValueWrapper> fromDocumentValueConverter() {
 		return new FromDocumentValueConverter<T, ValueWrapper>() {
 			@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
@@ -38,7 +38,6 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 import org.hibernate.search.util.impl.integrationtest.common.TestConfigurationProvider;
 import org.hibernate.search.util.impl.integrationtest.common.bean.ForbiddenBeanProvider;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappedIndex;
-import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapping;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingInitiator;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingKey;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingSchemaManagementStrategy;
@@ -249,7 +248,7 @@ public class SearchSetupHelper implements TestRule {
 			return overrides -> {
 				SearchIntegrationFinalizer finalizer =
 						integrationPartialBuildState.finalizer( propertySource.withOverride( overrides ), unusedPropertyChecker );
-				StubMapping mapping = finalizer.finalizeMapping(
+				finalizer.finalizeMapping(
 						mappingKey,
 						(context, partialMapping) -> partialMapping.finalizeMapping( schemaManagementStrategy )
 				);

--- a/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/BatchIndexingJobIT.java
+++ b/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/BatchIndexingJobIT.java
@@ -92,9 +92,9 @@ public class BatchIndexingJobIT {
 	public void initData() {
 		emf = setupHolder.entityManagerFactory();
 		jobOperator = JobTestUtil.getAndCheckRuntime();
-		List<Company> companies = new ArrayList();
-		List<Person> people = new ArrayList();
-		List<WhoAmI> whos = new ArrayList();
+		List<Company> companies = new ArrayList<>();
+		List<Person> people = new ArrayList<>();
+		List<WhoAmI> whos = new ArrayList<>();
 		for ( int i = 0; i < INSTANCE_PER_ENTITY_TYPE; i += 3 ) {
 			int index1 = i;
 			int index2 = i + 1;

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/OutboxPollingStrategyPropertyValueIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/OutboxPollingStrategyPropertyValueIT.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.List;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.metamodel.Type;
 
 import org.hibernate.search.engine.backend.analysis.AnalyzerNames;
 import org.hibernate.search.engine.environment.bean.BeanReference;
@@ -101,7 +102,7 @@ public class OutboxPollingStrategyPropertyValueIT {
 	@Test
 	public void metamodel_userEntitiesAndOutboxEventAndAgent() {
 		assertThat( setupHolder.sessionFactory().getMetamodel().getEntities() )
-				.extracting( e -> (Class) e.getJavaType() )
+				.<Class<?>>extracting( Type::getJavaType )
 				.containsExactlyInAnyOrder( IndexedEntity.class, OutboxEvent.class, Agent.class );
 	}
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontained/AutomaticIndexingManyToManyOwnedByContainedListBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontained/AutomaticIndexingManyToManyOwnedByContainedListBaseIT.java
@@ -187,14 +187,14 @@ public class AutomaticIndexingManyToManyOwnedByContainedListBaseIT
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
+		@SuppressWarnings({ "unchecked", "rawtypes" })
 		public MultiValuedPropertyAccessor<ContainingEntity, ContainedEntity, List<ContainedEntity>> containedIndexedEmbeddedWithCast() {
 			return new MultiValuedPropertyAccessor<>( ContainerPrimitives.collection(),
 					root -> (List) root.getContainedIndexedEmbeddedWithCast() );
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
+		@SuppressWarnings({ "unchecked", "rawtypes" })
 		public MultiValuedPropertyAccessor<ContainedEntity, ContainingEntity, List<ContainingEntity>> containingAsIndexedEmbeddedWithCast() {
 			return new MultiValuedPropertyAccessor<>( ContainerPrimitives.collection(),
 					root -> (List) root.getContainingAsIndexedEmbeddedWithCast() );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingListBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingListBaseIT.java
@@ -187,14 +187,14 @@ public class AutomaticIndexingManyToManyOwnedByContainingListBaseIT
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
+		@SuppressWarnings({ "unchecked", "rawtypes" })
 		public MultiValuedPropertyAccessor<ContainingEntity, ContainedEntity, List<ContainedEntity>> containedIndexedEmbeddedWithCast() {
 			return new MultiValuedPropertyAccessor<>( ContainerPrimitives.collection(),
 					root -> (List) root.getContainedIndexedEmbeddedWithCast() );
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
+		@SuppressWarnings({ "unchecked", "rawtypes" })
 		public MultiValuedPropertyAccessor<ContainedEntity, ContainingEntity, List<ContainingEntity>> containingAsIndexedEmbeddedWithCast() {
 			return new MultiValuedPropertyAccessor<>( ContainerPrimitives.collection(),
 					root -> (List) root.getContainingAsIndexedEmbeddedWithCast() );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT.java
@@ -212,14 +212,14 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapKeysBaseIT
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
+		@SuppressWarnings({ "unchecked", "rawtypes" })
 		public MultiValuedPropertyAccessor<ContainingEntity, ContainedEntity, Map<ContainedEntity, String>> containedIndexedEmbeddedWithCast() {
 			return new MultiValuedPropertyAccessor<>( MAP_KEYS_PRIMITIVES,
 					root -> (Map) root.getContainedIndexedEmbeddedWithCast() );
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
+		@SuppressWarnings({ "unchecked", "rawtypes" })
 		public MultiValuedPropertyAccessor<ContainedEntity, ContainingEntity, List<ContainingEntity>> containingAsIndexedEmbeddedWithCast() {
 			return new MultiValuedPropertyAccessor<>( ContainerPrimitives.collection(),
 					root -> (List) root.getContainingAsIndexedEmbeddedWithCast() );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingMapValuesBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingMapValuesBaseIT.java
@@ -198,7 +198,7 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapValuesBaseIT
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
+		@SuppressWarnings({"unchecked", "rawtypes"})
 		public MultiValuedPropertyAccessor<ContainingEntity, ContainedEntity, Map<String, ContainedEntity>> containedIndexedEmbeddedWithCast() {
 			return new MultiValuedPropertyAccessor<>(
 					MAP_VALUES_PRIMITIVES,
@@ -206,7 +206,7 @@ public class AutomaticIndexingManyToManyOwnedByContainingMapValuesBaseIT
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
+		@SuppressWarnings({"unchecked", "rawtypes"})
 		public MultiValuedPropertyAccessor<ContainedEntity, ContainingEntity, List<ContainingEntity>> containingAsIndexedEmbeddedWithCast() {
 			return new MultiValuedPropertyAccessor<>( ContainerPrimitives.collection(),
 					root -> (List) root.getContainingAsIndexedEmbeddedWithCast() );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingSortedMapValuesBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingSortedMapValuesBaseIT.java
@@ -201,7 +201,7 @@ public class AutomaticIndexingManyToManyOwnedByContainingSortedMapValuesBaseIT
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
+		@SuppressWarnings({"unchecked", "rawtypes"})
 		public MultiValuedPropertyAccessor<ContainingEntity, ContainedEntity, SortedMap<String, ContainedEntity>> containedIndexedEmbeddedWithCast() {
 			return new MultiValuedPropertyAccessor<>(
 					MAP_VALUES_PRIMITIVES,
@@ -209,7 +209,7 @@ public class AutomaticIndexingManyToManyOwnedByContainingSortedMapValuesBaseIT
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
+		@SuppressWarnings({"unchecked", "rawtypes"})
 		public MultiValuedPropertyAccessor<ContainedEntity, ContainingEntity, List<ContainingEntity>> containingAsIndexedEmbeddedWithCast() {
 			return new MultiValuedPropertyAccessor<>( ContainerPrimitives.collection(),
 					root -> (List) root.getContainingAsIndexedEmbeddedWithCast() );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingSortedSetBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingSortedSetBaseIT.java
@@ -191,14 +191,14 @@ public class AutomaticIndexingManyToManyOwnedByContainingSortedSetBaseIT
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
+		@SuppressWarnings({ "unchecked", "rawtypes" })
 		public MultiValuedPropertyAccessor<ContainingEntity, ContainedEntity, SortedSet<ContainedEntity>> containedIndexedEmbeddedWithCast() {
 			return new MultiValuedPropertyAccessor<>( ContainerPrimitives.collection(),
 					root -> (SortedSet) root.getContainedIndexedEmbeddedWithCast() );
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
+		@SuppressWarnings({ "unchecked", "rawtypes" })
 		public MultiValuedPropertyAccessor<ContainedEntity, ContainingEntity, List<ContainingEntity>> containingAsIndexedEmbeddedWithCast() {
 			return new MultiValuedPropertyAccessor<>( ContainerPrimitives.collection(),
 					root -> (List) root.getContainingAsIndexedEmbeddedWithCast() );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytoone/AutomaticIndexingManyToOneBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytoone/AutomaticIndexingManyToOneBaseIT.java
@@ -192,7 +192,7 @@ public class AutomaticIndexingManyToOneBaseIT
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
+		@SuppressWarnings({ "unchecked", "rawtypes" })
 		public MultiValuedPropertyAccessor<ContainedEntity, ContainingEntity, List<ContainingEntity>> containingAsIndexedEmbeddedWithCast() {
 			return new MultiValuedPropertyAccessor<>( ContainerPrimitives.collection(),
 					root -> (List) root.getContainingAsIndexedEmbeddedWithCast() );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetomany/AutomaticIndexingOneToManyListBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetomany/AutomaticIndexingOneToManyListBaseIT.java
@@ -188,7 +188,7 @@ public class AutomaticIndexingOneToManyListBaseIT
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
+		@SuppressWarnings({ "unchecked", "rawtypes" })
 		public MultiValuedPropertyAccessor<ContainingEntity, ContainedEntity, List<ContainedEntity>> containedIndexedEmbeddedWithCast() {
 			return new MultiValuedPropertyAccessor<>( ContainerPrimitives.collection(),
 					root -> (List) root.getContainedIndexedEmbeddedWithCast() );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/AutomaticIndexingBridgeExplicitDependenciesIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/AutomaticIndexingBridgeExplicitDependenciesIT.java
@@ -133,6 +133,7 @@ public class AutomaticIndexingBridgeExplicitDependenciesIT extends AbstractAutom
 		}
 	}
 
+	@SuppressWarnings("rawtypes")
 	public static class ContainingEntityMultiValuedPropertyBridge implements PropertyBridge<List> {
 
 		private final IndexObjectFieldReference propertyBridgeObjectFieldReference;
@@ -151,7 +152,7 @@ public class AutomaticIndexingBridgeExplicitDependenciesIT extends AbstractAutom
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
+		@SuppressWarnings({"unchecked", "rawtypes"})
 		public void write(DocumentElement target, List bridgedElement, PropertyBridgeWriteContext context) {
 			List<ContainingEntity> castedBridgedElement = (List<ContainingEntity>) bridgedElement;
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/AutomaticIndexingBridgeExplicitReindexingBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/AutomaticIndexingBridgeExplicitReindexingBaseIT.java
@@ -138,6 +138,7 @@ public class AutomaticIndexingBridgeExplicitReindexingBaseIT extends AbstractAut
 		}
 	}
 
+	@SuppressWarnings("rawtypes")
 	public static class ContainingEntityMultiValuedPropertyBridge implements PropertyBridge<List> {
 
 		private final IndexObjectFieldReference propertyBridgeObjectFieldReference;
@@ -157,7 +158,7 @@ public class AutomaticIndexingBridgeExplicitReindexingBaseIT extends AbstractAut
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
+		@SuppressWarnings({"unchecked", "rawtypes"})
 		public void write(DocumentElement target, List bridgedElement, PropertyBridgeWriteContext context) {
 			List<ContainingEntity> castedBridgedElement = (List<ContainingEntity>) bridgedElement;
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/dynamicmap/DynamicMapBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/dynamicmap/DynamicMapBaseIT.java
@@ -49,6 +49,7 @@ import org.junit.Test;
  * <p>
  * This test is rather simplistic because "dynamic-map" entity mapping is not fully supported in Hibernate Search yet.
  */
+@SuppressWarnings("rawtypes")
 public class DynamicMapBaseIT {
 
 	private static final String INDEX1_NAME = "Index1Name";

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToHibernateOrmScrollableResultsIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToHibernateOrmScrollableResultsIT.java
@@ -1036,7 +1036,7 @@ public class ToHibernateOrmScrollableResultsIT {
 				assertThat( implementor.isClosed() ).isTrue();
 
 				// Mutating methods should no longer work after the results are closed
-				Consumer exceptionExpectations = e -> assertThat( e )
+				Consumer<Throwable> exceptionExpectations = e -> assertThat( e )
 						.asInstanceOf( InstanceOfAssertFactories.THROWABLE )
 						.isInstanceOf( SearchException.class )
 						.hasMessageContaining( "Cannot use this ScrollableResults instance: it is closed" );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingCachingIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingCachingIT.java
@@ -222,7 +222,7 @@ public class MassIndexingCachingIT {
 				.as( "Second level cache put count" );
 	}
 
-	private Query cachedQuery(Session session, CacheMode cacheMode) {
+	private Query<IndexedEntity> cachedQuery(Session session, CacheMode cacheMode) {
 		Query<IndexedEntity> query = session.createQuery(
 				"select e from IndexedEntity e where e.id in (:ids)",
 				IndexedEntity.class

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldContainerExtractorBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldContainerExtractorBaseIT.java
@@ -87,6 +87,7 @@ public class FieldContainerExtractorBaseIT {
 	private static class MyContainer<T> {
 		private final List<T> elements;
 
+		@SafeVarargs
 		private MyContainer(T ... elements) {
 			this.elements = Arrays.asList( elements );
 		}

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/PropertyBridgeBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/PropertyBridgeBaseIT.java
@@ -1098,6 +1098,7 @@ public class PropertyBridgeBaseIT {
 		backendMock.verifyExpectationsMet();
 	}
 
+	@SuppressWarnings("rawtypes")
 	public static class RawTypeBridge implements PropertyBridge {
 
 		private final IndexFieldReference<String> fieldReference;
@@ -1113,6 +1114,7 @@ public class PropertyBridgeBaseIT {
 
 		public static class Binder implements PropertyBinder {
 			@Override
+			@SuppressWarnings("unchecked")
 			public void bind(PropertyBindingContext context) {
 				context.dependencies().useRootOnly();
 

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/TypeBridgeBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/TypeBridgeBaseIT.java
@@ -930,11 +930,11 @@ public class TypeBridgeBaseIT {
 	@Test
 	public void typeBridge_noGenericType() {
 		backendMock.expectSchema( INDEX_NAME, b -> b.field( "someField", String.class ) );
-		SearchMapping mapping = setupHelper.start().expectCustomBeans().setup( IndexedEntity.class );
+		SearchMapping mapping = setupHelper.start().expectCustomBeans().setup( IndexedEntityWithRawTypeBridge.class );
 		backendMock.verifyExpectationsMet();
 
 		try ( SearchSession session = mapping.createSession() ) {
-			IndexedEntity entity = new IndexedEntity();
+			IndexedEntityWithRawTypeBridge entity = new IndexedEntityWithRawTypeBridge();
 			entity.id = 739;
 
 			session.indexingPlan().add( entity );
@@ -945,6 +945,7 @@ public class TypeBridgeBaseIT {
 		backendMock.verifyExpectationsMet();
 	}
 
+	@SuppressWarnings("rawtypes")
 	public static class RawTypeBridge implements TypeBridge {
 
 		private final IndexFieldReference<String> fieldReference;
@@ -955,12 +956,13 @@ public class TypeBridgeBaseIT {
 
 		@Override
 		public void write(DocumentElement target, Object bridgedElement, TypeBridgeWriteContext context) {
-			IndexedEntity castedBridgedElement = (IndexedEntity) bridgedElement;
+			IndexedEntityWithRawTypeBridge castedBridgedElement = (IndexedEntityWithRawTypeBridge) bridgedElement;
 			target.addValue( fieldReference, castedBridgedElement.id.toString() );
 		}
 
 		public static class Binder implements TypeBinder {
 			@Override
+			@SuppressWarnings("unchecked")
 			public void bind(TypeBindingContext context) {
 				context.dependencies().useRootOnly();
 
@@ -973,7 +975,7 @@ public class TypeBridgeBaseIT {
 
 	@Indexed(index = INDEX_NAME)
 	@TypeBinding(binder = @TypeBinderRef(type = RawTypeBridge.Binder.class))
-	private static class IndexedEntity {
+	private static class IndexedEntityWithRawTypeBridge {
 		@DocumentId
 		Integer id;
 	}

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/search/loading/AbstractSearchQueryEntityLoadingIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/search/loading/AbstractSearchQueryEntityLoadingIT.java
@@ -69,7 +69,7 @@ public abstract class AbstractSearchQueryEntityLoadingIT {
 			List<Object> expectedLoadedEntities = entityCollector.collected;
 
 			assertSoftly( softAssertions -> {
-				softAssertions.assertThat( loadedEntities )
+				softAssertions.<Object>assertThat( loadedEntities )
 						.as(
 								"Loaded entities when targeting types " + targetClasses
 										+ " and when the backend returns document references " + hitDocumentReferences
@@ -78,7 +78,7 @@ public abstract class AbstractSearchQueryEntityLoadingIT {
 								element -> assertThat( element )
 										.isInstanceOfAny( targetClasses.toArray( new Class<?>[0] ) )
 						)
-						.containsExactlyElementsOf( (List) expectedLoadedEntities );
+						.containsExactlyElementsOf( expectedLoadedEntities );
 
 				assertionsContributor.accept( softAssertions );
 			} );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/loading/PersistenceTypeKey.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/loading/PersistenceTypeKey.java
@@ -25,7 +25,7 @@ public class PersistenceTypeKey<E, I> {
 		if ( o == null || getClass() != o.getClass() ) {
 			return false;
 		}
-		PersistenceTypeKey<E, I> typesKey = (PersistenceTypeKey<E, I>) o;
+		PersistenceTypeKey<?, ?> typesKey = (PersistenceTypeKey<?, ?>) o;
 		return idType.equals( typesKey.idType ) && entityType.equals( typesKey.entityType );
 	}
 

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/AbstractPojoIndexingProcessorFailureIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/AbstractPojoIndexingProcessorFailureIT.java
@@ -90,6 +90,7 @@ abstract class AbstractPojoIndexingProcessorFailureIT {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void containerExtraction() {
 		RootEntity root = new RootEntity();
 		root.id = 1;
@@ -126,6 +127,7 @@ abstract class AbstractPojoIndexingProcessorFailureIT {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void nested_containerExtraction() {
 		RootEntity root = new RootEntity();
 		root.id = 1;

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/AbstractPojoReindexingResolutionFailureIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/AbstractPojoReindexingResolutionFailureIT.java
@@ -89,6 +89,7 @@ abstract class AbstractPojoReindexingResolutionFailureIT {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void containerExtraction() {
 		NonRootEntity level1 = new NonRootEntity();
 		level1.containingInContainer = Mockito.mock( List.class );
@@ -124,6 +125,7 @@ abstract class AbstractPojoReindexingResolutionFailureIT {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void nested_containerExtraction() {
 		NonRootEntity level1 = new NonRootEntity();
 		level1.containingInContainer = Mockito.mock( List.class );

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/service/BorrowalService.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/service/BorrowalService.java
@@ -46,12 +46,14 @@ public class BorrowalService {
 		return accountRepo.save( account );
 	}
 
-	public <D extends Document<C>, C extends DocumentCopy<D>> Borrowal borrow(Person user, Library library, Document document, BorrowalType type) {
+	public <D extends Document<C>, C extends DocumentCopy<D>> Borrowal borrow(Person user, Library library,
+			Document<?> document, BorrowalType type) {
 		return borrow( user, library, document, 0, type );
 	}
 
-	public <D extends Document<C>, C extends DocumentCopy<D>> Borrowal borrow(Person user, Library library, Document document, int copyIndex, BorrowalType type) {
-		DocumentCopy copy = getCopy( document, library, copyIndex );
+	public <D extends Document<C>, C extends DocumentCopy<D>> Borrowal borrow(Person user, Library library,
+			Document<?> document, int copyIndex, BorrowalType type) {
+		DocumentCopy<?> copy = getCopy( document, library, copyIndex );
 		Borrowal borrowal = new Borrowal( user.getAccount(), copy, type );
 		user.getAccount().getBorrowals().add( borrowal );
 		copy.getBorrowals().add( borrowal );
@@ -74,7 +76,7 @@ public class BorrowalService {
 		return personRepo.searchPerson( terms, offset, limit );
 	}
 
-	private DocumentCopy getCopy(Document<DocumentCopy<?>> document, Library library, int copyIndex) {
+	private DocumentCopy<?> getCopy(Document<?> document, Library library, int copyIndex) {
 		return document.getCopies().stream()
 				.filter( c -> c.getLibrary().equals( library ) )
 				.skip( copyIndex )

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/loading/impl/JavaBeanLoadingContext.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/loading/impl/JavaBeanLoadingContext.java
@@ -100,7 +100,8 @@ public final class JavaBeanLoadingContext
 			PojoLoadingTypeContext<T> type) {
 		PojoRawTypeIdentifier<T> typeId = type.typeIdentifier();
 		return typeContextProvider.forExactType( typeId ).selectionLoadingStrategy()
-				.map( JavaBeanSelectionLoadingStrategy::new );
+				// Eclipse will complain about a raw type if we use a method reference here... for some reason.
+				.map( s -> new JavaBeanSelectionLoadingStrategy<>( s ) );
 	}
 
 	@Override

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/massindexing/impl/JavaBeanMassIndexer.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/massindexing/impl/JavaBeanMassIndexer.java
@@ -67,7 +67,7 @@ public class JavaBeanMassIndexer implements MassIndexer {
 	}
 
 	@Override
-	public CompletionStage start() {
+	public CompletionStage<?> start() {
 		return delegate.start();
 	}
 

--- a/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/massindexing/step/impl/HibernateSearchPartitionMapper.java
+++ b/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/massindexing/step/impl/HibernateSearchPartitionMapper.java
@@ -201,6 +201,7 @@ public class HibernateSearchPartitionMapper implements PartitionMapper {
 		}
 	}
 
+	@SuppressWarnings("unchecked") // Can't do much better without adding generics to EntityTypeDescriptor
 	private List<PartitionBound> buildPartitionUnitsFrom(EntityManagerFactory emf, StatelessSession ss,
 			EntityTypeDescriptor entityTypeDescriptor,
 			Integer maxResults, int fetchSize, int rowsPerPartition,

--- a/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/massindexing/step/spi/EntityReader.java
+++ b/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/massindexing/step/spi/EntityReader.java
@@ -308,7 +308,7 @@ public class EntityReader extends AbstractItemReader {
 		String hql = customQueryHql;
 
 		return (session, lastCheckpointInfo) -> {
-			Query query = session.createQuery( hql );
+			Query<?> query = session.createQuery( hql );
 
 			if ( lastCheckpointInfo != null ) {
 				query.setFirstResult( lastCheckpointInfo.getProcessedEntityCount() );

--- a/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/massindexing/util/impl/PersistenceUtil.java
+++ b/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/massindexing/util/impl/PersistenceUtil.java
@@ -46,7 +46,7 @@ public final class PersistenceUtil {
 	 */
 	public static Session openSession(EntityManagerFactory entityManagerFactory, String tenantId) {
 		SessionFactory sessionFactory = entityManagerFactory.unwrap( SessionFactory.class );
-		SessionBuilder builder = sessionFactory.withOptions();
+		SessionBuilder<?> builder = sessionFactory.withOptions();
 		if ( StringHelper.isNotEmpty( tenantId ) ) {
 			builder.tenantIdentifier( tenantId );
 		}
@@ -69,7 +69,7 @@ public final class PersistenceUtil {
 	 */
 	public static StatelessSession openStatelessSession(EntityManagerFactory entityManagerFactory, String tenantId) {
 		SessionFactory sessionFactory = entityManagerFactory.unwrap( SessionFactory.class );
-		StatelessSessionBuilder builder = sessionFactory.withStatelessOptions();
+		StatelessSessionBuilder<?> builder = sessionFactory.withStatelessOptions();
 		if ( StringHelper.isNotEmpty( tenantId ) ) {
 			builder.tenantIdentifier( tenantId );
 		}

--- a/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/massindexing/util/impl/SingularIdOrder.java
+++ b/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/massindexing/util/impl/SingularIdOrder.java
@@ -28,16 +28,19 @@ public class SingularIdOrder implements IdOrder {
 	}
 
 	@Override
+	@SuppressWarnings("unchecked") // Can't do better without addings generics for the ID type everywhere
 	public Predicate idGreater(CriteriaBuilder builder, Root<?> root, Object idObj) {
 		return builder.greaterThan( root.get( idPropertyName ), (Comparable<? super Object>) idObj );
 	}
 
 	@Override
+	@SuppressWarnings("unchecked") // Can't do better without addings generics for the ID type everywhere
 	public Predicate idGreaterOrEqual(CriteriaBuilder builder, Root<?> root, Object idObj) {
 		return builder.greaterThanOrEqualTo( root.get( idPropertyName ), (Comparable<? super Object>) idObj );
 	}
 
 	@Override
+	@SuppressWarnings("unchecked") // Can't do better without addings generics for the ID type everywhere
 	public Predicate idLesser(CriteriaBuilder builder, Root<?> root, Object idObj) {
 		return builder.lessThan( root.get( idPropertyName ), (Comparable<? super Object>) idObj );
 	}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/bootstrap/impl/HibernateSearchPreIntegrationService.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/bootstrap/impl/HibernateSearchPreIntegrationService.java
@@ -77,6 +77,7 @@ public abstract class HibernateSearchPreIntegrationService implements Service, A
 		}
 
 		@Override
+		@SuppressWarnings("rawtypes") // Can't do better: Map is raw in the superclass
 		public HibernateSearchPreIntegrationService initiateService(Map configurationValues,
 				ServiceRegistryImplementor registry) {
 			// Hibernate ORM may call this method twice if we return a null service.

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/ConditionalExpressionQueryFactory.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/ConditionalExpressionQueryFactory.java
@@ -32,6 +32,7 @@ public abstract class ConditionalExpressionQueryFactory<E, I> implements TypeQue
 	}
 
 	@Override
+	@SuppressWarnings("unchecked") // Can't do better here: EntityPersister has no generics
 	public Query<I> createQueryForIdentifierListing(SharedSessionContractImplementor session, EntityPersister persister,
 			Set<? extends Class<? extends E>> includedTypesFilter, ConditionalExpression conditionalExpression) {
 		return createQueryWithConditionalExpression( session,

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/CriteriaTypeQueryFactory.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/CriteriaTypeQueryFactory.java
@@ -67,6 +67,7 @@ class CriteriaTypeQueryFactory<E, I> extends ConditionalExpressionQueryFactory<E
 	}
 
 	@Override
+	@SuppressWarnings("rawtypes")
 	public Query<E> createQueryForLoadByUniqueProperty(SessionImplementor session, String parameterName) {
 		CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
 		ParameterExpression<Collection> idsParameter = criteriaBuilder.parameter( Collection.class, parameterName );

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/HibernateOrmEntityIdEntityLoadingStrategy.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/HibernateOrmEntityIdEntityLoadingStrategy.java
@@ -97,6 +97,7 @@ public class HibernateOrmEntityIdEntityLoadingStrategy<E, I>
 		return result;
 	}
 
+	@SuppressWarnings("unchecked") // Can't do better here: EntityPersister has no generics
 	private PojoSelectionEntityLoader<?> doCreate(EntityPersister entityPersister,
 			LoadingSessionContext sessionContext, EntityLoadingCacheLookupStrategy cacheLookupStrategy,
 			MutableEntityLoadingOptions loadingOptions) {

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/HqlTypeQueryFactory.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/HqlTypeQueryFactory.java
@@ -53,6 +53,7 @@ class HqlTypeQueryFactory<E, I> extends ConditionalExpressionQueryFactory<E, I> 
 	}
 
 	@Override
+	@SuppressWarnings("unchecked") // Can't do better here: the underlying method has no generics
 	public MultiIdentifierLoadAccess<E> createMultiIdentifierLoadAccess(SessionImplementor session) {
 		return session.byMultipleIds( entityPersister.getEntityName() );
 	}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/HibernateOrmMassIndexer.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/HibernateOrmMassIndexer.java
@@ -92,7 +92,7 @@ public class HibernateOrmMassIndexer implements MassIndexer {
 	}
 
 	@Override
-	public CompletionStage start() {
+	public CompletionStage<?> start() {
 		return delegate.start();
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmBootstrapIntrospector.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmBootstrapIntrospector.java
@@ -147,6 +147,7 @@ public class HibernateOrmBootstrapIntrospector extends AbstractPojoHCAnnBootstra
 		}
 	}
 
+	@SuppressWarnings("rawtypes")
 	private HibernateOrmDynamicMapRawTypeModel createDynamicMapTypeModel(String name) {
 		HibernateOrmBasicDynamicMapTypeMetadata ormMetadata = basicTypeMetadataProvider.getBasicDynamicMapTypeMetadata( name );
 		PojoRawTypeIdentifier<Map> typeIdentifier =

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmDynamicMapValueReadHandle.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmDynamicMapValueReadHandle.java
@@ -31,7 +31,7 @@ final class HibernateOrmDynamicMapValueReadHandle<T> implements ValueReadHandle<
 		if ( obj == null || !obj.getClass().equals( getClass() ) ) {
 			return false;
 		}
-		HibernateOrmDynamicMapValueReadHandle<?> other = (HibernateOrmDynamicMapValueReadHandle) obj;
+		HibernateOrmDynamicMapValueReadHandle<?> other = (HibernateOrmDynamicMapValueReadHandle<?>) obj;
 		return name.equals( other.name ) && type.equals( other.type );
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmGenericTypeModelFactory.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmGenericTypeModelFactory.java
@@ -32,7 +32,7 @@ public interface HibernateOrmGenericTypeModelFactory<T> {
 	}
 
 	// This cast is safe if the caller made sure that this name really points to a dynamic-map type
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	static HibernateOrmGenericTypeModelFactory<Map> dynamicMap(String name) {
 		return introspector -> SyntheticPojoGenericTypeModel.opaqueType(
 				(PojoRawTypeModel<Map>) introspector.typeModel( name )
@@ -46,7 +46,7 @@ public interface HibernateOrmGenericTypeModelFactory<T> {
 		);
 	}
 
-	static <C extends Collection> HibernateOrmGenericTypeModelFactory<C> collection(
+	static <C extends Collection<?>> HibernateOrmGenericTypeModelFactory<C> collection(
 			Class<C> collectionType, HibernateOrmGenericTypeModelFactory<?> elementType) {
 		return introspector -> SyntheticPojoGenericTypeModel.genericType(
 				introspector.typeModel( collectionType ),
@@ -54,7 +54,7 @@ public interface HibernateOrmGenericTypeModelFactory<T> {
 		);
 	}
 
-	static <M extends Map> HibernateOrmGenericTypeModelFactory<M> map(
+	static <M extends Map<?, ?>> HibernateOrmGenericTypeModelFactory<M> map(
 			Class<M> mapType,
 			HibernateOrmGenericTypeModelFactory<?> keyType,
 			HibernateOrmGenericTypeModelFactory<?> valueType) {

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmRawTypeIdentifierResolver.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmRawTypeIdentifierResolver.java
@@ -19,6 +19,7 @@ public class HibernateOrmRawTypeIdentifierResolver {
 		return PojoRawTypeIdentifier.of( javaClass );
 	}
 
+	@SuppressWarnings("rawtypes")
 	static PojoRawTypeIdentifier<Map> createDynamicMapTypeIdentifier(String name) {
 		return PojoRawTypeIdentifier.of( Map.class, name );
 	}
@@ -94,6 +95,7 @@ public class HibernateOrmRawTypeIdentifierResolver {
 			byHibernateOrmEntityName.put( hibernateOrmEntityName, typeIdentifier );
 		}
 
+		@SuppressWarnings("rawtypes")
 		void addDynamicMapEntityType(String jpaEntityName, String hibernateOrmEntityName) {
 			PojoRawTypeIdentifier<Map> typeIdentifier = createDynamicMapTypeIdentifier( hibernateOrmEntityName );
 			byJpaEntityName.put( jpaEntityName, typeIdentifier );

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java
@@ -52,6 +52,7 @@ import org.hibernate.type.Type;
 
 @SuppressForbiddenApis(reason = "We need to extend the internal AbstractProducedQuery"
 		+ " in order to implement a org.hibernate.query.Query")
+@SuppressWarnings("unchecked") // For some reason javac issues warnings for all methods returning this; IDEA doesn't.
 public final class HibernateOrmSearchQueryAdapter<R> extends AbstractProducedQuery<R> {
 
 	public static <R> HibernateOrmSearchQueryAdapter<R> create(SearchQuery<R> query) {
@@ -197,7 +198,7 @@ public final class HibernateOrmSearchQueryAdapter<R> extends AbstractProducedQue
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public Query<R> applyGraph(RootGraph graph, GraphSemantic semantic) {
 		loadingOptions.entityGraphHint( new EntityGraphHint<>( graph, semantic ), true );
 		return this;
@@ -440,7 +441,7 @@ public final class HibernateOrmSearchQueryAdapter<R> extends AbstractProducedQue
 	}
 
 	private static RootGraph<?> hintValueToEntityGraph(Object value) {
-		return (RootGraph) value;
+		return (RootGraph<?>) value;
 	}
 
 }

--- a/mapper/orm/src/test/java/org/hibernate/search/mapper/orm/HibernateOrmExtensionTest.java
+++ b/mapper/orm/src/test/java/org/hibernate/search/mapper/orm/HibernateOrmExtensionTest.java
@@ -93,6 +93,7 @@ public class HibernateOrmExtensionTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void toDocumentValueConverter() {
 		ToDocumentValueConvertContext context = new ToDocumentValueConvertContextImpl( mappingContext );
 		assertThat( context.extension( HibernateOrmExtension.get() ) ).isSameAs( mappingContext );
@@ -107,6 +108,7 @@ public class HibernateOrmExtensionTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void fromDocumentValueConverter() {
 		FromDocumentValueConvertContext context = new FromDocumentValueConvertContextImpl( sessionContext );
 		assertThat( context.extension( HibernateOrmExtension.get() ) ).isSameAs( sessionContext );

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultEnumBridge.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultEnumBridge.java
@@ -62,7 +62,7 @@ public final class DefaultEnumBridge<T extends Enum<T>> extends AbstractStringBa
 		}
 
 		@Override
-		@SuppressWarnings("unchecked") // The bridge resolver performs the checks using reflection
+		@SuppressWarnings({ "unchecked", "rawtypes" }) // The bridge resolver performs the checks using reflection
 		public void bind(IdentifierBindingContext<?> context) {
 			doBind( context, (Class) context.bridgedElement().rawType() );
 		}
@@ -72,7 +72,7 @@ public final class DefaultEnumBridge<T extends Enum<T>> extends AbstractStringBa
 		}
 
 		@Override
-		@SuppressWarnings("unchecked") // The bridge resolver performs the checks using reflection
+		@SuppressWarnings({ "unchecked", "rawtypes" }) // The bridge resolver performs the checks using reflection
 		public void bind(ValueBindingContext<?> context) {
 			doBind( context, (Class) context.bridgedElement().rawType() );
 		}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/mapping/DefaultBinderDefinitionStep.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/mapping/DefaultBinderDefinitionStep.java
@@ -9,7 +9,7 @@ package org.hibernate.search.mapper.pojo.bridge.mapping;
 import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.IdentifierBinder;
 import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.ValueBinder;
 
-public interface DefaultBinderDefinitionStep<S extends DefaultBinderDefinitionStep> {
+public interface DefaultBinderDefinitionStep<S extends DefaultBinderDefinitionStep<?>> {
 
 	/**
 	 * Use the given binder by default for properties with a matching type marked as document identifier

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/mapping/annotation/IdentifierBridgeRef.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/mapping/annotation/IdentifierBridgeRef.java
@@ -36,6 +36,7 @@ public @interface IdentifierBridgeRef {
 	 * Reference an identifier bridge by its type.
 	 * @return The type of the  identifier bridge.
 	 */
+	@SuppressWarnings("rawtypes") // For backwards compatibility reasons, we allow raw types
 	Class<? extends IdentifierBridge> type() default UndefinedBridgeImplementationType.class;
 
 	/**

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/mapping/annotation/ValueBridgeRef.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/mapping/annotation/ValueBridgeRef.java
@@ -40,6 +40,7 @@ public @interface ValueBridgeRef {
 	 * Reference a value bridge by its type.
 	 * @return The type of the value bridge.
 	 */
+	@SuppressWarnings("rawtypes") // For backwards compatibility reasons, we allow raw types
 	Class<? extends ValueBridge> type() default UndefinedBridgeImplementationType.class;
 
 	/**
@@ -50,7 +51,7 @@ public @interface ValueBridgeRef {
 	/**
 	 * Class used as a marker for the default value of the {@link #type()} attribute.
 	 */
-	abstract class UndefinedBridgeImplementationType implements ValueBridge {
+	abstract class UndefinedBridgeImplementationType implements ValueBridge<Void, Void> {
 		private UndefinedBridgeImplementationType() {
 		}
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/mapping/impl/BeanBinder.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/mapping/impl/BeanBinder.java
@@ -44,7 +44,7 @@ public final class BeanBinder
 	}
 
 	@Override
-	@SuppressWarnings({"unchecked"})
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public void bind(IdentifierBindingContext<?> context) {
 		BeanHolder<? extends IdentifierBridge> bridgeHolder = doBuild( context.beanResolver(), IdentifierBridge.class );
 		try {
@@ -59,7 +59,7 @@ public final class BeanBinder
 	}
 
 	@Override
-	@SuppressWarnings({"unchecked"})
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public void bind(ValueBindingContext<?> context) {
 		BeanHolder<? extends ValueBridge> bridgeHolder = doBuild( context.beanResolver(), ValueBridge.class );
 		try {
@@ -73,6 +73,7 @@ public final class BeanBinder
 		}
 	}
 
+	@SuppressWarnings("unchecked") // Using reflection
 	private <B extends IdentifierBridge<I>, I> void doBind(BeanHolder<B> bridgeHolder, IdentifierBindingContext<?> context) {
 		IdentifierBridge<I> bridge = bridgeHolder.get();
 		GenericTypeContext bridgeTypeContext = new GenericTypeContext( bridge.getClass() );
@@ -87,6 +88,7 @@ public final class BeanBinder
 		}
 	}
 
+	@SuppressWarnings("unchecked") // Using reflection
 	private <B extends ValueBridge<V, F>, V, F> void doBind(BeanHolder<B> bridgeHolder, ValueBindingContext<?> context) {
 		ValueBridge<V, F> bridge = bridgeHolder.get();
 		GenericTypeContext bridgeTypeContext = new GenericTypeContext( bridge.getClass() );

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/AnnotationProcessorProvider.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/AnnotationProcessorProvider.java
@@ -30,6 +30,7 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 import org.hibernate.search.util.common.reflect.impl.GenericTypeContext;
 import org.hibernate.search.util.common.reflect.impl.ReflectionUtils;
 
+@SuppressWarnings("rawtypes") // Using reflection for checks
 public class AnnotationProcessorProvider {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/spi/PojoRawTypeIdentifier.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/spi/PojoRawTypeIdentifier.java
@@ -52,7 +52,7 @@ public final class PojoRawTypeIdentifier<T> {
 		if ( ! ( obj instanceof PojoRawTypeIdentifier ) ) {
 			return false;
 		}
-		PojoRawTypeIdentifier other = (PojoRawTypeIdentifier) obj;
+		PojoRawTypeIdentifier<?> other = (PojoRawTypeIdentifier<?>) obj;
 		return javaClass.equals( other.javaClass )
 				&& Objects.equals( name, other.name );
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -1315,32 +1315,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <showWarnings>true</showWarnings>
-                    <showDeprecation>true</showDeprecation>
-                    <failOnWarning>true</failOnWarning>
-                    <release>${maven.compiler.release}</release>
-                    <testRelease>${maven.compiler.testRelease}</testRelease>
-                    <encoding>UTF-8</encoding>
-                    <!-- needed because of compiler bug: http://bugs.sun.com/view_bug.do?bug_id=6512707 -->
-                    <proc>none</proc>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>default-compile</id>
-                        <configuration>
-                            <fork>true</fork>
-                            <executable>${java-version.main.compiler}</executable>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>default-testCompile</id>
-                        <configuration>
-                            <fork>true</fork>
-                            <executable>${java-version.test.compiler}</executable>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>com.github.marschall</groupId>
@@ -1598,6 +1572,32 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${version.compiler.plugin}</version>
+                    <configuration>
+                        <showWarnings>true</showWarnings>
+                        <showDeprecation>true</showDeprecation>
+                        <failOnWarning>true</failOnWarning>
+                        <release>${maven.compiler.release}</release>
+                        <testRelease>${maven.compiler.testRelease}</testRelease>
+                        <encoding>UTF-8</encoding>
+                        <!-- needed because of compiler bug: http://bugs.sun.com/view_bug.do?bug_id=6512707 -->
+                        <proc>none</proc>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>default-compile</id>
+                            <configuration>
+                                <fork>true</fork>
+                                <executable>${java-version.main.compiler}</executable>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>default-testCompile</id>
+                            <configuration>
+                                <fork>true</fork>
+                                <executable>${java-version.test.compiler}</executable>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.bsc.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -173,8 +173,8 @@
         <module>util/internal/integrationtest</module>
         <module>parents/integrationtest</module>
         <module>integrationtest</module>
-        <module>jakarta</module>
         <module>documentation</module>
+        <module>jakarta</module>
     </modules>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1581,6 +1581,9 @@
                         <encoding>UTF-8</encoding>
                         <!-- needed because of compiler bug: http://bugs.sun.com/view_bug.do?bug_id=6512707 -->
                         <proc>none</proc>
+                        <compilerArgs>
+                            <compilerArg>-Xlint:unchecked</compilerArg>
+                        </compilerArgs>
                     </configuration>
                     <executions>
                         <execution>
@@ -2348,13 +2351,29 @@
                                 <release></release>
                                 <source>${maven.compiler.release}</source>
                                 <target>${maven.compiler.release}</target>
-                                <compilerArgs combine.self="override">
+                                <compilerArgs>
                                     <!-- Ignore warnings in generated code -->
                                     <compilerArg>-nowarn:[${project.build.directory}/generated-sources/apt]</compilerArg>
-                                    <!-- Ignore all warnings for now TODO HSEARCH-4387 finer configuration -->
-                                    <compilerArg>-warn:none</compilerArg>
+                                    <!-- For a list of warning categories that can be passed to -warn,
+                                         see https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/tree/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/messages.properties#n376
+                                     -->
+                                    <!-- Ignore warnings that we don't care about -->
+                                    <compilerArg>-warn:-serial,intfAnnotation</compilerArg>
+                                    <!-- Ignore warnings that give false positives with ecj (or are addressed by other tools) -->
+                                    <compilerArg>-warn:-unusedImport,warningToken,unusedPrivate,enumSwitch</compilerArg>
                                 </compilerArgs>
                             </configuration>
+                            <executions>
+                                <execution>
+                                    <id>default-testCompile</id>
+                                    <configuration>
+                                        <compilerArgs combine.children="append">
+                                            <!-- Ignore warnings that are too annoying for tests -->
+                                            <compilerArg>-warn:-unused,resource</compilerArg>
+                                        </compilerArgs>
+                                    </configuration>
+                                </execution>
+                            </executions>
                             <dependencies>
                                 <dependency>
                                     <groupId>org.codehaus.plexus</groupId>

--- a/util/common/src/main/java/org/hibernate/search/util/common/reflect/impl/FieldValueReadHandle.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/reflect/impl/FieldValueReadHandle.java
@@ -30,6 +30,7 @@ public final class FieldValueReadHandle<T> implements ValueReadHandle<T> {
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public T get(Object thiz) {
 		try {
 			return (T) field.get( thiz );
@@ -49,7 +50,7 @@ public final class FieldValueReadHandle<T> implements ValueReadHandle<T> {
 		if ( obj == null || !obj.getClass().equals( getClass() ) ) {
 			return false;
 		}
-		FieldValueReadHandle<?> other = (FieldValueReadHandle) obj;
+		FieldValueReadHandle<?> other = (FieldValueReadHandle<?>) obj;
 		return field.equals( other.field );
 	}
 

--- a/util/common/src/main/java/org/hibernate/search/util/common/reflect/impl/MethodHandleValueReadHandle.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/reflect/impl/MethodHandleValueReadHandle.java
@@ -59,7 +59,7 @@ public final class MethodHandleValueReadHandle<T> implements ValueReadHandle<T> 
 		if ( obj == null || !obj.getClass().equals( getClass() ) ) {
 			return false;
 		}
-		MethodHandleValueReadHandle<?> other = (MethodHandleValueReadHandle) obj;
+		MethodHandleValueReadHandle<?> other = (MethodHandleValueReadHandle<?>) obj;
 		return member.equals( other.member );
 	}
 

--- a/util/common/src/main/java/org/hibernate/search/util/common/reflect/impl/MethodValueReadHandle.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/reflect/impl/MethodValueReadHandle.java
@@ -31,6 +31,7 @@ public final class MethodValueReadHandle<T> implements ValueReadHandle<T> {
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public T get(Object thiz) {
 		try {
 			return (T) method.invoke( thiz );
@@ -59,7 +60,7 @@ public final class MethodValueReadHandle<T> implements ValueReadHandle<T> {
 		if ( obj == null || !obj.getClass().equals( getClass() ) ) {
 			return false;
 		}
-		MethodValueReadHandle<?> other = (MethodValueReadHandle) obj;
+		MethodValueReadHandle<?> other = (MethodValueReadHandle<?>) obj;
 		return method.equals( other.method );
 	}
 

--- a/util/common/src/main/java/org/hibernate/search/util/common/reflect/spi/MemberValueReadHandleFactory.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/reflect/spi/MemberValueReadHandleFactory.java
@@ -15,11 +15,11 @@ import org.hibernate.search.util.common.reflect.impl.MethodValueReadHandle;
 final class MemberValueReadHandleFactory implements ValueReadHandleFactory {
 	@Override
 	public ValueReadHandle<?> createForField(Field field) {
-		return new FieldValueReadHandle( field );
+		return new FieldValueReadHandle<>( field );
 	}
 
 	@Override
 	public ValueReadHandle<?> createForMethod(Method method) {
-		return new MethodValueReadHandle( method );
+		return new MethodValueReadHandle<>( method );
 	}
 }

--- a/util/common/src/main/java/org/hibernate/search/util/common/reflect/spi/MethodHandleValueReadHandleFactory.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/reflect/spi/MethodHandleValueReadHandleFactory.java
@@ -25,11 +25,11 @@ final class MethodHandleValueReadHandleFactory implements ValueReadHandleFactory
 
 	@Override
 	public ValueReadHandle<?> createForField(Field field) throws IllegalAccessException {
-		return new MethodHandleValueReadHandle( field, lookup.unreflectGetter( field ) );
+		return new MethodHandleValueReadHandle<>( field, lookup.unreflectGetter( field ) );
 	}
 
 	@Override
 	public ValueReadHandle<?> createForMethod(Method method) throws IllegalAccessException {
-		return new MethodHandleValueReadHandle( method, lookup.unreflect( method ) );
+		return new MethodHandleValueReadHandle<>( method, lookup.unreflect( method ) );
 	}
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/NormalizationUtils.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/NormalizationUtils.java
@@ -50,16 +50,16 @@ public final class NormalizationUtils {
 			return (T) normalize( (BigDecimal) object );
 		}
 		else if ( object instanceof Range ) {
-			return (T) normalize( (Range) object );
+			return (T) normalize( (Range<?>) object );
 		}
 		else if ( object instanceof Map.Entry ) {
-			return (T) normalize( (Map.Entry) object );
+			return (T) normalize( (Map.Entry<?, ?>) object );
 		}
 		else if ( object instanceof List ) {
-			return (T) normalize( (List) object );
+			return (T) normalize( (List<?>) object );
 		}
 		else if ( object instanceof Map ) {
-			return (T) normalize( (Map) object );
+			return (T) normalize( (Map<?, ?>) object );
 		}
 		else if ( object.getClass().isArray() ) {
 			// Primitive arrays not supported, since we don't need them yet.

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/assertion/NormalizedListHit.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/assertion/NormalizedListHit.java
@@ -15,7 +15,7 @@ import org.hibernate.search.util.impl.integrationtest.common.NormalizationUtils;
 
 public class NormalizedListHit {
 
-	public static List[] of(Consumer<Builder> contributor) {
+	public static List<?>[] of(Consumer<Builder> contributor) {
 		Builder builder = new Builder();
 		contributor.accept( builder );
 		return builder.build();

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/NextScrollWorkCall.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/NextScrollWorkCall.java
@@ -79,7 +79,7 @@ public class NextScrollWorkCall<T> extends Call<NextScrollWorkCall<?>> {
 	}
 
 	@Override
-	protected boolean isSimilarTo(NextScrollWorkCall other) {
+	protected boolean isSimilarTo(NextScrollWorkCall<?> other) {
 		return Objects.equals( indexNames, other.indexNames );
 	}
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/ScrollWorkCall.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/ScrollWorkCall.java
@@ -78,7 +78,7 @@ public class ScrollWorkCall<T> extends Call<ScrollWorkCall<?>> {
 	}
 
 	@Override
-	protected boolean isSimilarTo(ScrollWorkCall other) {
+	protected boolean isSimilarTo(ScrollWorkCall<?> other) {
 		return Objects.equals( indexNames, other.indexNames );
 	}
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/dsl/impl/StubIndexNamedPredicateBuilder.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/dsl/impl/StubIndexNamedPredicateBuilder.java
@@ -12,10 +12,8 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaNamedPr
 class StubIndexNamedPredicateBuilder
 	implements IndexSchemaNamedPredicateOptionsStep {
 
-	private final StubIndexSchemaDataNode.Builder schemaDataNodeBuilder;
-
+	@SuppressWarnings("unused")
 	StubIndexNamedPredicateBuilder(StubIndexSchemaDataNode.Builder schemaDataNodeBuilder) {
-		this.schemaDataNodeBuilder = schemaDataNodeBuilder;
 	}
 
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/common/impl/StubSearchIndexScope.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/common/impl/StubSearchIndexScope.java
@@ -137,7 +137,7 @@ public class StubSearchIndexScope
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	protected StubSearchIndexNodeContext createMultiIndexSearchValueFieldContext(String absolutePath,
 			List<StubSearchIndexNodeContext> fieldForEachIndex) {
 		return new StubMultiIndexSearchIndexValueFieldContext<>( this, absolutePath,
@@ -145,7 +145,7 @@ public class StubSearchIndexScope
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	protected StubSearchIndexNodeContext createMultiIndexSearchObjectFieldContext(String absolutePath,
 			List<StubSearchIndexNodeContext> fieldForEachIndex) {
 		return new StubMultiIndexSearchIndexCompositeNodeContext( this, absolutePath,

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubIdSearchProjection.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubIdSearchProjection.java
@@ -43,7 +43,7 @@ public class StubIdSearchProjection<I> implements StubSearchProjection<I> {
 		private final StubSearchProjection<I> projection;
 
 		public Builder(ProjectionConverter<String, ? extends I> converter) {
-			projection = new StubIdSearchProjection( converter );
+			projection = new StubIdSearchProjection<>( converter );
 		}
 
 		@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/query/impl/StubSearchQueryBuilder.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/query/impl/StubSearchQueryBuilder.java
@@ -59,7 +59,7 @@ public class StubSearchQueryBuilder<H> implements SearchQueryBuilder<H> {
 	@Override
 	public <A> void aggregation(AggregationKey<A> key, SearchAggregation<A> aggregation) {
 		// Just check the type and simulate building native constructs.
-		( (StubSearchAggregation) aggregation ).simulateBuild();
+		( (StubSearchAggregation<?>) aggregation ).simulateBuild();
 	}
 
 	@Override

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/ManagedAssert.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/ManagedAssert.java
@@ -23,31 +23,31 @@ public class ManagedAssert<T> extends AbstractObjectAssert<ManagedAssert<T>, T> 
 		super( t, ManagedAssert.class );
 	}
 
-	public ManagedAssert isInitialized(boolean expectInitialized) {
+	public ManagedAssert<T> isInitialized(boolean expectInitialized) {
 		isNotNull();
 		managedInitialization().isEqualTo( expectInitialized );
 		return this;
 	}
 
-	public ManagedAssert isInitialized() {
+	public ManagedAssert<T> isInitialized() {
 		return isInitialized( true );
 	}
 
-	public ManagedAssert isNotInitialized() {
+	public ManagedAssert<T> isNotInitialized() {
 		return isInitialized( false );
 	}
 
-	public ManagedAssert hasPropertyInitialized(String propertyName, boolean expectInitialized) {
+	public ManagedAssert<T> hasPropertyInitialized(String propertyName, boolean expectInitialized) {
 		isNotNull();
 		propertyInitialization( propertyName ).isEqualTo( expectInitialized );
 		return this;
 	}
 
-	public ManagedAssert hasPropertyInitialized(String propertyName) {
+	public ManagedAssert<T> hasPropertyInitialized(String propertyName) {
 		return hasPropertyInitialized( propertyName, true );
 	}
 
-	public ManagedAssert hasPropertyNotInitialized(String propertyName) {
+	public ManagedAssert<T> hasPropertyNotInitialized(String propertyName) {
 		return hasPropertyInitialized( propertyName, false );
 	}
 

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/TestPluggableMethod.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/TestPluggableMethod.java
@@ -143,7 +143,7 @@ class TestPluggableMethod<T> {
 			if ( o == null || getClass() != o.getClass() ) {
 				return false;
 			}
-			ArgumentKey that = (ArgumentKey) o;
+			ArgumentKey<?> that = (ArgumentKey<?>) o;
 			return Objects.equals( type, that.type ) && Objects.equals( name, that.name );
 		}
 

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/multitenancy/impl/MultitenancyTestHelperSchemaManagementTool.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/multitenancy/impl/MultitenancyTestHelperSchemaManagementTool.java
@@ -51,6 +51,7 @@ class MultitenancyTestHelperSchemaManagementTool
 		}
 
 		@Override
+		@SuppressWarnings("rawtypes") // Can't do better: Map is raw in the superclass
 		public SchemaManagementTool initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
 			return new MultitenancyTestHelperSchemaManagementTool( tenantIds );
 		}
@@ -87,6 +88,7 @@ class MultitenancyTestHelperSchemaManagementTool
 	}
 
 	@Override
+	@SuppressWarnings("rawtypes") // Can't do better: Map is raw in the superclass
 	public SchemaCreator getSchemaCreator(Map options) {
 		return new SchemaCreator() {
 			final SchemaCreatorImpl delegate = (SchemaCreatorImpl) toolDelegate.getSchemaCreator( options );
@@ -99,6 +101,7 @@ class MultitenancyTestHelperSchemaManagementTool
 	}
 
 	@Override
+	@SuppressWarnings("rawtypes") // Can't do better: Map is raw in the superclass
 	public SchemaDropper getSchemaDropper(Map options) {
 		return new SchemaDropper() {
 			final SchemaDropperImpl delegate = (SchemaDropperImpl) toolDelegate.getSchemaDropper( options );
@@ -122,11 +125,13 @@ class MultitenancyTestHelperSchemaManagementTool
 	}
 
 	@Override
+	@SuppressWarnings("rawtypes") // Can't do better: Map is raw in the superclass
 	public SchemaMigrator getSchemaMigrator(Map options) {
 		throw notSupported();
 	}
 
 	@Override
+	@SuppressWarnings("rawtypes") // Can't do better: Map is raw in the superclass
 	public SchemaValidator getSchemaValidator(Map options) {
 		throw notSupported();
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4387

This also enables many warnings for the Eclipse compiler, which has the advantage of more accurately reporting unchecked/rawtype problems in code than `javac`.

Eventually we'll probably want to disable that, but I'd like to try it for a while, and maybe eventually we'll move to something like ErrorProne to replace this.