### PR TITLE
HSEARCH-4430 + HSEARCH-4446 + HSEARCH-4448 + HSEARCH-4449 Dependency upgrades

### DIFF
--- a/jakarta/parents/integrationtest/pom.xml
+++ b/jakarta/parents/integrationtest/pom.xml
@@ -47,6 +47,22 @@
                 <groupId>org.jberet</groupId>
                 <artifactId>jberet-core</artifactId>
                 <version>${version.org.jberet.jakarta}</version>
+                <exclusions>
+                    <!-- These dependencies are marked as "provided" but will never be there at runtime.
+                         This confuses maven-enforcer-plugin, so we'll exclude them. -->
+                    <exclusion>
+                        <groupId>org.jboss.logging</groupId>
+                        <artifactId>jboss-logging-processor</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.infinispan</groupId>
+                        <artifactId>infinispan-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.infinispan</groupId>
+                        <artifactId>infinispan-commons</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jberet</groupId>

--- a/jakarta/parents/internal/pom.xml
+++ b/jakarta/parents/internal/pom.xml
@@ -47,6 +47,22 @@
                 <groupId>org.jberet</groupId>
                 <artifactId>jberet-core</artifactId>
                 <version>${version.org.jberet.jakarta}</version>
+                <exclusions>
+                    <!-- These dependencies are marked as "provided" but will never be there at runtime.
+                         This confuses maven-enforcer-plugin, so we'll exclude them. -->
+                    <exclusion>
+                        <groupId>org.jboss.logging</groupId>
+                        <artifactId>jboss-logging-processor</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.infinispan</groupId>
+                        <artifactId>infinispan-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.infinispan</groupId>
+                        <artifactId>infinispan-commons</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jberet</groupId>

--- a/jakarta/parents/public/pom.xml
+++ b/jakarta/parents/public/pom.xml
@@ -43,11 +43,19 @@
                 <artifactId>jberet-core</artifactId>
                 <version>${version.org.jberet.jakarta}</version>
                 <exclusions>
-                    <!-- This dependency is marked as "provided" but will never be there at runtime.
-                         This confuses maven-enforcer-plugin, so we'll exclude it. -->
+                    <!-- These dependencies are marked as "provided" but will never be there at runtime.
+                         This confuses maven-enforcer-plugin, so we'll exclude them. -->
                     <exclusion>
                         <groupId>org.jboss.logging</groupId>
                         <artifactId>jboss-logging-processor</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.infinispan</groupId>
+                        <artifactId>infinispan-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.infinispan</groupId>
+                        <artifactId>infinispan-commons</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/orm6/parents/integrationtest/pom.xml
+++ b/orm6/parents/integrationtest/pom.xml
@@ -55,6 +55,22 @@
                 <groupId>org.jberet</groupId>
                 <artifactId>jberet-core</artifactId>
                 <version>${version.org.jberet.jakarta}</version>
+                <exclusions>
+                    <!-- These dependencies are marked as "provided" but will never be there at runtime.
+                         This confuses maven-enforcer-plugin, so we'll exclude them. -->
+                    <exclusion>
+                        <groupId>org.jboss.logging</groupId>
+                        <artifactId>jboss-logging-processor</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.infinispan</groupId>
+                        <artifactId>infinispan-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.infinispan</groupId>
+                        <artifactId>infinispan-commons</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jberet</groupId>

--- a/orm6/parents/internal/pom.xml
+++ b/orm6/parents/internal/pom.xml
@@ -55,6 +55,22 @@
                 <groupId>org.jberet</groupId>
                 <artifactId>jberet-core</artifactId>
                 <version>${version.org.jberet.jakarta}</version>
+                <exclusions>
+                    <!-- These dependencies are marked as "provided" but will never be there at runtime.
+                         This confuses maven-enforcer-plugin, so we'll exclude them. -->
+                    <exclusion>
+                        <groupId>org.jboss.logging</groupId>
+                        <artifactId>jboss-logging-processor</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.infinispan</groupId>
+                        <artifactId>infinispan-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.infinispan</groupId>
+                        <artifactId>infinispan-commons</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jberet</groupId>

--- a/orm6/parents/public/pom.xml
+++ b/orm6/parents/public/pom.xml
@@ -51,11 +51,19 @@
                 <artifactId>jberet-core</artifactId>
                 <version>${version.org.jberet.jakarta}</version>
                 <exclusions>
-                    <!-- This dependency is marked as "provided" but will never be there at runtime.
-                         This confuses maven-enforcer-plugin, so we'll exclude it. -->
+                    <!-- These dependencies are marked as "provided" but will never be there at runtime.
+                         This confuses maven-enforcer-plugin, so we'll exclude them. -->
                     <exclusion>
                         <groupId>org.jboss.logging</groupId>
                         <artifactId>jboss-logging-processor</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.infinispan</groupId>
+                        <artifactId>infinispan-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.infinispan</groupId>
+                        <artifactId>infinispan-commons</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1102,11 +1102,19 @@
                 <artifactId>jberet-core</artifactId>
                 <version>${version.org.jberet}</version>
                 <exclusions>
-                    <!-- This dependency is marked as "provided" but will never be there at runtime.
-                         This confuses maven-enforcer-plugin, so we'll exclude it. -->
+                    <!-- These dependencies are marked as "provided" but will never be there at runtime.
+                         This confuses maven-enforcer-plugin, so we'll exclude them. -->
                     <exclusion>
                         <groupId>org.jboss.logging</groupId>
                         <artifactId>jboss-logging-processor</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.infinispan</groupId>
+                        <artifactId>infinispan-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.infinispan</groupId>
+                        <artifactId>infinispan-commons</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -358,7 +358,7 @@
         <version.compiler.plugin>3.9.0</version.compiler.plugin>
         <version.dependency.plugin>3.2.0</version.dependency.plugin>
         <!-- Check dependencies for security vulnerabilities -->
-        <version.dependency-check.plugin>6.5.2</version.dependency-check.plugin>
+        <version.dependency-check.plugin>6.5.3</version.dependency-check.plugin>
         <version.deploy.plugin>2.8.2</version.deploy.plugin>
         <version.org.eclipse.m2e.lifecycle-mapping>1.0.0</version.org.eclipse.m2e.lifecycle-mapping>
         <version.enforcer.plugin>3.0.0</version.enforcer.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
         <version.bundle.plugin>5.1.4</version.bundle.plugin>
         <version.clean.plugin>3.1.0</version.clean.plugin>
         <!-- Needing 3.6.2 at least because of MCOMPILER-294 -->
-        <version.compiler.plugin>3.8.1</version.compiler.plugin>
+        <version.compiler.plugin>3.9.0</version.compiler.plugin>
         <version.dependency.plugin>3.2.0</version.dependency.plugin>
         <!-- Check dependencies for security vulnerabilities -->
         <version.dependency-check.plugin>6.5.2</version.dependency-check.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -368,7 +368,7 @@
         <version.install.plugin>2.5.2</version.install.plugin>
         <version.io.takari.maven>0.7.7</version.io.takari.maven>
         <version.japicmp.plugin>0.15.4</version.japicmp.plugin>
-        <version.jar.plugin>3.2.1</version.jar.plugin>
+        <version.jar.plugin>3.2.2</version.jar.plugin>
         <version.javadoc.plugin>3.3.1</version.javadoc.plugin>
         <version.jdeps.plugin>0.5.1</version.jdeps.plugin>
         <version.nexus-staging.plugin>1.6.8</version.nexus-staging.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -404,7 +404,7 @@
         <version.asciidoctor.plugin>2.2.1</version.asciidoctor.plugin>
         <version.org.hibernate.infra.hibernate-asciidoctor-theme>1.0.4.Final</version.org.hibernate.infra.hibernate-asciidoctor-theme>
         <version.org.jruby>9.3.2.0</version.org.jruby>
-        <version.org.asciidoctor.asciidoctorj>2.5.2</version.org.asciidoctor.asciidoctorj>
+        <version.org.asciidoctor.asciidoctorj>2.5.3</version.org.asciidoctor.asciidoctorj>
         <version.org.asciidoctor.asciidoctorj-pdf>1.5.0-alpha.18</version.org.asciidoctor.asciidoctorj-pdf>
 
         <!-- Maven Central repository -->

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently from the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 7.16+ -->
-        <version.org.elasticsearch.client>7.16.2</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>7.16.3</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-7.12) becomes the default. -->

--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
         <!-- Reactive-streams: used by the AWS SDK -->
         <version.org.reactivestreams.reactive-streams>1.0.3</version.org.reactivestreams.reactive-streams>
         <!-- slf4j: used by the AWS SDK -->
-        <version.org.slf4j>1.7.32</version.org.slf4j>
+        <version.org.slf4j>1.7.33</version.org.slf4j>
 
         <!-- >>> ORM -->
         <version.org.hibernate>5.6.3.Final</version.org.hibernate>

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
         <!-- Main dependencies -->
 
         <!-- >>> Common -->
-        <version.org.jboss.logging.jboss-logging>3.4.2.Final</version.org.jboss.logging.jboss-logging>
+        <version.org.jboss.logging.jboss-logging>3.4.3.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.2.1.Final</version.org.jboss.logging.jboss-logging-tools>
         <javadoc.org.hibernate.search.url>https://docs.jboss.org/hibernate/search/${parsed-version.org.hibernate.search.majorVersion}.${parsed-version.org.hibernate.search.minorVersion}/api/</javadoc.org.hibernate.search.url>
 


### PR DESCRIPTION
* [HSEARCH-4449](https://hibernate.atlassian.net/browse/HSEARCH-4449): Upgrade to slf4j 1.7.33
* [HSEARCH-4448](https://hibernate.atlassian.net/browse/HSEARCH-4448): Upgrade to JBoss logging 3.4.3.Final
* [HSEARCH-4446](https://hibernate.atlassian.net/browse/HSEARCH-4446): Upgrade to Elasticsearch client 7.16.3
* [HSEARCH-4430](https://hibernate.atlassian.net/browse/HSEARCH-4430): Upgrade to latest version of build dependencies

