### PR TITLE
HSEARCH-4340 + HSEARCH-4396 + HSEARCH-4397 Run tests against Elasticsearch 7.16

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/ElasticsearchRangeAggregation.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/ElasticsearchRangeAggregation.java
@@ -153,7 +153,7 @@ public class ElasticsearchRangeAggregation<F, K>
 		private JsonElement convertToFieldValue(K value) {
 			try {
 				F converted = toFieldValueConverter.toDocumentValue( value, scope.toDocumentValueConvertContext() );
-				return codec.encode( converted );
+				return codec.encodeForAggregation( converted );
 			}
 			catch (RuntimeException e) {
 				throw log.cannotConvertDslParameter( e.getMessage(), e, field.eventContext() );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchFieldCodec.java
@@ -23,10 +23,20 @@ public interface ElasticsearchFieldCodec<F> {
 		return encode( value );
 	}
 
+	/**
+	 * Encodes a value for inclusion in an aggregation request.
+	 *
+	 * @param value The value to encode.
+	 * @return The encoded value.
+	 */
+	default JsonElement encodeForAggregation(F value) {
+		return encode( value );
+	}
+
 	F decode(JsonElement element);
 
 	/**
-	 * Decode the key returned by an aggregation.
+	 * Decodes the key returned by a term aggregation.
 	 * @param key The "key" property  returned by the aggregation.
 	 * May be a number, a string, ... depending on the field type.
 	 * @param keyAsString The "key_as_string" property returned by the term aggregation.

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchLongFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchLongFieldCodec.java
@@ -11,6 +11,7 @@ import org.hibernate.search.backend.elasticsearch.gson.impl.JsonElementTypes;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonPrimitive;
+import com.google.gson.LongSerializationPolicy;
 
 public class ElasticsearchLongFieldCodec implements ElasticsearchFieldCodec<Long> {
 	public static final ElasticsearchLongFieldCodec INSTANCE = new ElasticsearchLongFieldCodec();
@@ -24,6 +25,12 @@ public class ElasticsearchLongFieldCodec implements ElasticsearchFieldCodec<Long
 			return JsonNull.INSTANCE;
 		}
 		return new JsonPrimitive( value );
+	}
+
+	@Override
+	public JsonElement encodeForAggregation(Long value) {
+		// Workaround for https://github.com/elastic/elasticsearch/issues/81529
+		return LongSerializationPolicy.STRING.serialize( value );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -230,7 +230,7 @@ public class ElasticsearchDialectFactoryTest {
 	@TestForIssue(jiraKey = "HSEARCH-3563")
 	public void elastic_7() {
 		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7", "7.13.2",
+				ElasticsearchDistributionName.ELASTIC, "7", "7.16.0",
 				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
 		);
 	}
@@ -531,6 +531,25 @@ public class ElasticsearchDialectFactoryTest {
 				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
 		);
 	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4340")
+	public void elastic_7_16() {
+		testSuccess(
+				ElasticsearchDistributionName.ELASTIC, "7.16", "7.16.0",
+				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4340")
+	public void elastic_7_16_0() {
+		testSuccess(
+				ElasticsearchDistributionName.ELASTIC, "7.16.0", "7.16.0",
+				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+		);
+	}
+
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3563")

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/BackendConfigurations.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/BackendConfigurations.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.testsupport;
 
 import static org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration.BACKEND_TYPE;
 
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.backend.lucene.cfg.LuceneIndexSettings;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.ElasticsearchBackendConfiguration;
 import org.hibernate.search.util.impl.integrationtest.backend.lucene.LuceneBackendConfiguration;
@@ -64,13 +65,9 @@ public final class BackendConfigurations {
 					@Override
 					public <C extends MappingSetupHelper<C, ?, ?>.AbstractSetupContext> C setup(C setupContext,
 							String backendNameOrNull, TestConfigurationProvider configurationProvider) {
-						// Make sure automatically created indexes will have an appropriate number of shards
-						testElasticsearchClient.template( "sharded_index" )
-								.create(
-										"*",
-										"{'number_of_shards': " + shardCount + "}"
-								);
-						return super.setup( setupContext, backendNameOrNull, configurationProvider );
+						return super.setup( setupContext, backendNameOrNull, configurationProvider )
+								.withBackendProperty( ElasticsearchIndexSettings.SCHEMA_MANAGEMENT_SETTINGS_FILE,
+										"index-settings-for-tests/" + shardCount + "-shards.json" );
 					}
 				};
 			default:

--- a/documentation/src/test/resources/index-settings-for-tests/4-shards.json
+++ b/documentation/src/test/resources/index-settings-for-tests/4-shards.json
@@ -1,0 +1,1 @@
+{"number_of_shards": 4}

--- a/integrationtest/backend/elasticsearch/src/test/resources/index-settings-for-tests/1-shards.json
+++ b/integrationtest/backend/elasticsearch/src/test/resources/index-settings-for-tests/1-shards.json
@@ -1,0 +1,1 @@
+{"number_of_shards": 1}

--- a/integrationtest/backend/elasticsearch/src/test/resources/index-settings-for-tests/2-shards.json
+++ b/integrationtest/backend/elasticsearch/src/test/resources/index-settings-for-tests/2-shards.json
@@ -1,0 +1,1 @@
+{"number_of_shards": 2}

--- a/integrationtest/backend/elasticsearch/src/test/resources/index-settings-for-tests/3-shards.json
+++ b/integrationtest/backend/elasticsearch/src/test/resources/index-settings-for-tests/3-shards.json
@@ -1,0 +1,1 @@
+{"number_of_shards": 3}

--- a/integrationtest/backend/elasticsearch/src/test/resources/index-settings-for-tests/4-shards.json
+++ b/integrationtest/backend/elasticsearch/src/test/resources/index-settings-for-tests/4-shards.json
@@ -1,0 +1,1 @@
+{"number_of_shards": 4}

--- a/integrationtest/backend/elasticsearch/src/test/resources/index-settings-for-tests/5-replicas.json
+++ b/integrationtest/backend/elasticsearch/src/test/resources/index-settings-for-tests/5-replicas.json
@@ -1,0 +1,1 @@
+{"number_of_replicas": 5}

--- a/integrationtest/backend/elasticsearch/src/test/resources/index-settings-for-tests/rare-periodic-refresh.json
+++ b/integrationtest/backend/elasticsearch/src/test/resources/index-settings-for-tests/rare-periodic-refresh.json
@@ -1,0 +1,1 @@
+{"refresh_interval": "2h" }

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/LuceneTckBackendHelper.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/LuceneTckBackendHelper.java
@@ -66,8 +66,8 @@ public class LuceneTckBackendHelper implements TckBackendHelper {
 	}
 
 	@Override
-	public TckBackendSetupStrategy<?> createPeriodicRefreshBackendSetupStrategy(int refreshIntervalMs) {
+	public TckBackendSetupStrategy<?> createRarePeriodicRefreshBackendSetupStrategy() {
 		return new LuceneTckBackendSetupStrategy()
-				.setProperty( "io.refresh_interval", String.valueOf( refreshIntervalMs ) );
+				.setProperty( "io.refresh_interval", String.valueOf( 1_000_000 ) );
 	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendHelper.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendHelper.java
@@ -33,6 +33,6 @@ public interface TckBackendHelper {
 
 	TckBackendSetupStrategy<?> createHashBasedShardingBackendSetupStrategy(int shardCount);
 
-	TckBackendSetupStrategy<?> createPeriodicRefreshBackendSetupStrategy(int refreshIntervalMs);
+	TckBackendSetupStrategy<?> createRarePeriodicRefreshBackendSetupStrategy();
 
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceRefreshIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceRefreshIT.java
@@ -17,10 +17,8 @@ import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappedInde
 
 public class IndexWorkspaceRefreshIT extends AbstractIndexWorkspaceSimpleOperationIT {
 
-	private static final int VERY_LONG_INTERVAL_MS = 1_000_000;
-
 	public IndexWorkspaceRefreshIT() {
-		super( new SearchSetupHelper( helper -> helper.createPeriodicRefreshBackendSetupStrategy( VERY_LONG_INTERVAL_MS ) ) );
+		super( new SearchSetupHelper( helper -> helper.createRarePeriodicRefreshBackendSetupStrategy() ) );
 	}
 
 	@Override

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/testsupport/BackendConfigurations.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/testsupport/BackendConfigurations.java
@@ -8,6 +8,7 @@ package org.hibernate.search.integrationtest.mapper.orm.realbackend.testsupport;
 
 import static org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration.BACKEND_TYPE;
 
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.backend.lucene.cfg.LuceneIndexSettings;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.ElasticsearchBackendConfiguration;
 import org.hibernate.search.util.impl.integrationtest.backend.lucene.LuceneBackendConfiguration;
@@ -52,13 +53,9 @@ public class BackendConfigurations {
 					@Override
 					public <C extends MappingSetupHelper<C, ?, ?>.AbstractSetupContext> C setup(C setupContext,
 							String backendNameOrNull, TestConfigurationProvider configurationProvider) {
-						// Make sure automatically created indexes will have an appropriate number of shards
-						testElasticsearchClient.template( "sharded_index" )
-								.create(
-										"*",
-										"{'number_of_shards': " + shardCount + "}"
-								);
-						return super.setup( setupContext, backendNameOrNull, configurationProvider );
+						return super.setup( setupContext, backendNameOrNull, configurationProvider )
+								.withBackendProperty( ElasticsearchIndexSettings.SCHEMA_MANAGEMENT_SETTINGS_FILE,
+										"index-settings-for-tests/" + shardCount + "-shards.json" );
 					}
 				};
 			default:

--- a/integrationtest/mapper/orm-realbackend/src/test/resources/index-settings-for-tests/64-shards.json
+++ b/integrationtest/mapper/orm-realbackend/src/test/resources/index-settings-for-tests/64-shards.json
@@ -1,0 +1,1 @@
+{"number_of_shards": 64}

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -578,7 +578,7 @@
             <properties>
                 <test.elasticsearch.run.elastic.skip>${test.elasticsearch.run.skip}</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.distribution>elastic</test.elasticsearch.connection.distribution>
-                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-7.13}</test.elasticsearch.connection.version>
+                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-7.16}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch712TestDialect</test.elasticsearch.testdialect>
             </properties>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -525,7 +525,7 @@
         <test.elasticsearch.connection.uris.defined></test.elasticsearch.connection.uris.defined>
 
         <test.elasticsearch.run.elastic.skip>true</test.elasticsearch.run.elastic.skip>
-        <test.elasticsearch.run.elastic.image.name>elasticsearch</test.elasticsearch.run.elastic.image.name>
+        <test.elasticsearch.run.elastic.image.name>elastic/elasticsearch</test.elasticsearch.run.elastic.image.name>
         <test.elasticsearch.run.elastic.image.tag>${test.elasticsearch.connection.version}</test.elasticsearch.run.elastic.image.tag>
         <test.elasticsearch.run.opensearch.skip>true</test.elasticsearch.run.opensearch.skip>
         <test.elasticsearch.run.opensearch.image.name>opensearchproject/opensearch</test.elasticsearch.run.opensearch.image.name>

--- a/pom.xml
+++ b/pom.xml
@@ -203,8 +203,8 @@
 
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently from the version of the remote cluster -->
-        <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 7.15+ -->
-        <version.org.elasticsearch.client>7.15.2</version.org.elasticsearch.client>
+        <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 7.16+ -->
+        <version.org.elasticsearch.client>7.16.0</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links and as the default when testing.
              We're trying to stick to a fully-OSS version as the default, so don't upgrade to 7.11 here. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,

--- a/pom.xml
+++ b/pom.xml
@@ -213,11 +213,14 @@
         <documentation.org.elasticsearch.url>https://www.elastic.co/guide/en/elasticsearch/reference/${parsed-version.org.elasticsearch.compatible.main.majorVersion}.${parsed-version.org.elasticsearch.compatible.main.minorVersion}</documentation.org.elasticsearch.url>
         <!-- The versions of Elasticsearch/OpenSearch advertised as compatible with Hibernate Search -->
         <!-- Make sure that 7.10 stays explicitly mentioned here, because that's the last open-source version -->
-        <version.org.elasticsearch.compatible.regularly-tested.text>5.6, 6.8, 7.10 or 7.12</version.org.elasticsearch.compatible.regularly-tested.text>
+        <version.org.elasticsearch.compatible.regularly-tested.text>5.6, 6.8, 7.10 or 7.16</version.org.elasticsearch.compatible.regularly-tested.text>
         <version.org.opensearch.compatible.regularly-tested.text>1.0</version.org.opensearch.compatible.regularly-tested.text>
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
         <version.org.elasticsearch.compatible.not-regularly-tested.text>6.0 or 7.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest micro of each Elasticsearch branch -->
+        <version.org.elasticsearch.latest-7.16>7.16.0</version.org.elasticsearch.latest-7.16>
+        <!-- 7.14 and 7.15 have annoying bugs that make almost all of our test suite fail, so we don't test them
+             See https://hibernate.atlassian.net/browse/HSEARCH-4340 -->
         <version.org.elasticsearch.latest-7.13>7.13.2</version.org.elasticsearch.latest-7.13>
         <version.org.elasticsearch.latest-7.12>7.12.1</version.org.elasticsearch.latest-7.12>
         <version.org.elasticsearch.latest-7.11>7.11.2</version.org.elasticsearch.latest-7.11>


### PR DESCRIPTION
* [HSEARCH-4397](https://hibernate.atlassian.net/browse/HSEARCH-4397): Switch to elastic/elasticsearch:* rather than the root elasticsearch:* for container images used in testing
* [HSEARCH-4396](https://hibernate.atlassian.net/browse/HSEARCH-4396): Upgrade to Elasticsearch client 7.16.0
* [HSEARCH-4340](https://hibernate.atlassian.net/browse/HSEARCH-4340): Run tests against Elasticsearch 7.16

