### PR TITLE
HSEARCH-4464 + HSEARCH-4470 Documentation improvements

### DIFF
--- a/documentation/src/main/asciidoc/reference/mapper-orm-mapping-indexedembedded.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapper-orm-mapping-indexedembedded.asciidoc
@@ -366,8 +366,7 @@ include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexedembedd
 
 Indexed-embedded fields can be structured in one of two ways,
 configured through the `structure` attribute of the `@IndexedEmbedded` annotation.
-To illustrate structure options, let's consider the following object tree,
-assuming the class `Book` is annotated with `@Indexed`
+To illustrate structure options, let's assume the class `Book` is annotated with `@Indexed`
 and its `authors` property is annotated with  `@IndexedEmbedded`:
 
 * Book instance
@@ -383,10 +382,26 @@ and its `authors` property is annotated with  `@IndexedEmbedded`:
 [[mapper-orm-indexedembedded-structure-flattened]]
 === [[mapper-orm-indexedembedded-storage-flattened]] `DEFAULT` or `FLATTENED` structure
 
-By default, indexed-embedded fields are "flattened",
+By default, or when using `@IndexedEmbedded(structure = FLATTENED)` as shown below,
+indexed-embedded fields are "flattened",
 meaning that the tree structure is not preserved.
 
-The book instance mentioned above would be indexed with a structure roughly similar to this:
+.`@IndexedEmbedded` with a flattened structure
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/flattened/Book.java[tags=include;!getters-setters]
+----
+<1> Explicitly set the structure of indexed-embedded to `FLATTENED`.
+This is not strictly necessary, since `FLATTENED` is the default.
+
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/flattened/Author.java[tags=include;!getters-setters]
+----
+====
+
+The book instance mentioned earlier would be indexed with a structure roughly similar to this:
 
  * Book document
  ** title = Leviathan Wakes
@@ -400,18 +415,44 @@ the knowledge of which last name corresponds to which first name has been lost.
 This is more efficient for indexing and querying,
 but can cause unexpected behavior when querying the index
 on both the author's first name and the author's last name.
-The book given in example
-would show up as a match to a query such as `authors.firstname:Ty AND authors.lastname:Abraham`,
-even though "Ty Abraham" is not one of this book's authors.
+
+For example, the book instance described above
+*would* show up as a match to a query such as `authors.firstname:Ty AND authors.lastname:Abraham`,
+even though "Ty Abraham" is not one of this book's authors:
+
+.Searching with a flattened structure
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/flattened/IndexedEmbeddedStructureFlattenedIT.java[tags=include]
+----
+<1> Require that hits have an author with the first name `Ty` and an author with the last name `Abraham`...
+but not necessarily the same author!
+<2> The hits will include a book whose authors are "Ty Daniel" and "Frank Abraham".
+====
 
 [[mapper-orm-indexedembedded-structure-nested]]
 === [[mapper-orm-indexedembedded-storage-nested]] `NESTED` structure
 
-When indexed-embedded elements are "nested",
+When indexed-embedded elements are "nested", i.e. when using `@IndexedEmbedded(structure = NESTED)` as shown below,
 the tree structure is preserved by transparently creating one separate "nested" document
 for each indexed-embedded element.
 
-The book instance mentioned above would be indexed with a structure roughly similar to this:
+.`@IndexedEmbedded` with a nested structure
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/nested/Book.java[tags=include;!getters-setters]
+----
+<1> Explicitly set the structure of indexed-embedded objects to `NESTED`.
+
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/nested/Author.java[tags=include;!getters-setters]
+----
+====
+
+The book instance mentioned earlier would be indexed with a structure roughly similar to this:
 
  * Book document
  ** title = Leviathan Wakes
@@ -435,9 +476,21 @@ If special care is taken when building predicates on fields within nested docume
 using a <<search-dsl-predicate-nested,`nested` predicate>>,
 queries containing predicates on both the author's first name and the author's last name
 will behave as one would (intuitively) expect.
-The book given in example
+
+For example, the book instance described above
 would *not* show up as a match to a query such as `authors.firstname:Ty AND authors.lastname:Abraham`,
-as long as a `nested` predicate is used.
+thanks to the `nested` predicate (which can only be used when indexing with the `NESTED` structure):
+
+.Searching with a nested structure
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/nested/IndexedEmbeddedStructureNestedIT.java[tags=include]
+----
+<1> Require that the two constraints (first name and last name) apply to the *same* author.
+<2> Require that hits have an author with the first name `Ty` and an author with the last name `Abraham`.
+<3> The hits will *not* include a book whose authors are "Ty Daniel" and "Frank Abraham".
+====
 
 [[mapper-orm-indexedembedded-programmatic]]
 == Programmatic mapping

--- a/documentation/src/main/asciidoc/reference/search-dsl-projection.asciidoc
+++ b/documentation/src/main/asciidoc/reference/search-dsl-projection.asciidoc
@@ -363,9 +363,14 @@ include::{sourcedir}/org/hibernate/search/documentation/search/projection/Lucene
 
 [NOTE]
 ====
-The returned document is not _exactly_ the one that was indexed.
+The returned document is similar to the one that was indexed.
 
-In particular:
+For example, if a value was transformed by the `toIndexedValue` method
+of a <<mapper-orm-bridge-valuebridge,value bridge>> upon indexing,
+this transformed value (after encoding) will be the value included in the document:
+Hibernate Search will not convert it back using `ValueBridge#fromIndexedValue`.
+
+However, there are some differences between the returned document and the one that was indexed:
 
 * Only stored fields are present.
 * Even stored fields may not have the same `FieldType` as they originally had.
@@ -373,6 +378,14 @@ In particular:
 i.e. even fields from <<mapper-orm-indexedembedded-structure-nested,nested documents>>
 are all added to same returned document.
 * <<mapper-orm-bridge-index-field-dsl-dynamic,Dynamic fields>> may be missing.
+
+If you want a projection that retrieves the value as it was in your entity upon indexing,
+use a <<search-dsl-projection-field,`field` projection>>.
+====
+
+
+[NOTE]
+====
 ====
 
 [[search-dsl-projection-extensions-lucene-explanation]]
@@ -407,6 +420,21 @@ include::components/elasticsearch-json-warning.asciidoc[]
 ----
 include::{sourcedir}/org/hibernate/search/documentation/search/projection/ElasticsearchProjectionDslIT.java[tags=elasticsearch-source]
 ----
+====
+
+[NOTE]
+====
+The source is returned exactly as it appears in the response from Elasticsearch.
+In particular, Hibernate Search will not apply any kind of the conversions
+described in <<search-dsl-projected-value-type>>.
+
+For example, if a value was transformed by the `toIndexedValue` method
+of a <<mapper-orm-bridge-valuebridge,value bridge>> upon indexing,
+this transformed value will be the value included in the source:
+Hibernate Search will not convert it back using `ValueBridge#fromIndexedValue`.
+
+If you want a projection that retrieves the value as it was in your entity upon indexing,
+use a <<search-dsl-projection-field,`field` projection>>.
 ====
 
 [[search-dsl-projection-extensions-elasticsearch-explanation]]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/flattened/Author.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/flattened/Author.java
@@ -1,0 +1,73 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.mapper.orm.indexedembedded.structure.flattened;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+
+// tag::include[]
+@Entity
+public class Author {
+
+	@Id
+	private Integer id;
+
+	@FullTextField(analyzer = "name")
+	private String firstName;
+
+	@FullTextField(analyzer = "name")
+	private String lastName;
+
+	@ManyToMany(mappedBy = "authors")
+	private List<Book> books = new ArrayList<>();
+
+	public Author() {
+	}
+
+	// Getters and setters
+	// ...
+
+	// tag::getters-setters[]
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getFirstName() {
+		return firstName;
+	}
+
+	public void setFirstName(String firstName) {
+		this.firstName = firstName;
+	}
+
+	public String getLastName() {
+		return lastName;
+	}
+
+	public void setLastName(String lastName) {
+		this.lastName = lastName;
+	}
+
+	public List<Book> getBooks() {
+		return books;
+	}
+
+	public void setBooks(List<Book> books) {
+		this.books = books;
+	}
+	// end::getters-setters[]
+}
+// end::include[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/flattened/Book.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/flattened/Book.java
@@ -1,0 +1,67 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.mapper.orm.indexedembedded.structure.flattened;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+
+import org.hibernate.search.engine.backend.types.ObjectStructure;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+
+// tag::include[]
+@Entity
+@Indexed
+public class Book {
+
+	@Id
+	private Integer id;
+
+	@FullTextField(analyzer = "english")
+	private String title;
+
+	@ManyToMany
+	@IndexedEmbedded(structure = ObjectStructure.FLATTENED) // <1>
+	private List<Author> authors = new ArrayList<>();
+
+	public Book() {
+	}
+
+	// Getters and setters
+	// ...
+
+	// tag::getters-setters[]
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public List<Author> getAuthors() {
+		return authors;
+	}
+
+	public void setAuthors(List<Author> authors) {
+		this.authors = authors;
+	}
+	// end::getters-setters[]
+}
+// end::include[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/flattened/IndexedEmbeddedStructureFlattenedIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/flattened/IndexedEmbeddedStructureFlattenedIT.java
@@ -1,0 +1,102 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.mapper.orm.indexedembedded.structure.flattened;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import javax.persistence.EntityManagerFactory;
+
+import org.hibernate.search.documentation.testsupport.BackendConfigurations;
+import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
+import org.hibernate.search.engine.backend.types.ObjectStructure;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class IndexedEmbeddedStructureFlattenedIT {
+
+	@Parameterized.Parameters(name = "{0}")
+	public static List<?> params() {
+		return DocumentationSetupHelper.testParamsForBothAnnotationsAndProgrammatic(
+				BackendConfigurations.simple(),
+				mapping -> {
+					TypeMappingStep bookMapping = mapping.type( Book.class );
+					bookMapping.indexed();
+					bookMapping.property( "title" )
+							.fullTextField().analyzer( "english" );
+					bookMapping.property( "authors" )
+							.indexedEmbedded().structure( ObjectStructure.FLATTENED );
+					TypeMappingStep authorMapping = mapping.type( Author.class );
+					authorMapping.property( "firstName" )
+							.fullTextField().analyzer( "name" );
+					authorMapping.property( "lastName" )
+							.fullTextField().analyzer( "name" );
+				} );
+	}
+
+	@Parameterized.Parameter
+	@Rule
+	public DocumentationSetupHelper setupHelper;
+
+	private EntityManagerFactory entityManagerFactory;
+
+	@Before
+	public void setup() {
+		entityManagerFactory = setupHelper.start().setup( Book.class, Author.class );
+	}
+
+	@Test
+	public void smoke() {
+		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+			Book book = new Book();
+			book.setId( 1 );
+			book.setTitle( "Leviathan Wakes" );
+
+			Author author1 = new Author();
+			author1.setId( 1 );
+			author1.setFirstName( "Daniel" );
+			author1.setLastName( "Abraham" );
+			book.getAuthors().add( author1 );
+			author1.getBooks().add( book );
+
+			Author author2 = new Author();
+			author2.setId( 2 );
+			author2.setFirstName( "Ty" );
+			author2.setLastName( "Frank" );
+			book.getAuthors().add( author2 );
+			author2.getBooks().add( book );
+
+			entityManager.persist( author1 );
+			entityManager.persist( author2 );
+			entityManager.persist( book );
+		} );
+
+		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+			SearchSession searchSession = Search.session( entityManager );
+
+			// tag::include[]
+			List<Book> hits = searchSession.search( Book.class )
+					.where( f -> f.bool()
+							.must( f.match().field( "authors.firstName" ).matching( "Ty" ) ) // <1>
+							.must( f.match().field( "authors.lastName" ).matching( "Abraham" ) ) ) // <1>
+					.fetchHits( 20 );
+
+			assertThat( hits ).isNotEmpty(); // <2>
+			// end::include[]
+		} );
+	}
+
+}

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/nested/Author.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/nested/Author.java
@@ -1,0 +1,73 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.mapper.orm.indexedembedded.structure.nested;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+
+// tag::include[]
+@Entity
+public class Author {
+
+	@Id
+	private Integer id;
+
+	@FullTextField(analyzer = "name")
+	private String firstName;
+
+	@FullTextField(analyzer = "name")
+	private String lastName;
+
+	@ManyToMany(mappedBy = "authors")
+	private List<Book> books = new ArrayList<>();
+
+	public Author() {
+	}
+
+	// Getters and setters
+	// ...
+
+	// tag::getters-setters[]
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getFirstName() {
+		return firstName;
+	}
+
+	public void setFirstName(String firstName) {
+		this.firstName = firstName;
+	}
+
+	public String getLastName() {
+		return lastName;
+	}
+
+	public void setLastName(String lastName) {
+		this.lastName = lastName;
+	}
+
+	public List<Book> getBooks() {
+		return books;
+	}
+
+	public void setBooks(List<Book> books) {
+		this.books = books;
+	}
+	// end::getters-setters[]
+}
+// end::include[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/nested/Book.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/nested/Book.java
@@ -1,0 +1,67 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.mapper.orm.indexedembedded.structure.nested;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+
+import org.hibernate.search.engine.backend.types.ObjectStructure;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+
+// tag::include[]
+@Entity
+@Indexed
+public class Book {
+
+	@Id
+	private Integer id;
+
+	@FullTextField(analyzer = "english")
+	private String title;
+
+	@ManyToMany
+	@IndexedEmbedded(structure = ObjectStructure.NESTED) // <1>
+	private List<Author> authors = new ArrayList<>();
+
+	public Book() {
+	}
+
+	// Getters and setters
+	// ...
+
+	// tag::getters-setters[]
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public List<Author> getAuthors() {
+		return authors;
+	}
+
+	public void setAuthors(List<Author> authors) {
+		this.authors = authors;
+	}
+	// end::getters-setters[]
+}
+// end::include[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/nested/IndexedEmbeddedStructureNestedIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/nested/IndexedEmbeddedStructureNestedIT.java
@@ -1,0 +1,102 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.mapper.orm.indexedembedded.structure.nested;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import javax.persistence.EntityManagerFactory;
+
+import org.hibernate.search.documentation.testsupport.BackendConfigurations;
+import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
+import org.hibernate.search.engine.backend.types.ObjectStructure;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class IndexedEmbeddedStructureNestedIT {
+
+	@Parameterized.Parameters(name = "{0}")
+	public static List<?> params() {
+		return DocumentationSetupHelper.testParamsForBothAnnotationsAndProgrammatic(
+				BackendConfigurations.simple(),
+				mapping -> {
+					TypeMappingStep bookMapping = mapping.type( Book.class );
+					bookMapping.indexed();
+					bookMapping.property( "title" )
+							.fullTextField().analyzer( "english" );
+					bookMapping.property( "authors" )
+							.indexedEmbedded().structure( ObjectStructure.NESTED );
+					TypeMappingStep authorMapping = mapping.type( Author.class );
+					authorMapping.property( "firstName" )
+							.fullTextField().analyzer( "name" );
+					authorMapping.property( "lastName" )
+							.fullTextField().analyzer( "name" );
+				} );
+	}
+
+	@Parameterized.Parameter
+	@Rule
+	public DocumentationSetupHelper setupHelper;
+
+	private EntityManagerFactory entityManagerFactory;
+
+	@Before
+	public void setup() {
+		entityManagerFactory = setupHelper.start().setup( Book.class, Author.class );
+	}
+
+	@Test
+	public void smoke() {
+		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+			Book book = new Book();
+			book.setId( 1 );
+			book.setTitle( "Leviathan Wakes" );
+
+			Author author1 = new Author();
+			author1.setId( 1 );
+			author1.setFirstName( "Daniel" );
+			author1.setLastName( "Abraham" );
+			book.getAuthors().add( author1 );
+			author1.getBooks().add( book );
+
+			Author author2 = new Author();
+			author2.setId( 2 );
+			author2.setFirstName( "Ty" );
+			author2.setLastName( "Frank" );
+			book.getAuthors().add( author2 );
+			author2.getBooks().add( book );
+
+			entityManager.persist( author1 );
+			entityManager.persist( author2 );
+			entityManager.persist( book );
+		} );
+
+		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+			SearchSession searchSession = Search.session( entityManager );
+
+			// tag::include[]
+			List<Book> hits = searchSession.search( Book.class )
+					.where( f -> f.nested().objectField( "authors" ).nest( f.bool() // <1>
+							.must( f.match().field( "authors.firstName" ).matching( "Ty" ) ) // <2>
+							.must( f.match().field( "authors.lastName" ).matching( "Abraham" ) ) ) ) // <2>
+					.fetchHits( 20 );
+
+			assertThat( hits ).isEmpty(); // <3>
+			// end::include[]
+		} );
+	}
+
+}


### PR DESCRIPTION
* [HSEARCH-4470](https://hibernate.atlassian.net/browse/HSEARCH-4470): Add mapping code examples to the documentation of @IndexedEmbedded.structure
* [HSEARCH-4464](https://hibernate.atlassian.net/browse/HSEARCH-4464): Document that custom bridges or projection converters are not applied to fields for source()/document() projections

