### PR TITLE
HSEARCH-4465 + HSEARCH-4467 + HSEARCH-4468 Upgrade dependencies

### DIFF
--- a/build/config/src/main/java/org/hibernate/checkstyle/checks/regexp/DoubleSpacesCheck.java
+++ b/build/config/src/main/java/org/hibernate/checkstyle/checks/regexp/DoubleSpacesCheck.java
@@ -50,6 +50,11 @@ public class DoubleSpacesCheck extends AbstractCheck {
 	}
 
 	@Override
+	// Suppress deprecation warning on getFileContents()
+	// because there is no alternative for CommentSuppressor/StringSuppressor.
+	// See com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck.beginTree
+	// See https://github.com/checkstyle/checkstyle/issues/11166
+	@SuppressWarnings("deprecation")
 	public void beginTree(DetailAST aRootAST) {
 		initializeSuppressors( getFileContents() );
 		processLines( Arrays.asList( getLines() ) );

--- a/pom.xml
+++ b/pom.xml
@@ -384,12 +384,6 @@
         <version.scripting.plugin>3.0.0</version.scripting.plugin>
         <version.gpg.plugin>3.0.1</version.gpg.plugin>
         <version.org.codehaus.groovy-jsr223>3.0.9</version.org.codehaus.groovy-jsr223>
-        <!--
-            Please don't change the name of this property, it may be used and
-            overridden by a CI job of the Checkstyle project so that they can
-            check for regressions. Which is obviously good for us, too.
-         -->
-        <puppycrawl.checkstyle.version>8.41</puppycrawl.checkstyle.version>
         <version.com.puppycrawl.tools.checkstyle>9.3</version.com.puppycrawl.tools.checkstyle>
 
         <!-- Asciidoctor -->
@@ -438,6 +432,9 @@
         <!-- IMPORTANT: For Java 8, this must be the path to the JDK, not to the JRE -->
         <java-version.test.launcher.java_home>${java-version.test.compiler.java_home}</java-version.test.launcher.java_home>
         <java-version.test.launcher>${java-version.test.launcher.java_home}/bin/java</java-version.test.launcher>
+
+	<!-- Set this through a property so that it can be overridden from the commandline -->
+	<maven.compiler.failOnWarning>true</maven.compiler.failOnWarning>
 
         <maven.compiler.release>${java-version.main.release}</maven.compiler.release>
         <maven.compiler.testRelease>${java-version.test.release}</maven.compiler.testRelease>
@@ -1670,7 +1667,7 @@
                     <configuration>
                         <showWarnings>true</showWarnings>
                         <showDeprecation>true</showDeprecation>
-                        <failOnWarning>true</failOnWarning>
+                        <failOnWarning>${maven.compiler.failOnWarning}</failOnWarning>
                         <release>${maven.compiler.release}</release>
                         <testRelease>${maven.compiler.testRelease}</testRelease>
                         <encoding>UTF-8</encoding>
@@ -2339,20 +2336,8 @@
             </activation>
             <properties>
                 <surefire.jvm.args.java-version></surefire.jvm.args.java-version>
+		<maven.compiler.failOnWarning>false</maven.compiler.failOnWarning>
             </properties>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-compiler-plugin</artifactId>
-                            <configuration>
-                                <failOnWarning>false</failOnWarning>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
         </profile>
 
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -394,7 +394,7 @@
 
         <!-- Asciidoctor -->
 
-        <version.asciidoctor.plugin>2.2.1</version.asciidoctor.plugin>
+        <version.asciidoctor.plugin>2.2.2</version.asciidoctor.plugin>
         <version.org.hibernate.infra.hibernate-asciidoctor-theme>1.0.4.Final</version.org.hibernate.infra.hibernate-asciidoctor-theme>
         <version.org.jruby>9.3.2.0</version.org.jruby>
         <version.org.asciidoctor.asciidoctorj>2.5.3</version.org.asciidoctor.asciidoctorj>

--- a/pom.xml
+++ b/pom.xml
@@ -390,7 +390,7 @@
             check for regressions. Which is obviously good for us, too.
          -->
         <puppycrawl.checkstyle.version>8.41</puppycrawl.checkstyle.version>
-        <version.com.puppycrawl.tools.checkstyle>9.2.1</version.com.puppycrawl.tools.checkstyle>
+        <version.com.puppycrawl.tools.checkstyle>9.3</version.com.puppycrawl.tools.checkstyle>
 
         <!-- Asciidoctor -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@
         <version.jakarta.xml.bind>3.0.1</version.jakarta.xml.bind>
         <version.jakarta.activation>2.0.1</version.jakarta.activation>
         <version.org.jboss.spec.javax.interceptor.jboss-interceptor-api_1.2_spec>1.0.1.Final</version.org.jboss.spec.javax.interceptor.jboss-interceptor-api_1.2_spec>
-        <version.jakarta.interceptor-api>2.0.0</version.jakarta.interceptor-api>
+        <version.jakarta.interceptor-api>2.0.1</version.jakarta.interceptor-api>
         <!-- This is used to generate a link to the Java EE javadoc -->
         <javadoc.javaee.url>https://javaee.github.io/javaee-spec/javadocs/</javadoc.javaee.url>
         <javadoc.jakarta.batch.url>https://jakarta.ee/specifications/batch/2.0/apidocs/</javadoc.jakarta.batch.url>

--- a/pom.xml
+++ b/pom.xml
@@ -310,7 +310,7 @@
         <version.org.osgi.core>6.0.0</version.org.osgi.core>
 
         <version.org.hamcrest>2.2</version.org.hamcrest>
-        <version.org.mockito>4.2.0</version.org.mockito>
+        <version.org.mockito>4.3.1</version.org.mockito>
         <version.org.assertj.assertj-core>3.22.0</version.org.assertj.assertj-core>
         <version.org.awaitily>4.1.1</version.org.awaitily>
         <version.org.skyscreamer.jsonassert>1.5.0</version.org.skyscreamer.jsonassert>

--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
         <!-- Reactive-streams: used by the AWS SDK -->
         <version.org.reactivestreams.reactive-streams>1.0.3</version.org.reactivestreams.reactive-streams>
         <!-- slf4j: used by the AWS SDK -->
-        <version.org.slf4j>1.7.33</version.org.slf4j>
+        <version.org.slf4j>1.7.35</version.org.slf4j>
 
         <!-- >>> ORM -->
         <version.org.hibernate>5.6.5.Final</version.org.hibernate>

--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,7 @@
         <version.help.plugin>3.2.0</version.help.plugin>
         <version.install.plugin>2.5.2</version.install.plugin>
         <version.io.takari.maven>0.7.7</version.io.takari.maven>
-        <version.japicmp.plugin>0.15.4</version.japicmp.plugin>
+        <version.japicmp.plugin>0.15.6</version.japicmp.plugin>
         <version.jar.plugin>3.2.2</version.jar.plugin>
         <version.javadoc.plugin>3.3.1</version.javadoc.plugin>
         <version.jdeps.plugin>0.5.1</version.jdeps.plugin>


### PR DESCRIPTION
* [HSEARCH-4468](https://hibernate.atlassian.net/browse/HSEARCH-4468): Upgrade to slf4j 1.7.35
* [HSEARCH-4467](https://hibernate.atlassian.net/browse/HSEARCH-4467): Upgrade build dependencies to the latest version
* [HSEARCH-4465](https://hibernate.atlassian.net/browse/HSEARCH-4465): Upgrade -orm6 artifacts to Hibernate ORM 6.0.0.CR1 (**follow-up** on #2866)

