### PR TITLE
HSEARCH-4498 Fluent definition of composite projections

### DIFF
--- a/documentation/src/main/asciidoc/reference/components/deprecated-warning.asciidoc
+++ b/documentation/src/main/asciidoc/reference/components/deprecated-warning.asciidoc
@@ -1,0 +1,10 @@
+[WARNING]
+====
+Features detailed in this section are _deprecated_: they should be avoided in favor of non-deprecated alternatives.
+
+The usual https://hibernate.org/community/compatibility-policy/[compatibility policy] applies,
+meaning the features are expected to remain available at least until the next major version of Hibernate Search.
+Beyond that, they may be altered in a backward-incompatible way -- or even removed.
+
+Usage of deprecated features is not recommended.
+====

--- a/documentation/src/main/asciidoc/reference/search-dsl-projection.asciidoc
+++ b/documentation/src/main/asciidoc/reference/search-dsl-projection.asciidoc
@@ -289,51 +289,115 @@ include::{sourcedir}/org/hibernate/search/documentation/search/projection/Projec
 [[search-dsl-projection-composite]]
 == `composite`: combine projections
 
-The `composite` projection applies multiple projections and combines their results.
+The `composite` projection applies multiple projections and combines their results,
+either as a `List<?>` or as a single object generated using a custom transformer.
 
-To preserve type-safety, you can provide a custom combining function.
-The combining function can be a `Function`, a `BiFunction`,
-or a `org.hibernate.search.util.common.function.TriFunction`.
+To preserve type-safety, you can provide a custom transformer.
+The transformer can be a `Function`, a `BiFunction`,
+or a `org.hibernate.search.util.common.function.TriFunction`,
+depending on the number of inner projections.
 It will receive values returned by inner projections and return an object combining these values.
 
-Depending on the type of function,
-either one, two, or three additional arguments are expected,
-one for each inner projection.
-
-.Returning custom objects created from multiple projected values
+.Returning custom objects created from multiple projected values with `.composite().from(...).as(...)`
 ====
 [source, JAVA, indent=0, subs="+callouts"]
 ----
 include::{sourcedir}/org/hibernate/search/documentation/search/projection/ProjectionDslIT.java[tags=composite-customObject]
 ----
+<1> Call `.composite()`.
+<2> Define the first inner projection as a projection on the `title` field.
+<3> Define the second inner projection as a projection on the `genre` field.
+<4> Define the result of the composite projection as the result of calling the constructor of a custom object, `MyPair`.
+The constructor of `MyPair` will be called for each matched document,
+with the value of the `title` field as its first argument,
+and the value of the `genre` field as its second argument.
+<5> The hits will be the result of calling the constructor for each matched document,
+in this case `MyPair` instances.
+====
+
+If you pass more than 3 projections as arguments,
+then the transform function will have to take a `List<?>` as an argument,
+and will be set using `asList(...)` instead of `as(..,)`:
+
+.Returning custom objects created from multiple projected values with `.composite().from(...).asList(...)`
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/search/projection/ProjectionDslIT.java[tags=composite-customObject-asList]
+----
+<1> Call `.composite()`.
+<2> Define the first inner projection as a projection on the `title` field.
+<3> Define the second inner projection as a projection on the `genre` field.
+<4> Define the third inner projection as a projection on the `pageCount` field.
+<5> Define the fourth inner projection as a projection on the `description` field.
+<6> Define the result of the composite projection as the result of calling a lambda.
+The lambda will take elements of the list (the results of projections defined above, in order),
+cast them, and pass them to the constructor of a custom class, `MyTuple4`.
+<7> The hits will be the result of calling the lambda for each matched document,
+in this case `MyTuple4` instances.
+====
+
+If you don't mind receiving the result of inner projections as a `List<?>`,
+you can do without the transformer by calling `asList()`:
+
+.Returning a `List` of projected values with `.composite().add(...).asList()`
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/search/projection/ProjectionDslIT.java[tags=composite-list]
+----
+<1> Call `.composite()`.
+<2> Define the first inner projection as a projection on the `title` field.
+<3> Define the second inner projection as a projection on the `genre` field.
+<4> Define the result of the projection as a list,
+meaning the hits will be `List` instances with the value of the `title` field of the matched document at index `0`,
+and the value of the `genre` field of the matched document at index `1`.
+<5> The hits will be `List` instances holding the result of the inner projections, in the given order, for each matched document.
+====
+
+Alternatively, to get the result as a `List<?>`,
+you can use the shorter variant of `.composite(...)` that directly takes projections as arguments:
+
+.Returning a `List` of projected values with `.composite(...)`
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/search/projection/ProjectionDslIT.java[tags=composite-list-singlestep]
+----
 <1> Call `.composite(...)`.
-<2> Use the constructor of a custom object, `MyPair`, as the combining function.
+<2> Define the first projection to combine as a projection on the `title` field.
+<3> Define the second projection to combine as a projection on the `genre` field.
+<4> The hits will be `List` instances holding the result of the given projections, in the given order, for each matched document,
+meaning the hits will be `List` instances with the value of the `title` field of the matched document at index `0`,
+and the value of the `genre` field of the matched document at index `1`.
+====
+
+[[search-dsl-projection-composite-deprecated-variants]]
+=== Deprecated variants
+
+include::components/deprecated-warning.asciidoc[]
+
+A few `.composite(...)` methods accepting both a function and a list of projections
+are available on `SearchProjectionFactory`, but they are deprecated.
+
+.Deprecated variant of `composite`
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/search/projection/ProjectionDslIT.java[tags=composite-customObject-singlestep]
+----
+<1> Call `.composite(...)`.
+<2> Define the transformer as the constructor of a custom object, `MyPair`.
 <3> Define the first projection to combine as a projection on the `title` field,
 meaning the constructor of `MyPair` will be called for each matched document
 with the value of the `title` field as its first argument.
 <4> Define the second projection to combine as a projection on the `genre` field,
 meaning the constructor of `MyPair` will be called for each matched document
 with the value of the `genre` field as its second argument.
-<5> The hits will be the result of calling the combining function for each matched document,
+<5> The hits will be the result of calling the transformer for each matched document,
 in this case `MyPair` instances.
 ====
 
-If you need more inner projections, or simply if you don't mind receiving the result of inner projections as a `List<?>`,
-you can use the variant of `.composite(...)` that doesn't expect a function argument:
-
-.Returning a `List` of projected values
-====
-[source, JAVA, indent=0, subs="+callouts"]
-----
-include::{sourcedir}/org/hibernate/search/documentation/search/projection/ProjectionDslIT.java[tags=composite-list]
-----
-<1> Call `.composite(...)`.
-<2> Define the first projection to combine as a projection on the `title` field,
-meaning the hits will be `List` instances with the value of the `title` field of the matched document at index `0`.
-<3> Define the second projection to combine as a projection on the `genre` field,
-meaning the hits will be `List` instances with the value of the `genre` field of the matched document at index `1`.
-<4> The hits will be `List` instances holding the result of the given projections, in the given order, for each matched document.
-====
 
 [[search-dsl-projection-extensions]]
 == Backend-specific extensions

--- a/documentation/src/test/java/org/hibernate/search/documentation/backend/lucene/type/asnative/LuceneNativeTypeIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/backend/lucene/type/asnative/LuceneNativeTypeIT.java
@@ -58,11 +58,9 @@ public class LuceneNativeTypeIT {
 
 			List<Result> result = searchSession.search( WebPage.class )
 					.extension( LuceneExtension.get() )
-					.select( f -> f.composite(
-							Result::new,
-							f.entity(),
-							f.field( "pageRank", Float.class )
-					) )
+					.select( f -> f.composite()
+							.from( f.entity(), f.field( "pageRank", Float.class ) )
+							.as( Result::new ) )
 					.where( f -> f.fromLuceneQuery(
 							// This affects the document score based on the pageRank
 							FeatureField.newSaturationQuery( "pageRank", "pageRank" )

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/projection/Book.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/projection/Book.java
@@ -15,6 +15,7 @@ import javax.persistence.ManyToMany;
 import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
@@ -33,6 +34,12 @@ public class Book {
 
 	@KeywordField(projectable = Projectable.YES)
 	private Genre genre;
+
+	@GenericField(projectable = Projectable.YES)
+	private Integer pageCount;
+
+	@FullTextField(analyzer = "english", projectable = Projectable.YES)
+	private String description;
 
 	@ManyToMany
 	@IndexedEmbedded(structure = ObjectStructure.NESTED)
@@ -63,6 +70,22 @@ public class Book {
 
 	public void setGenre(Genre genre) {
 		this.genre = genre;
+	}
+
+	public Integer getPageCount() {
+		return pageCount;
+	}
+
+	public void setPageCount(Integer pageCount) {
+		this.pageCount = pageCount;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
 	}
 
 	public List<Author> getAuthors() {

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/projection/ProjectionDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/projection/ProjectionDslIT.java
@@ -328,6 +328,7 @@ public class ProjectionDslIT {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void composite() {
 		withinSearchSession( searchSession -> {
 			// tag::composite-customObject[]

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/CompositeProjectionAsStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/CompositeProjectionAsStep.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.projection.dsl;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * The step in a "multi-step" composite projection definition
+ * where one or more inner projections have been defined
+ * and the result of the composite projection can be defined.
+ */
+public interface CompositeProjectionAsStep {
+
+	/**
+	 * Defines the result of the composite projection
+	 * as {@link List} that will contain the results of inner projections defined so far, in order.
+	 *
+	 * @return The next DSL step.
+	 */
+	CompositeProjectionOptionsStep<?, List<?>> asList();
+
+	/**
+	 * Defines the result of the composite projection
+	 * as the result of applying the given function to a {@link List} containing
+	 * the results of inner projections defined so far, in order.
+	 *
+	 * @param transformer A function to transform the values of inner projections added so far.
+	 * @return The next DSL step.
+	 * @param <V> The type of values returned by the transformer.
+	 */
+	<V> CompositeProjectionOptionsStep<?, V> asList(Function<List<?>, V> transformer);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/CompositeProjectionFrom1AsStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/CompositeProjectionFrom1AsStep.java
@@ -1,0 +1,31 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.projection.dsl;
+
+import java.util.function.Function;
+
+/**
+ * The step in a "multi-step" composite projection definition
+ * where a single inner projection has been defined
+ * and the result of the composite projection can be defined.
+ *
+ * @param <V1> The type of values returned by the single inner projection.
+ */
+public interface CompositeProjectionFrom1AsStep<V1>
+		extends CompositeProjectionAsStep {
+
+	/**
+	 * Defines the result of the composite projection
+	 * as the result of applying the given function to the single inner projection defined so far.
+	 *
+	 * @param transformer A function to transform the values of inner projections defined so far.
+	 * @return The next DSL step.
+	 * @param <V> The type of values returned by the transformer.
+	 */
+	<V> CompositeProjectionOptionsStep<?, V> as(Function<V1, V> transformer);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/CompositeProjectionFrom2AsStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/CompositeProjectionFrom2AsStep.java
@@ -1,0 +1,32 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.projection.dsl;
+
+import java.util.function.BiFunction;
+
+/**
+ * The step in a "multi-step" composite projection definition
+ * where 2 inner projections have been defined
+ * and the result of the composite projection can be defined.
+ *
+ * @param <V1> The type of values returned by the first inner projection.
+ * @param <V2> The type of values returned by the second inner projection.
+ */
+public interface CompositeProjectionFrom2AsStep<V1, V2>
+		extends CompositeProjectionAsStep {
+
+	/**
+	 * Defines the result of the composite projection
+	 * as the result of applying the given function to the two inner projections defined so far.
+	 *
+	 * @param transformer A function to transform the values of inner projections defined so far.
+	 * @return The next DSL step.
+	 * @param <V> The type of values returned by the transformer.
+	 */
+	<V> CompositeProjectionOptionsStep<?, V> as(BiFunction<V1, V2, V> transformer);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/CompositeProjectionFrom3AsStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/CompositeProjectionFrom3AsStep.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.projection.dsl;
+
+import org.hibernate.search.util.common.function.TriFunction;
+
+/**
+ * The step in a "multi-step" composite projection definition
+ * where 3 inner projections have been defined
+ * and the result of the composite projection can be defined.
+ *
+ * @param <V1> The type of values returned by the first inner projection.
+ * @param <V2> The type of values returned by the second inner projection.
+ * @param <V3> The type of values returned by the third inner projection.
+ */
+public interface CompositeProjectionFrom3AsStep<V1, V2, V3>
+		extends CompositeProjectionAsStep {
+
+	/**
+	 * Defines the result of the composite projection
+	 * as the result of applying the given function to the three inner projections defined so far.
+	 *
+	 * @param transformer A function to transform the values of inner projections defined so far.
+	 * @return The next DSL step.
+	 * @param <V> The type of values returned by the transformer.
+	 */
+	<V> CompositeProjectionOptionsStep<?, V> as(TriFunction<V1, V2, V3, V> transformer);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/CompositeProjectionFromStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/CompositeProjectionFromStep.java
@@ -1,0 +1,117 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.projection.dsl;
+
+import org.hibernate.search.engine.search.projection.SearchProjection;
+
+/**
+ * A step in a "multi-step" composite projection definition
+ * where one can define inner projections to get values from.
+ */
+public interface CompositeProjectionFromStep {
+
+	/**
+	 * Defines one inner projection to get values from,
+	 * based on a previously-built {@link SearchProjection}.
+	 *
+	 * @param projection The inner projection.
+	 * @return The next DSL step.
+	 * @param <V1> The type of values returned by the inner projection.
+	 */
+	<V1> CompositeProjectionFrom1AsStep<V1> from(SearchProjection<V1> projection);
+
+	/**
+	 * Defines one inner projection to get values from,
+	 * based on an almost-built {@link SearchProjection}.
+	 *
+	 * @param dslFinalStep A final step in the projection DSL allowing the retrieval of the inner projection.
+	 * @return The next DSL step.
+	 * @param <V1> The type of values returned by the inner projection.
+	 */
+	default <V1> CompositeProjectionFrom1AsStep<V1> from(ProjectionFinalStep<V1> dslFinalStep) {
+		return from( dslFinalStep.toProjection() );
+	}
+
+	/**
+	 * Defines two inner projections to get values from,
+	 * based on previously-built {@link SearchProjection}s.
+	 *
+	 * @param projection1 The first inner projection.
+	 * @param projection2 The second inner projection.
+	 * @return The next DSL step.
+	 * @param <V1> The type of values returned by the first inner projection.
+	 * @param <V2> The type of values returned by the second inner projection.
+	 */
+	<V1, V2> CompositeProjectionFrom2AsStep<V1, V2> from(SearchProjection<V1> projection1,
+			SearchProjection<V2> projection2);
+
+	/**
+	 * Defines two inner projections to get values from,
+	 * based on almost-built {@link SearchProjection}s.
+	 *
+	 * @param dslFinalStep1 A final step in the projection DSL allowing the retrieval of the first inner projection.
+	 * @param dslFinalStep2 A final step in the projection DSL allowing the retrieval of the second inner projection.
+	 * @return The next DSL step.
+	 * @param <V1> The type of values returned by the first inner projection.
+	 * @param <V2> The type of values returned by the second inner projection.
+	 */
+	default <V1, V2> CompositeProjectionFrom2AsStep<V1, V2> from(ProjectionFinalStep<V1> dslFinalStep1,
+			ProjectionFinalStep<V2> dslFinalStep2) {
+		return from( dslFinalStep1.toProjection(), dslFinalStep2.toProjection() );
+	}
+
+	/**
+	 * Defines three inner projections to get values from,
+	 * based on previously-built {@link SearchProjection}s.
+	 *
+	 * @param projection1 The first inner projection.
+	 * @param projection2 The second inner projection.
+	 * @param projection3 The third inner projection.
+	 * @return The next DSL step.
+	 * @param <V1> The type of values returned by the first inner projection.
+	 * @param <V2> The type of values returned by the second inner projection.
+	 * @param <V3> The type of values returned by the third inner projection.
+	 */
+	<V1, V2, V3> CompositeProjectionFrom3AsStep<V1, V2, V3> from(SearchProjection<V1> projection1,
+			SearchProjection<V2> projection2, SearchProjection<V3> projection3);
+
+	/**
+	 * Defines three inner projections to get values from,
+	 * based on almost-built {@link SearchProjection}s.
+	 *
+	 * @param dslFinalStep1 A final step in the projection DSL allowing the retrieval of the first inner projection.
+	 * @param dslFinalStep2 A final step in the projection DSL allowing the retrieval of the second inner projection.
+	 * @param dslFinalStep3 A final step in the projection DSL allowing the retrieval of the third inner projection.
+	 * @return The next DSL step.
+	 * @param <V1> The type of values returned by the first inner projection.
+	 * @param <V2> The type of values returned by the second inner projection.
+	 * @param <V3> The type of values returned by the third inner projection.
+	 */
+	default <V1, V2, V3> CompositeProjectionFrom3AsStep<V1, V2, V3> from(ProjectionFinalStep<V1> dslFinalStep1,
+			ProjectionFinalStep<V2> dslFinalStep2, ProjectionFinalStep<V3> dslFinalStep3) {
+		return from( dslFinalStep1.toProjection(), dslFinalStep2.toProjection(), dslFinalStep3.toProjection() );
+	}
+
+	/**
+	 * Defines multiple inner projections to get values from,
+	 * based on previously-built {@link SearchProjection}s.
+	 *
+	 * @param projections The inner projections, in order.
+	 * @return The next DSL step.
+	 */
+	CompositeProjectionAsStep from(SearchProjection<?>... projections);
+
+	/**
+	 * Defines multiple inner projections to get values from,
+	 * based on almost-built {@link SearchProjection}s.
+	 *
+	 * @param dslFinalSteps The final steps in the projection DSL allowing the retrieval of inner projections, in order.
+	 * @return The next DSL step.
+	 */
+	CompositeProjectionAsStep from(ProjectionFinalStep<?>... dslFinalSteps);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/CompositeProjectionOptionsStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/CompositeProjectionOptionsStep.java
@@ -7,7 +7,8 @@
 package org.hibernate.search.engine.search.projection.dsl;
 
 /**
- * The initial and final step in a composite projection definition, where optional parameters can be set.
+ * The final step in a composite projection definition
+ * where optional parameters can be set.
  *
  * @param <S> The "self" type (the actual exposed type of this step).
  * @param <T> The type of composed projections.

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/SearchProjectionFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/SearchProjectionFactory.java
@@ -159,6 +159,14 @@ public interface SearchProjectionFactory<R, E> {
 	DistanceToFieldProjectionValueStep<?, Double> distance(String fieldPath, GeoPoint center);
 
 	/**
+	 * Starts the definition of a composite projection,
+	 * which will combine multiple given projections.
+	 *
+	 * @return A DSL step where the "composite" projection can be defined in more details.
+	 */
+	CompositeProjectionFromStep composite();
+
+	/**
 	 * Create a projection that will compose a {@link List} based on the given projections.
 	 *
 	 * @param projections The projections used to populate the list, in order.

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/SearchProjectionFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/SearchProjectionFactory.java
@@ -172,9 +172,7 @@ public interface SearchProjectionFactory<R, E> {
 	 * @param projections The projections used to populate the list, in order.
 	 * @return A DSL step where the "composite" projection can be defined in more details.
 	 */
-	default CompositeProjectionOptionsStep<?, List<?>> composite(SearchProjection<?>... projections) {
-		return composite( Function.identity(), projections );
-	}
+	CompositeProjectionOptionsStep<?, List<?>> composite(SearchProjection<?>... projections);
 
 	/**
 	 * Create a projection that will compose a {@link List} based on the given almost-built projections.
@@ -183,7 +181,11 @@ public interface SearchProjectionFactory<R, E> {
 	 * @return A DSL step where the "composite" projection can be defined in more details.
 	 */
 	default CompositeProjectionOptionsStep<?, List<?>> composite(ProjectionFinalStep<?>... dslFinalSteps) {
-		return composite( Function.identity(), dslFinalSteps );
+		SearchProjection<?>[] projections = new SearchProjection<?>[dslFinalSteps.length];
+		for ( int i = 0; i < dslFinalSteps.length; i++ ) {
+			projections[i] = dslFinalSteps[i].toProjection();
+		}
+		return composite( projections );
 	}
 
 	/**
@@ -194,7 +196,9 @@ public interface SearchProjectionFactory<R, E> {
 	 * @param <T> The type of the custom object composing the projected elements.
 	 * @return A DSL step where the "composite" projection can be defined in more details.
 	 */
-	<T> CompositeProjectionOptionsStep<?, T> composite(Function<List<?>, T> transformer, SearchProjection<?>... projections);
+	default <T> CompositeProjectionOptionsStep<?, T> composite(Function<List<?>, T> transformer, SearchProjection<?>... projections) {
+		return composite().from( projections ).asList( transformer );
+	}
 
 	/**
 	 * Create a projection that will compose a custom object based on the given almost-built projections.
@@ -206,11 +210,7 @@ public interface SearchProjectionFactory<R, E> {
 	 */
 	default <T> CompositeProjectionOptionsStep<?, T> composite(Function<List<?>, T> transformer,
 			ProjectionFinalStep<?>... dslFinalSteps) {
-		SearchProjection<?>[] projections = new SearchProjection<?>[dslFinalSteps.length];
-		for ( int i = 0; i < dslFinalSteps.length; i++ ) {
-			projections[i] = dslFinalSteps[i].toProjection();
-		}
-		return composite( transformer, projections );
+		return composite().from( dslFinalSteps ).asList( transformer );
 	}
 
 	/**
@@ -222,7 +222,9 @@ public interface SearchProjectionFactory<R, E> {
 	 * @param <T> The type of the custom object composing the projected element.
 	 * @return A DSL step where the "composite" projection can be defined in more details.
 	 */
-	<P, T> CompositeProjectionOptionsStep<?, T> composite(Function<P, T> transformer, SearchProjection<P> projection);
+	default <P, T> CompositeProjectionOptionsStep<?, T> composite(Function<P, T> transformer, SearchProjection<P> projection) {
+		return composite().from( projection ).as( transformer );
+	}
 
 	/**
 	 * Create a projection that will compose a custom object based on one almost-built projection.
@@ -235,7 +237,7 @@ public interface SearchProjectionFactory<R, E> {
 	 * @return A DSL step where the "composite" projection can be defined in more details.
 	 */
 	default <P, T> CompositeProjectionOptionsStep<?, T> composite(Function<P, T> transformer, ProjectionFinalStep<P> dslFinalStep) {
-		return composite( transformer, dslFinalStep.toProjection() );
+		return composite().from( dslFinalStep ).as( transformer );
 	}
 
 	/**
@@ -249,8 +251,10 @@ public interface SearchProjectionFactory<R, E> {
 	 * @param <T> The type of the custom object composing the projected elements.
 	 * @return A DSL step where the "composite" projection can be defined in more details.
 	 */
-	<P1, P2, T> CompositeProjectionOptionsStep<?, T> composite(BiFunction<P1, P2, T> transformer,
-			SearchProjection<P1> projection1, SearchProjection<P2> projection2);
+	default <P1, P2, T> CompositeProjectionOptionsStep<?, T> composite(BiFunction<P1, P2, T> transformer,
+			SearchProjection<P1> projection1, SearchProjection<P2> projection2) {
+		return composite().from( projection1, projection2 ).as( transformer );
+	}
 
 	/**
 	 * Create a projection that will compose a custom object based on two almost-built projections.
@@ -267,10 +271,7 @@ public interface SearchProjectionFactory<R, E> {
 	 */
 	default <P1, P2, T> CompositeProjectionOptionsStep<?, T> composite(BiFunction<P1, P2, T> transformer,
 			ProjectionFinalStep<P1> dslFinalStep1, ProjectionFinalStep<P2> dslFinalStep2) {
-		return composite(
-				transformer,
-				dslFinalStep1.toProjection(), dslFinalStep2.toProjection()
-		);
+		return composite().from( dslFinalStep1, dslFinalStep2 ).as( transformer );
 	}
 
 	/**
@@ -286,8 +287,10 @@ public interface SearchProjectionFactory<R, E> {
 	 * @param <T> The type of the custom object composing the projected elements.
 	 * @return A DSL step where the "composite" projection can be defined in more details.
 	 */
-	<P1, P2, P3, T> CompositeProjectionOptionsStep<?, T> composite(TriFunction<P1, P2, P3, T> transformer,
-			SearchProjection<P1> projection1, SearchProjection<P2> projection2, SearchProjection<P3> projection3);
+	default <P1, P2, P3, T> CompositeProjectionOptionsStep<?, T> composite(TriFunction<P1, P2, P3, T> transformer,
+			SearchProjection<P1> projection1, SearchProjection<P2> projection2, SearchProjection<P3> projection3) {
+		return composite().from( projection1, projection2, projection3 ).as( transformer );
+	}
 
 	/**
 	 * Create a projection that will compose a custom object based on three almost-built projections.
@@ -308,10 +311,7 @@ public interface SearchProjectionFactory<R, E> {
 	default <P1, P2, P3, T> CompositeProjectionOptionsStep<?, T> composite(TriFunction<P1, P2, P3, T> transformer,
 			ProjectionFinalStep<P1> dslFinalStep1, ProjectionFinalStep<P2> dslFinalStep2,
 			ProjectionFinalStep<P3> dslFinalStep3) {
-		return composite(
-				transformer,
-				dslFinalStep1.toProjection(), dslFinalStep2.toProjection(), dslFinalStep3.toProjection()
-		);
+		return composite().from( dslFinalStep1, dslFinalStep2, dslFinalStep3 ).as( transformer );
 	}
 
 	/**

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/SearchProjectionFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/SearchProjectionFactory.java
@@ -195,7 +195,9 @@ public interface SearchProjectionFactory<R, E> {
 	 * @param projections The projections used to populate the list, in order.
 	 * @param <T> The type of the custom object composing the projected elements.
 	 * @return A DSL step where the "composite" projection can be defined in more details.
+	 * @deprecated Use {@code .composite().from( projections ).asList( transformer )} instead.
 	 */
+	@Deprecated
 	default <T> CompositeProjectionOptionsStep<?, T> composite(Function<List<?>, T> transformer, SearchProjection<?>... projections) {
 		return composite().from( projections ).asList( transformer );
 	}
@@ -207,7 +209,9 @@ public interface SearchProjectionFactory<R, E> {
 	 * @param dslFinalSteps The final steps in the projection DSL allowing the retrieval of {@link SearchProjection}s.
 	 * @param <T> The type of the custom object composing the projected elements.
 	 * @return A DSL step where the "composite" projection can be defined in more details.
+	 * @deprecated Use {@code .composite().from( dslFinalSteps ).asList( transformer )} instead.
 	 */
+	@Deprecated
 	default <T> CompositeProjectionOptionsStep<?, T> composite(Function<List<?>, T> transformer,
 			ProjectionFinalStep<?>... dslFinalSteps) {
 		return composite().from( dslFinalSteps ).asList( transformer );
@@ -221,7 +225,9 @@ public interface SearchProjectionFactory<R, E> {
 	 * @param <P> The type of the element passed to the transformer.
 	 * @param <T> The type of the custom object composing the projected element.
 	 * @return A DSL step where the "composite" projection can be defined in more details.
+	 * @deprecated Use {@code .composite().from( projection ).as( transformer )} instead.
 	 */
+	@Deprecated
 	default <P, T> CompositeProjectionOptionsStep<?, T> composite(Function<P, T> transformer, SearchProjection<P> projection) {
 		return composite().from( projection ).as( transformer );
 	}
@@ -235,7 +241,9 @@ public interface SearchProjectionFactory<R, E> {
 	 * @param <P> The type of the element passed to the transformer.
 	 * @param <T> The type of the custom object composing the projected element.
 	 * @return A DSL step where the "composite" projection can be defined in more details.
+	 * @deprecated Use {@code .composite().from( dslFinalStep ).as( transformer )} instead.
 	 */
+	@Deprecated
 	default <P, T> CompositeProjectionOptionsStep<?, T> composite(Function<P, T> transformer, ProjectionFinalStep<P> dslFinalStep) {
 		return composite().from( dslFinalStep ).as( transformer );
 	}
@@ -250,7 +258,10 @@ public interface SearchProjectionFactory<R, E> {
 	 * @param <P2> The type of the second element passed to the transformer.
 	 * @param <T> The type of the custom object composing the projected elements.
 	 * @return A DSL step where the "composite" projection can be defined in more details.
+	 * @deprecated Use {@code .composite().from( projection1, projection2 ).as( transformer )}
+	 * instead.
 	 */
+	@Deprecated
 	default <P1, P2, T> CompositeProjectionOptionsStep<?, T> composite(BiFunction<P1, P2, T> transformer,
 			SearchProjection<P1> projection1, SearchProjection<P2> projection2) {
 		return composite().from( projection1, projection2 ).as( transformer );
@@ -268,7 +279,10 @@ public interface SearchProjectionFactory<R, E> {
 	 * @param <P2> The type of the second element passed to the transformer.
 	 * @param <T> The type of the custom object composing the projected elements.
 	 * @return A DSL step where the "composite" projection can be defined in more details.
+	 * @deprecated Use {@code .composite().from( dslFinalStep1, dslFinalStep2 ).as( transformer )}
+	 * instead.
 	 */
+	@Deprecated
 	default <P1, P2, T> CompositeProjectionOptionsStep<?, T> composite(BiFunction<P1, P2, T> transformer,
 			ProjectionFinalStep<P1> dslFinalStep1, ProjectionFinalStep<P2> dslFinalStep2) {
 		return composite().from( dslFinalStep1, dslFinalStep2 ).as( transformer );
@@ -286,7 +300,10 @@ public interface SearchProjectionFactory<R, E> {
 	 * @param <P3> The type of the third element passed to the transformer.
 	 * @param <T> The type of the custom object composing the projected elements.
 	 * @return A DSL step where the "composite" projection can be defined in more details.
+	 * @deprecated Use {@code .composite().from( projection1, projection2, projection3 ).as( transformer )}
+	 * instead.
 	 */
+	@Deprecated
 	default <P1, P2, P3, T> CompositeProjectionOptionsStep<?, T> composite(TriFunction<P1, P2, P3, T> transformer,
 			SearchProjection<P1> projection1, SearchProjection<P2> projection2, SearchProjection<P3> projection3) {
 		return composite().from( projection1, projection2, projection3 ).as( transformer );
@@ -307,7 +324,10 @@ public interface SearchProjectionFactory<R, E> {
 	 * @param <P3> The type of the third element passed to the transformer.
 	 * @param <T> The type of the custom object composing the projected elements.
 	 * @return A DSL step where the "composite" projection can be defined in more details.
+	 * @deprecated Use {@code .composite().from( dslFinalStep1, dslFinalStep2, dslFinalStep3 ).as( transformer )}
+	 * instead.
 	 */
+	@Deprecated
 	default <P1, P2, P3, T> CompositeProjectionOptionsStep<?, T> composite(TriFunction<P1, P2, P3, T> transformer,
 			ProjectionFinalStep<P1> dslFinalStep1, ProjectionFinalStep<P2> dslFinalStep2,
 			ProjectionFinalStep<P3> dslFinalStep3) {

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/impl/AbstractCompositeProjectionAsStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/impl/AbstractCompositeProjectionAsStep.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.projection.dsl.impl;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.hibernate.search.engine.search.projection.SearchProjection;
+import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionAsStep;
+import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionOptionsStep;
+import org.hibernate.search.engine.search.projection.dsl.spi.SearchProjectionDslContext;
+
+abstract class AbstractCompositeProjectionAsStep
+		implements CompositeProjectionAsStep {
+
+	final SearchProjectionDslContext<?> dslContext;
+
+	public AbstractCompositeProjectionAsStep(SearchProjectionDslContext<?> dslContext) {
+		this.dslContext = dslContext;
+	}
+
+	@Override
+	public final CompositeProjectionOptionsStep<?, List<?>> asList() {
+		return asList( Function.identity() );
+	}
+
+	@Override
+	public final <V> CompositeProjectionOptionsStep<?, V> asList(Function<List<?>, V> transformer) {
+		return new CompositeProjectionOptionsStepImpl<>( dslContext, transformer, toProjectionArray() );
+	}
+
+	abstract SearchProjection<?>[] toProjectionArray();
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/impl/CompositeProjectionFrom1AsStepImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/impl/CompositeProjectionFrom1AsStepImpl.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.projection.dsl.impl;
+
+import java.util.function.Function;
+
+import org.hibernate.search.engine.search.projection.SearchProjection;
+import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionFrom1AsStep;
+import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionOptionsStep;
+import org.hibernate.search.engine.search.projection.dsl.spi.SearchProjectionDslContext;
+
+class CompositeProjectionFrom1AsStepImpl<V1> extends AbstractCompositeProjectionAsStep
+		implements CompositeProjectionFrom1AsStep<V1> {
+
+	final SearchProjection<V1> inner1;
+
+	public CompositeProjectionFrom1AsStepImpl(SearchProjectionDslContext<?> dslContext,
+			SearchProjection<V1> inner1) {
+		super( dslContext );
+		this.inner1 = inner1;
+	}
+
+	@Override
+	public <V> CompositeProjectionOptionsStep<?, V> as(Function<V1, V> transformer) {
+		return new CompositeProjectionOptionsStepImpl<>( dslContext, transformer, inner1 );
+	}
+
+	@Override
+	SearchProjection<?>[] toProjectionArray() {
+		return new SearchProjection<?>[] { inner1 };
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/impl/CompositeProjectionFrom2AsStepImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/impl/CompositeProjectionFrom2AsStepImpl.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.projection.dsl.impl;
+
+import java.util.function.BiFunction;
+
+import org.hibernate.search.engine.search.projection.SearchProjection;
+import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionFrom2AsStep;
+import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionOptionsStep;
+import org.hibernate.search.engine.search.projection.dsl.spi.SearchProjectionDslContext;
+
+class CompositeProjectionFrom2AsStepImpl<V1, V2>
+		extends AbstractCompositeProjectionAsStep
+		implements CompositeProjectionFrom2AsStep<V1, V2> {
+
+	final SearchProjection<V1> inner1;
+	final SearchProjection<V2> inner2;
+
+	public CompositeProjectionFrom2AsStepImpl(SearchProjectionDslContext<?> dslContext,
+			SearchProjection<V1> inner1, SearchProjection<V2> inner2) {
+		super( dslContext );
+		this.inner1 = inner1;
+		this.inner2 = inner2;
+	}
+
+	@Override
+	public <V> CompositeProjectionOptionsStep<?, V> as(BiFunction<V1, V2, V> transformer) {
+		return new CompositeProjectionOptionsStepImpl<>( dslContext, transformer, inner1, inner2 );
+	}
+
+	@Override
+	SearchProjection<?>[] toProjectionArray() {
+		return new SearchProjection<?>[] { inner1, inner2 };
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/impl/CompositeProjectionFrom3AsStepImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/impl/CompositeProjectionFrom3AsStepImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.projection.dsl.impl;
+
+import org.hibernate.search.engine.search.projection.SearchProjection;
+import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionFrom3AsStep;
+import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionOptionsStep;
+import org.hibernate.search.engine.search.projection.dsl.spi.SearchProjectionDslContext;
+import org.hibernate.search.util.common.function.TriFunction;
+
+class CompositeProjectionFrom3AsStepImpl<V1, V2, V3>
+		extends AbstractCompositeProjectionAsStep
+		implements CompositeProjectionFrom3AsStep<V1, V2, V3> {
+
+	final SearchProjection<V1> inner1;
+	final SearchProjection<V2> inner2;
+	final SearchProjection<V3> inner3;
+
+	public CompositeProjectionFrom3AsStepImpl(SearchProjectionDslContext<?> dslContext,
+			SearchProjection<V1> inner1, SearchProjection<V2> inner2, SearchProjection<V3> inner3) {
+		super( dslContext );
+		this.inner1 = inner1;
+		this.inner2 = inner2;
+		this.inner3 = inner3;
+	}
+
+	@Override
+	public <V> CompositeProjectionOptionsStep<?, V> as(TriFunction<V1, V2, V3, V> transformer) {
+		return new CompositeProjectionOptionsStepImpl<>( dslContext, transformer, inner1, inner2, inner3 );
+	}
+
+	@Override
+	SearchProjection<?>[] toProjectionArray() {
+		return new SearchProjection<?>[] { inner1, inner2, inner3 };
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/impl/CompositeProjectionFromAnyNumberAsStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/impl/CompositeProjectionFromAnyNumberAsStep.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.projection.dsl.impl;
+
+import org.hibernate.search.engine.search.projection.SearchProjection;
+import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionAsStep;
+import org.hibernate.search.engine.search.projection.dsl.spi.SearchProjectionDslContext;
+
+class CompositeProjectionFromAnyNumberAsStep extends AbstractCompositeProjectionAsStep
+		implements CompositeProjectionAsStep {
+
+	final SearchProjection<?>[] inner;
+
+	public CompositeProjectionFromAnyNumberAsStep(SearchProjectionDslContext<?> dslContext,
+			SearchProjection<?>[] inner) {
+		super( dslContext );
+		this.inner = inner;
+	}
+
+	@Override
+	SearchProjection<?>[] toProjectionArray() {
+		return inner;
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/impl/CompositeProjectionFromStepImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/impl/CompositeProjectionFromStepImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.projection.dsl.impl;
+
+import org.hibernate.search.engine.search.projection.SearchProjection;
+import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionAsStep;
+import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionFrom1AsStep;
+import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionFrom2AsStep;
+import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionFrom3AsStep;
+import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionFromStep;
+import org.hibernate.search.engine.search.projection.dsl.ProjectionFinalStep;
+import org.hibernate.search.engine.search.projection.dsl.spi.SearchProjectionDslContext;
+import org.hibernate.search.util.common.impl.Contracts;
+
+public class CompositeProjectionFromStepImpl implements CompositeProjectionFromStep {
+
+	private final SearchProjectionDslContext<?> dslContext;
+
+	public CompositeProjectionFromStepImpl(SearchProjectionDslContext<?> dslContext) {
+		this.dslContext = dslContext;
+	}
+
+	@Override
+	public <V1> CompositeProjectionFrom1AsStep<V1> from(SearchProjection<V1> projection) {
+		return new CompositeProjectionFrom1AsStepImpl<>( dslContext, projection );
+	}
+
+	@Override
+	public <V1, V2> CompositeProjectionFrom2AsStep<V1, V2> from(SearchProjection<V1> projection1,
+			SearchProjection<V2> projection2) {
+		return new CompositeProjectionFrom2AsStepImpl<>( dslContext, projection1, projection2 );
+	}
+
+	@Override
+	public <V1, V2, V3> CompositeProjectionFrom3AsStep<V1, V2, V3> from(SearchProjection<V1> projection1,
+			SearchProjection<V2> projection2, SearchProjection<V3> projection3) {
+		return new CompositeProjectionFrom3AsStepImpl<>( dslContext, projection1, projection2, projection3 );
+	}
+
+	@Override
+	public CompositeProjectionAsStep from(SearchProjection<?>... projections) {
+		Contracts.assertNotNullNorEmpty( projections, "projections" );
+		return new CompositeProjectionFromAnyNumberAsStep( dslContext, projections );
+	}
+
+	@Override
+	public final CompositeProjectionAsStep from(ProjectionFinalStep<?>... dslFinalSteps) {
+		Contracts.assertNotNullNorEmpty( dslFinalSteps, "dslFinalSteps" );
+		SearchProjection<?>[] projections = new SearchProjection<?>[dslFinalSteps.length];
+		for ( int i = 0; i < dslFinalSteps.length; i++ ) {
+			projections[i] = dslFinalSteps[i].toProjection();
+		}
+		return from( projections );
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/spi/AbstractSearchProjectionFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/spi/AbstractSearchProjectionFactory.java
@@ -13,6 +13,7 @@ import java.util.function.Function;
 import org.hibernate.search.engine.common.dsl.spi.DslExtensionState;
 import org.hibernate.search.engine.search.common.ValueConvert;
 import org.hibernate.search.engine.search.projection.SearchProjection;
+import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionInner1Step;
 import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionOptionsStep;
 import org.hibernate.search.engine.search.projection.dsl.DistanceToFieldProjectionValueStep;
 import org.hibernate.search.engine.search.projection.dsl.DocumentReferenceProjectionOptionsStep;
@@ -94,6 +95,12 @@ public abstract class AbstractSearchProjectionFactory<
 	public DistanceToFieldProjectionValueStep<?, Double> distance(String fieldPath, GeoPoint center) {
 		Contracts.assertNotNull( center, "center" );
 		return new DistanceToFieldProjectionValueStepImpl( dslContext, fieldPath, center );
+	}
+
+	@Override
+	public CompositeProjectionInner1Step composite() {
+		// TODO
+		throw new IllegalStateException("Not implemented yet");
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/spi/AbstractSearchProjectionFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/spi/AbstractSearchProjectionFactory.java
@@ -13,7 +13,7 @@ import java.util.function.Function;
 import org.hibernate.search.engine.common.dsl.spi.DslExtensionState;
 import org.hibernate.search.engine.search.common.ValueConvert;
 import org.hibernate.search.engine.search.projection.SearchProjection;
-import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionInner1Step;
+import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionFromStep;
 import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionOptionsStep;
 import org.hibernate.search.engine.search.projection.dsl.DistanceToFieldProjectionValueStep;
 import org.hibernate.search.engine.search.projection.dsl.DocumentReferenceProjectionOptionsStep;
@@ -26,6 +26,7 @@ import org.hibernate.search.engine.search.projection.dsl.ScoreProjectionOptionsS
 import org.hibernate.search.engine.search.projection.dsl.SearchProjectionFactoryExtension;
 import org.hibernate.search.engine.search.projection.dsl.SearchProjectionFactoryExtensionIfSupportedStep;
 import org.hibernate.search.engine.search.projection.dsl.impl.CompositeProjectionOptionsStepImpl;
+import org.hibernate.search.engine.search.projection.dsl.impl.CompositeProjectionFromStepImpl;
 import org.hibernate.search.engine.search.projection.dsl.impl.DistanceToFieldProjectionValueStepImpl;
 import org.hibernate.search.engine.search.projection.dsl.impl.DocumentReferenceProjectionOptionsStepImpl;
 import org.hibernate.search.engine.search.projection.dsl.impl.EntityProjectionOptionsStepImpl;
@@ -98,9 +99,8 @@ public abstract class AbstractSearchProjectionFactory<
 	}
 
 	@Override
-	public CompositeProjectionInner1Step composite() {
-		// TODO
-		throw new IllegalStateException("Not implemented yet");
+	public CompositeProjectionFromStep composite() {
+		return new CompositeProjectionFromStepImpl( dslContext );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/spi/AbstractSearchProjectionFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/dsl/spi/AbstractSearchProjectionFactory.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.engine.search.projection.dsl.spi;
 
 import java.util.List;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.hibernate.search.engine.common.dsl.spi.DslExtensionState;
@@ -37,7 +36,6 @@ import org.hibernate.search.engine.search.projection.dsl.impl.ScoreProjectionOpt
 import org.hibernate.search.engine.search.projection.dsl.impl.SearchProjectionFactoryExtensionStep;
 import org.hibernate.search.engine.search.projection.spi.SearchProjectionIndexScope;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.util.common.function.TriFunction;
 import org.hibernate.search.util.common.impl.Contracts;
 
 
@@ -104,41 +102,8 @@ public abstract class AbstractSearchProjectionFactory<
 	}
 
 	@Override
-	public <T> CompositeProjectionOptionsStep<?, T> composite(Function<List<?>, T> transformer,
-			SearchProjection<?>... projections) {
-		Contracts.assertNotNull( transformer, "transformer" );
-		Contracts.assertNotNullNorEmpty( projections, "projections" );
-
-		return new CompositeProjectionOptionsStepImpl<>( dslContext, transformer, projections );
-	}
-
-	@Override
-	public <P, T> CompositeProjectionOptionsStep<?, T> composite(Function<P, T> transformer, SearchProjection<P> projection) {
-		Contracts.assertNotNull( transformer, "transformer" );
-		Contracts.assertNotNull( projection, "projection" );
-
-		return new CompositeProjectionOptionsStepImpl<>( dslContext, transformer, projection );
-	}
-
-	@Override
-	public <P1, P2, T> CompositeProjectionOptionsStep<?, T> composite(BiFunction<P1, P2, T> transformer,
-			SearchProjection<P1> projection1, SearchProjection<P2> projection2) {
-		Contracts.assertNotNull( transformer, "transformer" );
-		Contracts.assertNotNull( projection1, "projection1" );
-		Contracts.assertNotNull( projection2, "projection2" );
-
-		return new CompositeProjectionOptionsStepImpl<>( dslContext, transformer, projection1, projection2 );
-	}
-
-	@Override
-	public <P1, P2, P3, T> CompositeProjectionOptionsStep<?, T> composite(TriFunction<P1, P2, P3, T> transformer,
-			SearchProjection<P1> projection1, SearchProjection<P2> projection2, SearchProjection<P3> projection3) {
-		Contracts.assertNotNull( transformer, "transformer" );
-		Contracts.assertNotNull( projection1, "projection1" );
-		Contracts.assertNotNull( projection2, "projection2" );
-		Contracts.assertNotNull( projection3, "projection3" );
-
-		return new CompositeProjectionOptionsStepImpl<>( dslContext, transformer, projection1, projection2, projection3 );
+	public CompositeProjectionOptionsStep<?, List<?>> composite(SearchProjection<?>... projections) {
+		return new CompositeProjectionOptionsStepImpl<>( dslContext, Function.identity(), projections );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/dsl/SearchQuerySelectStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/dsl/SearchQuerySelectStep.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.engine.search.query.dsl;
 
 import java.util.List;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -98,7 +97,7 @@ public interface SearchQuerySelectStep<
 	 * Note that using this method will force you to use casts when consuming the results,
 	 * since the returned lists are not typed ({@code List<?>} instead of {@code List<T>}).
 	 * You can replace calls to this method advantageously with calls to {@link #select(Function)}
-	 * defining a {@link SearchProjectionFactory#composite(BiFunction, SearchProjection, SearchProjection) composite projection}.
+	 * defining a {@link SearchProjectionFactory#composite() composite projection}.
 	 *
 	 * @param projections A list of previously-created {@link SearchProjection} objects.
 	 * @return The next step.

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -110,11 +110,10 @@ public class ElasticsearchExtensionIT {
 		ElasticsearchSearchQuerySelectStep<DocumentReference, DocumentReference, StubLoadingOptionsStep> context1 =
 				scope.query().extension( ElasticsearchExtension.get() );
 		ElasticsearchSearchQueryWhereStep<DocumentReference, StubLoadingOptionsStep> context2 = context1.select(
-				f -> f.composite(
+				f -> f.composite()
+						.from( f.documentReference(), f.source() )
 						// We don't care about the source, it's just to test that the factory context allows ES-specific projection
-						(docRef, source) -> docRef,
-						f.documentReference(), f.source()
-				)
+						.as( (docRef, source) -> docRef )
 		);
 		// Note we can use Elasticsearch-specific predicates immediately
 		ElasticsearchSearchQueryOptionsStep<DocumentReference, StubLoadingOptionsStep> context3 =

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
@@ -121,11 +121,10 @@ public class LuceneExtensionIT {
 		LuceneSearchQuerySelectStep<DocumentReference, DocumentReference, StubLoadingOptionsStep> context1 =
 				scope.query().extension( LuceneExtension.get() );
 		LuceneSearchQueryWhereStep<DocumentReference, StubLoadingOptionsStep> context2 = context1.select(
-				f -> f.composite(
+				f -> f.composite()
+						.from( f.documentReference(), f.document() )
 						// We don't care about the document, it's just to test that the factory context allows Lucene-specific projection
-						(docRef, document) -> docRef,
-						f.documentReference(), f.document()
-				)
+						.as( (docRef, document) -> docRef )
 		);
 		// Note we can use Lucene-specific predicates immediately
 		LuceneSearchQueryOptionsStep<DocumentReference, StubLoadingOptionsStep> context3 =

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/bool/BooleanSortAndRangePredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/bool/BooleanSortAndRangePredicateIT.java
@@ -23,7 +23,7 @@ import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
 import org.hibernate.search.engine.search.sort.dsl.SearchSortFactory;
 import org.hibernate.search.integrationtest.backend.tck.search.predicate.RangePredicateSpecificsIT;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.integrationtest.backend.tck.search.sort.FieldSearchSortBaseIT;
+import org.hibernate.search.integrationtest.backend.tck.search.sort.FieldSortBaseIT;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
@@ -35,7 +35,7 @@ import org.junit.Test;
 /**
  * Tests sorting and ranging behaviour querying a boolean type field
  *
- * @see FieldSearchSortBaseIT
+ * @see FieldSortBaseIT
  * @see RangePredicateSpecificsIT
  */
 public class BooleanSortAndRangePredicateIT {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AbstractSpatialWithinPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AbstractSpatialWithinPredicateIT.java
@@ -18,7 +18,7 @@ import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIn
 import org.junit.Before;
 import org.junit.Rule;
 
-public abstract class AbstractSpatialWithinSearchPredicateIT {
+public abstract class AbstractSpatialWithinPredicateIT {
 
 	protected static final String OURSON_QUI_BOIT_ID = "ourson qui boit";
 	protected static final GeoPoint OURSON_QUI_BOIT_GEO_POINT = GeoPoint.of( 45.7705687,4.835233 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SpatialWithinBoundingBoxPredicateSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SpatialWithinBoundingBoxPredicateSpecificsIT.java
@@ -13,7 +13,7 @@ import org.hibernate.search.engine.spatial.GeoPoint;
 
 import org.junit.Test;
 
-public class SpatialWithinBoundingBoxPredicateSpecificsIT extends AbstractSpatialWithinSearchPredicateIT {
+public class SpatialWithinBoundingBoxPredicateSpecificsIT extends AbstractSpatialWithinPredicateIT {
 
 	private static final GeoBoundingBox BOUNDING_BOX_1 = GeoBoundingBox.of(
 			GeoPoint.of( 45.785889, 4.819749 ),

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SpatialWithinCirclePredicateSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SpatialWithinCirclePredicateSpecificsIT.java
@@ -13,7 +13,7 @@ import org.hibernate.search.engine.spatial.GeoPoint;
 
 import org.junit.Test;
 
-public class SpatialWithinCirclePredicateSpecificsIT extends AbstractSpatialWithinSearchPredicateIT {
+public class SpatialWithinCirclePredicateSpecificsIT extends AbstractSpatialWithinPredicateIT {
 
 	private static final GeoPoint METRO_HOTEL_DE_VILLE = GeoPoint.of( 45.7673396, 4.833743 );
 	private static final GeoPoint METRO_GARIBALDI = GeoPoint.of( 45.7515926, 4.8514779 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SpatialWithinPolygonPredicateSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SpatialWithinPolygonPredicateSpecificsIT.java
@@ -13,7 +13,7 @@ import org.hibernate.search.engine.spatial.GeoPolygon;
 
 import org.junit.Test;
 
-public class SpatialWithinPolygonPredicateSpecificsIT extends AbstractSpatialWithinSearchPredicateIT {
+public class SpatialWithinPolygonPredicateSpecificsIT extends AbstractSpatialWithinPredicateIT {
 
 	private static final GeoPolygon POLYGON_1 = GeoPolygon.of(
 			GeoPoint.of( 45.785889, 4.819749 ),

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/CompositeProjectionMultiStepIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/CompositeProjectionMultiStepIT.java
@@ -47,10 +47,10 @@ import org.junit.runner.RunWith;
  * e.g. {@code f.composite().from( otherProjection1, otherProjection2 ).as( MyPair::new ) },
  * as opposed to the single-step DSL,
  * e.g. {@code f.composite( MyPair::new, otherProjection1, otherProjection2 ) },
- * which is tested in {@link CompositeSearchProjectionSingleStepIT}.
+ * which is tested in {@link CompositeProjectionSingleStepIT}.
  */
 @RunWith(Enclosed.class)
-public class CompositeSearchProjectionMultiStepIT {
+public class CompositeProjectionMultiStepIT {
 
 	private static final String DOCUMENT_1 = "1";
 	private static final String DOCUMENT_2 = "2";

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/CompositeProjectionSingleStepIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/CompositeProjectionSingleStepIT.java
@@ -34,10 +34,10 @@ import org.junit.Test;
  * e.g. {@code f.composite( MyPair::new, otherProjection1, otherProjection2 ) },
  * as opposed to the multi-step DSL,
  * e.g. {@code f.composite().from( otherProjection1, otherProjection2 ).as( MyPair::new ) },
- * which is tested in {@link CompositeSearchProjectionMultiStepIT}.
+ * which is tested in {@link CompositeProjectionMultiStepIT}.
  */
 @SuppressWarnings("deprecation")
-public class CompositeSearchProjectionSingleStepIT {
+public class CompositeProjectionSingleStepIT {
 
 	private static final String DOCUMENT_1 = "1";
 	private static final String DOCUMENT_2 = "2";

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/CompositeSearchProjectionMultiStepIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/CompositeSearchProjectionMultiStepIT.java
@@ -1,0 +1,380 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.search.projection;
+
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactory;
+import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
+import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionAsStep;
+import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionFrom1AsStep;
+import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionFrom2AsStep;
+import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionFrom3AsStep;
+import org.hibernate.search.engine.search.projection.dsl.CompositeProjectionFromStep;
+import org.hibernate.search.engine.search.projection.dsl.ProjectionFinalStep;
+import org.hibernate.search.engine.search.projection.dsl.SearchProjectionFactory;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.StandardFieldMapper;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ValueWrapper;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+import org.hibernate.search.util.impl.test.data.Pair;
+import org.hibernate.search.util.impl.test.data.Triplet;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests composite projections created through the multi-step DSL,
+ * e.g. {@code f.composite().from( otherProjection1, otherProjection2 ).as( MyPair::new ) },
+ * as opposed to the single-step DSL,
+ * e.g. {@code f.composite( MyPair::new, otherProjection1, otherProjection2 ) },
+ * which is tested in {@link CompositeSearchProjectionSingleStepIT}.
+ */
+@RunWith(Enclosed.class)
+public class CompositeSearchProjectionMultiStepIT {
+
+	private static final String DOCUMENT_1 = "1";
+	private static final String DOCUMENT_2 = "2";
+	private static final String DOCUMENT_3 = "3";
+
+	@ClassRule
+	public static final SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private static final SimpleMappedIndex<IndexBinding> index = SimpleMappedIndex.of( IndexBinding::new );
+
+	@BeforeClass
+	public static void setup() {
+		setupHelper.start().withIndex( index ).setup();
+
+		index.bulkIndexer()
+				.add( DOCUMENT_1, document -> {
+					index.binding().field1.document1Value.write( document );
+					index.binding().field2.document1Value.write( document );
+					index.binding().field3.document1Value.write( document );
+					index.binding().field4.document1Value.write( document );
+				} )
+				.add( DOCUMENT_2, document -> {
+					index.binding().field1.document2Value.write( document );
+					index.binding().field2.document2Value.write( document );
+					index.binding().field3.document2Value.write( document );
+					index.binding().field4.document2Value.write( document );
+				} )
+				.add( DOCUMENT_3, document -> {
+					index.binding().field1.document3Value.write( document );
+					index.binding().field2.document3Value.write( document );
+					index.binding().field3.document3Value.write( document );
+					index.binding().field4.document3Value.write( document );
+				} )
+				.join();
+	}
+
+	@Test
+	public void takariCpSuiteWorkaround() {
+		// Workaround to get Takari-CPSuite to run this test.
+	}
+
+	private abstract static class AbstractFromAnyNumberIT {
+
+		@Test
+		public void asList() {
+			assertThatQuery( index.query()
+					.select( f -> doFrom( f, f.composite() ).asList() )
+					.where( f -> f.matchAll() ) )
+					.hasHitsAnyOrder( expectedLists() );
+		}
+
+		@Test
+		public void asList_transformer() {
+			assertThatQuery( index.query()
+					.select( f -> doFrom( f, f.composite() ).asList( ValueWrapper<List<?>>::new ) )
+					.where( f -> f.matchAll() ) )
+					.hasHitsAnyOrder( expectedLists().stream().<ValueWrapper<List<?>>>map( ValueWrapper::new )
+							.collect( Collectors.toList() ) );
+		}
+
+		protected abstract CompositeProjectionAsStep doFrom(SearchProjectionFactory<?, ?> f,
+				CompositeProjectionFromStep step);
+
+		protected abstract Collection<List<?>> expectedLists();
+
+	}
+
+	private abstract static class AbstractFromSpecificNumberIT<S extends CompositeProjectionAsStep, T>
+			extends AbstractFromAnyNumberIT {
+
+		@Test
+		public void as_transformer() {
+			assertThatQuery( index.query()
+					.select( f -> doAs( doFrom( f, f.composite() ) ) )
+					.where( f -> f.matchAll() ) )
+					.hasHitsAnyOrder( expectedTransformed() );
+		}
+
+		@Override
+		protected abstract S doFrom(SearchProjectionFactory<?, ?> f, CompositeProjectionFromStep step);
+
+		protected abstract ProjectionFinalStep<T> doAs(S step);
+
+		protected abstract Collection<T> expectedTransformed();
+
+	}
+
+	public static class From1IT
+			extends AbstractFromSpecificNumberIT<CompositeProjectionFrom1AsStep<String>, ValueWrapper<String>> {
+		@Override
+		protected CompositeProjectionFrom1AsStep<String> doFrom(SearchProjectionFactory<?, ?> f,
+				CompositeProjectionFromStep step) {
+			return step.from( f.field( index.binding().field1.relativeFieldName, String.class ) );
+		}
+
+		@Override
+		protected ProjectionFinalStep<ValueWrapper<String>> doAs(CompositeProjectionFrom1AsStep<String> step) {
+			return step.as( ValueWrapper<String>::new );
+		}
+
+		@Override
+		protected Collection<List<?>> expectedLists() {
+			return Arrays.asList(
+					Collections.singletonList( index.binding().field1.document1Value.indexedValue ),
+					Collections.singletonList( index.binding().field1.document2Value.indexedValue ),
+					Collections.singletonList( index.binding().field1.document3Value.indexedValue )
+			);
+		}
+
+		@Override
+		protected Collection<ValueWrapper<String>> expectedTransformed() {
+			return Arrays.asList(
+					new ValueWrapper<>( index.binding().field1.document1Value.indexedValue ),
+					new ValueWrapper<>( index.binding().field1.document2Value.indexedValue ),
+					new ValueWrapper<>( index.binding().field1.document3Value.indexedValue )
+			);
+		}
+	}
+
+	public static class From2IT
+			extends AbstractFromSpecificNumberIT<CompositeProjectionFrom2AsStep<String, String>, Pair<String, String>> {
+		@Override
+		protected CompositeProjectionFrom2AsStep<String, String> doFrom(SearchProjectionFactory<?, ?> f,
+				CompositeProjectionFromStep step) {
+			return step.from( f.field( index.binding().field1.relativeFieldName, String.class ),
+					f.field( index.binding().field2.relativeFieldName, String.class ) );
+		}
+
+		@Override
+		protected ProjectionFinalStep<Pair<String, String>> doAs(CompositeProjectionFrom2AsStep<String, String> step) {
+			return step.as( Pair::new );
+		}
+
+		@Override
+		protected Collection<List<?>> expectedLists() {
+			return Arrays.asList(
+					Arrays.asList( index.binding().field1.document1Value.indexedValue,
+							index.binding().field2.document1Value.indexedValue ),
+					Arrays.asList( index.binding().field1.document2Value.indexedValue,
+							index.binding().field2.document2Value.indexedValue ),
+					Arrays.asList( index.binding().field1.document3Value.indexedValue,
+							index.binding().field2.document3Value.indexedValue )
+			);
+		}
+
+		@Override
+		protected Collection<Pair<String, String>> expectedTransformed() {
+			return Arrays.asList(
+					new Pair<>( index.binding().field1.document1Value.indexedValue,
+							index.binding().field2.document1Value.indexedValue ),
+					new Pair<>( index.binding().field1.document2Value.indexedValue,
+							index.binding().field2.document2Value.indexedValue ),
+					new Pair<>( index.binding().field1.document3Value.indexedValue,
+							index.binding().field2.document3Value.indexedValue )
+			);
+		}
+	}
+
+	public static class From3IT
+			extends AbstractFromSpecificNumberIT<CompositeProjectionFrom3AsStep<String, String, LocalDate>, Triplet<String, String, LocalDate>> {
+		@Override
+		protected CompositeProjectionFrom3AsStep<String, String, LocalDate> doFrom(SearchProjectionFactory<?, ?> f,
+				CompositeProjectionFromStep step) {
+			return step.from( f.field( index.binding().field1.relativeFieldName, String.class ),
+					f.field( index.binding().field2.relativeFieldName, String.class ),
+					f.field( index.binding().field3.relativeFieldName, LocalDate.class ) );
+		}
+
+		@Override
+		protected ProjectionFinalStep<Triplet<String, String, LocalDate>> doAs(
+				CompositeProjectionFrom3AsStep<String, String, LocalDate> step) {
+			return step.as( Triplet::new );
+		}
+
+		@Override
+		protected Collection<List<?>> expectedLists() {
+			return Arrays.asList(
+					Arrays.asList( index.binding().field1.document1Value.indexedValue,
+							index.binding().field2.document1Value.indexedValue,
+							index.binding().field3.document1Value.indexedValue ),
+					Arrays.asList( index.binding().field1.document2Value.indexedValue,
+							index.binding().field2.document2Value.indexedValue,
+							index.binding().field3.document2Value.indexedValue ),
+					Arrays.asList( index.binding().field1.document3Value.indexedValue,
+							index.binding().field2.document3Value.indexedValue,
+							index.binding().field3.document3Value.indexedValue )
+			);
+		}
+
+		@Override
+		protected Collection<Triplet<String, String, LocalDate>> expectedTransformed() {
+			return Arrays.asList(
+					new Triplet<>( index.binding().field1.document1Value.indexedValue,
+							index.binding().field2.document1Value.indexedValue,
+							index.binding().field3.document1Value.indexedValue ),
+					new Triplet<>( index.binding().field1.document2Value.indexedValue,
+							index.binding().field2.document2Value.indexedValue,
+							index.binding().field3.document2Value.indexedValue ),
+					new Triplet<>( index.binding().field1.document3Value.indexedValue,
+							index.binding().field2.document3Value.indexedValue,
+							index.binding().field3.document3Value.indexedValue )
+			);
+		}
+	}
+
+	public static class From4IT
+			extends AbstractFromAnyNumberIT {
+		@Override
+		protected CompositeProjectionAsStep doFrom(SearchProjectionFactory<?, ?> f, CompositeProjectionFromStep step) {
+			return step.from( f.field( index.binding().field1.relativeFieldName, String.class ),
+					f.field( index.binding().field2.relativeFieldName, String.class ),
+					f.field( index.binding().field3.relativeFieldName, LocalDate.class ),
+					f.field( index.binding().field4.relativeFieldName, String.class ) );
+		}
+
+		@Override
+		protected Collection<List<?>> expectedLists() {
+			return Arrays.asList(
+					Arrays.asList( index.binding().field1.document1Value.indexedValue,
+							index.binding().field2.document1Value.indexedValue,
+							index.binding().field3.document1Value.indexedValue,
+							index.binding().field4.document1Value.indexedValue ),
+					Arrays.asList( index.binding().field1.document2Value.indexedValue,
+							index.binding().field2.document2Value.indexedValue,
+							index.binding().field3.document2Value.indexedValue,
+							index.binding().field4.document2Value.indexedValue ),
+					Arrays.asList( index.binding().field1.document3Value.indexedValue,
+							index.binding().field2.document3Value.indexedValue,
+							index.binding().field3.document3Value.indexedValue,
+							index.binding().field4.document3Value.indexedValue )
+			);
+		}
+	}
+
+	public static class SpecificsIT {
+		@Test
+		public void compositeInComposite() {
+			assertThatQuery( index.query()
+					.select( f -> f.composite().from(
+							f.composite().from(
+									f.field( index.binding().field1.relativeFieldName, String.class ),
+									f.field( index.binding().field2.relativeFieldName, String.class )
+							).as( Pair::new ),
+							f.score()
+					).as( Pair::new ) )
+					.where( f -> f.matchAll() ) )
+					.hasHitsAnyOrder(
+							new Pair<>( new Pair<>( index.binding().field1.document1Value.indexedValue,
+									index.binding().field2.document1Value.indexedValue ), 1.0F ),
+							new Pair<>( new Pair<>( index.binding().field1.document2Value.indexedValue,
+									index.binding().field2.document2Value.indexedValue ), 1.0F ),
+							new Pair<>( new Pair<>( index.binding().field1.document3Value.indexedValue,
+									index.binding().field2.document3Value.indexedValue ), 1.0F )
+					);
+		}
+	}
+
+	private static class IndexBinding {
+		final FieldModel<String> field1;
+		final FieldModel<String> field2;
+		final FieldModel<LocalDate> field3;
+		final FieldModel<String> field4;
+
+		IndexBinding(IndexSchemaElement root) {
+			field1 = FieldModel.mapper( String.class, "field1value1", "field1value2", "field1value3" )
+					.map( root, "field1" );
+			field2 = FieldModel.mapper( String.class, "field2value1", "field2value2", "field2value3" )
+					.map( root, "field2" );
+			field3 = FieldModel.mapper( LocalDate.class,
+							LocalDate.of( 2017, 12, 3 ),
+							LocalDate.of( 2017, 12, 4 ),
+							LocalDate.of( 2017, 12, 5 ) )
+					.map( root, "field3" );
+			field4 = FieldModel.mapper( String.class, "field4value1", "field4value2", "field4value3" )
+					.map( root, "field4" );
+		}
+	}
+
+	private static class ValueModel<F> {
+		private final IndexFieldReference<F> reference;
+		final F indexedValue;
+
+		private ValueModel(IndexFieldReference<F> reference, F indexedValue) {
+			this.reference = reference;
+			this.indexedValue = indexedValue;
+		}
+
+		public void write(DocumentElement target) {
+			target.addValue( reference, indexedValue );
+		}
+	}
+
+	private static class FieldModel<F> {
+		static <F> StandardFieldMapper<F, FieldModel<F>> mapper(Class<F> type,
+				F document1Value, F document2Value, F document3Value) {
+			return mapper(
+					c -> (StandardIndexFieldTypeOptionsStep<?, F>) c.as( type ),
+					document1Value, document2Value, document3Value
+			);
+		}
+
+		static <F> StandardFieldMapper<F, FieldModel<F>> mapper(
+				Function<IndexFieldTypeFactory, StandardIndexFieldTypeOptionsStep<?, F>> configuration,
+				F document1Value, F document2Value, F document3Value) {
+			return StandardFieldMapper.of(
+					configuration,
+					c -> c.projectable( Projectable.YES ),
+					(reference, name) -> new FieldModel<>( reference, name, document1Value, document2Value, document3Value )
+			);
+		}
+
+		final String relativeFieldName;
+
+		final ValueModel<F> document1Value;
+		final ValueModel<F> document2Value;
+		final ValueModel<F> document3Value;
+
+		private FieldModel(IndexFieldReference<F> reference, String relativeFieldName,
+				F document1Value, F document2Value, F document3Value) {
+			this.relativeFieldName = relativeFieldName;
+			this.document1Value = new ValueModel<>( reference, document1Value );
+			this.document2Value = new ValueModel<>( reference, document2Value );
+			this.document3Value = new ValueModel<>( reference, document3Value );
+		}
+	}
+
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/CompositeSearchProjectionSingleStepIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/CompositeSearchProjectionSingleStepIT.java
@@ -36,6 +36,7 @@ import org.junit.Test;
  * e.g. {@code f.composite().from( otherProjection1, otherProjection2 ).as( MyPair::new ) },
  * which is tested in {@link CompositeSearchProjectionMultiStepIT}.
  */
+@SuppressWarnings("deprecation")
 public class CompositeSearchProjectionSingleStepIT {
 
 	private static final String DOCUMENT_1 = "1";

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/CompositeSearchProjectionSingleStepIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/CompositeSearchProjectionSingleStepIT.java
@@ -29,7 +29,14 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class CompositeSearchProjectionIT {
+/**
+ * Tests composite projections created through the single-step DSL,
+ * e.g. {@code f.composite( MyPair::new, otherProjection1, otherProjection2 ) },
+ * as opposed to the multi-step DSL,
+ * e.g. {@code f.composite().from( otherProjection1, otherProjection2 ).as( MyPair::new ) },
+ * which is tested in {@link CompositeSearchProjectionMultiStepIT}.
+ */
+public class CompositeSearchProjectionSingleStepIT {
 
 	private static final String DOCUMENT_1 = "1";
 	private static final String DOCUMENT_2 = "2";

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/DistanceProjectionSingleValuedBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/DistanceProjectionSingleValuedBaseIT.java
@@ -9,25 +9,28 @@ package org.hibernate.search.integrationtest.backend.tck.search.projection;
 import static org.hibernate.search.integrationtest.backend.tck.testsupport.types.values.IndexableGeoPointWithDistanceFromCenterValues.CENTER_POINT_1;
 import static org.hibernate.search.integrationtest.backend.tck.testsupport.types.values.IndexableGeoPointWithDistanceFromCenterValues.CENTER_POINT_2;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.TestComparators.APPROX_KM_COMPARATOR;
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.TestComparators.APPROX_MILES_COMPARATOR;
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.TestComparators.APPROX_M_COMPARATOR;
 import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.documentProvider;
+import static org.junit.Assume.assumeTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.types.Sortable;
-import org.hibernate.search.engine.search.common.SortMode;
 import org.hibernate.search.engine.spatial.DistanceUnit;
 import org.hibernate.search.engine.spatial.GeoPoint;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.model.singlefield.AbstractObjectBinding;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.model.singlefield.SingleFieldIndexBinding;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.GeoPointFieldTypeDescriptor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values.AscendingUniqueDistanceFromCenterValues;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values.IndexableGeoPointWithDistanceFromCenterValues;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TestedFieldStructure;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.TestComparators;
@@ -47,29 +50,21 @@ import org.junit.runners.Parameterized;
 import org.assertj.core.api.ListAssert;
 
 /**
- * Tests basic behavior of projections on the distance between a given point and the value of a multi-valued field.
+ * Tests basic behavior of projections on the distance between a given point and the value of a single-valued field.
  */
 @RunWith(Parameterized.class)
-@TestForIssue(jiraKey = "HSEARCH-3391")
-public class DistanceSearchProjectionMultiValuedBaseIT {
+public class DistanceProjectionSingleValuedBaseIT {
 
 	private static final GeoPointFieldTypeDescriptor fieldType = GeoPointFieldTypeDescriptor.INSTANCE;
 	private static final Set<FieldTypeDescriptor<GeoPoint>> supportedFieldTypes = Collections.singleton( fieldType );
 	private static List<DataSet> dataSets;
-
-	private static final Comparator<Iterable<Double>> APPROX_M_COMPARATOR =
-			TestComparators.lexicographic( TestComparators.APPROX_M_COMPARATOR );
-	private static final Comparator<Iterable<Double>> APPROX_KM_COMPARATOR =
-			TestComparators.lexicographic( TestComparators.APPROX_KM_COMPARATOR );
-	private static final Comparator<Iterable<Double>> APPROX_MILES_COMPARATOR =
-			TestComparators.lexicographic( TestComparators.APPROX_MILES_COMPARATOR );
 
 	@Parameterized.Parameters(name = "{0}")
 	public static Object[][] parameters() {
 		dataSets = new ArrayList<>();
 		List<Object[]> parameters = new ArrayList<>();
 		for ( TestedFieldStructure fieldStructure : TestedFieldStructure.all() ) {
-			if ( fieldStructure.isSingleValued() ) {
+			if ( fieldStructure.isMultiValued() ) {
 				continue;
 			}
 			DataSet dataSet = new DataSet( fieldStructure );
@@ -83,13 +78,13 @@ public class DistanceSearchProjectionMultiValuedBaseIT {
 	public static SearchSetupHelper setupHelper = new SearchSetupHelper();
 
 	private static final SimpleMappedIndex<SingleFieldIndexBinding> mainIndex =
-			SimpleMappedIndex.of( root -> SingleFieldIndexBinding.create(
+			SimpleMappedIndex.of( root -> SingleFieldIndexBinding.createWithSingleValuedNestedFields(
 					root, supportedFieldTypes,
 					c -> c.projectable( Projectable.YES )
 			) )
 					.name( "main" );
 	private static final SimpleMappedIndex<SingleFieldIndexBinding> sortableIndex =
-			SimpleMappedIndex.of( root -> SingleFieldIndexBinding.create(
+			SimpleMappedIndex.of( root -> SingleFieldIndexBinding.createWithSingleValuedNestedFields(
 					root, supportedFieldTypes,
 					c -> c.projectable( Projectable.YES ).sortable( Sortable.YES )
 			) )
@@ -110,7 +105,7 @@ public class DistanceSearchProjectionMultiValuedBaseIT {
 	private final TestedFieldStructure fieldStructure;
 	private final DataSet dataSet;
 
-	public DistanceSearchProjectionMultiValuedBaseIT(TestedFieldStructure fieldStructure, DataSet dataSet) {
+	public DistanceProjectionSingleValuedBaseIT(TestedFieldStructure fieldStructure, DataSet dataSet) {
 		this.fieldStructure = fieldStructure;
 		this.dataSet = dataSet;
 	}
@@ -123,34 +118,61 @@ public class DistanceSearchProjectionMultiValuedBaseIT {
 
 		assertThatQuery( scope.query()
 				// Do NOT add any additional projection here: this serves as a non-regression test for HSEARCH-3618
-				.select( f -> f.distance( fieldPath, CENTER_POINT_1 ).multi() )
+				.select( f -> f.distance( fieldPath, CENTER_POINT_1 ) )
 				.where( f -> f.matchAll() )
 				.routing( dataSet.routingKey )
 				.toQuery() )
 				.hits().asIs()
 				.usingElementComparator( APPROX_M_COMPARATOR )
 				.containsExactlyInAnyOrder(
-						dataSet.getFieldDistancesFromCenter1( 1 ),
-						dataSet.getFieldDistancesFromCenter1( 2 ),
-						dataSet.getFieldDistancesFromCenter1( 3 ),
-						Collections.emptyList() // Empty document
+						dataSet.getFieldDistanceFromCenter1( 1 ),
+						dataSet.getFieldDistanceFromCenter1( 2 ),
+						dataSet.getFieldDistanceFromCenter1( 3 ),
+						null // Empty document
+				);
+	}
+
+	/**
+	 * Test requesting a multi-valued projection on a single-valued field.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3391")
+	public void multi() {
+		StubMappingScope scope = mainIndex.createScope();
+
+		String fieldPath = getFieldPath();
+
+		assertThatQuery( scope.query()
+				.select( f -> f.distance( fieldPath, CENTER_POINT_1 ).multi() )
+				.where( f -> f.matchAll() )
+				.routing( dataSet.routingKey )
+				.toQuery() )
+				.hits().asIs()
+				.usingElementComparator( TestComparators.lexicographic( APPROX_M_COMPARATOR ) )
+				.containsExactlyInAnyOrder(
+						Collections.singletonList( dataSet.getFieldDistanceFromCenter1( 1 ) ),
+						Collections.singletonList( dataSet.getFieldDistanceFromCenter1( 2 ) ),
+						Collections.singletonList( dataSet.getFieldDistanceFromCenter1( 3 ) ),
+						// Empty document
+						TckConfiguration.get().getBackendFeatures().projectionPreservesNulls()
+								? Collections.singletonList( null )
+								: Collections.emptyList()
 				);
 	}
 
 	/**
 	 * Test that mentioning the same projection twice works as expected.
 	 */
-	@SuppressWarnings("unchecked")
 	@Test
 	public void duplicated() {
 		StubMappingScope scope = mainIndex.createScope();
 
 		String fieldPath = getFieldPath();
 
-		ListAssert<Pair<List<Double>, List<Double>>> hitsAssert = assertThatQuery( scope.query()
+		ListAssert<Pair<Double, Double>> hitsAssert = assertThatQuery( scope.query()
 				.select( f -> f.composite()
-						.from( f.distance( fieldPath, CENTER_POINT_1 ).multi(),
-								f.distance( fieldPath, CENTER_POINT_1 ).multi() )
+						.from( f.distance( fieldPath, CENTER_POINT_1 ),
+								f.distance( fieldPath, CENTER_POINT_1 ) )
 						.as( Pair::new ) )
 				.where( f -> f.matchAll() )
 				.routing( dataSet.routingKey )
@@ -160,18 +182,18 @@ public class DistanceSearchProjectionMultiValuedBaseIT {
 		hitsAssert.extracting( Pair::elem0 )
 				.usingElementComparator( APPROX_M_COMPARATOR )
 				.containsExactlyInAnyOrder(
-						dataSet.getFieldDistancesFromCenter1( 1 ),
-						dataSet.getFieldDistancesFromCenter1( 2 ),
-						dataSet.getFieldDistancesFromCenter1( 3 ),
-						Collections.emptyList() // Empty document
+						dataSet.getFieldDistanceFromCenter1( 1 ),
+						dataSet.getFieldDistanceFromCenter1( 2 ),
+						dataSet.getFieldDistanceFromCenter1( 3 ),
+						null
 				);
 		hitsAssert.extracting( Pair::elem1 )
 				.usingElementComparator( APPROX_M_COMPARATOR )
 				.containsExactlyInAnyOrder(
-						dataSet.getFieldDistancesFromCenter1( 1 ),
-						dataSet.getFieldDistancesFromCenter1( 2 ),
-						dataSet.getFieldDistancesFromCenter1( 3 ),
-						Collections.emptyList() // Empty document
+						dataSet.getFieldDistanceFromCenter1( 1 ),
+						dataSet.getFieldDistanceFromCenter1( 2 ),
+						dataSet.getFieldDistanceFromCenter1( 3 ),
+						null
 				);
 	}
 
@@ -184,16 +206,16 @@ public class DistanceSearchProjectionMultiValuedBaseIT {
 
 		assertThatQuery( scope.query()
 				// Do NOT add any additional projection here: this serves as a non-regression test for HSEARCH-3618
-				.select( f -> f.distance( fieldPath, AscendingUniqueDistanceFromCenterValues.CENTER_POINT ).multi() )
+				.select( f -> f.distance( fieldPath, AscendingUniqueDistanceFromCenterValues.CENTER_POINT ) )
 				.where( f -> f.matchAll() )
 				.routing( dataSet.routingKey )
 				.toQuery() )
 				.hits().asIs()
 				.usingElementComparator( APPROX_M_COMPARATOR )
 				.containsExactlyInAnyOrder(
-						dataSet.getSortableFieldDistancesFromCenter( 1 ),
-						dataSet.getSortableFieldDistancesFromCenter( 2 ),
-						dataSet.getSortableFieldDistancesFromCenter( 3 )
+						dataSet.getSortableFieldDistanceFromCenter( 1 ),
+						dataSet.getSortableFieldDistanceFromCenter( 2 ),
+						dataSet.getSortableFieldDistanceFromCenter( 3 )
 				);
 	}
 
@@ -210,7 +232,7 @@ public class DistanceSearchProjectionMultiValuedBaseIT {
 
 		assertThatQuery( scope.query()
 				// Do NOT add any additional projection here: this serves as a non-regression test for HSEARCH-3618
-				.select( f -> f.distance( fieldPath, AscendingUniqueDistanceFromCenterValues.CENTER_POINT ).multi() )
+				.select( f -> f.distance( fieldPath, AscendingUniqueDistanceFromCenterValues.CENTER_POINT ) )
 				.where( f -> f.matchAll() )
 				.sort( f -> f.distance( fieldPath, AscendingUniqueDistanceFromCenterValues.CENTER_POINT ) )
 				.routing( dataSet.routingKey )
@@ -218,9 +240,9 @@ public class DistanceSearchProjectionMultiValuedBaseIT {
 				.hits().asIs()
 				.usingElementComparator( APPROX_M_COMPARATOR )
 				.containsExactly( // in this order
-						dataSet.getSortableFieldDistancesFromCenter( 1 ),
-						dataSet.getSortableFieldDistancesFromCenter( 2 ),
-						dataSet.getSortableFieldDistancesFromCenter( 3 )
+						dataSet.getSortableFieldDistanceFromCenter( 1 ),
+						dataSet.getSortableFieldDistanceFromCenter( 2 ),
+						dataSet.getSortableFieldDistanceFromCenter( 3 )
 				);
 	}
 
@@ -229,7 +251,7 @@ public class DistanceSearchProjectionMultiValuedBaseIT {
 		StubMappingScope scope = mainIndex.createScope();
 
 		assertThatQuery( scope.query()
-				.select( f -> f.distance( getFieldPath(), CENTER_POINT_1 ).multi()
+				.select( f -> f.distance( getFieldPath(), CENTER_POINT_1 )
 						.unit( DistanceUnit.KILOMETERS ) )
 				.where( f -> f.matchAll() )
 				.routing( dataSet.routingKey )
@@ -237,10 +259,10 @@ public class DistanceSearchProjectionMultiValuedBaseIT {
 				.hits().asIs()
 				.usingElementComparator( APPROX_KM_COMPARATOR )
 				.containsExactlyInAnyOrder(
-						divideAll( dataSet.getFieldDistancesFromCenter1( 1 ), 1000 ),
-						divideAll( dataSet.getFieldDistancesFromCenter1( 2 ), 1000 ),
-						divideAll( dataSet.getFieldDistancesFromCenter1( 3 ), 1000 ),
-						Collections.emptyList() // Empty document
+						dataSet.getFieldDistanceFromCenter1( 1 ) / 1000,
+						dataSet.getFieldDistanceFromCenter1( 2 ) / 1000,
+						dataSet.getFieldDistanceFromCenter1( 3 ) / 1000,
+						null
 				);
 	}
 
@@ -249,7 +271,7 @@ public class DistanceSearchProjectionMultiValuedBaseIT {
 		StubMappingScope scope = mainIndex.createScope();
 
 		assertThatQuery( scope.query()
-				.select( f -> f.distance( getFieldPath(), CENTER_POINT_1 ).multi()
+				.select( f -> f.distance( getFieldPath(), CENTER_POINT_1 )
 						.unit( DistanceUnit.MILES ) )
 				.where( f -> f.matchAll() )
 				.routing( dataSet.routingKey )
@@ -257,10 +279,10 @@ public class DistanceSearchProjectionMultiValuedBaseIT {
 				.hits().asIs()
 				.usingElementComparator( APPROX_MILES_COMPARATOR )
 				.containsExactlyInAnyOrder(
-						divideAll( dataSet.getFieldDistancesFromCenter1( 1 ), 1_609.344 ),
-						divideAll( dataSet.getFieldDistancesFromCenter1( 2 ), 1_609.344 ),
-						divideAll( dataSet.getFieldDistancesFromCenter1( 3 ), 1_609.344 ),
-						Collections.emptyList() // Empty document
+						dataSet.getFieldDistanceFromCenter1( 1 ) / 1_609.344,
+						dataSet.getFieldDistanceFromCenter1( 2 ) / 1_609.344,
+						dataSet.getFieldDistanceFromCenter1( 3 ) / 1_609.344,
+						null
 				);
 	}
 
@@ -268,11 +290,11 @@ public class DistanceSearchProjectionMultiValuedBaseIT {
 	public void several() {
 		StubMappingScope scope = mainIndex.createScope();
 
-		ListAssert<Triplet<List<Double>, List<Double>, List<Double>>> hitsAssert = assertThatQuery( scope.query()
+		ListAssert<Triplet<Double, Double, Double>> hitsAssert = assertThatQuery( scope.query()
 				.select( f -> f.composite()
-						.from( f.distance( getFieldPath(), CENTER_POINT_1 ).multi(),
-								f.distance( getFieldPath(), CENTER_POINT_2 ).multi(),
-								f.distance( getFieldPath(), CENTER_POINT_1 ).multi().unit( DistanceUnit.KILOMETERS ) )
+						.from( f.distance( getFieldPath(), CENTER_POINT_1 ),
+								f.distance( getFieldPath(), CENTER_POINT_2 ),
+								f.distance( getFieldPath(), CENTER_POINT_1 ).unit( DistanceUnit.KILOMETERS ) )
 						.as( Triplet::new ) )
 				.where( f -> f.matchAll() )
 				.routing( dataSet.routingKey )
@@ -282,35 +304,55 @@ public class DistanceSearchProjectionMultiValuedBaseIT {
 		hitsAssert.extracting( Triplet::elem0 )
 				.usingElementComparator( APPROX_M_COMPARATOR )
 				.containsExactlyInAnyOrder(
-						dataSet.getFieldDistancesFromCenter1( 1 ),
-						dataSet.getFieldDistancesFromCenter1( 2 ),
-						dataSet.getFieldDistancesFromCenter1( 3 ),
-						Collections.emptyList() // Empty document
+						dataSet.getFieldDistanceFromCenter1( 1 ),
+						dataSet.getFieldDistanceFromCenter1( 2 ),
+						dataSet.getFieldDistanceFromCenter1( 3 ),
+						null
 				);
 		hitsAssert.extracting( Triplet::elem1 )
 				.usingElementComparator( APPROX_M_COMPARATOR )
 				.containsExactlyInAnyOrder(
-						dataSet.getFieldDistancesFromCenter2( 1 ),
-						dataSet.getFieldDistancesFromCenter2( 2 ),
-						dataSet.getFieldDistancesFromCenter2( 3 ),
-						Collections.emptyList() // Empty document
+						dataSet.getFieldDistanceFromCenter2( 1 ),
+						dataSet.getFieldDistanceFromCenter2( 2 ),
+						dataSet.getFieldDistanceFromCenter2( 3 ),
+						null
 				);
 		hitsAssert.extracting( Triplet::elem2 )
 				.usingElementComparator( APPROX_KM_COMPARATOR )
 				.containsExactlyInAnyOrder(
-						divideAll( dataSet.getFieldDistancesFromCenter1( 1 ), 1000 ),
-						divideAll( dataSet.getFieldDistancesFromCenter1( 2 ), 1000 ),
-						divideAll( dataSet.getFieldDistancesFromCenter1( 3 ), 1000 ),
-						Collections.emptyList() // Empty document
+						dataSet.getFieldDistanceFromCenter1( 1 ) / 1000,
+						dataSet.getFieldDistanceFromCenter1( 2 ) / 1000,
+						dataSet.getFieldDistanceFromCenter1( 3 ) / 1000,
+						null
+				);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4162")
+	public void factoryWithRoot() {
+		AbstractObjectBinding parentObjectBinding = mainIndex.binding().getParentObject( fieldStructure );
+
+		assumeTrue( "This test is only relevant when the field is located on an object field",
+				parentObjectBinding.absolutePath != null );
+
+		assertThatQuery( mainIndex.query()
+				.select( f -> f.withRoot( parentObjectBinding.absolutePath )
+						.distance( parentObjectBinding.getRelativeFieldName( fieldStructure, fieldType ), CENTER_POINT_1 ) )
+				.where( f -> f.matchAll() )
+				.routing( dataSet.routingKey )
+				.toQuery() )
+				.hits().asIs()
+				.usingElementComparator( APPROX_M_COMPARATOR )
+				.containsExactlyInAnyOrder(
+						dataSet.getFieldDistanceFromCenter1( 1 ),
+						dataSet.getFieldDistanceFromCenter1( 2 ),
+						dataSet.getFieldDistanceFromCenter1( 3 ),
+						null // Empty document
 				);
 	}
 
 	private String getFieldPath() {
 		return mainIndex.binding().getFieldPath( fieldStructure, fieldType );
-	}
-
-	private static List<Double> divideAll(List<Double> distances, double denominator) {
-		return distances.stream().map( v -> v / denominator ).collect( Collectors.toList() );
 	}
 
 	private static class DataSet {
@@ -332,50 +374,49 @@ public class DistanceSearchProjectionMultiValuedBaseIT {
 
 		private void contribute(BulkIndexer mainIndexer, BulkIndexer sortableIndexer) {
 			mainIndexer.add( documentProvider( emptyDocId( 1 ), routingKey,
-					document -> mainIndex.binding().initMultiValued( fieldType, fieldStructure.location,
-							document, Collections.emptyList() ) ) );
+					document -> mainIndex.binding().initSingleValued( fieldType, fieldStructure.location,
+							document, null ) ) );
 			mainIndexer.add( documentProvider( docId( 1 ), routingKey,
-					document -> mainIndex.binding().initMultiValued( fieldType, fieldStructure.location,
-							document, getFieldValues( 1 ) ) ) );
+					document -> mainIndex.binding().initSingleValued( fieldType, fieldStructure.location,
+							document, getFieldValue( 1 ) ) ) );
 			mainIndexer.add( documentProvider( docId( 2 ), routingKey,
-					document -> mainIndex.binding().initMultiValued( fieldType, fieldStructure.location,
-							document, getFieldValues( 2 ) ) ) );
+					document -> mainIndex.binding().initSingleValued( fieldType, fieldStructure.location,
+							document, getFieldValue( 2 ) ) ) );
 			mainIndexer.add( documentProvider( docId( 3 ), routingKey,
-					document -> mainIndex.binding().initMultiValued( fieldType, fieldStructure.location,
-							document, getFieldValues( 3 ) ) ) );
+					document -> mainIndex.binding().initSingleValued( fieldType, fieldStructure.location,
+							document, getFieldValue( 3 ) ) ) );
 
 			sortableIndexer.add( documentProvider( docId( 2 ), routingKey,
-					document -> sortableIndex.binding().initMultiValued( fieldType, fieldStructure.location,
-							document, getSortableFieldValues( 2 ) ) ) );
+					document -> sortableIndex.binding().initSingleValued( fieldType, fieldStructure.location,
+							document, getSortableFieldValue( 2 ) ) ) );
 			sortableIndexer.add( documentProvider( docId( 1 ), routingKey,
-					document -> sortableIndex.binding().initMultiValued( fieldType, fieldStructure.location,
-							document, getSortableFieldValues( 1 ) ) ) );
+					document -> sortableIndex.binding().initSingleValued( fieldType, fieldStructure.location,
+							document, getSortableFieldValue( 1 ) ) ) );
 			sortableIndexer.add( documentProvider( docId( 3 ), routingKey,
-					document -> sortableIndex.binding().initMultiValued( fieldType, fieldStructure.location,
-							document, getSortableFieldValues( 3 ) ) ) );
+					document -> sortableIndex.binding().initSingleValued( fieldType, fieldStructure.location,
+							document, getSortableFieldValue( 3 ) ) ) );
 		}
 
-		private List<GeoPoint> getFieldValues(int documentNumber) {
-			return IndexableGeoPointWithDistanceFromCenterValues.INSTANCE.getMulti().get( documentNumber - 1 );
+		private GeoPoint getFieldValue(int documentNumber) {
+			return IndexableGeoPointWithDistanceFromCenterValues.INSTANCE.getSingle().get( documentNumber - 1 );
 		}
 
-		private List<GeoPoint> getSortableFieldValues(int documentNumber) {
-			return AscendingUniqueDistanceFromCenterValues.INSTANCE.getMultiResultingInSingle( SortMode.MIN )
+		private GeoPoint getSortableFieldValue(int documentNumber) {
+			return AscendingUniqueDistanceFromCenterValues.INSTANCE.getSingle().get( documentNumber - 1 );
+		}
+
+		private double getFieldDistanceFromCenter1(int documentNumber) {
+			return IndexableGeoPointWithDistanceFromCenterValues.INSTANCE.getSingleDistancesFromCenterPoint1()
 					.get( documentNumber - 1 );
 		}
 
-		private List<Double> getFieldDistancesFromCenter1(int documentNumber) {
-			return IndexableGeoPointWithDistanceFromCenterValues.INSTANCE.getMultiDistancesFromCenterPoint1()
+		private double getFieldDistanceFromCenter2(int documentNumber) {
+			return IndexableGeoPointWithDistanceFromCenterValues.INSTANCE.getSingleDistancesFromCenterPoint2()
 					.get( documentNumber - 1 );
 		}
 
-		private List<Double> getFieldDistancesFromCenter2(int documentNumber) {
-			return IndexableGeoPointWithDistanceFromCenterValues.INSTANCE.getMultiDistancesFromCenterPoint2()
-					.get( documentNumber - 1 );
-		}
-
-		private List<Double> getSortableFieldDistancesFromCenter(int documentNumber) {
-			return AscendingUniqueDistanceFromCenterValues.INSTANCE.getMultiDistancesFromCenterPointForMinDataset()
+		private Double getSortableFieldDistanceFromCenter(int documentNumber) {
+			return AscendingUniqueDistanceFromCenterValues.INSTANCE.getSingleDistancesFromCenterPoint()
 					.get( documentNumber - 1 );
 		}
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/DistanceProjectionTypeCheckingAndConversionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/DistanceProjectionTypeCheckingAndConversionIT.java
@@ -44,7 +44,7 @@ import org.junit.Test;
  * Tests behavior related to type checking and type conversion of
  * projections on the distance between a field value and a given point.
  */
-public class DistanceSearchProjectionTypeCheckingAndConversionIT {
+public class DistanceProjectionTypeCheckingAndConversionIT {
 
 	private static final GeoPointFieldTypeDescriptor fieldType = GeoPointFieldTypeDescriptor.INSTANCE;
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/DistanceProjectionTypeIndependentIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/DistanceProjectionTypeIndependentIT.java
@@ -30,9 +30,9 @@ import org.junit.Test;
  * for distance projections.
  * <p>
  * Behavior that is specific to the field type is tested elsewhere,
- * e.g. {@link DistanceSearchProjectionSingleValuedBaseIT} and {@link DistanceSearchProjectionTypeCheckingAndConversionIT}.
+ * e.g. {@link DistanceProjectionSingleValuedBaseIT} and {@link DistanceProjectionTypeCheckingAndConversionIT}.
  */
-public class DistanceSearchProjectionTypeIndependentIT {
+public class DistanceProjectionTypeIndependentIT {
 
 	private static final GeoPoint SOME_POINT = GeoPoint.of( 45.749828, 4.854172 );
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/DistanceProjectionUnsupportedTypesIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/DistanceProjectionUnsupportedTypesIT.java
@@ -32,7 +32,7 @@ import org.junit.runners.Parameterized;
  * i.e. error messages.
  */
 @RunWith(Parameterized.class)
-public class DistanceSearchProjectionUnsupportedTypesIT<F> {
+public class DistanceProjectionUnsupportedTypesIT<F> {
 
 	private static Stream<FieldTypeDescriptor<?>> unsupportedTypeDescriptors() {
 		return FieldTypeDescriptor.getAll().stream()
@@ -60,7 +60,7 @@ public class DistanceSearchProjectionUnsupportedTypesIT<F> {
 
 	private final FieldTypeDescriptor<F> fieldTypeDescriptor;
 
-	public DistanceSearchProjectionUnsupportedTypesIT(FieldTypeDescriptor<F> fieldTypeDescriptor) {
+	public DistanceProjectionUnsupportedTypesIT(FieldTypeDescriptor<F> fieldTypeDescriptor) {
 		this.fieldTypeDescriptor = fieldTypeDescriptor;
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/DistanceSearchProjectionMultiValuedBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/DistanceSearchProjectionMultiValuedBaseIT.java
@@ -148,11 +148,10 @@ public class DistanceSearchProjectionMultiValuedBaseIT {
 		String fieldPath = getFieldPath();
 
 		ListAssert<Pair<List<Double>, List<Double>>> hitsAssert = assertThatQuery( scope.query()
-				.select( f -> f.composite(
-						Pair::new,
-						f.distance( fieldPath, CENTER_POINT_1 ).multi(),
-						f.distance( fieldPath, CENTER_POINT_1 ).multi()
-				) )
+				.select( f -> f.composite()
+						.from( f.distance( fieldPath, CENTER_POINT_1 ).multi(),
+								f.distance( fieldPath, CENTER_POINT_1 ).multi() )
+						.as( Pair::new ) )
 				.where( f -> f.matchAll() )
 				.routing( dataSet.routingKey )
 				.toQuery() )
@@ -270,12 +269,11 @@ public class DistanceSearchProjectionMultiValuedBaseIT {
 		StubMappingScope scope = mainIndex.createScope();
 
 		ListAssert<Triplet<List<Double>, List<Double>, List<Double>>> hitsAssert = assertThatQuery( scope.query()
-				.select( f -> f.composite(
-						Triplet::new,
-						f.distance( getFieldPath(), CENTER_POINT_1 ).multi(),
-						f.distance( getFieldPath(), CENTER_POINT_2 ).multi(),
-						f.distance( getFieldPath(), CENTER_POINT_1 ).multi().unit( DistanceUnit.KILOMETERS )
-				) )
+				.select( f -> f.composite()
+						.from( f.distance( getFieldPath(), CENTER_POINT_1 ).multi(),
+								f.distance( getFieldPath(), CENTER_POINT_2 ).multi(),
+								f.distance( getFieldPath(), CENTER_POINT_1 ).multi().unit( DistanceUnit.KILOMETERS ) )
+						.as( Triplet::new ) )
 				.where( f -> f.matchAll() )
 				.routing( dataSet.routingKey )
 				.toQuery() )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/DistanceSearchProjectionSingleValuedBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/DistanceSearchProjectionSingleValuedBaseIT.java
@@ -170,11 +170,10 @@ public class DistanceSearchProjectionSingleValuedBaseIT {
 		String fieldPath = getFieldPath();
 
 		ListAssert<Pair<Double, Double>> hitsAssert = assertThatQuery( scope.query()
-				.select( f -> f.composite(
-						Pair::new,
-						f.distance( fieldPath, CENTER_POINT_1 ),
-						f.distance( fieldPath, CENTER_POINT_1 )
-				) )
+				.select( f -> f.composite()
+						.from( f.distance( fieldPath, CENTER_POINT_1 ),
+								f.distance( fieldPath, CENTER_POINT_1 ) )
+						.as( Pair::new ) )
 				.where( f -> f.matchAll() )
 				.routing( dataSet.routingKey )
 				.toQuery() )
@@ -292,12 +291,11 @@ public class DistanceSearchProjectionSingleValuedBaseIT {
 		StubMappingScope scope = mainIndex.createScope();
 
 		ListAssert<Triplet<Double, Double, Double>> hitsAssert = assertThatQuery( scope.query()
-				.select( f -> f.composite(
-						Triplet::new,
-						f.distance( getFieldPath(), CENTER_POINT_1 ),
-						f.distance( getFieldPath(), CENTER_POINT_2 ),
-						f.distance( getFieldPath(), CENTER_POINT_1 ).unit( DistanceUnit.KILOMETERS )
-				) )
+				.select( f -> f.composite()
+						.from( f.distance( getFieldPath(), CENTER_POINT_1 ),
+								f.distance( getFieldPath(), CENTER_POINT_2 ),
+								f.distance( getFieldPath(), CENTER_POINT_1 ).unit( DistanceUnit.KILOMETERS ) )
+						.as( Triplet::new ) )
 				.where( f -> f.matchAll() )
 				.routing( dataSet.routingKey )
 				.toQuery() )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldProjectionMultiValuedBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldProjectionMultiValuedBaseIT.java
@@ -8,7 +8,6 @@ package org.hibernate.search.integrationtest.backend.tck.search.projection;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
 import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.documentProvider;
-import static org.junit.Assume.assumeTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -18,10 +17,8 @@ import java.util.function.Function;
 
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.types.Projectable;
-import org.hibernate.search.integrationtest.backend.tck.testsupport.model.singlefield.AbstractObjectBinding;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.model.singlefield.SingleFieldIndexBinding;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
-import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TestedFieldStructure;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
@@ -36,12 +33,13 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 /**
- * Tests basic behavior of projections on a single-valued field, common to all supported types.
+ * Tests basic behavior of projections on a multi-valued field, common to all supported types.
  * <p>
- * See {@link FieldSearchProjectionMultiValuedBaseIT} for multi-valued fields.
+ * See {@link FieldProjectionSingleValuedBaseIT} for single-valued fields.
  */
 @RunWith(Parameterized.class)
-public class FieldSearchProjectionSingleValuedBaseIT<F> {
+@TestForIssue(jiraKey = "HSEARCH-3391")
+public class FieldProjectionMultiValuedBaseIT<F> {
 
 	private static final List<FieldTypeDescriptor<?>> supportedFieldTypes = FieldTypeDescriptor.getAll();
 	private static List<DataSet<?>> dataSets;
@@ -52,7 +50,7 @@ public class FieldSearchProjectionSingleValuedBaseIT<F> {
 		List<Object[]> parameters = new ArrayList<>();
 		for ( FieldTypeDescriptor<?> fieldType : supportedFieldTypes ) {
 			for ( TestedFieldStructure fieldStructure : TestedFieldStructure.all() ) {
-				if ( fieldStructure.isMultiValued() ) {
+				if ( fieldStructure.isSingleValued() ) {
 					continue;
 				}
 				DataSet<?> dataSet = new DataSet<>( fieldStructure, fieldType );
@@ -67,8 +65,7 @@ public class FieldSearchProjectionSingleValuedBaseIT<F> {
 	public static SearchSetupHelper setupHelper = new SearchSetupHelper();
 
 	private static final Function<IndexSchemaElement, SingleFieldIndexBinding> bindingFactory =
-			root -> SingleFieldIndexBinding.createWithSingleValuedNestedFields( root, supportedFieldTypes,
-					c -> c.projectable( Projectable.YES ) );
+			root -> SingleFieldIndexBinding.create( root, supportedFieldTypes, c -> c.projectable( Projectable.YES ) );
 
 	private static final SimpleMappedIndex<SingleFieldIndexBinding> index = SimpleMappedIndex.of( bindingFactory );
 
@@ -87,7 +84,7 @@ public class FieldSearchProjectionSingleValuedBaseIT<F> {
 	private final FieldTypeDescriptor<F> fieldType;
 	private final DataSet<F> dataSet;
 
-	public FieldSearchProjectionSingleValuedBaseIT(TestedFieldStructure fieldStructure,
+	public FieldProjectionMultiValuedBaseIT(TestedFieldStructure fieldStructure,
 			FieldTypeDescriptor<F> fieldType, DataSet<F> dataSet) {
 		this.fieldStructure = fieldStructure;
 		this.fieldType = fieldType;
@@ -101,15 +98,15 @@ public class FieldSearchProjectionSingleValuedBaseIT<F> {
 		String fieldPath = getFieldPath();
 
 		assertThatQuery( scope.query()
-				.select( f -> f.field( fieldPath, fieldType.getJavaType() ) )
+				.select( f -> f.field( fieldPath, fieldType.getJavaType() ).multi() )
 				.where( f -> f.matchAll() )
 				.routing( dataSet.routingKey )
 				.toQuery() )
 				.hasHitsAnyOrder(
-						dataSet.getFieldValue( 1 ),
-						dataSet.getFieldValue( 2 ),
-						dataSet.getFieldValue( 3 ),
-						null // Empty document
+						dataSet.getFieldValues( 1 ),
+						dataSet.getFieldValues( 2 ),
+						dataSet.getFieldValues( 3 ),
+						Collections.emptyList() // Empty document
 				);
 	}
 
@@ -120,41 +117,15 @@ public class FieldSearchProjectionSingleValuedBaseIT<F> {
 		String fieldPath = getFieldPath();
 
 		assertThatQuery( scope.query()
-				.select( f -> f.field( fieldPath ) )
+				.select( f -> f.field( fieldPath ).multi() )
 				.where( f -> f.matchAll() )
 				.routing( dataSet.routingKey )
 				.toQuery() )
 				.hasHitsAnyOrder(
-						dataSet.getFieldValue( 1 ),
-						dataSet.getFieldValue( 2 ),
-						dataSet.getFieldValue( 3 ),
-						null // Empty document
-				);
-	}
-
-	/**
-	 * Test requesting a multi-valued projection on a single-valued field.
-	 */
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3391")
-	public void multi() {
-		StubMappingScope scope = index.createScope();
-
-		String fieldPath = getFieldPath();
-
-		assertThatQuery( scope.query()
-				.select( f -> f.field( fieldPath, fieldType.getJavaType() ).multi() )
-				.where( f -> f.matchAll() )
-				.routing( dataSet.routingKey )
-				.toQuery() )
-				.hasHitsAnyOrder(
-						Collections.singletonList( dataSet.getFieldValue( 1 ) ),
-						Collections.singletonList( dataSet.getFieldValue( 2 ) ),
-						Collections.singletonList( dataSet.getFieldValue( 3 ) ),
-						// Empty document
-						TckConfiguration.get().getBackendFeatures().projectionPreservesNulls()
-								? Collections.singletonList( null )
-								: Collections.emptyList()
+						Collections.unmodifiableList( dataSet.getFieldValues( 1 ) ),
+						Collections.unmodifiableList( dataSet.getFieldValues( 2 ) ),
+						Collections.unmodifiableList( dataSet.getFieldValues( 3 ) ),
+						Collections.emptyList() // Empty document
 				);
 	}
 
@@ -170,40 +141,18 @@ public class FieldSearchProjectionSingleValuedBaseIT<F> {
 		assertThatQuery( scope.query()
 				.select( f ->
 						f.composite(
-								f.field( fieldPath, fieldType.getJavaType() ),
-								f.field( fieldPath, fieldType.getJavaType() )
+								f.field( fieldPath, fieldType.getJavaType() ).multi(),
+								f.field( fieldPath, fieldType.getJavaType() ).multi()
 						)
 				)
 				.where( f -> f.matchAll() )
 				.routing( dataSet.routingKey )
 				.toQuery() )
 				.hasHitsAnyOrder(
-						Arrays.asList( dataSet.getFieldValue( 1 ), dataSet.getFieldValue( 1 ) ),
-						Arrays.asList( dataSet.getFieldValue( 2 ), dataSet.getFieldValue( 2 ) ),
-						Arrays.asList( dataSet.getFieldValue( 3 ), dataSet.getFieldValue( 3 ) ),
-						Arrays.asList( null, null ) // Empty document
-				);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4162")
-	public void factoryWithRoot() {
-		AbstractObjectBinding parentObjectBinding = index.binding().getParentObject( fieldStructure );
-
-		assumeTrue( "This test is only relevant when the field is located on an object field",
-				parentObjectBinding.absolutePath != null );
-
-		assertThatQuery( index.query()
-				.select( f -> f.withRoot( parentObjectBinding.absolutePath )
-						.field( parentObjectBinding.getRelativeFieldName( fieldStructure, fieldType ), fieldType.getJavaType() ) )
-				.where( f -> f.matchAll() )
-				.routing( dataSet.routingKey )
-				.toQuery() )
-				.hasHitsAnyOrder(
-						dataSet.getFieldValue( 1 ),
-						dataSet.getFieldValue( 2 ),
-						dataSet.getFieldValue( 3 ),
-						null // Empty document
+						Arrays.asList( dataSet.getFieldValues( 1 ), dataSet.getFieldValues( 1 ) ),
+						Arrays.asList( dataSet.getFieldValues( 2 ), dataSet.getFieldValues( 2 ) ),
+						Arrays.asList( dataSet.getFieldValues( 3 ), dataSet.getFieldValues( 3 ) ),
+						Arrays.asList( Collections.emptyList(), Collections.emptyList() ) // Empty document
 				);
 	}
 
@@ -232,21 +181,21 @@ public class FieldSearchProjectionSingleValuedBaseIT<F> {
 
 		private void contribute(BulkIndexer indexer) {
 			indexer.add( documentProvider( emptyDocId( 1 ), routingKey,
-					document -> index.binding().initSingleValued( fieldType, fieldStructure.location,
-							document, null ) ) );
+					document -> index.binding().initMultiValued( fieldType, fieldStructure.location,
+							document, Collections.emptyList() ) ) );
 			indexer.add( documentProvider( docId( 1 ), routingKey,
-					document -> index.binding().initSingleValued( fieldType, fieldStructure.location,
-							document, getFieldValue( 1 ) ) ) );
+					document -> index.binding().initMultiValued( fieldType, fieldStructure.location,
+							document, getFieldValues( 1 ) ) ) );
 			indexer.add( documentProvider( docId( 2 ), routingKey,
-					document -> index.binding().initSingleValued( fieldType, fieldStructure.location,
-							document, getFieldValue( 2 ) ) ) );
+					document -> index.binding().initMultiValued( fieldType, fieldStructure.location,
+							document, getFieldValues( 2 ) ) ) );
 			indexer.add( documentProvider( docId( 3 ), routingKey,
-					document -> index.binding().initSingleValued( fieldType, fieldStructure.location,
-							document, getFieldValue( 3 ) ) ) );
+					document -> index.binding().initMultiValued( fieldType, fieldStructure.location,
+							document, getFieldValues( 3 ) ) ) );
 		}
 
-		private F getFieldValue(int documentNumber) {
-			return fieldType.getIndexableValues().getSingle().get( documentNumber - 1 );
+		private List<F> getFieldValues(int documentNumber) {
+			return fieldType.getIndexableValues().getMulti().get( documentNumber - 1 );
 		}
 	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldProjectionTypeCheckingAndConversionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldProjectionTypeCheckingAndConversionIT.java
@@ -47,7 +47,7 @@ import org.junit.runners.Parameterized;
  * projections on field value.
  */
 @RunWith(Parameterized.class)
-public class FieldSearchProjectionTypeCheckingAndConversionIT<F> {
+public class FieldProjectionTypeCheckingAndConversionIT<F> {
 
 	private static final List<FieldTypeDescriptor<?>> supportedFieldTypes = FieldTypeDescriptor.getAll();
 
@@ -94,7 +94,7 @@ public class FieldSearchProjectionTypeCheckingAndConversionIT<F> {
 
 	private final FieldTypeDescriptor<F> fieldType;
 
-	public FieldSearchProjectionTypeCheckingAndConversionIT(FieldTypeDescriptor<F> fieldType) {
+	public FieldProjectionTypeCheckingAndConversionIT(FieldTypeDescriptor<F> fieldType) {
 		this.fieldType = fieldType;
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldProjectionTypeIndependentIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldProjectionTypeIndependentIT.java
@@ -28,9 +28,9 @@ import org.junit.Test;
  * for projections on field value.
  * <p>
  * Behavior that is specific to the field type is tested elsewhere,
- * e.g. {@link FieldSearchProjectionSingleValuedBaseIT} and {@link FieldSearchProjectionTypeCheckingAndConversionIT}.
+ * e.g. {@link FieldProjectionSingleValuedBaseIT} and {@link FieldProjectionTypeCheckingAndConversionIT}.
  */
-public class FieldSearchProjectionTypeIndependentIT {
+public class FieldProjectionTypeIndependentIT {
 
 	@ClassRule
 	public static final SearchSetupHelper setupHelper = new SearchSetupHelper();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/IdentifierProjectionBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/IdentifierProjectionBaseIT.java
@@ -30,7 +30,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class IdentifierSearchProjectionBaseIT {
+public class IdentifierProjectionBaseIT {
 
 	@Rule
 	public final SearchSetupHelper setupHelper = new SearchSetupHelper();
@@ -52,7 +52,7 @@ public class IdentifierSearchProjectionBaseIT {
 	private final String[] compatibleIndexIds = new String[3];
 	private final String[] compatibleIndexNames = new String[3];
 
-	public IdentifierSearchProjectionBaseIT() {
+	public IdentifierProjectionBaseIT() {
 		initValues();
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
@@ -57,7 +57,7 @@ import org.mockito.junit.MockitoRule;
 import org.mockito.quality.Strictness;
 
 /**
- * Generic tests for projections. More specific tests can be found in other classes, such as {@link FieldSearchProjectionSingleValuedBaseIT}.
+ * Generic tests for projections. More specific tests can be found in other classes, such as {@link FieldProjectionSingleValuedBaseIT}.
  */
 @SuppressWarnings("unchecked") // Mocking parameterized types
 public class SearchProjectionIT {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryResultLoadingOrTransformingIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryResultLoadingOrTransformingIT.java
@@ -366,18 +366,16 @@ public class SearchQueryResultLoadingOrTransformingIT {
 
 		StubMappingScope scope = index.createScope();
 		SearchQuery<StubTransformedHit> query = scope.query()
-				.select( f ->
-						f.composite(
-								hitTransformerMock,
-								f.field( "string", String.class ).toProjection(),
-								f.field( "string_analyzed", String.class ).toProjection(),
-								f.field( "integer", Integer.class ).toProjection(),
-								f.field( "localDate", LocalDate.class ).toProjection(),
-								f.field( "geoPoint", GeoPoint.class ).toProjection(),
-								f.documentReference().toProjection(),
-								f.entityReference().toProjection(),
-								f.entity().toProjection()
-						)
+				.select( f -> f.composite()
+						.from( f.field( "string", String.class ),
+								f.field( "string_analyzed", String.class ),
+								f.field( "integer", Integer.class ),
+								f.field( "localDate", LocalDate.class ),
+								f.field( "geoPoint", GeoPoint.class ),
+								f.documentReference(),
+								f.entityReference(),
+								f.entity() )
+						.asList( hitTransformerMock )
 				)
 				.where( f -> f.matchAll() )
 				.toQuery();
@@ -428,14 +426,12 @@ public class SearchQueryResultLoadingOrTransformingIT {
 		GenericStubMappingScope<StubTransformedReference, StubLoadedObject> scope =
 				index.createGenericScope();
 		SearchQuery<StubTransformedHit> query = scope.query( loadingContextMock )
-				.select( f ->
-						f.composite(
-								hitTransformerMock,
-								f.field( "string", String.class ).toProjection(),
+				.select( f -> f.composite()
+						.from( f.field( "string", String.class ).toProjection(),
 								f.documentReference().toProjection(),
 								f.entityReference().toProjection(),
-								f.entity().toProjection()
-						)
+								f.entity().toProjection() )
+						.asList( hitTransformerMock )
 				)
 				.where( f -> f.matchAll() )
 				.toQuery();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/CompositeSortIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/CompositeSortIT.java
@@ -33,7 +33,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class CompositeSearchSortIT {
+public class CompositeSortIT {
 
 	private static final String DOCUMENT_1 = "1";
 	private static final String DOCUMENT_2 = "2";

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/DistanceSortBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/DistanceSortBaseIT.java
@@ -50,7 +50,7 @@ import org.junit.runners.Parameterized;
  * Tests basic behavior of sorts by distance.
  */
 @RunWith(Parameterized.class)
-public class DistanceSearchSortBaseIT {
+public class DistanceSortBaseIT {
 
 	private static final GeoPointFieldTypeDescriptor fieldType = GeoPointFieldTypeDescriptor.INSTANCE;
 	private static final Set<FieldTypeDescriptor<GeoPoint>> supportedFieldTypes = Collections.singleton( fieldType );
@@ -112,7 +112,7 @@ public class DistanceSearchSortBaseIT {
 	private final DataSet dataSetForAsc;
 	private final DataSet dataSetForDesc;
 
-	public DistanceSearchSortBaseIT(TestedFieldStructure fieldStructure, SortMode sortMode,
+	public DistanceSortBaseIT(TestedFieldStructure fieldStructure, SortMode sortMode,
 			DataSet dataSetForAsc, DataSet dataSetForDesc) {
 		this.fieldStructure = fieldStructure;
 		this.sortMode = sortMode;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/DistanceSortFilteringSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/DistanceSortFilteringSpecificsIT.java
@@ -33,9 +33,9 @@ import org.junit.Test;
 /**
  * Tests behavior related to
  * {@link org.hibernate.search.engine.search.sort.dsl.SortFilterStep#filter(Function) filtering}
- * that is not tested in {@link DistanceSearchSortBaseIT}.
+ * that is not tested in {@link DistanceSortBaseIT}.
  */
-public class DistanceSearchSortFilteringSpecificsIT {
+public class DistanceSortFilteringSpecificsIT {
 
 	@ClassRule
 	public static SearchSetupHelper setupHelper = new SearchSetupHelper();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/DistanceSortTypeCheckingAndConversionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/DistanceSortTypeCheckingAndConversionIT.java
@@ -52,7 +52,7 @@ import org.junit.Test;
  * Tests behavior related to type checking and type conversion of DSL arguments
  * for sorts by field value.
  */
-public class DistanceSearchSortTypeCheckingAndConversionIT {
+public class DistanceSortTypeCheckingAndConversionIT {
 
 	private static final GeoPointFieldTypeDescriptor fieldType = GeoPointFieldTypeDescriptor.INSTANCE;
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/DistanceSortUnsupportedTypesIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/DistanceSortUnsupportedTypesIT.java
@@ -34,7 +34,7 @@ import org.junit.runners.Parameterized;
  * i.e. error messages.
  */
 @RunWith(Parameterized.class)
-public class DistanceSearchSortUnsupportedTypesIT<F> {
+public class DistanceSortUnsupportedTypesIT<F> {
 
 	private static Stream<FieldTypeDescriptor<?>> unsupportedTypeDescriptors() {
 		return FieldTypeDescriptor.getAll().stream()
@@ -62,7 +62,7 @@ public class DistanceSearchSortUnsupportedTypesIT<F> {
 
 	private final FieldTypeDescriptor<F> fieldTypeDescriptor;
 
-	public DistanceSearchSortUnsupportedTypesIT(FieldTypeDescriptor<F> fieldTypeDescriptor) {
+	public DistanceSortUnsupportedTypesIT(FieldTypeDescriptor<F> fieldTypeDescriptor) {
 		this.fieldTypeDescriptor = fieldTypeDescriptor;
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSortBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSortBaseIT.java
@@ -56,7 +56,7 @@ import org.junit.runners.Parameterized;
  * Tests basic behavior of sorts by field value common to all supported types.
  */
 @RunWith(Parameterized.class)
-public class FieldSearchSortBaseIT<F> {
+public class FieldSortBaseIT<F> {
 
 	private static Set<FieldTypeDescriptor<?>> supportedFieldTypes;
 	private static List<DataSet<?>> dataSets;
@@ -124,7 +124,7 @@ public class FieldSearchSortBaseIT<F> {
 	private final DataSet<F> dataSetForAsc;
 	private final DataSet<F> dataSetForDesc;
 
-	public FieldSearchSortBaseIT(TestedFieldStructure fieldStructure,
+	public FieldSortBaseIT(TestedFieldStructure fieldStructure,
 			FieldTypeDescriptor<F> fieldType, SortMode sortMode,
 			DataSet<F> dataSetForAsc, DataSet<F> dataSetForDesc) {
 		this.fieldStructure = fieldStructure;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSortFilteringSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSortFilteringSpecificsIT.java
@@ -38,10 +38,10 @@ import org.junit.runners.Parameterized;
 /**
  * Tests behavior related to
  * {@link org.hibernate.search.engine.search.sort.dsl.SortFilterStep#filter(Function) filtering}
- * that is not tested in {@link FieldSearchSortBaseIT}.
+ * that is not tested in {@link FieldSortBaseIT}.
  */
 @RunWith(Parameterized.class)
-public class FieldSearchSortFilteringSpecificsIT<F> {
+public class FieldSortFilteringSpecificsIT<F> {
 
 	private static Stream<FieldTypeDescriptor<?>> supportedTypeDescriptors() {
 		return FieldTypeDescriptor.getAll().stream()
@@ -69,7 +69,7 @@ public class FieldSearchSortFilteringSpecificsIT<F> {
 
 	private final FieldTypeDescriptor<F> fieldTypeDescriptor;
 
-	public FieldSearchSortFilteringSpecificsIT(FieldTypeDescriptor<F> fieldTypeDescriptor) {
+	public FieldSortFilteringSpecificsIT(FieldTypeDescriptor<F> fieldTypeDescriptor) {
 		this.fieldTypeDescriptor = fieldTypeDescriptor;
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSortScaledSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSortScaledSpecificsIT.java
@@ -24,7 +24,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-public class FieldSearchSortScaledSpecificsIT {
+public class FieldSortScaledSpecificsIT {
 
 	@ClassRule
 	public static SearchSetupHelper setupHelper = new SearchSetupHelper();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSortTypeCheckingAndConversionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSortTypeCheckingAndConversionIT.java
@@ -58,7 +58,7 @@ import org.junit.runners.Parameterized;
  * for sorts by field value.
  */
 @RunWith(Parameterized.class)
-public class FieldSearchSortTypeCheckingAndConversionIT<F> {
+public class FieldSortTypeCheckingAndConversionIT<F> {
 
 	private static final List<FieldTypeDescriptor<?>> supportedFieldTypes = new ArrayList<>();
 
@@ -117,7 +117,7 @@ public class FieldSearchSortTypeCheckingAndConversionIT<F> {
 
 	private final FieldTypeDescriptor<F> fieldTypeDescriptor;
 
-	public FieldSearchSortTypeCheckingAndConversionIT(FieldTypeDescriptor<F> fieldTypeDescriptor) {
+	public FieldSortTypeCheckingAndConversionIT(FieldTypeDescriptor<F> fieldTypeDescriptor) {
 		this.fieldTypeDescriptor = fieldTypeDescriptor;
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSortTypeIndependentIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSortTypeIndependentIT.java
@@ -26,9 +26,9 @@ import org.junit.Test;
  * for sorts by field value.
  * <p>
  * Behavior that is specific to the field type is tested elsewhere,
- * e.g. {@link FieldSearchSortBaseIT} and {@link FieldSearchSortUnsupportedTypesIT}.
+ * e.g. {@link FieldSortBaseIT} and {@link FieldSortUnsupportedTypesIT}.
  */
-public class FieldSearchSortTypeIndependentIT {
+public class FieldSortTypeIndependentIT {
 
 	@Rule
 	public final SearchSetupHelper setupHelper = new SearchSetupHelper();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSortUnsupportedTypesIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSortUnsupportedTypesIT.java
@@ -35,7 +35,7 @@ import org.junit.runners.Parameterized;
  * i.e. error messages.
  */
 @RunWith(Parameterized.class)
-public class FieldSearchSortUnsupportedTypesIT<F> {
+public class FieldSortUnsupportedTypesIT<F> {
 
 	private static Stream<FieldTypeDescriptor<?>> unsupportedTypeDescriptors() {
 		return FieldTypeDescriptor.getAll().stream()
@@ -63,7 +63,7 @@ public class FieldSearchSortUnsupportedTypesIT<F> {
 
 	private final FieldTypeDescriptor<F> fieldTypeDescriptor;
 
-	public FieldSearchSortUnsupportedTypesIT(FieldTypeDescriptor<F> fieldTypeDescriptor) {
+	public FieldSortUnsupportedTypesIT(FieldTypeDescriptor<F> fieldTypeDescriptor) {
 		this.fieldTypeDescriptor = fieldTypeDescriptor;
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/SearchSortIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/SearchSortIT.java
@@ -45,7 +45,7 @@ import org.junit.Test;
 
 /**
  * Generic tests for sorts. More specific tests can be found in other classes,
- * such as {@link FieldSearchSortBaseIT} or {@link DistanceSearchSortBaseIT}.
+ * such as {@link FieldSortBaseIT} or {@link DistanceSortBaseIT}.
  */
 public class SearchSortIT {
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/DistanceProjectionComplexCasesIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/DistanceProjectionComplexCasesIT.java
@@ -14,7 +14,7 @@ import java.util.List;
 import org.hibernate.search.engine.spatial.DistanceUnit;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.integrationtest.backend.tck.search.predicate.AbstractSpatialWithinSearchPredicateIT;
-import org.hibernate.search.integrationtest.backend.tck.search.projection.DistanceSearchProjectionSingleValuedBaseIT;
+import org.hibernate.search.integrationtest.backend.tck.search.projection.DistanceProjectionSingleValuedBaseIT;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.TestComparators;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 
@@ -22,13 +22,13 @@ import org.junit.Test;
 
 import org.assertj.core.api.ListAssert;
 
-public class DistanceSearchProjectionComplexCasesIT extends AbstractSpatialWithinSearchPredicateIT {
+public class DistanceProjectionComplexCasesIT extends AbstractSpatialWithinSearchPredicateIT {
 
 	private static final Comparator<? super Double> APPROX_M_COMPARATOR = TestComparators.approximateDouble( 10.0 );
 	private static final Comparator<? super Double> APPROX_KM_COMPARATOR = TestComparators.approximateDouble( 0.010 );
 
 	/**
-	 * See also {@link DistanceSearchProjectionSingleValuedBaseIT#several()}.
+	 * See also {@link DistanceProjectionSingleValuedBaseIT#several()}.
 	 * <p>
 	 * The main difference is that we're targeting multiple fields here.
 	 */
@@ -75,7 +75,7 @@ public class DistanceSearchProjectionComplexCasesIT extends AbstractSpatialWithi
 	}
 
 	/**
-	 * See also {@link DistanceSearchProjectionSingleValuedBaseIT#sortable_withSort()}.
+	 * See also {@link DistanceProjectionSingleValuedBaseIT#sortable_withSort()}.
 	 * <p>
 	 * The main difference is that we're composing multiple sorts here.
 	 */

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/DistanceProjectionComplexCasesIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/DistanceProjectionComplexCasesIT.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 import org.hibernate.search.engine.spatial.DistanceUnit;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.integrationtest.backend.tck.search.predicate.AbstractSpatialWithinSearchPredicateIT;
+import org.hibernate.search.integrationtest.backend.tck.search.predicate.AbstractSpatialWithinPredicateIT;
 import org.hibernate.search.integrationtest.backend.tck.search.projection.DistanceProjectionSingleValuedBaseIT;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.TestComparators;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 import org.assertj.core.api.ListAssert;
 
-public class DistanceProjectionComplexCasesIT extends AbstractSpatialWithinSearchPredicateIT {
+public class DistanceProjectionComplexCasesIT extends AbstractSpatialWithinPredicateIT {
 
 	private static final Comparator<? super Double> APPROX_M_COMPARATOR = TestComparators.approximateDouble( 10.0 );
 	private static final Comparator<? super Double> APPROX_KM_COMPARATOR = TestComparators.approximateDouble( 0.010 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/DistanceSearchableSortableIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/DistanceSearchableSortableIT.java
@@ -25,7 +25,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class DistanceSearchSearchableSortableIT {
+public class DistanceSearchableSortableIT {
 
 	private static final String OURSON_QUI_BOIT_ID = "ourson qui boit";
 	private static final GeoPoint OURSON_QUI_BOIT_GEO_POINT = GeoPoint.of( 45.7705687, 4.835233 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TestedFieldStructure.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TestedFieldStructure.java
@@ -11,6 +11,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import org.hibernate.search.integrationtest.backend.tck.search.sort.FieldSortBaseIT;
+
 /**
  * Represents the structure of a tested field: located at the root or in a nested document,
  * single-valued or multi-valued, ...
@@ -23,7 +25,7 @@ import java.util.Objects;
  * You need set up your test to create one field per structure,
  * and then query the "fieldStructure" object in your test instance to target a different field
  * based on that.
- * See for example {@link org.hibernate.search.integrationtest.backend.tck.search.sort.FieldSearchSortBaseIT}.
+ * See for example {@link FieldSortBaseIT}.
  */
 public class TestedFieldStructure {
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexingFieldTypesIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexingFieldTypesIT.java
@@ -92,11 +92,10 @@ public class IndexingFieldTypesIT<F> {
 
 		for ( int i = 0; i < values.size(); i++ ) {
 			SearchQuery<IdAndValue<F>> query = scope.query()
-					.select( f -> f.composite(
-							(id, val) -> new IdAndValue<>( id, val ),
-							f.id( String.class ),
-							f.field( absoluteFieldPath, typeDescriptor.getJavaType() )
-					) )
+					.select( f -> f.composite()
+							.from( f.id( String.class ),
+									f.field( absoluteFieldPath, typeDescriptor.getJavaType() ) )
+							.as( (id, val) -> new IdAndValue<>( id, val ) ) )
 					.where( f -> f.matchAll() )
 					.toQuery();
 
@@ -132,11 +131,10 @@ public class IndexingFieldTypesIT<F> {
 
 		for ( int i = 0; i < values.size(); i++ ) {
 			SearchQuery<IdAndValue<F>> query = scope.query()
-					.select( f -> f.composite(
-							(ref, val) -> new IdAndValue<>( ref.id(), val ),
-							f.entityReference(),
-							f.field( absoluteFieldPath, typeDescriptor.getJavaType() )
-					) )
+					.select( f -> f.composite()
+							.from( f.entityReference(),
+									f.field( absoluteFieldPath, typeDescriptor.getJavaType() ) )
+							.as( (ref, val) -> new IdAndValue<>( ref.id(), val ) ) )
 					.where( f -> f.matchAll() )
 					.toQuery();
 
@@ -179,11 +177,10 @@ public class IndexingFieldTypesIT<F> {
 
 		for ( int i = 0; i < values.size(); i++ ) {
 			SearchQuery<IdAndValue<F>> query = scope.query()
-					.select( f -> f.composite(
-							(ref, val) -> new IdAndValue<>( ref.id(), val ),
-							f.entityReference(),
-							f.field( absoluteFieldPath, typeDescriptor.getJavaType() )
-					) )
+					.select( f -> f.composite()
+							.from( f.entityReference(),
+									f.field( absoluteFieldPath, typeDescriptor.getJavaType() ) )
+							.as( (ref, val) -> new IdAndValue<>( ref.id(), val ) ) )
 					.where( f -> f.matchAll() )
 					.toQuery();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/SearchQueryBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/SearchQueryBaseIT.java
@@ -546,17 +546,12 @@ public class SearchQueryBaseIT {
 			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Book_Author_Score> query = searchSession.search( Book.class )
-					.select( f ->
-							f.composite(
-									Book_Author_Score::new,
-									f.composite(
-											Book_Author::new,
-											f.entity().toProjection(),
-											f.field( "author.name", String.class ).toProjection()
-									).toProjection(),
-									f.score().toProjection()
-							)
-					)
+					.select( f -> f.composite()
+							.from( f.composite()
+									.from( f.entity(), f.field( "author.name", String.class ) )
+									.as( Book_Author::new ),
+									f.score() )
+							.as( Book_Author_Score::new ) )
 					.where( f -> f.matchAll() )
 					.toQuery();
 
@@ -594,16 +589,12 @@ public class SearchQueryBaseIT {
 			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Book_Author_Score> query = searchSession.search( Book.class )
-					.select( f ->
-							f.composite(
-									Book_Author_Score::new,
-									f.composite(
-											Book_Author::new,
-											f.entity(),
-											f.field( "author.name", String.class )
-									),
-									f.score()
-							)
+					.select( f -> f.composite()
+							.from( f.composite()
+									.from( f.entity(), f.field( "author.name", String.class ) )
+									.as( Book_Author::new ),
+									f.score() )
+							.as( Book_Author_Score::new )
 					)
 					.where( f -> f.matchAll() )
 					.toQuery();

--- a/integrationtest/v5migrationhelper/engine/src/test/java/org/hibernate/search/testsupport/migration/V5MigrationJavaBeanSearchScopeAdapter.java
+++ b/integrationtest/v5migrationhelper/engine/src/test/java/org/hibernate/search/testsupport/migration/V5MigrationJavaBeanSearchScopeAdapter.java
@@ -56,13 +56,16 @@ public class V5MigrationJavaBeanSearchScopeAdapter implements V5MigrationSearchS
 	@Override
 	public SearchProjection<Object> idProjection() {
 		SearchProjectionFactory<EntityReference, ?> factory = delegate.projection();
-		return factory.composite( EntityReference::id, factory.entityReference() ).toProjection();
+		// Not using factory.id() because that one throws an exception if IDs have inconsistent types.
+		return factory.composite().from( factory.entityReference() )
+				.as( EntityReference::id ).toProjection();
 	}
 
 	@Override
 	public SearchProjection<? extends Class<?>> objectClassProjection() {
 		SearchProjectionFactory<EntityReference, ?> factory = delegate.projection();
-		return factory.composite( EntityReference::type, factory.entityReference() ).toProjection();
+		return factory.composite().from( factory.entityReference() )
+				.as( EntityReference::type ).toProjection();
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubCompositeBiFunctionProjection.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubCompositeBiFunctionProjection.java
@@ -7,28 +7,24 @@
 package org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.projection.impl;
 
 import java.util.List;
+import java.util.function.BiFunction;
 
 import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
-import org.hibernate.search.util.common.function.TriFunction;
 
-class StubCompositeTriFunctionSearchProjection<P1, P2, P3, P> implements StubCompositeSearchProjection<P> {
+class StubCompositeBiFunctionProjection<P1, P2, P> implements StubCompositeProjection<P> {
 
-	private final TriFunction<P1, P2, P3, P> transformer;
+	private final BiFunction<P1, P2, P> transformer;
 
 	private final StubSearchProjection<P1> projection1;
 
 	private final StubSearchProjection<P2> projection2;
 
-	private final StubSearchProjection<P3> projection3;
-
-	StubCompositeTriFunctionSearchProjection(TriFunction<P1, P2, P3, P> transformer,
-			StubSearchProjection<P1> projection1, StubSearchProjection<P2> projection2,
-			StubSearchProjection<P3> projection3) {
+	StubCompositeBiFunctionProjection(BiFunction<P1, P2, P> transformer,
+			StubSearchProjection<P1> projection1, StubSearchProjection<P2> projection2) {
 		this.transformer = transformer;
 		this.projection1 = projection1;
 		this.projection2 = projection2;
-		this.projection3 = projection3;
 	}
 
 	@Override
@@ -38,8 +34,7 @@ class StubCompositeTriFunctionSearchProjection<P1, P2, P3, P> implements StubCom
 
 		return new Object[] {
 				projection1.extract( projectionHitMapper, listFromIndex.get( 0 ), context ),
-				projection2.extract( projectionHitMapper, listFromIndex.get( 1 ), context ),
-				projection3.extract( projectionHitMapper, listFromIndex.get( 2 ), context )
+				projection2.extract( projectionHitMapper, listFromIndex.get( 1 ), context )
 		};
 	}
 
@@ -50,8 +45,7 @@ class StubCompositeTriFunctionSearchProjection<P1, P2, P3, P> implements StubCom
 
 		return transformer.apply(
 				projection1.transform( loadingResult, extractedElements[0], context ),
-				projection2.transform( loadingResult, extractedElements[0], context ),
-				projection3.transform( loadingResult, extractedElements[0], context )
+				projection2.transform( loadingResult, extractedElements[1], context )
 		);
 	}
 
@@ -61,7 +55,6 @@ class StubCompositeTriFunctionSearchProjection<P1, P2, P3, P> implements StubCom
 				.append( "[" )
 				.append( "projection1=" ).append( projection1 )
 				.append( ", projection2=" ).append( projection2 )
-				.append( ", projection3=" ).append( projection3 )
 				.append( "]" );
 		return sb.toString();
 	}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubCompositeFunctionProjection.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubCompositeFunctionProjection.java
@@ -11,13 +11,13 @@ import java.util.function.Function;
 import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
-class StubCompositeFunctionSearchProjection<P1, P> implements StubCompositeSearchProjection<P> {
+class StubCompositeFunctionProjection<P1, P> implements StubCompositeProjection<P> {
 
 	private final Function<P1, P> transformer;
 
 	private final StubSearchProjection<P1> projection;
 
-	StubCompositeFunctionSearchProjection(Function<P1, P> transformer,
+	StubCompositeFunctionProjection(Function<P1, P> transformer,
 			StubSearchProjection<P1> projection) {
 		this.transformer = transformer;
 		this.projection = projection;

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubCompositeListProjection.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubCompositeListProjection.java
@@ -13,13 +13,13 @@ import java.util.function.Function;
 import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
-class StubCompositeListSearchProjection<P> implements StubCompositeSearchProjection<P> {
+class StubCompositeListProjection<P> implements StubCompositeProjection<P> {
 
 	private final Function<List<?>, P> transformer;
 
 	private final List<StubSearchProjection<?>> children;
 
-	StubCompositeListSearchProjection(Function<List<?>, P> transformer,
+	StubCompositeListProjection(Function<List<?>, P> transformer,
 			List<StubSearchProjection<?>> children) {
 		this.transformer = transformer;
 		this.children = children;

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubCompositeProjection.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubCompositeProjection.java
@@ -6,6 +6,6 @@
  */
 package org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.projection.impl;
 
-public interface StubCompositeSearchProjection<P> extends StubSearchProjection<P> {
+public interface StubCompositeProjection<P> extends StubSearchProjection<P> {
 
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubCompositeTriFunctionProjection.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubCompositeTriFunctionProjection.java
@@ -7,24 +7,28 @@
 package org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.projection.impl;
 
 import java.util.List;
-import java.util.function.BiFunction;
 
 import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
+import org.hibernate.search.util.common.function.TriFunction;
 
-class StubCompositeBiFunctionSearchProjection<P1, P2, P> implements StubCompositeSearchProjection<P> {
+class StubCompositeTriFunctionProjection<P1, P2, P3, P> implements StubCompositeProjection<P> {
 
-	private final BiFunction<P1, P2, P> transformer;
+	private final TriFunction<P1, P2, P3, P> transformer;
 
 	private final StubSearchProjection<P1> projection1;
 
 	private final StubSearchProjection<P2> projection2;
 
-	StubCompositeBiFunctionSearchProjection(BiFunction<P1, P2, P> transformer,
-			StubSearchProjection<P1> projection1, StubSearchProjection<P2> projection2) {
+	private final StubSearchProjection<P3> projection3;
+
+	StubCompositeTriFunctionProjection(TriFunction<P1, P2, P3, P> transformer,
+			StubSearchProjection<P1> projection1, StubSearchProjection<P2> projection2,
+			StubSearchProjection<P3> projection3) {
 		this.transformer = transformer;
 		this.projection1 = projection1;
 		this.projection2 = projection2;
+		this.projection3 = projection3;
 	}
 
 	@Override
@@ -34,7 +38,8 @@ class StubCompositeBiFunctionSearchProjection<P1, P2, P> implements StubComposit
 
 		return new Object[] {
 				projection1.extract( projectionHitMapper, listFromIndex.get( 0 ), context ),
-				projection2.extract( projectionHitMapper, listFromIndex.get( 1 ), context )
+				projection2.extract( projectionHitMapper, listFromIndex.get( 1 ), context ),
+				projection3.extract( projectionHitMapper, listFromIndex.get( 2 ), context )
 		};
 	}
 
@@ -45,7 +50,8 @@ class StubCompositeBiFunctionSearchProjection<P1, P2, P> implements StubComposit
 
 		return transformer.apply(
 				projection1.transform( loadingResult, extractedElements[0], context ),
-				projection2.transform( loadingResult, extractedElements[1], context )
+				projection2.transform( loadingResult, extractedElements[0], context ),
+				projection3.transform( loadingResult, extractedElements[0], context )
 		);
 	}
 
@@ -55,6 +61,7 @@ class StubCompositeBiFunctionSearchProjection<P1, P2, P> implements StubComposit
 				.append( "[" )
 				.append( "projection1=" ).append( projection1 )
 				.append( ", projection2=" ).append( projection2 )
+				.append( ", projection3=" ).append( projection3 )
 				.append( "]" );
 		return sb.toString();
 	}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubDefaultProjection.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubDefaultProjection.java
@@ -9,17 +9,17 @@ package org.hibernate.search.util.impl.integrationtest.common.stub.backend.searc
 import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
-class StubDefaultSearchProjection<T> implements StubSearchProjection<T> {
+class StubDefaultProjection<T> implements StubSearchProjection<T> {
 
 	@SuppressWarnings("rawtypes")
-	private static final StubSearchProjection INSTANCE = new StubDefaultSearchProjection();
+	private static final StubSearchProjection INSTANCE = new StubDefaultProjection();
 
 	@SuppressWarnings("unchecked")
-	static <T> StubDefaultSearchProjection<T> get() {
-		return (StubDefaultSearchProjection<T>) INSTANCE;
+	static <T> StubDefaultProjection<T> get() {
+		return (StubDefaultProjection<T>) INSTANCE;
 	}
 
-	private StubDefaultSearchProjection() {
+	private StubDefaultProjection() {
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubDistanceToFieldProjection.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubDistanceToFieldProjection.java
@@ -16,9 +16,9 @@ import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.common.impl.StubSearchIndexScope;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.common.impl.AbstractStubSearchQueryElementFactory;
 
-public abstract class StubDistanceToFieldSearchProjection<T> implements StubSearchProjection<T> {
+public abstract class StubDistanceToFieldProjection<T> implements StubSearchProjection<T> {
 
-	private StubDistanceToFieldSearchProjection() {
+	private StubDistanceToFieldProjection() {
 	}
 
 	public static class Factory extends AbstractStubSearchQueryElementFactory<DistanceToFieldProjectionBuilder> {

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubEntityProjection.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubEntityProjection.java
@@ -10,17 +10,17 @@ import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
-public class StubEntitySearchProjection<T> implements StubSearchProjection<T> {
+public class StubEntityProjection<T> implements StubSearchProjection<T> {
 
 	@SuppressWarnings("rawtypes")
-	private static final StubSearchProjection INSTANCE = new StubEntitySearchProjection();
+	private static final StubSearchProjection INSTANCE = new StubEntityProjection();
 
 	@SuppressWarnings("unchecked")
-	public static <T> StubEntitySearchProjection<T> get() {
-		return (StubEntitySearchProjection<T>) INSTANCE;
+	public static <T> StubEntityProjection<T> get() {
+		return (StubEntityProjection<T>) INSTANCE;
 	}
 
-	private StubEntitySearchProjection() {
+	private StubEntityProjection() {
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubFieldProjection.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubFieldProjection.java
@@ -20,11 +20,11 @@ import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.common.impl.StubSearchIndexScope;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.common.impl.AbstractStubSearchQueryElementFactory;
 
-public class StubFieldSearchProjection<F, V> implements StubSearchProjection<V> {
+public class StubFieldProjection<F, V> implements StubSearchProjection<V> {
 	private final Class<F> valueClass;
 	private final ProjectionConverter<F, ? extends V> converter;
 
-	private StubFieldSearchProjection(Class<F> valueClass, ProjectionConverter<F, ? extends V> converter) {
+	private StubFieldProjection(Class<F> valueClass, ProjectionConverter<F, ? extends V> converter) {
 		this.valueClass = valueClass;
 		this.converter = converter;
 	}
@@ -76,7 +76,7 @@ public class StubFieldSearchProjection<F, V> implements StubSearchProjection<V> 
 
 		@Override
 		public SearchProjection<V> build() {
-			return new StubFieldSearchProjection<>( valueClass, converter );
+			return new StubFieldProjection<>( valueClass, converter );
 		}
 
 		@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubIdProjection.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubIdProjection.java
@@ -13,11 +13,11 @@ import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 import org.hibernate.search.engine.search.projection.SearchProjection;
 import org.hibernate.search.engine.search.projection.spi.IdProjectionBuilder;
 
-public class StubIdSearchProjection<I> implements StubSearchProjection<I> {
+public class StubIdProjection<I> implements StubSearchProjection<I> {
 
 	private final ProjectionConverter<String, ? extends I> converter;
 
-	private StubIdSearchProjection(ProjectionConverter<String, ? extends I> converter) {
+	private StubIdProjection(ProjectionConverter<String, ? extends I> converter) {
 		this.converter = converter;
 	}
 
@@ -43,7 +43,7 @@ public class StubIdSearchProjection<I> implements StubSearchProjection<I> {
 		private final StubSearchProjection<I> projection;
 
 		public Builder(ProjectionConverter<String, ? extends I> converter) {
-			projection = new StubIdSearchProjection<>( converter );
+			projection = new StubIdProjection<>( converter );
 		}
 
 		@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubReferenceProjection.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubReferenceProjection.java
@@ -10,17 +10,17 @@ import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
-public class StubReferenceSearchProjection<T> implements StubSearchProjection<T> {
+public class StubReferenceProjection<T> implements StubSearchProjection<T> {
 
 	@SuppressWarnings("rawtypes")
-	private static final StubSearchProjection INSTANCE = new StubReferenceSearchProjection();
+	private static final StubSearchProjection INSTANCE = new StubReferenceProjection();
 
 	@SuppressWarnings("unchecked")
-	public static <T> StubReferenceSearchProjection<T> get() {
-		return (StubReferenceSearchProjection<T>) INSTANCE;
+	public static <T> StubReferenceProjection<T> get() {
+		return (StubReferenceProjection<T>) INSTANCE;
 	}
 
-	private StubReferenceSearchProjection() {
+	private StubReferenceProjection() {
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubSearchProjectionBuilderFactory.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubSearchProjectionBuilderFactory.java
@@ -39,25 +39,25 @@ public class StubSearchProjectionBuilderFactory implements SearchProjectionBuild
 		return new DocumentReferenceProjectionBuilder() {
 			@Override
 			public SearchProjection<DocumentReference> build() {
-				return StubDefaultSearchProjection.get();
+				return StubDefaultProjection.get();
 			}
 		};
 	}
 
 	@Override
 	public <E> EntityProjectionBuilder<E> entity() {
-		return StubEntitySearchProjection::get;
+		return StubEntityProjection::get;
 	}
 
 	@Override
 	public <R> EntityReferenceProjectionBuilder<R> entityReference() {
-		return StubReferenceSearchProjection::get;
+		return StubReferenceProjection::get;
 	}
 
 	@Override
 	public <I> IdProjectionBuilder<I> id(Class<I> identifierType) {
 		SearchIndexIdentifierContext identifier = scope.identifier();
-		return new StubIdSearchProjection.Builder<>(
+		return new StubIdProjection.Builder<>(
 				identifier.projectionConverter().withConvertedType( identifierType, identifier ) );
 	}
 
@@ -66,7 +66,7 @@ public class StubSearchProjectionBuilderFactory implements SearchProjectionBuild
 		return new ScoreProjectionBuilder() {
 			@Override
 			public SearchProjection<Float> build() {
-				return StubDefaultSearchProjection.get();
+				return StubDefaultProjection.get();
 			}
 		};
 	}
@@ -77,7 +77,7 @@ public class StubSearchProjectionBuilderFactory implements SearchProjectionBuild
 		return new CompositeProjectionBuilder<T>() {
 			@Override
 			public SearchProjection<T> build() {
-				return new StubCompositeListSearchProjection<>( transformer,
+				return new StubCompositeListProjection<>( transformer,
 						Arrays.stream( projections ).map( p -> toImplementation( p ) ).collect( Collectors.toList() ) );
 			}
 
@@ -96,7 +96,7 @@ public class StubSearchProjectionBuilderFactory implements SearchProjectionBuild
 		return new CompositeProjectionBuilder<T>() {
 			@Override
 			public SearchProjection<T> build() {
-				return new StubCompositeFunctionSearchProjection<>( transformer, toImplementation( projection ) );
+				return new StubCompositeFunctionProjection<>( transformer, toImplementation( projection ) );
 			}
 		};
 	}
@@ -107,7 +107,7 @@ public class StubSearchProjectionBuilderFactory implements SearchProjectionBuild
 		return new CompositeProjectionBuilder<T>() {
 			@Override
 			public SearchProjection<T> build() {
-				return new StubCompositeBiFunctionSearchProjection<>( transformer, toImplementation( projection1 ),
+				return new StubCompositeBiFunctionProjection<>( transformer, toImplementation( projection1 ),
 						toImplementation( projection2 ) );
 			}
 		};
@@ -119,7 +119,7 @@ public class StubSearchProjectionBuilderFactory implements SearchProjectionBuild
 		return new CompositeProjectionBuilder<T>() {
 			@Override
 			public SearchProjection<T> build() {
-				return new StubCompositeTriFunctionSearchProjection<>( transformer, toImplementation( projection1 ),
+				return new StubCompositeTriFunctionProjection<>( transformer, toImplementation( projection1 ),
 						toImplementation( projection2 ), toImplementation( projection3 ) );
 			}
 		};

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/impl/StubIndexValueFieldType.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/impl/StubIndexValueFieldType.java
@@ -24,8 +24,8 @@ import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.common.impl.StubSearchIndexValueFieldTypeContext;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.common.impl.AbstractStubSearchQueryElementFactory;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.predicate.impl.StubSearchPredicate;
-import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.projection.impl.StubDistanceToFieldSearchProjection;
-import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.projection.impl.StubFieldSearchProjection;
+import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.projection.impl.StubDistanceToFieldProjection;
+import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.projection.impl.StubFieldProjection;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.sort.impl.StubSearchSort;
 
 public final class StubIndexValueFieldType<F>
@@ -82,8 +82,8 @@ public final class StubIndexValueFieldType<F>
 					SortTypeKeys.FIELD,
 					SortTypeKeys.DISTANCE
 			);
-			queryElementFactory( ProjectionTypeKeys.FIELD, new StubFieldSearchProjection.Factory() );
-			queryElementFactory( ProjectionTypeKeys.DISTANCE, new StubDistanceToFieldSearchProjection.Factory() );
+			queryElementFactory( ProjectionTypeKeys.FIELD, new StubFieldProjection.Factory() );
+			queryElementFactory( ProjectionTypeKeys.DISTANCE, new StubDistanceToFieldProjection.Factory() );
 			queryElementFactory( AggregationTypeKeys.TERMS, new StubSearchAggregation.TermsFactory() );
 			queryElementFactory( AggregationTypeKeys.RANGE, new StubSearchAggregation.RangeFactory() );
 		}

--- a/v5migrationhelper/engine/src/main/java/org/hibernate/search/query/engine/impl/HSQueryImpl.java
+++ b/v5migrationhelper/engine/src/main/java/org/hibernate/search/query/engine/impl/HSQueryImpl.java
@@ -250,10 +250,13 @@ public class HSQueryImpl<LOS> implements HSQuery {
 		}
 
 		if ( tupleTransformer != null ) {
-			return factory.composite( list -> tupleTransformer.transform( list.toArray(), projectedFields ), projections ).toProjection();
+			return factory.composite()
+					.from( projections )
+					.asList( list -> tupleTransformer.transform( list.toArray(), projectedFields ) )
+					.toProjection();
 		}
 		else {
-			return factory.composite( List::toArray, projections ).toProjection();
+			return factory.composite().from( projections ).asList( List::toArray ).toProjection();
 		}
 	}
 
@@ -262,7 +265,7 @@ public class HSQueryImpl<LOS> implements HSQuery {
 		if ( field == null ) {
 			// Hack to return null when a null field name is requested,
 			// which is what Search 5 used to do...
-			return factory.composite( ignored -> null, factory.documentReference() ).toProjection();
+			return factory.composite().from( factory.documentReference() ).as( ignored -> null ).toProjection();
 		}
 		switch ( field ) {
 			case ProjectionConstants.THIS:

--- a/v5migrationhelper/orm/src/main/java/org/hibernate/search/FullTextQuery.java
+++ b/v5migrationhelper/orm/src/main/java/org/hibernate/search/FullTextQuery.java
@@ -20,7 +20,6 @@ import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.RootGraph;
 import org.hibernate.query.Query;
 import org.hibernate.query.spi.QueryImplementor;
-import org.hibernate.search.engine.search.projection.dsl.ProjectionFinalStep;
 import org.hibernate.search.engine.search.projection.dsl.SearchProjectionFactory;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.engine.search.query.dsl.SearchQueryOptionsStep;
@@ -58,7 +57,7 @@ public interface FullTextQuery extends org.hibernate.search.jpa.FullTextQuery, Q
 	 * create a search query with {@link SearchSession#search(Class)},
 	 * and define your projections using {@link SearchQuerySelectStep#select(Function)}.
 	 * See in particular the composite projection, which allows applying a function to another projection:
-	 * {@link SearchProjectionFactory#composite(Function, ProjectionFinalStep)}.
+	 * {@link SearchProjectionFactory#composite()}.
 	 * Refer to the <a href="https://hibernate.org/search/documentation/migrate/6.0/">migration guide</a> for more information.
 	 */
 	@Deprecated

--- a/v5migrationhelper/orm/src/main/java/org/hibernate/search/jpa/FullTextQuery.java
+++ b/v5migrationhelper/orm/src/main/java/org/hibernate/search/jpa/FullTextQuery.java
@@ -20,7 +20,6 @@ import org.apache.lucene.search.Sort;
 import org.hibernate.search.backend.lucene.LuceneExtension;
 import org.hibernate.search.engine.ProjectionConstants;
 import org.hibernate.search.engine.search.aggregation.AggregationKey;
-import org.hibernate.search.engine.search.projection.dsl.ProjectionFinalStep;
 import org.hibernate.search.engine.search.projection.dsl.SearchProjectionFactory;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.engine.search.query.SearchQueryExtension;
@@ -169,7 +168,7 @@ public interface FullTextQuery extends Query, ProjectionConstants {
 	 * create a search query with {@link SearchSession#search(Class)},
 	 * and define your projections using {@link SearchQuerySelectStep#select(Function)}.
 	 * See in particular the composite projection, which allows applying a function to another projection:
-	 * {@link SearchProjectionFactory#composite(Function, ProjectionFinalStep)}.
+	 * {@link SearchProjectionFactory#composite()}.
 	 * Refer to the <a href="https://hibernate.org/search/documentation/migrate/6.0/">migration guide</a> for more information.
 	 */
 	@Deprecated

--- a/v5migrationhelper/orm/src/main/java/org/hibernate/search/scope/impl/V5MigrationOrmSearchScopeAdapter.java
+++ b/v5migrationhelper/orm/src/main/java/org/hibernate/search/scope/impl/V5MigrationOrmSearchScopeAdapter.java
@@ -56,13 +56,16 @@ public class V5MigrationOrmSearchScopeAdapter implements V5MigrationSearchScope 
 	@Override
 	public SearchProjection<Object> idProjection() {
 		SearchProjectionFactory<EntityReference, ?> factory = delegate.projection();
-		return factory.composite( EntityReference::id, factory.entityReference() ).toProjection();
+		// Not using factory.id() because that one throws an exception if IDs have inconsistent types.
+		return factory.composite().from( factory.entityReference() )
+				.as( EntityReference::id ).toProjection();
 	}
 
 	@Override
 	public SearchProjection<? extends Class<?>> objectClassProjection() {
 		SearchProjectionFactory<EntityReference, ?> factory = delegate.projection();
-		return factory.composite( EntityReference::type, factory.entityReference() ).toProjection();
+		return factory.composite().from( factory.entityReference() )
+				.as( EntityReference::type ).toProjection();
 	}
 
 	@Override


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4498

Slight improvement over #2920.

I wanted to implement more dramatic changes, i.e. moving the call to `.as(...)` in first position so that we can get rid of the call to `.multi()` in [HSEARCH-3943](https://hibernate.atlassian.net/browse/HSEARCH-3943).
Unfortunately, that turned out not to be possible, because that prevents the compiler from inferring the types of arguments to the function passed to `.as(...)`, which is very, very annoying when the argument to `as` is a reference to the constructor of a generic class (`Pair::new`) or a lambda.

So, it looks like we won't be able to improve much on this API.