### PR TITLE
HSEARCH-4409 + HSEARCH-4416 Upgrade build dependencies to the latest version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     assignees: ["yrodiere"]
     open-pull-requests-limit: 5
     ignore:

--- a/pom.xml
+++ b/pom.xml
@@ -331,7 +331,7 @@
         <version.assembly.plugin>3.1.0</version.assembly.plugin>
         <version.buildhelper.plugin>3.2.0</version.buildhelper.plugin>
         <version.checkstyle.plugin>3.1.2</version.checkstyle.plugin>
-        <version.bundle.plugin>5.1.2</version.bundle.plugin>
+        <version.bundle.plugin>5.1.3</version.bundle.plugin>
         <version.clean.plugin>3.1.0</version.clean.plugin>
         <!-- Needing 3.6.2 at least because of MCOMPILER-294 -->
         <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
         <!-- Test dependencies -->
 
         <!-- >>> Common -->
-        <version.log4j>2.15.0</version.log4j>
+        <version.log4j>2.16.0</version.log4j>
         <version.junit>4.13.2</version.junit>
         <version.org.osgi.core>6.0.0</version.org.osgi.core>
 


### PR DESCRIPTION
* [HSEARCH-4416](https://hibernate.atlassian.net/browse/HSEARCH-4416): Upgrade to log4j 2.16.0
* [HSEARCH-4409](https://hibernate.atlassian.net/browse/HSEARCH-4409): Upgrade build dependencies to the latest version

