### PR TITLE
HSEARCH-4435 Custom Elasticsearch settings/mapping require the backend to be started

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendImpl.java
@@ -94,6 +94,7 @@ class ElasticsearchBackendImpl implements BackendImplementor,
 	private final ElasticsearchSimpleWorkOrchestrator generalPurposeOrchestrator;
 
 	private final ElasticsearchIndexFieldTypeFactoryProvider typeFactoryProvider;
+	private final Gson userFacingGson;
 	private final MultiTenancyStrategy multiTenancyStrategy;
 	private final BeanHolder<? extends IndexLayoutStrategy> indexLayoutStrategyHolder;
 	private final TypeNameMapping typeNameMapping;
@@ -120,6 +121,7 @@ class ElasticsearchBackendImpl implements BackendImplementor,
 		);
 		this.multiTenancyStrategy = multiTenancyStrategy;
 		this.typeFactoryProvider = typeFactoryProvider;
+		this.userFacingGson = userFacingGson;
 		this.indexLayoutStrategyHolder = indexLayoutStrategyHolder;
 		this.typeNameMapping = typeNameMapping;
 
@@ -304,7 +306,7 @@ class ElasticsearchBackendImpl implements BackendImplementor,
 				throw log.customIndexSettingsFileNotFound( filePath, indexEventContext );
 			}
 			try ( Reader reader = new InputStreamReader( inputStream, StandardCharsets.UTF_8 ) ) {
-				return link.getGsonProvider().getGson().fromJson( reader, IndexSettings.class );
+				return userFacingGson.fromJson( reader, IndexSettings.class );
 			}
 		}
 		catch (IOException e) {
@@ -329,7 +331,7 @@ class ElasticsearchBackendImpl implements BackendImplementor,
 				throw log.customIndexMappingFileNotFound( filePath, indexEventContext );
 			}
 			try ( Reader reader = new InputStreamReader( inputStream, StandardCharsets.UTF_8 ) ) {
-				return link.getGsonProvider().getGson().fromJson( reader, RootTypeMapping.class );
+				return userFacingGson.fromJson( reader, RootTypeMapping.class );
 			}
 		}
 		catch (IOException e) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchLinkImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchLinkImpl.java
@@ -161,7 +161,7 @@ class ElasticsearchLinkImpl implements ElasticsearchLink {
 	private void checkStarted() {
 		if ( clientImplementor == null ) {
 			throw new AssertionFailure(
-					"Attempt to retrieve Elasticsearch client or related information before the backend was started."
+					"Attempt to retrieve Elasticsearch client or related information before the Elasticsearch client was started."
 			);
 		}
 	}

--- a/integrationtest/backend/elasticsearch/src/test/resources/bootstrap-it/custom-mapping.json
+++ b/integrationtest/backend/elasticsearch/src/test/resources/bootstrap-it/custom-mapping.json
@@ -1,0 +1,7 @@
+{
+  "properties":{
+    "custom":{
+      "type":"keyword"
+    }
+  }
+}

--- a/integrationtest/backend/elasticsearch/src/test/resources/bootstrap-it/custom-settings.json
+++ b/integrationtest/backend/elasticsearch/src/test/resources/bootstrap-it/custom-settings.json
@@ -1,0 +1,3 @@
+{
+  "number_of_replicas": "42"
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4435
