### PR TITLE
HSEARCH-4481 + HSEARCH-4484 + HSEARCH-4485 + HSEARCH-4486 Dependency upgrades

### DIFF
--- a/backend/elasticsearch-aws/src/main/java/org/hibernate/search/backend/elasticsearch/aws/impl/AwsSigningRequestInterceptor.java
+++ b/backend/elasticsearch-aws/src/main/java/org/hibernate/search/backend/elasticsearch/aws/impl/AwsSigningRequestInterceptor.java
@@ -8,6 +8,7 @@ package org.hibernate.search.backend.elasticsearch.aws.impl;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -16,7 +17,6 @@ import org.hibernate.search.util.common.AssertionFailure;
 import org.hibernate.search.util.common.logging.impl.Log;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
-import org.apache.commons.codec.Charsets;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpHost;
@@ -118,7 +118,7 @@ class AwsSigningRequestInterceptor implements HttpRequestInterceptor {
 		int queryStart = pathAndQuery.indexOf( '?' );
 		if ( queryStart >= 0 ) {
 			path = pathAndQuery.substring( 0, queryStart );
-			queryParameters = URLEncodedUtils.parse( pathAndQuery.substring( queryStart + 1 ), Charsets.UTF_8 );
+			queryParameters = URLEncodedUtils.parse( pathAndQuery.substring( queryStart + 1 ), StandardCharsets.UTF_8 );
 		}
 		else {
 			path = pathAndQuery;

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/client/impl/GsonHttpEntityTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/client/impl/GsonHttpEntityTest.java
@@ -17,6 +17,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,7 +36,6 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import org.apache.commons.codec.Charsets;
 import org.apache.http.Header;
 import org.apache.http.nio.ContentEncoder;
 
@@ -156,7 +156,7 @@ public class GsonHttpEntityTest {
 			builder.append( "\n" );
 		}
 		this.expectedPayloadString = builder.toString();
-		this.expectedContentLength = Charsets.UTF_8.encode( expectedPayloadString ).limit();
+		this.expectedContentLength = StandardCharsets.UTF_8.encode( expectedPayloadString ).limit();
 	}
 
 	@Test
@@ -244,7 +244,7 @@ public class GsonHttpEntityTest {
 			while ( !contentEncoder.isCompleted() ) {
 				entity.produceContent( contentEncoder, StubIOControl.INSTANCE );
 			}
-			return outputStream.toString( Charsets.UTF_8.name() );
+			return outputStream.toString( StandardCharsets.UTF_8.name() );
 		}
 		finally {
 			entity.close();
@@ -254,13 +254,13 @@ public class GsonHttpEntityTest {
 	private String doWriteTo(GsonHttpEntity entity) throws IOException {
 		try ( ByteArrayOutputStream outputStream = new ByteArrayOutputStream() ) {
 			entity.writeTo( outputStream );
-			return outputStream.toString( Charsets.UTF_8.name() );
+			return outputStream.toString( StandardCharsets.UTF_8.name() );
 		}
 	}
 
 	private String doGetContent(GsonHttpEntity entity) throws IOException {
 		try ( InputStream inputStream = entity.getContent();
-				Reader reader = new InputStreamReader( inputStream, Charsets.UTF_8 );
+				Reader reader = new InputStreamReader( inputStream, StandardCharsets.UTF_8 );
 				BufferedReader bufferedReader = new BufferedReader( reader ) ) {
 			StringBuilder builder = new StringBuilder();
 			int read;

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
         <!-- The latest micro of other Elasticsearch distributions -->
         <version.org.opensearch.latest-1.2>1.2.1</version.org.opensearch.latest-1.2>
         <version.org.opensearch.latest-1.0>1.0.0</version.org.opensearch.latest-1.0>
-        <version.com.google.code.gson>2.8.9</version.com.google.code.gson>
+        <version.com.google.code.gson>2.9.0</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.17.94</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, the AWS SDK and in tests (wiremock, ...) -->
         <version.com.fasterxml.jackson>2.13.1</version.com.fasterxml.jackson>

--- a/pom.xml
+++ b/pom.xml
@@ -364,7 +364,7 @@
         <version.jar.plugin>3.2.2</version.jar.plugin>
         <version.javadoc.plugin>3.3.2</version.javadoc.plugin>
         <version.jdeps.plugin>0.5.1</version.jdeps.plugin>
-        <version.nexus-staging.plugin>1.6.8</version.nexus-staging.plugin>
+        <version.nexus-staging.plugin>1.6.10</version.nexus-staging.plugin>
         <version.processor.plugin>4.5-jdk8</version.processor.plugin>
         <version.project-info.plugin>3.2.1</version.project-info.plugin>
         <version.release.plugin>2.5.3</version.release.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
         <!-- Reactive-streams: used by the AWS SDK -->
         <version.org.reactivestreams.reactive-streams>1.0.3</version.org.reactivestreams.reactive-streams>
         <!-- slf4j: used by the AWS SDK -->
-        <version.org.slf4j>1.7.35</version.org.slf4j>
+        <version.org.slf4j>1.7.36</version.org.slf4j>
 
         <!-- >>> ORM -->
         <version.org.hibernate>5.6.5.Final</version.org.hibernate>

--- a/pom.xml
+++ b/pom.xml
@@ -202,8 +202,8 @@
 
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently from the version of the remote cluster -->
-        <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 7.17+ -->
-        <version.org.elasticsearch.client>7.17.0</version.org.elasticsearch.client>
+        <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.0+ -->
+        <version.org.elasticsearch.client>8.0.0</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-7.12) becomes the default. -->

--- a/pom.xml
+++ b/pom.xml
@@ -362,7 +362,7 @@
         <version.io.takari.maven>0.7.7</version.io.takari.maven>
         <version.japicmp.plugin>0.15.6</version.japicmp.plugin>
         <version.jar.plugin>3.2.2</version.jar.plugin>
-        <version.javadoc.plugin>3.3.1</version.javadoc.plugin>
+        <version.javadoc.plugin>3.3.2</version.javadoc.plugin>
         <version.jdeps.plugin>0.5.1</version.jdeps.plugin>
         <version.nexus-staging.plugin>1.6.8</version.nexus-staging.plugin>
         <version.processor.plugin>4.5-jdk8</version.processor.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -452,7 +452,7 @@
                 Note the version of ECJ is overridden because the one bundled with the latest plexus-compiler version
                 is outdated and leads to compilation errors.
          -->
-        <version.org.codehaus.plexus.plexus-compiler.compiler-eclipse>2.9.0</version.org.codehaus.plexus.plexus-compiler.compiler-eclipse>
+        <version.org.codehaus.plexus.plexus-compiler.compiler-eclipse>2.10.0</version.org.codehaus.plexus.plexus-compiler.compiler-eclipse>
         <version.org.eclipse.jdt.ecj>3.28.0</version.org.eclipse.jdt.ecj>
 
         <!--


### PR DESCRIPTION
* [HSEARCH-4486](https://hibernate.atlassian.net/browse/HSEARCH-4486): Upgrade to slf4j 1.7.36
* [HSEARCH-4485](https://hibernate.atlassian.net/browse/HSEARCH-4485): Upgrade to GSON 2.9.0
* [HSEARCH-4484](https://hibernate.atlassian.net/browse/HSEARCH-4484): Upgrade build dependencies to the latest version
* [HSEARCH-4481](https://hibernate.atlassian.net/browse/HSEARCH-4481): Upgrade to elasticsearch-rest-client 8.0.0

