### PR TITLE
Backport HSEARCH-4416 to branch 6.0 - Upgrade to log4j 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
         <!-- Test dependencies -->
 
         <!-- >>> Common -->
-        <version.log4j>2.15.0</version.log4j>
+        <version.log4j>2.16.0</version.log4j>
         <version.junit>4.13.2</version.junit>
 
         <version.org.hamcrest>2.2</version.org.hamcrest>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4416

Partial backport of #2789