### PR TITLE
HSEARCH-4401 Lucene backend ignores limit when offset + limit is higher than Integer.MAX_VALUE instead of reporting that it cannot handle it

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
@@ -588,4 +588,8 @@ public interface Log extends BasicLogger {
 			value = "Param with name '%1$s' has not been defined for the named predicate '%2$s'.")
 	SearchException paramNotDefined(String name, String predicateName, @Param EventContext context);
 
+	@Message(id = ID_OFFSET + 151,
+			value = "Offset + limit should be lower than Integer.MAX_VALUE, offset: '%1$s', limit: '%2$s'.")
+	IOException offsetLimitExceedsMaxValue(int offset, Integer limit);
+
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearcherImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearcherImpl.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.backend.lucene.search.query.impl;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.Map;
 
 import org.hibernate.search.backend.lucene.logging.impl.Log;
@@ -33,6 +34,7 @@ class LuceneSearcherImpl<H> implements LuceneSearcher<LuceneLoadableSearchResult
 	private static final int PREFETCH_HITS_SIZE = 100;
 	private static final int PREFETCH_TOTAL_HIT_COUNT_THRESHOLD = 10_000;
 
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 	private static final Log queryLog = LoggerFactory.make( Log.class, DefaultLogCategories.QUERY );
 
 	private final LuceneSearchQueryRequestContext requestContext;
@@ -82,6 +84,10 @@ class LuceneSearcherImpl<H> implements LuceneSearcher<LuceneLoadableSearchResult
 	private LuceneExtractableSearchResult<H> doSearch(IndexSearcher indexSearcher,
 			IndexReaderMetadataResolver metadataResolver,
 			int offset, Integer limit, int totalHitCountThreshold) throws IOException {
+		if ( limit != null && (long) offset + limit > Integer.MAX_VALUE ) {
+			throw log.offsetLimitExceedsMaxValue( offset, limit );
+		}
+
 		queryLog.executingLuceneQuery( requestContext.getLuceneQuery() );
 
 		int maxDocs = getMaxDocs( indexSearcher.getIndexReader(), offset, limit );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryFetchIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryFetchIT.java
@@ -120,6 +120,13 @@ public class SearchQueryFetchIT {
 				.hasNoHits();
 	}
 
+	@Test
+	public void fetch_offset_limit_exceedsMaxValue() {
+		assertThatThrownBy( () -> matchAllQuerySortByField().fetch( 1, Integer.MAX_VALUE ) )
+				// error message will depend on the specific backend
+				.isInstanceOf( SearchException.class );
+	}
+
 	/**
 	 * Same as the test above, but with the default, score sort.
 	 * This is important in the Lucene implementation in particular,


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4401