### PR TITLE
HSEARCH-4450 + HSEARCH-4451 Various improvements for integrators

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/spi/GsonClasses.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/spi/GsonClasses.java
@@ -7,38 +7,8 @@
 package org.hibernate.search.backend.elasticsearch.gson.spi;
 
 import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Set;
-
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.aliases.impl.IndexAliasDefinition;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.aliases.impl.IndexAliasDefinitionJsonAdapterFactory;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.AnalysisDefinition;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.AnalysisDefinitionJsonAdapterFactory;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.AnalyzerDefinition;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.AnalyzerDefinitionJsonAdapterFactory;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.CharFilterDefinition;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.NormalizerDefinition;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.NormalizerDefinitionJsonAdapterFactory;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.TokenFilterDefinition;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.TokenizerDefinition;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.AbstractTypeMapping;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.DynamicTemplate;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.DynamicTemplateJsonAdapterFactory;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.DynamicType;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.FormatJsonAdapter;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.NamedDynamicTemplate;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.NamedDynamicTemplateJsonAdapterFactory;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.PropertyMapping;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.PropertyMappingJsonAdapterFactory;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.RootTypeMapping;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.RootTypeMappingJsonAdapterFactory;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.RoutingType;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.RoutingTypeJsonAdapter;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.settings.impl.Analysis;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.settings.impl.AnalysisJsonAdapterFactory;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.settings.impl.IndexSettings;
-import org.hibernate.search.backend.elasticsearch.lowlevel.index.settings.impl.IndexSettingsJsonAdapterFactory;
 
 public final class GsonClasses {
 
@@ -46,48 +16,46 @@ public final class GsonClasses {
 	}
 
 	/**
-	 * @return A set of all classes that will be involved in GSON serialization and will require reflection support.
+	 * @return A set of names of all classes that will be involved in GSON serialization and will require reflection support.
 	 * Useful to enable reflection for these classes in GraalVM-based native images.
 	 */
-	public static Set<Class<?>> typesRequiringReflection() {
-		List<Class<?>> base = Arrays.asList(
-				AbstractTypeMapping.class,
-				DynamicType.class,
-				FormatJsonAdapter.class,
-				RoutingTypeJsonAdapter.class,
-				PropertyMapping.class,
-				PropertyMappingJsonAdapterFactory.class,
-				RootTypeMapping.class,
-				RootTypeMappingJsonAdapterFactory.class,
-				RoutingType.class,
-				IndexSettings.class,
-				IndexSettingsJsonAdapterFactory.class,
-				Analysis.class,
-				AnalysisJsonAdapterFactory.class,
-				AnalysisDefinition.class,
-				AnalyzerDefinition.class,
-				AnalyzerDefinitionJsonAdapterFactory.class,
-				NormalizerDefinition.class,
-				NormalizerDefinitionJsonAdapterFactory.class,
-				TokenizerDefinition.class,
-				TokenFilterDefinition.class,
-				CharFilterDefinition.class,
-				AnalysisDefinitionJsonAdapterFactory.class,
-				IndexAliasDefinition.class,
-				IndexAliasDefinitionJsonAdapterFactory.class,
-				DynamicTemplate.class,
-				DynamicTemplateJsonAdapterFactory.class,
-				NamedDynamicTemplate.class,
-				NamedDynamicTemplateJsonAdapterFactory.class
-		);
-		Set<Class<?>> result = new LinkedHashSet<>();
-		for ( Class<?> clazz : base ) {
-			Class<?> currentClass = clazz;
-			while ( currentClass != Object.class ) {
-				result.add( currentClass );
-				currentClass = currentClass.getSuperclass();
-			}
-		}
-		return result;
+	public static Set<String> typesRequiringReflection() {
+		return new HashSet<>( Arrays.asList(
+				"org.hibernate.search.backend.elasticsearch.gson.impl.AbstractConfiguredExtraPropertiesJsonAdapterFactory",
+				"org.hibernate.search.backend.elasticsearch.gson.impl.AbstractConfiguredExtraPropertiesJsonAdapterFactory$Adapter",
+				"org.hibernate.search.backend.elasticsearch.gson.impl.AbstractExtraPropertiesJsonAdapter",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.aliases.impl.IndexAliasDefinition",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.AbstractCompositeAnalysisDefinition",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.AnalysisDefinition",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.AnalyzerDefinition",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.CharFilterDefinition",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.NormalizerDefinition",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.TokenFilterDefinition",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.TokenizerDefinition",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.AbstractTypeMapping",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.DynamicTemplate",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.DynamicType",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.FormatJsonAdapter",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.NamedDynamicTemplate",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.NamedDynamicTemplateJsonAdapterFactory$Adapter",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.PropertyMapping",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.RootTypeMapping",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.RoutingType",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.RoutingTypeJsonAdapter",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.settings.impl.Analysis",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.settings.impl.IndexSettings",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.aliases.impl.IndexAliasDefinitionJsonAdapterFactory",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.AnalysisDefinitionJsonAdapterFactory",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.AnalyzerDefinitionJsonAdapterFactory",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.NormalizerDefinitionJsonAdapterFactory",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.AbstractTypeMappingJsonAdapterFactory",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.DynamicTemplateJsonAdapterFactory",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.NamedDynamicTemplateJsonAdapterFactory",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.PropertyMappingJsonAdapterFactory",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.RootTypeMappingJsonAdapterFactory",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.settings.impl.AnalysisJsonAdapterFactory",
+				"org.hibernate.search.backend.elasticsearch.lowlevel.index.settings.impl.IndexSettingsJsonAdapterFactory"
+		) );
 	}
+
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/lowlevel/index/analysis/impl/AbstractCompositeAnalysisDefinition.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/lowlevel/index/analysis/impl/AbstractCompositeAnalysisDefinition.java
@@ -16,7 +16,7 @@ import com.google.gson.annotations.SerializedName;
  * A superclass to both {@link AnalyzerDefinition} and {@link NormalizerDefinition}.
  *
  */
-abstract class AbstractCompositeAnalysisDefinition extends AnalysisDefinition {
+public abstract class AbstractCompositeAnalysisDefinition extends AnalysisDefinition {
 
 	@SerializedName("filter")
 	private List<String> tokenFilters;

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/gson/spi/GsonClassesTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/gson/spi/GsonClassesTest.java
@@ -18,7 +18,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 import org.hibernate.search.backend.elasticsearch.ElasticsearchExtension;
 import org.hibernate.search.util.impl.test.logging.Log;
@@ -46,10 +45,6 @@ public class GsonClassesTest {
 				ElasticsearchExtension.class, "hibernate-search-backend-elasticsearch" ) );
 	}
 
-	private List<String> typesRequiringReflectionAsStrings() {
-		return GsonClasses.typesRequiringReflection().stream().map( Class::getName ).collect( Collectors.toList() );
-	}
-
 	@Test
 	public void testNoMissingGsonAnnotatedClass() {
 		Set<DotName> gsonAnnotations = findRuntimeAnnotations( gsonIndex );
@@ -72,7 +67,7 @@ public class GsonClassesTest {
 
 		Log.INSTANCE.infof( "GSON-annotated classes and subclasses: %s", annotatedClassesAndSubclasses );
 		assertThat( annotatedClassesAndSubclasses ).isNotEmpty();
-		assertThat( typesRequiringReflectionAsStrings() ).containsAll( annotatedClassesAndSubclasses );
+		assertThat( GsonClasses.typesRequiringReflection() ).containsAll( annotatedClassesAndSubclasses );
 	}
 
 	@Test
@@ -89,7 +84,7 @@ public class GsonClassesTest {
 
 		Log.INSTANCE.infof( "Gson contract implementations: %s", classes );
 		assertThat( classes ).isNotEmpty();
-		assertThat( typesRequiringReflectionAsStrings() ).containsAll( classes );
+		assertThat( GsonClasses.typesRequiringReflection() ).containsAll( classes );
 	}
 
 }

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/gson/spi/GsonClassesTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/gson/spi/GsonClassesTest.java
@@ -13,7 +13,7 @@ import static org.hibernate.search.util.impl.test.jar.JandexUtils.findRuntimeAnn
 import static org.hibernate.search.util.impl.test.jar.JarUtils.determineJarOrDirectoryLocation;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -31,6 +31,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
 
 import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
 
 public class GsonClassesTest {
@@ -67,12 +68,14 @@ public class GsonClassesTest {
 
 	@Test
 	public void testNoMissingGsonContractImplementations() {
-		List<DotName> gsonContracts = Collections.singletonList(
-				DotName.createSimple( TypeAdapterFactory.class.getName() ) );
+		List<DotName> gsonContracts = Arrays.asList(
+				DotName.createSimple( TypeAdapterFactory.class.getName() ),
+				DotName.createSimple( TypeAdapter.class.getName() )
+		);
 
 		Set<DotName> classes = new HashSet<>();
 		for ( DotName gsonContract : gsonContracts ) {
-			for ( ClassInfo implementor : backendElasticsearchIndex.getAllKnownImplementors( gsonContract ) ) {
+			for ( ClassInfo implementor : backendElasticsearchIndex.getAllKnownSubclasses( gsonContract ) ) {
 				classes.add( implementor.name() );
 			}
 		}

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/HibernateOrmMapperOutboxPollingSettings.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/HibernateOrmMapperOutboxPollingSettings.java
@@ -10,7 +10,6 @@ import static java.lang.String.join;
 
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.util.common.annotation.Incubating;
-import org.hibernate.search.util.common.impl.Contracts;
 
 @Incubating
 public final class HibernateOrmMapperOutboxPollingSettings {
@@ -418,18 +417,34 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	}
 
 	/**
+	 * Builds a configuration property key for coordination, with the given radical.
+	 * <p>
+	 * See {@link CoordinationRadicals} for available radicals.
+	 * <p>
+	 * Example result: "{@code hibernate.search.coordination.tenant.myTenant.event_processor.enabled}"
+	 *
+	 * @param radical The radical of the configuration property (see constants in {@link CoordinationRadicals})
+	 * @return the concatenated prefix + tenant ID + radical
+	 */
+	public static String coordinationKey(String radical) {
+		return join( ".", HibernateOrmMapperSettings.COORDINATION, radical );
+	}
+
+	/**
 	 * Builds a configuration property key for coordination for the given tenant, with the given radical.
 	 * <p>
 	 * See {@link CoordinationRadicals} for available radicals.
 	 * <p>
 	 * Example result: "{@code hibernate.search.coordination.tenant.myTenant.event_processor.enabled}"
 	 *
-	 * @param tenantId The identifier of the tenant whose coordination to configure.
+	 * @param tenantId The identifier of the tenant whose coordination to configure, or {@code null} to configure defaults.
 	 * @param radical The radical of the configuration property (see constants in {@link CoordinationRadicals})
 	 * @return the concatenated prefix + tenant ID + radical
 	 */
 	public static String coordinationKey(String tenantId, String radical) {
-		Contracts.assertNotNull( tenantId, "tenantId" );
+		if ( tenantId == null ) {
+			return coordinationKey( radical );
+		}
 		return join( ".", COORDINATION_TENANTS, tenantId, radical );
 	}
 

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/mapping/spi/HibernateOrmMapperOutboxPollingClasses.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/mapping/spi/HibernateOrmMapperOutboxPollingClasses.java
@@ -1,0 +1,51 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.orm.coordination.outboxpolling.mapping.spi;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public final class HibernateOrmMapperOutboxPollingClasses {
+
+	private HibernateOrmMapperOutboxPollingClasses() {
+	}
+
+	/**
+	 * @return A set of names of all classes that will be involved in Avro serialization
+	 * and thus will require reflection support.
+	 * Useful to enable reflection for these classes in GraalVM-based native images.
+	 */
+	public static Set<String> avroTypes() {
+		return new HashSet<>( Arrays.asList(
+				"org.hibernate.search.mapper.orm.coordination.outboxpolling.avro.generated.impl.DocumentRoutesDescriptorDto$Builder",
+				"org.hibernate.search.mapper.orm.coordination.outboxpolling.avro.generated.impl.DirtinessDescriptorDto$Builder",
+				"org.hibernate.search.mapper.orm.coordination.outboxpolling.avro.generated.impl.DirtinessDescriptorDto",
+				"org.hibernate.search.mapper.orm.coordination.outboxpolling.avro.generated.impl.DocumentRoutesDescriptorDto",
+				"org.hibernate.search.mapper.orm.coordination.outboxpolling.avro.generated.impl.DocumentRouteDescriptorDto$Builder",
+				"org.hibernate.search.mapper.orm.coordination.outboxpolling.avro.generated.impl.PojoIndexingQueueEventPayloadDto",
+				"org.hibernate.search.mapper.orm.coordination.outboxpolling.avro.generated.impl.DocumentRouteDescriptorDto",
+				"org.hibernate.search.mapper.orm.coordination.outboxpolling.avro.generated.impl.PojoIndexingQueueEventPayloadDto$Builder"
+		) );
+	}
+
+	/**
+	 * @return A set of names of all classes that will be involved in Hibernate ORM mapping
+	 * and thus will require reflection support.
+	 * Useful to enable reflection for these classes in GraalVM-based native images.
+	 */
+	public static Set<String> hibernateOrmTypes() {
+		return new HashSet<>( Arrays.asList(
+				"org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.AgentType",
+				"org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl.OutboxEvent",
+				"org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.Agent",
+				"org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl.OutboxEvent$Status",
+				"org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.AgentState"
+		) );
+	}
+
+}

--- a/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/HibernateOrmMapperOutboxPollingSettingsTest.java
+++ b/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/HibernateOrmMapperOutboxPollingSettingsTest.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
@@ -15,10 +14,12 @@ public class HibernateOrmMapperOutboxPollingSettingsTest {
 
 	@Test
 	public void coordinationKey() {
+		assertThat( HibernateOrmMapperOutboxPollingSettings.coordinationKey( "foo.bar" ) )
+				.isEqualTo( "hibernate.search.coordination.foo.bar" );
 		assertThat( HibernateOrmMapperOutboxPollingSettings.coordinationKey( "myTenant", "foo.bar" ) )
 				.isEqualTo( "hibernate.search.coordination.tenants.myTenant.foo.bar" );
-		assertThatThrownBy( () -> HibernateOrmMapperOutboxPollingSettings.coordinationKey( null, "foo.bar" ) )
-				.isInstanceOf( IllegalArgumentException.class );
+		assertThat( HibernateOrmMapperOutboxPollingSettings.coordinationKey( null, "foo.bar" ) )
+				.isEqualTo( "hibernate.search.coordination.foo.bar" );
 	}
 
 }

--- a/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/mapping/spi/HibernateOrmMapperOutboxPollingClassesTest.java
+++ b/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/mapping/spi/HibernateOrmMapperOutboxPollingClassesTest.java
@@ -1,0 +1,152 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.orm.coordination.outboxpolling.mapping.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.test.jar.JandexIndexingUtils.indexJarOrDirectory;
+import static org.hibernate.search.util.impl.test.jar.JarUtils.determineJarOrDirectoryLocation;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.HibernateOrmMapperOutboxPollingSettings;
+import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.Agent;
+import org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl.OutboxEvent;
+import org.hibernate.search.util.impl.test.jar.JandexUtils;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+
+import org.apache.avro.specific.AvroGenerated;
+
+/**
+ * Tests that hardcoded lists of classes stay up-to-date.
+ */
+public class HibernateOrmMapperOutboxPollingClassesTest {
+
+	private static Index outboxPollingIndex;
+
+	@BeforeClass
+	public static void index() throws IOException {
+		outboxPollingIndex = indexJarOrDirectory( determineJarOrDirectoryLocation(
+				HibernateOrmMapperOutboxPollingSettings.class,
+				"hibernate-search-mapper-orm-coordination-outbox-polling"
+		) );
+	}
+
+	@Test
+	public void testNoMissingAvroGeneratedClass() {
+		Set<String> annotatedClasses = new HashSet<>();
+		for ( AnnotationInstance annotationInstance : outboxPollingIndex
+				.getAnnotations( DotName.createSimple( AvroGenerated.class.getName() ) ) ) {
+			DotName className = JandexUtils.extractDeclaringClass( annotationInstance.target() ).name();
+			annotatedClasses.add( className.toString() );
+		}
+
+		assertThat( annotatedClasses ).isNotEmpty();
+		assertThat( HibernateOrmMapperOutboxPollingClasses.avroTypes() )
+				.containsExactlyInAnyOrderElementsOf( annotatedClasses );
+	}
+
+	@Test
+	public void testNoMissingJpaModelClass() {
+		Set<DotName> modelClasses = collectModelClassesRecursively( outboxPollingIndex, new HashSet<>( Arrays.asList(
+				DotName.createSimple( OutboxEvent.class.getName() ),
+				DotName.createSimple( Agent.class.getName() )
+		) ) );
+
+		Set<String> modelClassNames = modelClasses.stream().map( DotName::toString ).collect( Collectors.toSet() );
+
+		// Despite being referenced from entities, these types are not included in the JPA model.
+		modelClassNames.removeAll( Arrays.asList(
+				"org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.AgentReference",
+				"org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl.OutboxEventReference",
+				"org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.ShardAssignmentDescriptor"
+		) );
+
+		assertThat( modelClassNames ).isNotEmpty();
+		assertThat( HibernateOrmMapperOutboxPollingClasses.hibernateOrmTypes() )
+				.containsExactlyInAnyOrderElementsOf( modelClassNames );
+	}
+
+	private static Set<DotName> collectModelClassesRecursively(Index index, Set<DotName> initialClasses) {
+		Set<DotName> classes = new HashSet<>();
+		for ( DotName initialClass : initialClasses ) {
+			collectModelClassesRecursively( index, initialClass, classes );
+		}
+		return classes;
+	}
+
+	private static void collectModelClassesRecursively(Index index, DotName className, Set<DotName> classes) {
+		if ( className.toString().startsWith( "java." ) ) {
+			return;
+		}
+		if ( !classes.add( className ) ) {
+			return;
+		}
+		ClassInfo clazz = index.getClassByName( className );
+		collectModelClassesRecursively( index, clazz.superName(), classes );
+		for ( DotName interfaceName : clazz.interfaceNames() ) {
+			collectModelClassesRecursively( index, interfaceName, classes );
+		}
+		for ( FieldInfo field : clazz.fields() ) {
+			collectModelClassesRecursively( index, field.type(), classes );
+		}
+		for ( FieldInfo field : clazz.fields() ) {
+			collectModelClassesRecursively( index, field.type(), classes );
+		}
+		for ( MethodInfo methodInfo : clazz.methods() ) {
+			if ( !methodInfo.parameters().isEmpty() ) {
+				// Definitely not a getter, just skip.
+				continue;
+			}
+			collectModelClassesRecursively( index, methodInfo.returnType(), classes );
+		}
+	}
+
+	private static void collectModelClassesRecursively(Index index, Type type, Set<DotName> classes) {
+		switch ( type.kind() ) {
+			case CLASS:
+				collectModelClassesRecursively( index, type.name(), classes );
+				break;
+			case ARRAY:
+				collectModelClassesRecursively( index, type.asArrayType().component(), classes );
+				break;
+			case TYPE_VARIABLE:
+				for ( Type bound : type.asTypeVariable().bounds() ) {
+					collectModelClassesRecursively( index, bound, classes );
+				}
+				break;
+			case WILDCARD_TYPE:
+				collectModelClassesRecursively( index, type.asWildcardType().extendsBound(), classes );
+				collectModelClassesRecursively( index, type.asWildcardType().superBound(), classes );
+				break;
+			case PARAMETERIZED_TYPE:
+				collectModelClassesRecursively( index, type.name(), classes );
+				for ( Type argument : type.asParameterizedType().arguments() ) {
+					collectModelClassesRecursively( index, argument, classes );
+				}
+				break;
+			case PRIMITIVE:
+			case VOID:
+			case UNRESOLVED_TYPE_VARIABLE:
+				// Ignore
+				break;
+		}
+	}
+}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/cfg/HibernateOrmMapperSettings.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/cfg/HibernateOrmMapperSettings.java
@@ -148,6 +148,11 @@ public final class HibernateOrmMapperSettings {
 	public static final String SCHEMA_MANAGEMENT_STRATEGY = PREFIX + Radicals.SCHEMA_MANAGEMENT_STRATEGY;
 
 	/**
+	 * The root property for properties related to coordination.
+	 */
+	public static final String COORDINATION = PREFIX + HibernateOrmMapperSettings.Radicals.COORDINATION;
+
+	/**
 	 * The strategy for coordinating between nodes of a distributed application.
 	 * <p>
 	 * Expects a reference to a coordination strategy;

--- a/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/jar/JandexUtils.java
+++ b/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/jar/JandexUtils.java
@@ -17,7 +17,10 @@ import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.Index;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
 
 public final class JandexUtils {
 	private static final DotName RETENTION = DotName.createSimple( Retention.class.getName() );
@@ -83,6 +86,80 @@ public final class JandexUtils {
 		}
 		for ( ClassInfo subclass : index.getAllKnownSubclasses( className ) ) {
 			collectClassHierarchiesRecursively( index, subclass.name(), classes );
+		}
+	}
+
+	private static Set<DotName> collectModelClassesRecursively(Index index, Set<DotName> initialClasses) {
+		Set<DotName> classes = new HashSet<>();
+		for ( DotName initialClass : initialClasses ) {
+			collectModelClassesRecursively( index, initialClass, classes );
+		}
+		return classes;
+	}
+
+	private static void collectModelClassesRecursively(Index index, DotName className, Set<DotName> classes) {
+		if ( className.toString().startsWith( "java." ) ) {
+			return;
+		}
+		if ( classes.contains( className ) ) {
+			return;
+		}
+		ClassInfo clazz = index.getClassByName( className );
+		if ( clazz == null ) {
+			return;
+		}
+		classes.add( className );
+		collectModelClassesRecursively( index, clazz.superName(), classes );
+		for ( DotName interfaceName : clazz.interfaceNames() ) {
+			collectModelClassesRecursively( index, interfaceName, classes );
+		}
+		for ( ClassInfo subclass : index.getAllKnownSubclasses( className ) ) {
+			collectModelClassesRecursively( index, subclass.name(), classes );
+		}
+
+		for ( FieldInfo field : clazz.fields() ) {
+			collectModelClassesRecursively( index, field.type(), classes );
+		}
+		for ( FieldInfo field : clazz.fields() ) {
+			collectModelClassesRecursively( index, field.type(), classes );
+		}
+		for ( MethodInfo methodInfo : clazz.methods() ) {
+			if ( !methodInfo.parameters().isEmpty() ) {
+				// Definitely not a getter, just skip.
+				continue;
+			}
+			collectModelClassesRecursively( index, methodInfo.returnType(), classes );
+		}
+	}
+
+	private static void collectModelClassesRecursively(Index index, Type type, Set<DotName> classes) {
+		switch ( type.kind() ) {
+			case CLASS:
+				collectModelClassesRecursively( index, type.name(), classes );
+				break;
+			case ARRAY:
+				collectModelClassesRecursively( index, type.asArrayType().component(), classes );
+				break;
+			case TYPE_VARIABLE:
+				for ( Type bound : type.asTypeVariable().bounds() ) {
+					collectModelClassesRecursively( index, bound, classes );
+				}
+				break;
+			case WILDCARD_TYPE:
+				collectModelClassesRecursively( index, type.asWildcardType().extendsBound(), classes );
+				collectModelClassesRecursively( index, type.asWildcardType().superBound(), classes );
+				break;
+			case PARAMETERIZED_TYPE:
+				collectModelClassesRecursively( index, type.name(), classes );
+				for ( Type argument : type.asParameterizedType().arguments() ) {
+					collectModelClassesRecursively( index, argument, classes );
+				}
+				break;
+			case PRIMITIVE:
+			case VOID:
+			case UNRESOLVED_TYPE_VARIABLE:
+				// Ignore
+				break;
 		}
 	}
 }


### PR DESCRIPTION
* [HSEARCH-4451](https://hibernate.atlassian.net/browse/HSEARCH-4451): Allow null tenant IDs in HibernateOrmMapperOutboxPollingSettings#coordinationKey
* [HSEARCH-4450](https://hibernate.atlassian.net/browse/HSEARCH-4450): Expose list of outbox-polling classes requiring reflection through an SPI

