### PR TITLE
HSEARCH-4405 + HSEARCH-4406 Upgrade to log4j 2.15, jruby-complete 9.3.2.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,6 @@ updates:
       # AWS SDK releases way too often (every week?); ignore all patch updates
       - dependency-name: "software.amazon.awssdk:*"
         update-types: ["version-update:semver-patch"]
+      # JRuby releases way too often (every two weeks?) and is only used during the build; ignore all patch updates
+      - dependency-name: "org.jruby:jruby-complete"
+        update-types: ["version-update:semver-patch"]

--- a/pom.xml
+++ b/pom.xml
@@ -379,7 +379,7 @@
 
         <version.asciidoctor.plugin>2.2.1</version.asciidoctor.plugin>
         <version.org.hibernate.infra.hibernate-asciidoctor-theme>1.0.4.Final</version.org.hibernate.infra.hibernate-asciidoctor-theme>
-        <version.org.jruby>9.3.1.0</version.org.jruby>
+        <version.org.jruby>9.3.2.0</version.org.jruby>
         <version.org.asciidoctor.asciidoctorj>2.5.2</version.org.asciidoctor.asciidoctorj>
         <version.org.asciidoctor.asciidoctorj-pdf>1.5.0-alpha.18</version.org.asciidoctor.asciidoctorj-pdf>
 

--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@
         <!-- Test dependencies -->
 
         <!-- >>> Common -->
-        <version.log4j>2.14.1</version.log4j>
+        <version.log4j>2.15.0</version.log4j>
         <version.junit>4.13.2</version.junit>
         <version.org.osgi.core>6.0.0</version.org.osgi.core>
 


### PR DESCRIPTION
* [HSEARCH-4406](https://hibernate.atlassian.net/browse/HSEARCH-4406): Upgrade to jruby-complete 9.3.2.0
* [HSEARCH-4405](https://hibernate.atlassian.net/browse/HSEARCH-4405): Upgrade to log4j 2.15

