### PR TITLE
HSEARCH-4222 + HSEARCH-4469 Newer JDK testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -194,6 +194,8 @@ stage('Configure') {
 					new JdkBuildEnvironment(version: '17', testCompilerTool: 'OpenJDK 17 Latest',
 							condition: TestCondition.AFTER_MERGE),
 					new JdkBuildEnvironment(version: '18', testCompilerTool: 'OpenJDK 18 Latest',
+							condition: TestCondition.AFTER_MERGE),
+					new JdkBuildEnvironment(version: '19', testCompilerTool: 'OpenJDK 19 Latest',
 							condition: TestCondition.AFTER_MERGE)
 			],
 			compiler: [

--- a/pom.xml
+++ b/pom.xml
@@ -2359,8 +2359,6 @@
                 </property>
             </activation>
             <properties>
-                <!-- ForbiddenAPIs doesn't provide bundled signatures for JDK16 yet. -->
-                <forbiddenapis.skip>true</forbiddenapis.skip>
                 <!-- We need net.bytebuddy.experimental=true to make BytecodeEnhancementIT and mockito-based tests pass -->
                 <surefire.jvm.args.java-version>
                     -Djdk.attach.allowAttachSelf=true
@@ -2381,8 +2379,6 @@
                 </property>
             </activation>
             <properties>
-                <!-- ForbiddenAPIs doesn't provide bundled signatures for JDK17 yet. -->
-                <forbiddenapis.skip>true</forbiddenapis.skip>
                 <!-- We need net.bytebuddy.experimental=true to make BytecodeEnhancementIT and mockito-based tests pass -->
                 <surefire.jvm.args.java-version>
                     -Djdk.attach.allowAttachSelf=true

--- a/pom.xml
+++ b/pom.xml
@@ -2359,12 +2359,6 @@
                 </property>
             </activation>
             <properties>
-                <!-- We need net.bytebuddy.experimental=true to make BytecodeEnhancementIT and mockito-based tests pass -->
-                <surefire.jvm.args.java-version>
-                    -Djdk.attach.allowAttachSelf=true
-                    -Dnet.bytebuddy.experimental=true
-                    --illegal-access=deny
-                </surefire.jvm.args.java-version>
                 <!-- Spring isn't ready for JDK16 yet -->
                 <failsafe.spring.skip>true</failsafe.spring.skip>
             </properties>
@@ -2379,11 +2373,6 @@
                 </property>
             </activation>
             <properties>
-                <!-- We need net.bytebuddy.experimental=true to make BytecodeEnhancementIT and mockito-based tests pass -->
-                <surefire.jvm.args.java-version>
-                    -Djdk.attach.allowAttachSelf=true
-                    -Dnet.bytebuddy.experimental=true
-                </surefire.jvm.args.java-version>
                 <!-- Spring isn't ready for JDK17 yet -->
                 <failsafe.spring.skip>true</failsafe.spring.skip>
             </properties>
@@ -2400,11 +2389,6 @@
             <properties>
                 <!-- ForbiddenAPIs doesn't provide bundled signatures for JDK18 yet. -->
                 <forbiddenapis.skip>true</forbiddenapis.skip>
-                <!-- We need net.bytebuddy.experimental=true to make BytecodeEnhancementIT and mockito-based tests pass -->
-                <surefire.jvm.args.java-version>
-                    -Djdk.attach.allowAttachSelf=true
-                    -Dnet.bytebuddy.experimental=true
-                </surefire.jvm.args.java-version>
                 <!-- Spring isn't ready for JDK18 yet -->
                 <failsafe.spring.skip>true</failsafe.spring.skip>
             </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -2426,6 +2426,27 @@
         </profile>
 
         <profile>
+            <id>testWithJdk19</id>
+            <activation>
+                <property>
+                    <name>java-version.test.release</name>
+                    <value>19</value>
+                </property>
+            </activation>
+            <properties>
+                <!-- ForbiddenAPIs doesn't provide bundled signatures for JDK19 yet. -->
+                <forbiddenapis.skip>true</forbiddenapis.skip>
+                <!-- We need net.bytebuddy.experimental=true to make BytecodeEnhancementIT and mockito-based tests pass -->
+                <surefire.jvm.args.java-version>
+                    -Djdk.attach.allowAttachSelf=true
+                    -Dnet.bytebuddy.experimental=true
+                </surefire.jvm.args.java-version>
+                <!-- Spring isn't ready for JDK19 yet -->
+                <failsafe.spring.skip>true</failsafe.spring.skip>
+            </properties>
+        </profile>
+
+        <profile>
             <id>compiler-eclipse</id>
             <build>
                 <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2351,17 +2351,6 @@
         </profile>
 
         <profile>
-            <id>jdk16+</id>
-            <activation>
-                <jdk>[16,)</jdk>
-            </activation>
-            <properties>
-                <!-- ForbiddenAPIs doesn't provide bundled signatures for JDK16+ yet. -->
-                <forbiddenapis.skip>true</forbiddenapis.skip>
-            </properties>
-        </profile>
-
-        <profile>
             <id>testWithJdk16</id>
             <activation>
                 <property>


### PR DESCRIPTION
* [HSEARCH-4469](https://hibernate.atlassian.net/browse/HSEARCH-4469): Test Hibernate Search against OpenJDK 19
* [HSEARCH-4222](https://hibernate.atlassian.net/browse/HSEARCH-4222): Re-enable forbiddenapis on JDK16/JDK17+

