### PR TITLE
HSEARCH-4415 Define maven gpg plugin for public artifacts

### DIFF
--- a/parents/public/pom.xml
+++ b/parents/public/pom.xml
@@ -252,5 +252,31 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>release</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -382,6 +382,7 @@
         <version.moditect.plugin>1.0.0.RC2</version.moditect.plugin>
         <version.sonar.plugin>3.9.1.2184</version.sonar.plugin>
         <version.scripting.plugin>3.0.0</version.scripting.plugin>
+        <version.gpg.plugin>3.0.1</version.gpg.plugin>
         <version.org.codehaus.groovy-jsr223>3.0.9</version.org.codehaus.groovy-jsr223>
         <!--
             Please don't change the name of this property, it may be used and
@@ -2229,6 +2230,11 @@
                             <version>${version.org.codehaus.groovy-jsr223}</version> <!-- look for latest -->
                         </dependency>
                     </dependencies>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>${version.gpg.plugin}</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-antrun-plugin</artifactId>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4415

This change should be limited to where a new deploy/release is performed.

To test the deploy run the maven command:
``` bash
mvn clean deploy -X -DskipTests -DperformRelease=true
```

There are a series of pre requirements:

1. The Maven settings.xml file must contain the nexus coordinates and the GPG passphrase:
``` xml
<servers>
  <server>
    <id>ossrh</id>
    <username>ossrh-username</username>
    <password>ossrh-password</password>
  </server>
  <server>
    <id>gpg.passphrase</id>
    <passphrase>fax</passphrase>
  </server>
</servers>
```

2. The private key must be imported into the local machine GPG process
``` bash
gpg --batch --import $gpg_secret
```
To make the worker node we could consider the idea of [this blog](https://titanwolf.org/Network/Articles/Article?AID=d1f01d06-02f5-4194-879f-1f2e7f8960be).