### PR TITLE
HSEARCH-4473 + HSEARCH-4474 Run tests against Elasticsearch 7.17

### DIFF
--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -550,6 +550,23 @@ public class ElasticsearchDialectFactoryTest {
 		);
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4473")
+	public void elastic_7_17() {
+		testSuccess(
+				ElasticsearchDistributionName.ELASTIC, "7.17", "7.17.0",
+				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4473")
+	public void elastic_7_17_0() {
+		testSuccess(
+				ElasticsearchDistributionName.ELASTIC, "7.17.0", "7.17.0",
+				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+		);
+	}
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3563")

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -580,7 +580,7 @@
             <properties>
                 <test.elasticsearch.run.elastic.skip>${test.elasticsearch.run.skip}</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.distribution>elastic</test.elasticsearch.connection.distribution>
-                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-7.16}</test.elasticsearch.connection.version>
+                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-7.17}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch712TestDialect</test.elasticsearch.testdialect>
             </properties>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -207,15 +207,16 @@
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-7.12) becomes the default. -->
-        <version.org.elasticsearch.compatible.main>${version.org.elasticsearch.latest-7.16}</version.org.elasticsearch.compatible.main>
+        <version.org.elasticsearch.compatible.main>${version.org.elasticsearch.latest-7.17}</version.org.elasticsearch.compatible.main>
         <documentation.org.elasticsearch.url>https://www.elastic.co/guide/en/elasticsearch/reference/${parsed-version.org.elasticsearch.compatible.main.majorVersion}.${parsed-version.org.elasticsearch.compatible.main.minorVersion}</documentation.org.elasticsearch.url>
         <!-- The versions of Elasticsearch/OpenSearch advertised as compatible with Hibernate Search -->
         <!-- Make sure that 7.10 stays explicitly mentioned here, because that's the last open-source version -->
-        <version.org.elasticsearch.compatible.regularly-tested.text>5.6, 6.8, 7.10 or 7.16</version.org.elasticsearch.compatible.regularly-tested.text>
+        <version.org.elasticsearch.compatible.regularly-tested.text>5.6, 6.8, 7.10 or 7.17</version.org.elasticsearch.compatible.regularly-tested.text>
         <version.org.opensearch.compatible.regularly-tested.text>1.0 or 1.2</version.org.opensearch.compatible.regularly-tested.text>
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
         <version.org.elasticsearch.compatible.not-regularly-tested.text>6.0 or 7.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest micro of each Elasticsearch branch -->
+        <version.org.elasticsearch.latest-7.17>7.17.0</version.org.elasticsearch.latest-7.17>
         <version.org.elasticsearch.latest-7.16>7.16.3</version.org.elasticsearch.latest-7.16>
         <!-- 7.14 and 7.15 have annoying bugs that make almost all of our test suite fail, so we don't test them
              See https://hibernate.atlassian.net/browse/HSEARCH-4340 -->

--- a/pom.xml
+++ b/pom.xml
@@ -202,8 +202,8 @@
 
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently from the version of the remote cluster -->
-        <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 7.16+ -->
-        <version.org.elasticsearch.client>7.16.3</version.org.elasticsearch.client>
+        <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 7.17+ -->
+        <version.org.elasticsearch.client>7.17.0</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-7.12) becomes the default. -->


### PR DESCRIPTION
* [HSEARCH-4474](https://hibernate.atlassian.net/browse/HSEARCH-4474): Upgrade to Elasticsearch client 7.17.0
* [HSEARCH-4473](https://hibernate.atlassian.net/browse/HSEARCH-4473): Run tests against Elasticsearch 7.17

Creating as draft, because I'd like to merge this in HSearch 6.2, and the `main` branch is still 6.1.x at the moment.