### PR TITLE
HSEARCH-4410 + HSEARCH-4411 + HSEARCH-4413 Run tests against Elasticsearch 7.16 by default instead of 7.10, upgrade to Elasticsearch 7.16.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,9 +228,9 @@ The following profiles are available:
   * `elasticsearch-7.3` for 7.3 to 7.6
   * `elasticsearch-7.7` for 7.7
   * `elasticsearch-7.8` for 7.8 to 7.9
-  * `elasticsearch-7.10` for 7.10 (**the default**)
+  * `elasticsearch-7.10` for 7.10
   * `elasticsearch-7.11` for 7.11 ([not open-source](https://opensource.org/node/1099))
-  * `elasticsearch-7.12` for 7.12+ ([not open-source](https://opensource.org/node/1099))
+  * `elasticsearch-7.12` for 7.12+ (**the default**) ([not open-source](https://opensource.org/node/1099))
 * [OpenSearch](https://www.opensearch.org/)
   * `opensearch-1.0` for 1.0
   * `opensearch-1.2` for 1.2+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -254,15 +254,15 @@ stage('Configure') {
 					new EsLocalBuildEnvironment(versionRange: '[7.8,7.10)', mavenProfile: 'elasticsearch-7.8',
 							condition: TestCondition.AFTER_MERGE),
 					new EsLocalBuildEnvironment(versionRange: '[7.10,7.11)', mavenProfile: 'elasticsearch-7.10',
-							condition: TestCondition.BEFORE_MERGE,
-							isDefault: true),
+							condition: TestCondition.AFTER_MERGE),
 					// Not testing 7.11 to make the build quicker.
 					// The only difference with 7.12+ is that wildcard predicates on analyzed fields get their pattern normalized,
 					// and that was deemed a bug: https://github.com/elastic/elasticsearch/pull/53127
 					new EsLocalBuildEnvironment(versionRange: '[7.11,7.12)', mavenProfile: 'elasticsearch-7.11',
 							condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(versionRange: '[7.12,7.x)', mavenProfile: 'elasticsearch-7.12',
-							condition: TestCondition.AFTER_MERGE),
+							condition: TestCondition.BEFORE_MERGE,
+							isDefault: true),
 
 					// --------------------------------------------
 					// OpenSearch

--- a/integrationtest/backend/elasticsearch/pom.xml
+++ b/integrationtest/backend/elasticsearch/pom.xml
@@ -229,13 +229,6 @@
         <!-- Elasticsearch 7.10 test environment (default) -->
         <profile>
             <id>elasticsearch-7.10</id>
-            <activation>
-                <!-- This must be re-defined here: the activation defined in the parent pom is not enough -->
-                <!-- Activate by default, i.e. if test.elasticsearch.connection.version has not been defined explicitly -->
-                <property>
-                    <name>!test.elasticsearch.connection.version</name>
-                </property>
-            </activation>
             <properties>
                 <failsafe.excludedGroups.elasticsearch.version>
                     <!-- Nothing here -->
@@ -256,6 +249,13 @@
         <!-- Elasticsearch 7.12+ test environment -->
         <profile>
             <id>elasticsearch-7.12</id>
+            <activation>
+                <!-- This must be re-defined here: the activation defined in the parent pom is not enough -->
+                <!-- Activate by default, i.e. if test.elasticsearch.connection.version has not been defined explicitly -->
+                <property>
+                    <name>!test.elasticsearch.connection.version</name>
+                </property>
+            </activation>
             <properties>
                 <failsafe.excludedGroups.elasticsearch.version>
                     <!-- Nothing here -->

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -547,12 +547,6 @@
         <!-- Elasticsearch 7.10 test environment (default) -->
         <profile>
             <id>elasticsearch-7.10</id>
-            <activation>
-                <!-- Activate by default, i.e. if test.elasticsearch.connection.version has not been defined explicitly -->
-                <property>
-                    <name>!test.elasticsearch.connection.version</name>
-                </property>
-            </activation>
             <properties>
                 <test.elasticsearch.run.elastic.skip>${test.elasticsearch.run.skip}</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.distribution>elastic</test.elasticsearch.connection.distribution>
@@ -575,6 +569,12 @@
         <!-- Elasticsearch 7.12+ test environment -->
         <profile>
             <id>elasticsearch-7.12</id>
+            <activation>
+                <!-- Activate by default, i.e. if test.elasticsearch.connection.version has not been defined explicitly -->
+                <property>
+                    <name>!test.elasticsearch.connection.version</name>
+                </property>
+            </activation>
             <properties>
                 <test.elasticsearch.run.elastic.skip>${test.elasticsearch.run.skip}</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.distribution>elastic</test.elasticsearch.connection.distribution>

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently from the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 7.16+ -->
-        <version.org.elasticsearch.client>7.16.0</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>7.16.2</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links and as the default when testing.
              We're trying to stick to a fully-OSS version as the default, so don't upgrade to 7.11 here. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
         <version.org.elasticsearch.compatible.not-regularly-tested.text>6.0 or 7.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest micro of each Elasticsearch branch -->
-        <version.org.elasticsearch.latest-7.16>7.16.0</version.org.elasticsearch.latest-7.16>
+        <version.org.elasticsearch.latest-7.16>7.16.2</version.org.elasticsearch.latest-7.16>
         <!-- 7.14 and 7.15 have annoying bugs that make almost all of our test suite fail, so we don't test them
              See https://hibernate.atlassian.net/browse/HSEARCH-4340 -->
         <version.org.elasticsearch.latest-7.13>7.13.2</version.org.elasticsearch.latest-7.13>

--- a/pom.xml
+++ b/pom.xml
@@ -205,11 +205,10 @@
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently from the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 7.16+ -->
         <version.org.elasticsearch.client>7.16.2</version.org.elasticsearch.client>
-        <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links and as the default when testing.
-             We're trying to stick to a fully-OSS version as the default, so don't upgrade to 7.11 here. -->
+        <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
-             to make sure the corresponding profile (e.g. elasticsearch-7.10) becomes the default. -->
-        <version.org.elasticsearch.compatible.main>${version.org.elasticsearch.latest-7.10}</version.org.elasticsearch.compatible.main>
+             to make sure the corresponding profile (e.g. elasticsearch-7.12) becomes the default. -->
+        <version.org.elasticsearch.compatible.main>${version.org.elasticsearch.latest-7.16}</version.org.elasticsearch.compatible.main>
         <documentation.org.elasticsearch.url>https://www.elastic.co/guide/en/elasticsearch/reference/${parsed-version.org.elasticsearch.compatible.main.majorVersion}.${parsed-version.org.elasticsearch.compatible.main.minorVersion}</documentation.org.elasticsearch.url>
         <!-- The versions of Elasticsearch/OpenSearch advertised as compatible with Hibernate Search -->
         <!-- Make sure that 7.10 stays explicitly mentioned here, because that's the last open-source version -->


### PR DESCRIPTION
* [HSEARCH-4413](https://hibernate.atlassian.net/browse/HSEARCH-4413): Run tests against Elasticsearch 7.16.2
* [HSEARCH-4411](https://hibernate.atlassian.net/browse/HSEARCH-4411): Run tests against Elasticsearch 7.16 by default instead of 7.10
* [HSEARCH-4410](https://hibernate.atlassian.net/browse/HSEARCH-4410): Upgrade to Elasticsearch client 7.16.2

