### PR TITLE
Backport HSEARCH-4391 + HSEARCH-4408 to branch 6.0 - Documentation fixes

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -251,11 +251,11 @@
                             <backend>html5</backend>
                             <sourceDocumentName>reference/index.asciidoc</sourceDocumentName>
                             <outputDirectory>${asciidoctor.base-output-dir}/reference/html_single</outputDirectory>
-                            <sourceHighlighter>prettify</sourceHighlighter>
                             <attributes>
                                 <stylesdir>css</stylesdir>
                                 <iconfont-remote>false</iconfont-remote>
                                 <iconfont-name>font-awesome/css/font-awesome.min</iconfont-name>
+                                <source-highlighter>coderay</source-highlighter>
                             </attributes>
                         </configuration>
                     </execution>
@@ -269,11 +269,11 @@
                             <backend>html5</backend>
                             <sourceDocumentName>internals/index.asciidoc</sourceDocumentName>
                             <outputDirectory>${asciidoctor.base-output-dir}/internals/html_single</outputDirectory>
-                            <sourceHighlighter>prettify</sourceHighlighter>
                             <attributes>
                                 <stylesdir>css</stylesdir>
                                 <iconfont-remote>false</iconfont-remote>
                                 <iconfont-name>font-awesome/css/font-awesome.min</iconfont-name>
+                                <source-highlighter>coderay</source-highlighter>
                             </attributes>
                         </configuration>
                     </execution>
@@ -287,11 +287,11 @@
                             <backend>html5</backend>
                             <sourceDocumentName>migration/index.asciidoc</sourceDocumentName>
                             <outputDirectory>${asciidoctor.base-output-dir}/migration/html_single</outputDirectory>
-                            <sourceHighlighter>prettify</sourceHighlighter>
                             <attributes>
                                 <stylesdir>css</stylesdir>
                                 <iconfont-remote>false</iconfont-remote>
                                 <iconfont-name>font-awesome/css/font-awesome.min</iconfont-name>
+                                <source-highlighter>coderay</source-highlighter>
                             </attributes>
                         </configuration>
                     </execution>
@@ -377,7 +377,6 @@
                                     <sourceDocumentName>reference/index.asciidoc</sourceDocumentName>
                                     <outputDirectory>${asciidoctor.base-output-dir}/reference/pdf</outputDirectory>
                                     <outputFile>hibernate_search_reference.pdf</outputFile>
-                                    <sourceHighlighter>coderay</sourceHighlighter>
                                     <attributes>
                                         <imagesDir>${asciidoctor.aggregated-resources-dir}/images/</imagesDir>
                                         <pdf-stylesdir>${asciidoctor.aggregated-resources-dir}/theme</pdf-stylesdir>
@@ -385,6 +384,7 @@
                                         <pdf-fontsdir>${asciidoctor.aggregated-resources-dir}/theme/fonts</pdf-fontsdir>
                                         <pagenums/>
                                         <idseparator>-</idseparator>
+                                        <source-highlighter>coderay</source-highlighter>
                                     </attributes>
                                 </configuration>
                             </execution>
@@ -399,7 +399,6 @@
                                     <sourceDocumentName>internals/index.asciidoc</sourceDocumentName>
                                     <outputDirectory>${asciidoctor.base-output-dir}/internals/pdf</outputDirectory>
                                     <outputFile>hibernate_search_internals.pdf</outputFile>
-                                    <sourceHighlighter>coderay</sourceHighlighter>
                                     <attributes>
                                         <imagesDir>${asciidoctor.aggregated-resources-dir}/images/</imagesDir>
                                         <pdf-stylesdir>${asciidoctor.aggregated-resources-dir}/theme</pdf-stylesdir>
@@ -407,6 +406,7 @@
                                         <pdf-fontsdir>${asciidoctor.aggregated-resources-dir}/theme/fonts</pdf-fontsdir>
                                         <pagenums/>
                                         <idseparator>-</idseparator>
+                                        <source-highlighter>coderay</source-highlighter>
                                     </attributes>
                                 </configuration>
                             </execution>
@@ -421,7 +421,6 @@
                                     <sourceDocumentName>migration/index.asciidoc</sourceDocumentName>
                                     <outputDirectory>${asciidoctor.base-output-dir}/migration/pdf</outputDirectory>
                                     <outputFile>hibernate_search_migration.pdf</outputFile>
-                                    <sourceHighlighter>coderay</sourceHighlighter>
                                     <attributes>
                                         <imagesDir>${asciidoctor.aggregated-resources-dir}/images/</imagesDir>
                                         <pdf-stylesdir>${asciidoctor.aggregated-resources-dir}/theme</pdf-stylesdir>
@@ -429,6 +428,7 @@
                                         <pdf-fontsdir>${asciidoctor.aggregated-resources-dir}/theme/fonts</pdf-fontsdir>
                                         <pagenums/>
                                         <idseparator>-</idseparator>
+                                        <source-highlighter>coderay</source-highlighter>
                                     </attributes>
                                 </configuration>
                             </execution>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -252,6 +252,7 @@
                             <sourceDocumentName>reference/index.asciidoc</sourceDocumentName>
                             <outputDirectory>${asciidoctor.base-output-dir}/reference/html_single</outputDirectory>
                             <attributes>
+                                <imagesdir>images</imagesdir>
                                 <stylesdir>css</stylesdir>
                                 <iconfont-remote>false</iconfont-remote>
                                 <iconfont-name>font-awesome/css/font-awesome.min</iconfont-name>
@@ -270,6 +271,7 @@
                             <sourceDocumentName>internals/index.asciidoc</sourceDocumentName>
                             <outputDirectory>${asciidoctor.base-output-dir}/internals/html_single</outputDirectory>
                             <attributes>
+                                <imagesdir>images</imagesdir>
                                 <stylesdir>css</stylesdir>
                                 <iconfont-remote>false</iconfont-remote>
                                 <iconfont-name>font-awesome/css/font-awesome.min</iconfont-name>
@@ -288,6 +290,7 @@
                             <sourceDocumentName>migration/index.asciidoc</sourceDocumentName>
                             <outputDirectory>${asciidoctor.base-output-dir}/migration/html_single</outputDirectory>
                             <attributes>
+                                <imagesdir>images</imagesdir>
                                 <stylesdir>css</stylesdir>
                                 <iconfont-remote>false</iconfont-remote>
                                 <iconfont-name>font-awesome/css/font-awesome.min</iconfont-name>
@@ -378,7 +381,7 @@
                                     <outputDirectory>${asciidoctor.base-output-dir}/reference/pdf</outputDirectory>
                                     <outputFile>hibernate_search_reference.pdf</outputFile>
                                     <attributes>
-                                        <imagesDir>${asciidoctor.aggregated-resources-dir}/images/</imagesDir>
+                                        <imagesdir>${asciidoctor.aggregated-resources-dir}/images/</imagesdir>
                                         <pdf-stylesdir>${asciidoctor.aggregated-resources-dir}/theme</pdf-stylesdir>
                                         <pdf-style>hibernate</pdf-style>
                                         <pdf-fontsdir>${asciidoctor.aggregated-resources-dir}/theme/fonts</pdf-fontsdir>
@@ -400,7 +403,7 @@
                                     <outputDirectory>${asciidoctor.base-output-dir}/internals/pdf</outputDirectory>
                                     <outputFile>hibernate_search_internals.pdf</outputFile>
                                     <attributes>
-                                        <imagesDir>${asciidoctor.aggregated-resources-dir}/images/</imagesDir>
+                                        <imagesdir>${asciidoctor.aggregated-resources-dir}/images/</imagesdir>
                                         <pdf-stylesdir>${asciidoctor.aggregated-resources-dir}/theme</pdf-stylesdir>
                                         <pdf-style>hibernate</pdf-style>
                                         <pdf-fontsdir>${asciidoctor.aggregated-resources-dir}/theme/fonts</pdf-fontsdir>
@@ -422,7 +425,7 @@
                                     <outputDirectory>${asciidoctor.base-output-dir}/migration/pdf</outputDirectory>
                                     <outputFile>hibernate_search_migration.pdf</outputFile>
                                     <attributes>
-                                        <imagesDir>${asciidoctor.aggregated-resources-dir}/images/</imagesDir>
+                                        <imagesdir>${asciidoctor.aggregated-resources-dir}/images/</imagesdir>
                                         <pdf-stylesdir>${asciidoctor.aggregated-resources-dir}/theme</pdf-stylesdir>
                                         <pdf-style>hibernate</pdf-style>
                                         <pdf-fontsdir>${asciidoctor.aggregated-resources-dir}/theme/fonts</pdf-fontsdir>


### PR DESCRIPTION
* [HSEARCH-4408](https://hibernate.atlassian.net/browse/HSEARCH-4408): Fix syntax highlighting for code example not working anymore in 6.0/6.1 documentation
* [HSEARCH-4391](https://hibernate.atlassian.net/browse/HSEARCH-4391): Fix images not being displayed in the documentation

Backport of #2791