### PR TITLE
HSEARCH-4479 Remove redundant public modifier reported by checkstyle

### DIFF
--- a/v5migrationhelper/engine/src/main/java/org/hibernate/search/query/dsl/RangeMatchingContext.java
+++ b/v5migrationhelper/engine/src/main/java/org/hibernate/search/query/dsl/RangeMatchingContext.java
@@ -25,7 +25,7 @@ public interface RangeMatchingContext extends FieldCustomization<RangeMatchingCo
 	//FIXME: Is <T> correct or should we specialize to String and Numeric (or all the numeric types?
 	<T> FromRangeContext<T> from(T from);
 
-	public interface FromRangeContext<T> {
+	interface FromRangeContext<T> {
 		RangeTerminationExcludable to(T to);
 		FromRangeContext<T> excludeLimit();
 	}


### PR DESCRIPTION
Didn't open an issue in Jira for it.
Related Issue- https://github.com/checkstyle/checkstyle/issues/11268
Related PR- https://github.com/checkstyle/checkstyle/pull/11270

Every member class or interface declaration in the body of an interface declaration is implicitly public and static. See [JLS](https://docs.oracle.com/javase/specs/jls/se17/html/jls-9.html#jls-9.5) for more info.