### PR TITLE
Backport HSEARCH-3244 + HSEARCH-4415 + HSEARCH-4472 to branch 5.11 - Jenkinsfile improvements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -541,9 +541,15 @@ stage('Deploy') {
 		runBuildOnNode {
 			helper.withMavenWorkspace(mavenSettingsConfig: params.RELEASE_DRY_RUN ? null : helper.configuration.file.deployment.maven.settingsId) {
 				configFileProvider([configFile(fileId: 'release.config.ssh', targetLocation: env.HOME + '/.ssh/config')]) {
-					sshagent(['ed25519.Hibernate-CI.github.com', 'hibernate.filemgmt.jboss.org', 'hibernate-ci.frs.sourceforge.net']) {
+				withCredentials([file(credentialsId: 'release.gpg.private-key', variable: 'RELEASE_GPG_PRIVATE_KEY_PATH'),
+						string(credentialsId: 'release.gpg.passphrase', variable: 'RELEASE_GPG_PASSPHRASE')]) {
+				sshagent(['ed25519.Hibernate-CI.github.com', 'hibernate.filemgmt.jboss.org', 'hibernate-ci.frs.sourceforge.net']) {
+					try {
 						sh 'cat $HOME/.ssh/config'
 						sh "git clone https://github.com/hibernate/hibernate-noorm-release-scripts.git"
+
+						env.RELEASE_GPG_HOMEDIR = env.WORKSPACE_TMP + '/.gpg'
+						sh "bash -xe hibernate-noorm-release-scripts/setup.sh"
 						sh "bash -xe hibernate-noorm-release-scripts/prepare-release.sh search ${releaseVersion.toString()}"
 
 						String deployCommand = "bash -xe hibernate-noorm-release-scripts/deploy.sh search"
@@ -569,6 +575,16 @@ stage('Deploy') {
 						sh "bash -xe hibernate-noorm-release-scripts/update-version.sh search ${afterReleaseDevelopmentVersion.toString()}"
 						sh "bash -xe hibernate-noorm-release-scripts/push-upstream.sh search ${releaseVersion.toString()} ${helper.scmSource.branch.name} ${!params.RELEASE_DRY_RUN}"
 					}
+					finally {
+						try {
+							sh "bash -xe hibernate-noorm-release-scripts/cleanup.sh"
+						}
+						catch (Throwable t) {
+							echo 'Error cleaning up after release: ' + t.toString()
+						}
+					}
+				}
+				}
 				}
 			}
 		}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -568,7 +568,7 @@ class EsAwsBuildEnvironment extends BuildEnvironment {
 		null // No JDK needed for Elasticsearch: the Elasticsearch instance is remote.
 	}
 	String getNameEmbeddableVersion() {
-		version.replaceAll('\\.', '')
+		version.replaceAll('\\.', '-')
 	}
 	String getLockedResourcesLabel() {
 		"es-aws-${nameEmbeddableVersion}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -544,45 +544,9 @@ stage('Deploy') {
 				withCredentials([file(credentialsId: 'release.gpg.private-key', variable: 'RELEASE_GPG_PRIVATE_KEY_PATH'),
 						string(credentialsId: 'release.gpg.passphrase', variable: 'RELEASE_GPG_PASSPHRASE')]) {
 				sshagent(['ed25519.Hibernate-CI.github.com', 'hibernate.filemgmt.jboss.org', 'hibernate-ci.frs.sourceforge.net']) {
-					try {
-						sh 'cat $HOME/.ssh/config'
-						sh "git clone https://github.com/hibernate/hibernate-noorm-release-scripts.git"
-
-						env.RELEASE_GPG_HOMEDIR = env.WORKSPACE_TMP + '/.gpg'
-						sh "bash -xe hibernate-noorm-release-scripts/setup.sh"
-						sh "bash -xe hibernate-noorm-release-scripts/prepare-release.sh search ${releaseVersion.toString()}"
-
-						String deployCommand = "bash -xe hibernate-noorm-release-scripts/deploy.sh search"
-						if (!params.RELEASE_DRY_RUN) {
-							sh deployCommand
-						} else {
-							echo "WARNING: Not deploying. Would have executed:"
-							echo deployCommand
-						}
-
-						String uploadDistributionCommand = "bash -xe hibernate-noorm-release-scripts/upload-distribution.sh search ${releaseVersion.toString()}"
-						String uploadDocumentationCommand = "bash -xe hibernate-noorm-release-scripts/upload-documentation.sh search ${releaseVersion.toString()} ${releaseVersion.family}"
-						if (!params.RELEASE_DRY_RUN) {
-							sh uploadDistributionCommand
-							sh uploadDocumentationCommand
-						}
-						else {
-							echo "WARNING: Not uploading anything. Would have executed:"
-							echo uploadDistributionCommand
-							echo uploadDocumentationCommand
-						}
-
-						sh "bash -xe hibernate-noorm-release-scripts/update-version.sh search ${afterReleaseDevelopmentVersion.toString()}"
-						sh "bash -xe hibernate-noorm-release-scripts/push-upstream.sh search ${releaseVersion.toString()} ${helper.scmSource.branch.name} ${!params.RELEASE_DRY_RUN}"
-					}
-					finally {
-						try {
-							sh "bash -xe hibernate-noorm-release-scripts/cleanup.sh"
-						}
-						catch (Throwable t) {
-							echo 'Error cleaning up after release: ' + t.toString()
-						}
-					}
+					sh 'cat $HOME/.ssh/config'
+					sh "git clone https://github.com/hibernate/hibernate-noorm-release-scripts.git"
+					sh "bash -xe hibernate-noorm-release-scripts/release.sh ${params.RELEASE_DRY_RUN ? '-d' : ''} search ${releaseVersion.toString()} ${afterReleaseDevelopmentVersion.toString()}"
 				}
 				}
 				}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -230,6 +230,7 @@ stage('Configure') {
 			buildDiscarder(
 					logRotator(daysToKeepStr: '90')
 			),
+			disableConcurrentBuilds(abortPrevious: true),
 			pipelineTriggers(
 					// HSEARCH-3417: do not add snapshotDependencies() here, this was known to cause problems.
 					[

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -546,6 +546,7 @@ stage('Deploy') {
 				sshagent(['ed25519.Hibernate-CI.github.com', 'hibernate.filemgmt.jboss.org', 'hibernate-ci.frs.sourceforge.net']) {
 					sh 'cat $HOME/.ssh/config'
 					sh "git clone https://github.com/hibernate/hibernate-noorm-release-scripts.git"
+					env.RELEASE_GPG_HOMEDIR = env.WORKSPACE_TMP + '/.gpg'
 					sh "bash -xe hibernate-noorm-release-scripts/release.sh ${params.RELEASE_DRY_RUN ? '-d' : ''} search ${releaseVersion.toString()} ${afterReleaseDevelopmentVersion.toString()}"
 				}
 				}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,13 +56,12 @@ import org.hibernate.jenkins.pipeline.helpers.version.Version
  *
  * #### Nexus deployment
  *
- * This job includes two deployment modes:
- *
- * - A deployment of snapshot artifacts for every non-PR build on "primary" branches (main and maintenance branches).
- * - A full release when starting the job with specific parameters.
- *
- * In the first case, the name of a Maven settings file must be provided in the job configuration file
+ * This job is only able to deploy snapshot artifacts,
+ * for every non-PR build on "primary" branches (main and maintenance branches),
+ * but the name of a Maven settings file must be provided in the job configuration file
  * (see below).
+ *
+ * For actual releases, see jenkins/release.groovy.
  *
  * #### AWS
  *
@@ -130,8 +129,7 @@ import org.hibernate.jenkins.pipeline.helpers.version.Version
  *     deployment:
  *       maven:
  *         # String containing the ID of a Maven settings file registered using the config-file-provider Jenkins plugin.
- *         # The settings must provide credentials to the servers with ID
- *         # 'jboss-releases-repository' and 'jboss-snapshots-repository'.
+ *         # The settings must provide credentials to the server with ID 'ossrh'.
  *         settingsId: ...
  */
 
@@ -149,11 +147,7 @@ import org.hibernate.jenkins.pipeline.helpers.version.Version
 
 @Field boolean enableDefaultBuild = false
 @Field boolean enableDefaultBuildIT = false
-@Field boolean performRelease = false
 @Field boolean deploySnapshot = false
-
-@Field Version releaseVersion
-@Field Version afterReleaseDevelopmentVersion
 
 this.helper = new JobHelper(this)
 
@@ -252,7 +246,7 @@ DEFAULT
 SUPPORTED
 ALL""",
 							description: """A set of environments that must be checked.
-'AUTOMATIC' picks a different set of environments based on the branch name and whether a release is being performed.
+'AUTOMATIC' picks a different set of environments based on the branch name.
 'DEFAULT' means a single build with the default environment expected by the Maven configuration,
 while other options will trigger multiple Maven executions in different environments."""
 					),
@@ -264,30 +258,11 @@ while other options will trigger multiple Maven executions in different environm
 If this parameter is non-empty, ENVIRONMENT_SET will be ignored and environments whose tag matches the given regex will be checked.
 Some useful filters: 'default', 'jdk', 'jdk-10', 'eclipse', 'postgresql', 'elasticsearch-local-[5.6'.
 """
-					),
-					string(
-							name: 'RELEASE_VERSION',
-							defaultValue: '',
-							description: 'The version to be released, e.g. 5.10.0.Final. Setting this triggers a release.',
-							trim: true
-					),
-					string(
-							name: 'RELEASE_DEVELOPMENT_VERSION',
-							defaultValue: '',
-							description: 'The next version to be used after the release, e.g. 5.10.0-SNAPSHOT.',
-							trim: true
-					),
-					booleanParam(
-							name: 'RELEASE_DRY_RUN',
-							defaultValue: false,
-							description: 'If true, just simulate the release, without pushing any commits or tags, and without uploading any artifacts or documentation.'
 					)
 			])
 	])
 
-	performRelease = (params.RELEASE_VERSION ? true : false)
-
-	if (!performRelease && helper.scmSource.branch.primary && !helper.scmSource.pullRequest) {
+	if (helper.scmSource.branch.primary && !helper.scmSource.pullRequest) {
 		if (helper.configuration.file?.deployment?.maven?.settingsId) {
 			deploySnapshot = true
 		}
@@ -340,32 +315,8 @@ Resulting execution plan:
     enableDefaultBuild=$enableDefaultBuild
     enableDefaultBuildIT=$enableDefaultBuildIT
     environments=${environments.enabledAsString}
-    performRelease=$performRelease
     deploySnapshot=$deploySnapshot
 """
-
-	if (performRelease) {
-		releaseVersion = Version.parseReleaseVersion(params.RELEASE_VERSION)
-		echo "Inferred version family for the release to '$releaseVersion.family'"
-
-		// Check that all the necessary parameters are set
-		if (!params.RELEASE_DEVELOPMENT_VERSION) {
-			throw new IllegalArgumentException(
-					"Missing value for parameter RELEASE_DEVELOPMENT_VERSION." +
-							" This parameter must be set when RELEASE_VERSION is set."
-			)
-		}
-		if (!params.RELEASE_DRY_RUN && !helper.configuration.file?.deployment?.maven?.settingsId) {
-			throw new IllegalArgumentException(
-					"Missing deployment configuration in job configuration file." +
-							" Cannot deploy artifacts during the release."
-			)
-		}
-	}
-
-	if (params.RELEASE_DEVELOPMENT_VERSION) {
-		afterReleaseDevelopmentVersion = Version.parseDevelopmentVersion(params.RELEASE_DEVELOPMENT_VERSION)
-	}
 }
 
 stage('Default build') {
@@ -536,24 +487,6 @@ stage('Deploy') {
 			}
 		}
 	}
-	else if (performRelease) {
-		echo "Performing full release for version ${releaseVersion.toString()}"
-		runBuildOnNode {
-			helper.withMavenWorkspace(mavenSettingsConfig: params.RELEASE_DRY_RUN ? null : helper.configuration.file.deployment.maven.settingsId) {
-				configFileProvider([configFile(fileId: 'release.config.ssh', targetLocation: env.HOME + '/.ssh/config')]) {
-				withCredentials([file(credentialsId: 'release.gpg.private-key', variable: 'RELEASE_GPG_PRIVATE_KEY_PATH'),
-						string(credentialsId: 'release.gpg.passphrase', variable: 'RELEASE_GPG_PASSPHRASE')]) {
-				sshagent(['ed25519.Hibernate-CI.github.com', 'hibernate.filemgmt.jboss.org', 'hibernate-ci.frs.sourceforge.net']) {
-					sh 'cat $HOME/.ssh/config'
-					sh "git clone https://github.com/hibernate/hibernate-noorm-release-scripts.git"
-					env.RELEASE_GPG_HOMEDIR = env.WORKSPACE_TMP + '/.gpg'
-					sh "bash -xe hibernate-noorm-release-scripts/release.sh ${params.RELEASE_DRY_RUN ? '-d' : ''} search ${releaseVersion.toString()} ${afterReleaseDevelopmentVersion.toString()}"
-				}
-				}
-				}
-			}
-		}
-	}
 	else {
 		echo "Skipping deployment"
 		helper.markStageSkipped()
@@ -696,9 +629,7 @@ void keepOnlyEnvironmentsFromSet(String environmentSetName) {
 			enableOptional = true
 			break
 		case 'AUTOMATIC':
-			if (params.RELEASE_VERSION) {
-				echo "Releasing version '$params.RELEASE_VERSION'."
-			} else if (helper.scmSource.pullRequest) {
+			if (helper.scmSource.pullRequest) {
 				echo "Building pull request '$helper.scmSource.pullRequest.id'"
 				enableDefaultEnv = true
 				enableBeforeMergeEnvs = true

--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -18,6 +18,12 @@
     <description>Configuration for the build of Hibernate Search</description>
 
     <properties>
+        <!-- Skip artifact deployment -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+        <!-- Skip javadoc generation -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+
         <!--
             This module generates the rules used in the Checkstyle and ForbiddenAPIs plugins,
             so obviously we cannot use those rules while building this module.
@@ -25,23 +31,6 @@
         <checkstyle.skip>true</checkstyle.skip>
         <forbiddenapis.skip>true</forbiddenapis.skip>
     </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 
     <dependencies>
         <dependency>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -24,6 +24,7 @@
     <properties>
         <!-- Skip artifact deployment -->
         <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
     </properties>
 
     <dependencies>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -22,6 +22,12 @@
     <description>The Hibernate Search reference manual</description>
 
     <properties>
+        <!-- Skip artifact deployment -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+        <!-- Skip javadoc generation -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+
         <asciidoctor.base-output-dir>${project.build.directory}/asciidoctor/en-US</asciidoctor.base-output-dir>
         <asciidoctor.theme-dir>${project.build.directory}/hibernate-asciidoctor-theme</asciidoctor.theme-dir>
         <asciidoctor.aggregated-resources-dir>${project.build.directory}/aggregated-resources</asciidoctor.aggregated-resources-dir>
@@ -33,11 +39,6 @@
         <html.google-analytics.tag-manager.id>GTM-NJWS5L</html.google-analytics.tag-manager.id>
         <html.google-analytics.tag-manager.channel>Hibernate</html.google-analytics.tag-manager.channel>
         <html.outdated-content.project-key>${html.meta.project-key}</html.outdated-content.project-key>
-
-        <!-- Skip artifact deployment -->
-        <maven.deploy.skip>true</maven.deploy.skip>
-        <!-- Skip javadoc generation -->
-        <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
 
     <build>

--- a/integrationtest/elasticsearch/pom.xml
+++ b/integrationtest/elasticsearch/pom.xml
@@ -22,6 +22,12 @@
     <description>Hibernate Search integration tests with Elasticsearch</description>
 
     <properties>
+        <!-- Skip artifact deployment -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+        <!-- Skip javadoc generation -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+
         <test.elasticsearch.failsafe.excludedGroups.version></test.elasticsearch.failsafe.excludedGroups.version>
         <!--
              By default, the following property skips AWS-related tests;
@@ -202,19 +208,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/integrationtest/jdk9-modules/pom.xml
+++ b/integrationtest/jdk9-modules/pom.xml
@@ -23,6 +23,14 @@
     <name>Hibernate Search JDK9 Modules Integration Tests</name>
     <description>Hibernate Search integration tests for JDK9 modules</description>
 
+    <properties>
+        <!-- Skip artifact deployment -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+        <!-- Skip javadoc generation -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -90,21 +98,6 @@
                     <target>9</target>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>true</showDeprecation>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
                 </configuration>
             </plugin>
 

--- a/integrationtest/jms/pom.xml
+++ b/integrationtest/jms/pom.xml
@@ -21,6 +21,14 @@
     <name>Hibernate Search JMS Integration Tests</name>
     <description>Hibernate Search integration tests for JMS indexing backend</description>
 
+    <properties>
+        <!-- Skip artifact deployment -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+        <!-- Skip javadoc generation -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.hibernate</groupId>
@@ -101,19 +109,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/integrationtest/jsr352/pom.xml
+++ b/integrationtest/jsr352/pom.xml
@@ -22,6 +22,11 @@
     <description>Hibernate Search integration tests for JSR-352</description>
 
     <properties>
+        <!-- Skip artifact deployment -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+        <!-- Skip javadoc generation -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
 
     <dependencies>
@@ -145,19 +150,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/integrationtest/narayana/pom.xml
+++ b/integrationtest/narayana/pom.xml
@@ -21,6 +21,14 @@
     <name>Hibernate Search Narayana Integration Tests</name>
     <description>Hibernate Search integration tests for Narayana</description>
 
+    <properties>
+        <!-- Skip artifact deployment -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+        <!-- Skip javadoc generation -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+    </properties>
+
     <dependencies>
         <!-- JBoss TS -->
         <dependency>
@@ -63,19 +71,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/integrationtest/osgi/karaf-features/pom.xml
+++ b/integrationtest/osgi/karaf-features/pom.xml
@@ -22,6 +22,14 @@
     <name>Hibernate Search Karaf Features Definition</name>
     <description>Hibernate Search Apache Karaf features</description>
 
+    <properties>
+        <!-- Skip artifact deployment -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+        <!-- Skip javadoc generation -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -73,21 +81,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/integrationtest/osgi/karaf-it/pom.xml
+++ b/integrationtest/osgi/karaf-it/pom.xml
@@ -23,6 +23,12 @@
     <description>Hibernate Search integration tests for OSGi using Apache Karaf</description>
 
     <properties>
+        <!-- Skip artifact deployment -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+        <!-- Skip javadoc generation -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+
         <enforcer.dependencyconvergence.skip>true</enforcer.dependencyconvergence.skip>
 
         <osgi.package.exports>!*</osgi.package.exports>
@@ -202,21 +208,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/integrationtest/performance/engine-elasticsearch/pom.xml
+++ b/integrationtest/performance/engine-elasticsearch/pom.xml
@@ -18,6 +18,14 @@
     <artifactId>hibernate-search-performance-engine-elasticsearch</artifactId>
     <name>Hibernate Search Engine-Elasticsearch Performance Testing</name>
     <description>Performance testing for the Hibernate Search engine module with an Elasticsearch backend</description>
+
+    <properties>
+        <!-- Skip artifact deployment -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+        <!-- Skip javadoc generation -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+    </properties>
  
     <dependencies>
         <dependency>

--- a/integrationtest/performance/engine-lucene/pom.xml
+++ b/integrationtest/performance/engine-lucene/pom.xml
@@ -18,6 +18,14 @@
     <artifactId>hibernate-search-performance-engine-lucene</artifactId>
     <name>Hibernate Search Engine-Lucene Performance Testing</name>
     <description>Performance testing for the Hibernate Search engine module with an embedded Lucene backend</description>
+
+    <properties>
+        <!-- Skip artifact deployment -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+        <!-- Skip javadoc generation -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+    </properties>
  
     <dependencies>
         <dependency>
@@ -74,19 +82,6 @@
                          </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.bsc.maven</groupId>

--- a/integrationtest/performance/orm/pom.xml
+++ b/integrationtest/performance/orm/pom.xml
@@ -21,6 +21,12 @@
     <description>Hibernate Search ORM Performance Tests</description>
 
     <properties>
+        <!-- Skip artifact deployment -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+        <!-- Skip javadoc generation -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+
         <!--
         Disable the dependency convergence rule, because the dependencies of WildFly feature packs do not converge
         -->
@@ -216,19 +222,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.wildfly.build</groupId>

--- a/integrationtest/performance/sandbox/pom.xml
+++ b/integrationtest/performance/sandbox/pom.xml
@@ -22,6 +22,12 @@
     <description>Hibernate Search Performance Tests which are not part of the build (they should be rewritten)</description>
 
     <properties>
+        <!-- Skip artifact deployment -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+        <!-- Skip javadoc generation -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -61,19 +67,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/integrationtest/spring/pom.xml
+++ b/integrationtest/spring/pom.xml
@@ -22,6 +22,12 @@
     <description>Hibernate Search integration tests with Spring Framework and JTA</description>
 
     <properties>
+        <!-- Skip artifact deployment -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+        <!-- Skip javadoc generation -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Override the version of Hibernate ORM in Spring Boot (5.1 or something as I'm writing this) -->
@@ -138,19 +144,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -22,6 +22,12 @@
     <description>Hibernate Search integration tests for WildFly</description>
 
     <properties>
+        <!-- Skip artifact deployment -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+        <!-- Skip javadoc generation -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+
         <!--
         Disable the dependency convergence rule, because the dependencies of WildFly feature packs do not converge
         -->
@@ -247,19 +253,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/jenkins/release.groovy
+++ b/jenkins/release.groovy
@@ -1,0 +1,90 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+@Library('hibernate-jenkins-pipeline-helpers@1.5') _
+
+pipeline {
+	agent {
+		label 'Worker&&Containers'
+	}
+	tools {
+		maven 'Apache Maven 3.8'
+		jdk 'OpenJDK 8 Latest'
+	}
+	options {
+		disableConcurrentBuilds(abortPrevious: false)
+	}
+	parameters {
+		string(
+				name: 'RELEASE_VERSION',
+				defaultValue: '',
+				description: 'The version to be released, e.g. 6.2.0.Final.',
+				trim: true
+		)
+		string(
+				name: 'DEVELOPMENT_VERSION',
+				defaultValue: '',
+				description: 'The next version to be used after the release, e.g. 6.2.0-SNAPSHOT.',
+				trim: true
+		)
+		booleanParam(
+				name: 'RELEASE_DRY_RUN',
+				defaultValue: false,
+				description: 'If true, just simulate the release, without pushing any commits or tags, and without uploading any artifacts or documentation.'
+		)
+	}
+	stages {
+		stage('Release') {
+			when {
+				beforeAgent true
+				// Releases must be triggered explicitly
+				// This is just for safety; normally the Jenkins job for this pipeline
+				// should be configured to "Suppress automatic SCM triggering"
+				// See https://stackoverflow.com/questions/58259326/prevent-jenkins-multibranch-pipeline-from-triggering-builds-for-new-branches
+				triggeredBy cause: "UserIdCause"
+			}
+			steps {
+				script {
+					// Check that all the necessary parameters are set
+					if (!params.RELEASE_VERSION) {
+						throw new IllegalArgumentException("Missing value for parameter RELEASE_VERSION.")
+					}
+					if (!params.DEVELOPMENT_VERSION) {
+						throw new IllegalArgumentException("Missing value for parameter DEVELOPMENT_VERSION.")
+					}
+
+					def releaseVersion = Version.parseReleaseVersion(params.RELEASE_VERSION)
+					def developmentVersion = Version.parseDevelopmentVersion(params.DEVELOPMENT_VERSION)
+					echo "Performing full release for version ${releaseVersion.toString()}"
+
+					withMaven(mavenSettingsConfig: params.RELEASE_DRY_RUN ? null : 'ci-hibernate.deploy.settings.maven',
+							mavenLocalRepo: env.WORKSPACE_TMP + '.m2repository') {
+						configFileProvider([configFile(fileId: 'release.config.ssh', targetLocation: env.HOME + '/.ssh/config')]) {
+							withCredentials([file(credentialsId: 'release.gpg.private-key', variable: 'RELEASE_GPG_PRIVATE_KEY_PATH'),
+											 string(credentialsId: 'release.gpg.passphrase', variable: 'RELEASE_GPG_PASSPHRASE')]) {
+								sshagent(['ed25519.Hibernate-CI.github.com', 'hibernate.filemgmt.jboss.org', 'hibernate-ci.frs.sourceforge.net']) {
+									sh 'cat $HOME/.ssh/config'
+									sh 'git clone https://github.com/hibernate/hibernate-noorm-release-scripts.git'
+									env.RELEASE_GPG_HOMEDIR = env.WORKSPACE_TMP + '/.gpg'
+									sh """
+										bash -xe hibernate-noorm-release-scripts/release.sh ${params.RELEASE_DRY_RUN ? '-d' : ''} \
+												search ${releaseVersion.toString()} ${developmentVersion.toString()}
+									"""
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	post {
+		always {
+			notifyBuildResult notifySuccessAfterSuccess: true, maintainers: 'yoann@hibernate.org'
+		}
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,7 @@
         <version.jacoco.plugin>0.8.3</version.jacoco.plugin>
         <version.coveralls.plugin>4.3.0</version.coveralls.plugin>
         <version.org.jboss.bridger.plugin>1.5.Final</version.org.jboss.bridger.plugin>
+        <version.gpg.plugin>3.0.1</version.gpg.plugin>
 
         <!--
             Please don't change the name of this property, it may be used and
@@ -1868,6 +1869,11 @@
                     <artifactId>bridger</artifactId>
                     <version>${version.org.jboss.bridger.plugin}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>${version.gpg.plugin}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -2002,6 +2008,33 @@
                                     <goal>javadoc-no-fork</goal>
                                 </goals>
                                 <phase>prepare-package</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>release</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -2035,6 +2035,10 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <configuration>
+                                    <homedir>${env.RELEASE_GPG_HOMEDIR}</homedir>
+                                    <passphrase>${env.RELEASE_GPG_PASSPHRASE}</passphrase>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -22,8 +22,12 @@
     <description>Hibernate Search Build-Related Reports</description>
 
     <properties>
+        <!-- Skip artifact deployment -->
         <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+        <!-- Skip javadoc generation -->
         <maven.javadoc.skip>true</maven.javadoc.skip>
+
         <!--
         Disable the dependency convergence rule, because the dependencies of various integration tests do not converge
         -->

--- a/sharedtestresources/pom.xml
+++ b/sharedtestresources/pom.xml
@@ -17,21 +17,17 @@
 
     <name>Shared test resources</name>
     <description>Contains resources which we want to reuse across multiple modules for testing purposes</description>
-    
+
+    <properties>
+        <!-- Skip artifact deployment -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+        <!-- Skip javadoc generation -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+    </properties>
+
     <build>
         <plugins>
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
* [HSEARCH-4472](https://hibernate.atlassian.net/browse/HSEARCH-4472): Move the release job to a separate Jenkinsfile
* [HSEARCH-4415](https://hibernate.atlassian.net/browse/HSEARCH-4415): Sign published artifacts
* [HSEARCH-3244](https://hibernate.atlassian.net/browse/HSEARCH-3244): Simplify configuration of AWS Elasticsearch endpoints in the Jenkins CI

