### PR TITLE
HSEARCH-4496 Upgrade to Elalsticsearch 8.0.1 (client and tested version)

### DIFF
--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -591,7 +591,7 @@ public class ElasticsearchDialectFactoryTest {
 	@TestForIssue(jiraKey = "HSEARCH-4475")
 	public void elastic_8_0() {
 		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "8.0", "8.0.0",
+				ElasticsearchDistributionName.ELASTIC, "8.0", "8.0.1",
 				Elasticsearch8ModelDialect.class, Elasticsearch80ProtocolDialect.class
 		);
 	}
@@ -601,6 +601,15 @@ public class ElasticsearchDialectFactoryTest {
 	public void elastic_8_0_0() {
 		testSuccess(
 				ElasticsearchDistributionName.ELASTIC, "8.0.0", "8.0.0",
+				Elasticsearch8ModelDialect.class, Elasticsearch80ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4496")
+	public void elastic_8_0_1() {
+		testSuccess(
+				ElasticsearchDistributionName.ELASTIC, "8.0.0", "8.0.1",
 				Elasticsearch8ModelDialect.class, Elasticsearch80ProtocolDialect.class
 		);
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -201,9 +201,9 @@
         <javadoc.org.apache.lucene.queryparser.url>https://lucene.apache.org/core/${javadoc.org.apache.lucene.tag}/queryparser/</javadoc.org.apache.lucene.queryparser.url>
 
         <!-- >>> Elasticsearch -->
-        <!-- The version of the Elasticsearch client used by Hibernate Search, independently from the version of the remote cluster -->
+        <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.0+ -->
-        <version.org.elasticsearch.client>8.0.0</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>8.0.1</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-8.0) becomes the default. -->

--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
         <version.org.elasticsearch.compatible.not-regularly-tested.text>6.0 or 7.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest micro of each Elasticsearch branch -->
-        <version.org.elasticsearch.latest-8.0>8.0.0</version.org.elasticsearch.latest-8.0>
+        <version.org.elasticsearch.latest-8.0>8.0.1</version.org.elasticsearch.latest-8.0>
         <version.org.elasticsearch.latest-7.17>7.17.0</version.org.elasticsearch.latest-7.17>
         <version.org.elasticsearch.latest-7.16>7.16.3</version.org.elasticsearch.latest-7.16>
         <!-- 7.14 and 7.15 have annoying bugs that make almost all of our test suite fail, so we don't test them


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4496
