### PR TITLE
HSEARCH-4389 + HSEARCH-4391 + HSEARCH-4408 Documentation fixes

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -236,6 +236,7 @@
                             <sourceDocumentName>reference/index.asciidoc</sourceDocumentName>
                             <outputDirectory>${asciidoctor.base-output-dir}/reference/html_single</outputDirectory>
                             <attributes>
+                                <imagesdir>images</imagesdir>
                                 <stylesdir>css</stylesdir>
                                 <iconfont-remote>false</iconfont-remote>
                                 <iconfont-name>font-awesome/css/font-awesome.min</iconfont-name>
@@ -254,6 +255,7 @@
                             <sourceDocumentName>internals/index.asciidoc</sourceDocumentName>
                             <outputDirectory>${asciidoctor.base-output-dir}/internals/html_single</outputDirectory>
                             <attributes>
+                                <imagesdir>images</imagesdir>
                                 <stylesdir>css</stylesdir>
                                 <iconfont-remote>false</iconfont-remote>
                                 <iconfont-name>font-awesome/css/font-awesome.min</iconfont-name>
@@ -272,6 +274,7 @@
                             <sourceDocumentName>migration/index.asciidoc</sourceDocumentName>
                             <outputDirectory>${asciidoctor.base-output-dir}/migration/html_single</outputDirectory>
                             <attributes>
+                                <imagesdir>images</imagesdir>
                                 <stylesdir>css</stylesdir>
                                 <iconfont-remote>false</iconfont-remote>
                                 <iconfont-name>font-awesome/css/font-awesome.min</iconfont-name>
@@ -367,7 +370,7 @@
                                     <outputDirectory>${asciidoctor.base-output-dir}/reference/pdf</outputDirectory>
                                     <outputFile>hibernate_search_reference.pdf</outputFile>
                                     <attributes>
-                                        <imagesDir>${asciidoctor.aggregated-resources-dir}/images/</imagesDir>
+                                        <imagesdir>${asciidoctor.aggregated-resources-dir}/images/</imagesdir>
                                         <pdf-stylesdir>${asciidoctor.aggregated-resources-dir}/theme</pdf-stylesdir>
                                         <pdf-style>hibernate</pdf-style>
                                         <pdf-fontsdir>${asciidoctor.aggregated-resources-dir}/theme/fonts</pdf-fontsdir>
@@ -389,7 +392,7 @@
                                     <outputDirectory>${asciidoctor.base-output-dir}/internals/pdf</outputDirectory>
                                     <outputFile>hibernate_search_internals.pdf</outputFile>
                                     <attributes>
-                                        <imagesDir>${asciidoctor.aggregated-resources-dir}/images/</imagesDir>
+                                        <imagesdir>${asciidoctor.aggregated-resources-dir}/images/</imagesdir>
                                         <pdf-stylesdir>${asciidoctor.aggregated-resources-dir}/theme</pdf-stylesdir>
                                         <pdf-style>hibernate</pdf-style>
                                         <pdf-fontsdir>${asciidoctor.aggregated-resources-dir}/theme/fonts</pdf-fontsdir>
@@ -411,7 +414,7 @@
                                     <outputDirectory>${asciidoctor.base-output-dir}/migration/pdf</outputDirectory>
                                     <outputFile>hibernate_search_migration.pdf</outputFile>
                                     <attributes>
-                                        <imagesDir>${asciidoctor.aggregated-resources-dir}/images/</imagesDir>
+                                        <imagesdir>${asciidoctor.aggregated-resources-dir}/images/</imagesdir>
                                         <pdf-stylesdir>${asciidoctor.aggregated-resources-dir}/theme</pdf-stylesdir>
                                         <pdf-style>hibernate</pdf-style>
                                         <pdf-fontsdir>${asciidoctor.aggregated-resources-dir}/theme/fonts</pdf-fontsdir>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -235,11 +235,11 @@
                             <backend>html5</backend>
                             <sourceDocumentName>reference/index.asciidoc</sourceDocumentName>
                             <outputDirectory>${asciidoctor.base-output-dir}/reference/html_single</outputDirectory>
-                            <sourceHighlighter>prettify</sourceHighlighter>
                             <attributes>
                                 <stylesdir>css</stylesdir>
                                 <iconfont-remote>false</iconfont-remote>
                                 <iconfont-name>font-awesome/css/font-awesome.min</iconfont-name>
+                                <source-highlighter>coderay</source-highlighter>
                             </attributes>
                         </configuration>
                     </execution>
@@ -253,11 +253,11 @@
                             <backend>html5</backend>
                             <sourceDocumentName>internals/index.asciidoc</sourceDocumentName>
                             <outputDirectory>${asciidoctor.base-output-dir}/internals/html_single</outputDirectory>
-                            <sourceHighlighter>prettify</sourceHighlighter>
                             <attributes>
                                 <stylesdir>css</stylesdir>
                                 <iconfont-remote>false</iconfont-remote>
                                 <iconfont-name>font-awesome/css/font-awesome.min</iconfont-name>
+                                <source-highlighter>coderay</source-highlighter>
                             </attributes>
                         </configuration>
                     </execution>
@@ -271,11 +271,11 @@
                             <backend>html5</backend>
                             <sourceDocumentName>migration/index.asciidoc</sourceDocumentName>
                             <outputDirectory>${asciidoctor.base-output-dir}/migration/html_single</outputDirectory>
-                            <sourceHighlighter>prettify</sourceHighlighter>
                             <attributes>
                                 <stylesdir>css</stylesdir>
                                 <iconfont-remote>false</iconfont-remote>
                                 <iconfont-name>font-awesome/css/font-awesome.min</iconfont-name>
+                                <source-highlighter>coderay</source-highlighter>
                             </attributes>
                         </configuration>
                     </execution>
@@ -366,7 +366,6 @@
                                     <sourceDocumentName>reference/index.asciidoc</sourceDocumentName>
                                     <outputDirectory>${asciidoctor.base-output-dir}/reference/pdf</outputDirectory>
                                     <outputFile>hibernate_search_reference.pdf</outputFile>
-                                    <sourceHighlighter>coderay</sourceHighlighter>
                                     <attributes>
                                         <imagesDir>${asciidoctor.aggregated-resources-dir}/images/</imagesDir>
                                         <pdf-stylesdir>${asciidoctor.aggregated-resources-dir}/theme</pdf-stylesdir>
@@ -374,6 +373,7 @@
                                         <pdf-fontsdir>${asciidoctor.aggregated-resources-dir}/theme/fonts</pdf-fontsdir>
                                         <pagenums/>
                                         <idseparator>-</idseparator>
+                                        <source-highlighter>coderay</source-highlighter>
                                     </attributes>
                                 </configuration>
                             </execution>
@@ -388,7 +388,6 @@
                                     <sourceDocumentName>internals/index.asciidoc</sourceDocumentName>
                                     <outputDirectory>${asciidoctor.base-output-dir}/internals/pdf</outputDirectory>
                                     <outputFile>hibernate_search_internals.pdf</outputFile>
-                                    <sourceHighlighter>coderay</sourceHighlighter>
                                     <attributes>
                                         <imagesDir>${asciidoctor.aggregated-resources-dir}/images/</imagesDir>
                                         <pdf-stylesdir>${asciidoctor.aggregated-resources-dir}/theme</pdf-stylesdir>
@@ -396,6 +395,7 @@
                                         <pdf-fontsdir>${asciidoctor.aggregated-resources-dir}/theme/fonts</pdf-fontsdir>
                                         <pagenums/>
                                         <idseparator>-</idseparator>
+                                        <source-highlighter>coderay</source-highlighter>
                                     </attributes>
                                 </configuration>
                             </execution>
@@ -410,7 +410,6 @@
                                     <sourceDocumentName>migration/index.asciidoc</sourceDocumentName>
                                     <outputDirectory>${asciidoctor.base-output-dir}/migration/pdf</outputDirectory>
                                     <outputFile>hibernate_search_migration.pdf</outputFile>
-                                    <sourceHighlighter>coderay</sourceHighlighter>
                                     <attributes>
                                         <imagesDir>${asciidoctor.aggregated-resources-dir}/images/</imagesDir>
                                         <pdf-stylesdir>${asciidoctor.aggregated-resources-dir}/theme</pdf-stylesdir>
@@ -418,6 +417,7 @@
                                         <pdf-fontsdir>${asciidoctor.aggregated-resources-dir}/theme/fonts</pdf-fontsdir>
                                         <pagenums/>
                                         <idseparator>-</idseparator>
+                                        <source-highlighter>coderay</source-highlighter>
                                     </attributes>
                                 </configuration>
                             </execution>

--- a/documentation/src/main/asciidoc/reference/coordination.asciidoc
+++ b/documentation/src/main/asciidoc/reference/coordination.asciidoc
@@ -425,21 +425,20 @@ by setting the following configuration properties:
 
 [source]
 ----
-hibernate.search.coordination.event_processor.shards.static = true
 hibernate.search.coordination.event_processor.shards.total_count = 4
 hibernate.search.coordination.event_processor.shards.assigned = 0
 ----
 
-* `shards.static` defines sharding as static.
-It defaults to `false` and must be set to `true` explicitly in order for
-the other configuration properties to be taken into account.
 * `shards.total_count` defines the total number of shards
 as an <<configuration-property-types,integer value>>.
-This property has no default and must be set explicitly when static sharding is enabled.
+This property has no default and must be set explicitly if you want static sharding.
 It must be set to the same value on all application nodes with assigned shards.
+When this property is set, `shards.assigned` must also be set
 * `shards.assigned` defines the shards assigned to the application node
 as an <<configuration-property-types,integer value>>, or multiple comma-separated integer values.
-This property has no default and must be set explicitly when static sharding is enabled.
+This property has no default and must be set explicitly if you want static sharding.
+When this property is set, `shards.total_count` must also be set.
++
 Shards are referred to by an index in the range `[0, total_count - 1]` (see above for `total_count`).
 A given application node must be assigned at least one shard
 but may be assigned multiple shards by setting `shards.assigned` to a comma-separated list,
@@ -462,7 +461,6 @@ and no shard at all to application nodes #2 and #3:
 ----
 # Node #0
 hibernate.search.coordination.strategy = outbox-polling
-hibernate.search.coordination.event_processor.shards.static = true
 hibernate.search.coordination.event_processor.shards.total_count = 2
 hibernate.search.coordination.event_processor.shards.assigned = 0
 ----
@@ -471,7 +469,6 @@ hibernate.search.coordination.event_processor.shards.assigned = 0
 ----
 # Node #1
 hibernate.search.coordination.strategy = outbox-polling
-hibernate.search.coordination.event_processor.shards.static = true
 hibernate.search.coordination.event_processor.shards.total_count = 2
 hibernate.search.coordination.event_processor.shards.assigned = 1
 ----

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/HibernateOrmMapperOutboxPollingSettings.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/HibernateOrmMapperOutboxPollingSettings.java
@@ -78,7 +78,7 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	 * Expects an Integer value of at least {@code 2},
 	 * or a String that can be parsed into such Integer value.
 	 * <p>
-	 * No default: must be provided when static sharding is enabled.
+	 * No default: must be provided explicitly if you want static sharding.
 	 */
 	public static final String COORDINATION_EVENT_PROCESSOR_SHARDS_TOTAL_COUNT = PREFIX + Radicals.COORDINATION_EVENT_PROCESSOR_SHARDS_TOTAL_COUNT;
 
@@ -89,7 +89,7 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	 * Failing that, some events may not be processed or may be processed twice or in the wrong order,
 	 * resulting in errors and/or out-of-sync indexes.
 	 * <p>
-	 * Only available when {@link HibernateOrmMapperSettings#AUTOMATIC_INDEXING_STRATEGY} is
+	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value #COORDINATION_STRATEGY_NAME}.
 	 * <p>
 	 * When this property is set, {@value #COORDINATION_EVENT_PROCESSOR_SHARDS_TOTAL_COUNT} must also be set.
@@ -100,7 +100,7 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	 * or a String containing multiple such shard index strings separated by commas,
 	 * or a {@code Collection<Integer>} containing such shard indices.
 	 * <p>
-	 * No default: must be provided when static sharding is enabled.
+	 * No default: must be provided explicitly if you want static sharding.
 	 */
 	public static final String COORDINATION_EVENT_PROCESSOR_SHARDS_ASSIGNED = PREFIX + Radicals.COORDINATION_EVENT_PROCESSOR_SHARDS_ASSIGNED;
 


### PR DESCRIPTION
* [HSEARCH-4408](https://hibernate.atlassian.net/browse/HSEARCH-4408): Fix syntax highlighting for code example not working anymore in 6.0/6.1 documentation
* [HSEARCH-4391](https://hibernate.atlassian.net/browse/HSEARCH-4391): Fix images not being displayed in the documentation
* [HSEARCH-4389](https://hibernate.atlassian.net/browse/HSEARCH-4389): Remove mentions of hibernate.search.coordination.event_processor.shards.static from the documentation

