### PR TITLE
HSEARCH-4409 + HSEARCH-4410 + HSEARCH-4411 + HSEARCH-4412 Upgrade build, Elasticsearch and OpenSearch dependencies to the latest version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     assignees: ["yrodiere"]
     open-pull-requests-limit: 5
     ignore:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,7 +232,8 @@ The following profiles are available:
   * `elasticsearch-7.11` for 7.11 ([not open-source](https://opensource.org/node/1099))
   * `elasticsearch-7.12` for 7.12+ (**the default**) ([not open-source](https://opensource.org/node/1099))
 * [OpenSearch](https://www.opensearch.org/)
-  * `opensearch-1.0` for 1.0+
+  * `opensearch-1.0` for 1.0
+  * `opensearch-1.2` for 1.2+
 
 Alternatively, you can prevent the build from launching an Elasticsearch server automatically
 and run Elasticsearch-related tests against your own server using the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,9 +228,9 @@ The following profiles are available:
   * `elasticsearch-7.3` for 7.3 to 7.6
   * `elasticsearch-7.7` for 7.7
   * `elasticsearch-7.8` for 7.8 to 7.9
-  * `elasticsearch-7.10` for 7.10 (**the default**)
+  * `elasticsearch-7.10` for 7.10
   * `elasticsearch-7.11` for 7.11 ([not open-source](https://opensource.org/node/1099))
-  * `elasticsearch-7.12` for 7.12+ ([not open-source](https://opensource.org/node/1099))
+  * `elasticsearch-7.12` for 7.12+ (**the default**) ([not open-source](https://opensource.org/node/1099))
 * [OpenSearch](https://www.opensearch.org/)
   * `opensearch-1.0` for 1.0+
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -254,15 +254,15 @@ stage('Configure') {
 					new EsLocalBuildEnvironment(versionRange: '[7.8,7.10)', mavenProfile: 'elasticsearch-7.8',
 							condition: TestCondition.AFTER_MERGE),
 					new EsLocalBuildEnvironment(versionRange: '[7.10,7.11)', mavenProfile: 'elasticsearch-7.10',
-							condition: TestCondition.BEFORE_MERGE,
-							isDefault: true),
+							condition: TestCondition.AFTER_MERGE),
 					// Not testing 7.11 to make the build quicker.
 					// The only difference with 7.12+ is that wildcard predicates on analyzed fields get their pattern normalized,
 					// and that was deemed a bug: https://github.com/elastic/elasticsearch/pull/53127
 					new EsLocalBuildEnvironment(versionRange: '[7.11,7.12)', mavenProfile: 'elasticsearch-7.11',
 							condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(versionRange: '[7.12,7.x)', mavenProfile: 'elasticsearch-7.12',
-							condition: TestCondition.AFTER_MERGE),
+							condition: TestCondition.BEFORE_MERGE,
+							isDefault: true),
 
 					// --------------------------------------------
 					// OpenSearch

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -267,6 +267,8 @@ stage('Configure') {
 					// --------------------------------------------
 					// OpenSearch
 					new OpenSearchEsLocalBuildEnvironment(version: '1.0', mavenProfile: 'opensearch-1.0',
+							condition: TestCondition.AFTER_MERGE),
+					new OpenSearchEsLocalBuildEnvironment(version: '1.2', mavenProfile: 'opensearch-1.2',
 							condition: TestCondition.AFTER_MERGE)
 			],
 			// Note that each of these environments will only be tested if the appropriate

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -582,7 +582,7 @@ public class ElasticsearchDialectFactoryTest {
 	@TestForIssue(jiraKey = "HSEARCH-4212")
 	public void openSearch_1() {
 		testSuccess(
-				ElasticsearchDistributionName.OPENSEARCH, "1", "1.0.0-rc1",
+				ElasticsearchDistributionName.OPENSEARCH, "1", "1.2.1",
 				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
 		);
 	}
@@ -619,6 +619,33 @@ public class ElasticsearchDialectFactoryTest {
 	public void openSearch_1_0_1() {
 		testSuccess(
 				ElasticsearchDistributionName.OPENSEARCH, "1.0.1", "1.0.1",
+				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4412")
+	public void openSearch_1_2() {
+		testSuccess(
+				ElasticsearchDistributionName.OPENSEARCH, "1.2", "1.2.1",
+				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4412")
+	public void openSearch_1_2_0() {
+		testSuccess(
+				ElasticsearchDistributionName.OPENSEARCH, "1.2.0", "1.2.0",
+				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4412")
+	public void openSearch_1_2_1() {
+		testSuccess(
+				ElasticsearchDistributionName.OPENSEARCH, "1.2.1", "1.2.1",
 				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
 		);
 	}

--- a/integrationtest/backend/elasticsearch/pom.xml
+++ b/integrationtest/backend/elasticsearch/pom.xml
@@ -229,13 +229,6 @@
         <!-- Elasticsearch 7.10 test environment (default) -->
         <profile>
             <id>elasticsearch-7.10</id>
-            <activation>
-                <!-- This must be re-defined here: the activation defined in the parent pom is not enough -->
-                <!-- Activate by default, i.e. if test.elasticsearch.connection.version has not been defined explicitly -->
-                <property>
-                    <name>!test.elasticsearch.connection.version</name>
-                </property>
-            </activation>
             <properties>
                 <failsafe.excludedGroups.elasticsearch.version>
                     <!-- Nothing here -->
@@ -256,6 +249,13 @@
         <!-- Elasticsearch 7.12+ test environment -->
         <profile>
             <id>elasticsearch-7.12</id>
+            <activation>
+                <!-- This must be re-defined here: the activation defined in the parent pom is not enough -->
+                <!-- Activate by default, i.e. if test.elasticsearch.connection.version has not been defined explicitly -->
+                <property>
+                    <name>!test.elasticsearch.connection.version</name>
+                </property>
+            </activation>
             <properties>
                 <failsafe.excludedGroups.elasticsearch.version>
                     <!-- Nothing here -->

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -547,12 +547,6 @@
         <!-- Elasticsearch 7.10 test environment (default) -->
         <profile>
             <id>elasticsearch-7.10</id>
-            <activation>
-                <!-- Activate by default, i.e. if test.elasticsearch.connection.version has not been defined explicitly -->
-                <property>
-                    <name>!test.elasticsearch.connection.version</name>
-                </property>
-            </activation>
             <properties>
                 <test.elasticsearch.run.elastic.skip>${test.elasticsearch.run.skip}</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.distribution>elastic</test.elasticsearch.connection.distribution>
@@ -575,6 +569,12 @@
         <!-- Elasticsearch 7.12+ test environment -->
         <profile>
             <id>elasticsearch-7.12</id>
+            <activation>
+                <!-- Activate by default, i.e. if test.elasticsearch.connection.version has not been defined explicitly -->
+                <property>
+                    <name>!test.elasticsearch.connection.version</name>
+                </property>
+            </activation>
             <properties>
                 <test.elasticsearch.run.elastic.skip>${test.elasticsearch.run.skip}</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.distribution>elastic</test.elasticsearch.connection.distribution>

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -594,6 +594,17 @@
             </properties>
         </profile>
 
+        <!-- OpenSearch 1.2+ test environment -->
+        <profile>
+            <id>opensearch-1.2</id>
+            <properties>
+                <test.elasticsearch.run.opensearch.skip>${test.elasticsearch.run.skip}</test.elasticsearch.run.opensearch.skip>
+                <test.elasticsearch.connection.distribution>opensearch</test.elasticsearch.connection.distribution>
+                <test.elasticsearch.connection.version>${version.org.opensearch.latest-1.2}</test.elasticsearch.connection.version>
+                <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch710TestDialect</test.elasticsearch.testdialect>
+            </properties>
+        </profile>
+
         <!-- =============================== -->
         <!-- Database profiles               -->
         <!-- =============================== -->

--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,7 @@
         <version.org.elasticsearch.latest-6.2>6.2.4</version.org.elasticsearch.latest-6.2>
         <version.org.elasticsearch.latest-5.6>5.6.16</version.org.elasticsearch.latest-5.6>
         <!-- The latest micro of other Elasticsearch distributions -->
+        <version.org.opensearch.latest-1.2>1.2.1</version.org.opensearch.latest-1.2>
         <version.org.opensearch.latest-1.0>1.0.0</version.org.opensearch.latest-1.0>
         <version.com.google.code.gson>2.8.9</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.17.94</version.software.amazon.awssdk>

--- a/pom.xml
+++ b/pom.xml
@@ -331,7 +331,7 @@
         <version.assembly.plugin>3.1.0</version.assembly.plugin>
         <version.buildhelper.plugin>3.2.0</version.buildhelper.plugin>
         <version.checkstyle.plugin>3.1.2</version.checkstyle.plugin>
-        <version.bundle.plugin>5.1.2</version.bundle.plugin>
+        <version.bundle.plugin>5.1.3</version.bundle.plugin>
         <version.clean.plugin>3.1.0</version.clean.plugin>
         <!-- Needing 3.6.2 at least because of MCOMPILER-294 -->
         <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -205,11 +205,10 @@
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently from the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 7.16+ -->
         <version.org.elasticsearch.client>7.16.1</version.org.elasticsearch.client>
-        <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links and as the default when testing.
-             We're trying to stick to a fully-OSS version as the default, so don't upgrade to 7.11 here. -->
+        <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
-             to make sure the corresponding profile (e.g. elasticsearch-7.10) becomes the default. -->
-        <version.org.elasticsearch.compatible.main>${version.org.elasticsearch.latest-7.10}</version.org.elasticsearch.compatible.main>
+             to make sure the corresponding profile (e.g. elasticsearch-7.12) becomes the default. -->
+        <version.org.elasticsearch.compatible.main>${version.org.elasticsearch.latest-7.16}</version.org.elasticsearch.compatible.main>
         <documentation.org.elasticsearch.url>https://www.elastic.co/guide/en/elasticsearch/reference/${parsed-version.org.elasticsearch.compatible.main.majorVersion}.${parsed-version.org.elasticsearch.compatible.main.minorVersion}</documentation.org.elasticsearch.url>
         <!-- The versions of Elasticsearch/OpenSearch advertised as compatible with Hibernate Search -->
         <!-- Make sure that 7.10 stays explicitly mentioned here, because that's the last open-source version -->

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently from the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 7.16+ -->
-        <version.org.elasticsearch.client>7.16.0</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>7.16.1</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links and as the default when testing.
              We're trying to stick to a fully-OSS version as the default, so don't upgrade to 7.11 here. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
         <!-- Test dependencies -->
 
         <!-- >>> Common -->
-        <version.log4j>2.15.0</version.log4j>
+        <version.log4j>2.16.0</version.log4j>
         <version.junit>4.13.2</version.junit>
         <version.org.osgi.core>6.0.0</version.org.osgi.core>
 


### PR DESCRIPTION
* [HSEARCH-4412](https://hibernate.atlassian.net/browse/HSEARCH-4412): Compatibility with OpenSearch 1.2.1
* [HSEARCH-4411](https://hibernate.atlassian.net/browse/HSEARCH-4411): Run tests against Elasticsearch 7.16 by default instead of 7.10
* [HSEARCH-4410](https://hibernate.atlassian.net/browse/HSEARCH-4410): Upgrade to Elasticsearch client 7.16.1
* [HSEARCH-4409](https://hibernate.atlassian.net/browse/HSEARCH-4409): Upgrade build dependencies to the latest version

