### PR TITLE
HSEARCH-4420 + HSEARCH-4421 + HSEARCH-4422 + HSEARCH-4424 Dependency upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,6 @@ updates:
       # JRuby releases way too often (every two weeks?) and is only used during the build; ignore all patch updates
       - dependency-name: "org.jruby:jruby-complete"
         update-types: ["version-update:semver-patch"]
+      # We don't care that much about being on the very latest version of some integration test dependencies
+      - dependency-name: "org.springframework.boot:*"
+        update-types: [ "version-update:semver-patch" ]

--- a/pom.xml
+++ b/pom.xml
@@ -376,7 +376,7 @@
             check for regressions. Which is obviously good for us, too.
          -->
         <puppycrawl.checkstyle.version>8.41</puppycrawl.checkstyle.version>
-        <version.com.puppycrawl.tools.checkstyle>9.2</version.com.puppycrawl.tools.checkstyle>
+        <version.com.puppycrawl.tools.checkstyle>9.2.1</version.com.puppycrawl.tools.checkstyle>
 
         <!-- Asciidoctor -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
 
         <version.org.hamcrest>2.2</version.org.hamcrest>
         <version.org.mockito>4.1.0</version.org.mockito>
-        <version.org.assertj.assertj-core>3.21.0</version.org.assertj.assertj-core>
+        <version.org.assertj.assertj-core>3.22.0</version.org.assertj.assertj-core>
         <version.org.awaitily>4.1.1</version.org.awaitily>
         <version.org.skyscreamer.jsonassert>1.5.0</version.org.skyscreamer.jsonassert>
         <version.io.takari.junit>1.2.7</version.io.takari.junit>

--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
         <version.org.google.guava>31.0.1-jre</version.org.google.guava>
 
         <!-- >>> Spring integration tests -->
-        <version.org.springframework.boot>2.6.1</version.org.springframework.boot>
+        <version.org.springframework.boot>2.6.2</version.org.springframework.boot>
 
         <!-- Maven plugins versions -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
         <!-- Nothing beyond common dependencies -->
 
         <!-- >>> Lucene -->
-        <version.org.apache.lucene>8.11.0</version.org.apache.lucene>
+        <version.org.apache.lucene>8.11.1</version.org.apache.lucene>
         <javadoc.org.apache.lucene.tag>${parsed-version.org.apache.lucene.majorVersion}_${parsed-version.org.apache.lucene.minorVersion}_${parsed-version.org.apache.lucene.incrementalVersion}</javadoc.org.apache.lucene.tag>
         <javadoc.org.apache.lucene.core.url>https://lucene.apache.org/core/${javadoc.org.apache.lucene.tag}/core/</javadoc.org.apache.lucene.core.url>
         <javadoc.org.apache.lucene.analyzers-common.url>https://lucene.apache.org/core/${javadoc.org.apache.lucene.tag}/analyzers-common/</javadoc.org.apache.lucene.analyzers-common.url>

--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
         <version.com.google.code.gson>2.8.9</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.17.94</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, the AWS SDK and in tests (wiremock, ...) -->
-        <version.com.fasterxml.jackson>2.13.0</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.13.1</version.com.fasterxml.jackson>
         <!--
              In the past, there has been jackson-databind bugfix releases without any jackson-core release,
              so we had to use different versions, e.g. jackson-core 2.9.9 and jackson-databind 2.9.9.3.

--- a/pom.xml
+++ b/pom.xml
@@ -337,7 +337,7 @@
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <version.dependency.plugin>3.2.0</version.dependency.plugin>
         <!-- Check dependencies for security vulnerabilities -->
-        <version.dependency-check.plugin>6.5.0</version.dependency-check.plugin>
+        <version.dependency-check.plugin>6.5.1</version.dependency-check.plugin>
         <version.deploy.plugin>2.8.2</version.deploy.plugin>
         <version.org.eclipse.m2e.lifecycle-mapping>1.0.0</version.org.eclipse.m2e.lifecycle-mapping>
         <version.enforcer.plugin>3.0.0</version.enforcer.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -311,7 +311,7 @@
         <version.org.jboss.weld.jakarta>4.0.2.Final</version.org.jboss.weld.jakarta>
 
         <!-- >>> Performance tests -->
-        <version.org.openjdk.jmh>1.33</version.org.openjdk.jmh>
+        <version.org.openjdk.jmh>1.34</version.org.openjdk.jmh>
 
         <!-- >>> JSR 352: JBatch runtime -->
         <version.com.ibm.jbatch>1.0</version.com.ibm.jbatch>

--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
              That's why we have two separate properties for jackson versions,
              even though they may have the same value from time to time.
          -->
-        <version.com.fasterxml.jackson.databind>2.13.0</version.com.fasterxml.jackson.databind>
+        <version.com.fasterxml.jackson.databind>2.13.1</version.com.fasterxml.jackson.databind>
         <!-- Reactive-streams: used by the AWS SDK -->
         <version.org.reactivestreams.reactive-streams>1.0.3</version.org.reactivestreams.reactive-streams>
         <!-- slf4j: used by the AWS SDK -->

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
         <!-- Test dependencies -->
 
         <!-- >>> Common -->
-        <version.log4j>2.16.0</version.log4j>
+        <version.log4j>2.17.1</version.log4j>
         <version.junit>4.13.2</version.junit>
         <version.org.osgi.core>6.0.0</version.org.osgi.core>
 


### PR DESCRIPTION
* [HSEARCH-4424](https://hibernate.atlassian.net/browse/HSEARCH-4424): Upgrade to latest version of build dependencies
* [HSEARCH-4422](https://hibernate.atlassian.net/browse/HSEARCH-4422): Upgrade to Jackson 2.13.1
* [HSEARCH-4421](https://hibernate.atlassian.net/browse/HSEARCH-4421): Upgrade to Log4j 2.17.1
* [HSEARCH-4420](https://hibernate.atlassian.net/browse/HSEARCH-4420): Upgrade to Lucene 8.11.1

