### PR TITLE
HSEARCH-4484 + HSEARCH-4502 Upgrade dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,11 @@ updates:
       - dependency-name: org.asciidoctor:asciidoctorj-pdf
       # We strictly align this dependency on the version used in Hibernate ORM.
       - dependency-name: org.jboss:jandex
-      # Newer majors of Weld follow the Jakarta specification (jakarta.* packages),
-      # but we follow Java EE (javax.* packages) for now.
+      # Newer majors of the following artifacts comply with the Jakarta specification (jakarta.* packages),
+      # but we comply with Java EE (javax.* packages) for now.
+      # TODO HSEARCH-4394 Remove these when switching to Jakarta EE as the default standard
       - dependency-name: "org.jboss.weld.se:*"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "org.jberet:*"
+        update-types: ["version-update:semver-major"]
+

--- a/pom.xml
+++ b/pom.xml
@@ -453,7 +453,7 @@
                 Note the version of ECJ is overridden because the one bundled with the latest plexus-compiler version
                 is outdated and leads to compilation errors.
          -->
-        <version.org.codehaus.plexus.plexus-compiler.compiler-eclipse>2.10.0</version.org.codehaus.plexus.plexus-compiler.compiler-eclipse>
+        <version.org.codehaus.plexus.plexus-compiler.compiler-eclipse>2.11.1</version.org.codehaus.plexus.plexus-compiler.compiler-eclipse>
         <version.org.eclipse.jdt.ecj>3.28.0</version.org.eclipse.jdt.ecj>
 
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -352,7 +352,7 @@
         <version.compiler.plugin>3.10.0</version.compiler.plugin>
         <version.dependency.plugin>3.2.0</version.dependency.plugin>
         <!-- Check dependencies for security vulnerabilities -->
-        <version.dependency-check.plugin>6.5.3</version.dependency-check.plugin>
+        <version.dependency-check.plugin>7.0.0</version.dependency-check.plugin>
         <version.deploy.plugin>2.8.2</version.deploy.plugin>
         <version.org.eclipse.m2e.lifecycle-mapping>1.0.0</version.org.eclipse.m2e.lifecycle-mapping>
         <version.enforcer.plugin>3.0.0</version.enforcer.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -385,7 +385,7 @@
         <version.sonar.plugin>3.9.1.2184</version.sonar.plugin>
         <version.scripting.plugin>3.0.0</version.scripting.plugin>
         <version.gpg.plugin>3.0.1</version.gpg.plugin>
-        <version.org.codehaus.groovy-jsr223>3.0.9</version.org.codehaus.groovy-jsr223>
+        <version.org.codehaus.groovy-jsr223>3.0.10</version.org.codehaus.groovy-jsr223>
         <version.com.puppycrawl.tools.checkstyle>10.0</version.com.puppycrawl.tools.checkstyle>
 
         <!-- Asciidoctor -->

--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,7 @@
         <!-- >>> JSR 352: JBeret SE dependencies -->
         <version.org.jboss.marshalling>2.0.12.Final</version.org.jboss.marshalling>
         <version.org.wildfly.security.wildfly-security-manager>1.1.2.Final</version.org.wildfly.security.wildfly-security-manager>
-        <version.org.google.guava>31.0.1-jre</version.org.google.guava>
+        <version.org.google.guava>31.1-jre</version.org.google.guava>
 
         <!-- >>> Spring integration tests -->
         <version.org.springframework.boot>2.6.2</version.org.springframework.boot>

--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
         <version.org.hamcrest>2.2</version.org.hamcrest>
         <version.org.mockito>4.3.1</version.org.mockito>
         <version.org.assertj.assertj-core>3.22.0</version.org.assertj.assertj-core>
-        <version.org.awaitily>4.1.1</version.org.awaitily>
+        <version.org.awaitily>4.2.0</version.org.awaitily>
         <version.org.skyscreamer.jsonassert>1.5.0</version.org.skyscreamer.jsonassert>
         <version.io.takari.junit>1.2.7</version.io.takari.junit>
         <version.com.h2database>2.1.210</version.com.h2database>

--- a/pom.xml
+++ b/pom.xml
@@ -386,7 +386,7 @@
         <version.scripting.plugin>3.0.0</version.scripting.plugin>
         <version.gpg.plugin>3.0.1</version.gpg.plugin>
         <version.org.codehaus.groovy-jsr223>3.0.9</version.org.codehaus.groovy-jsr223>
-        <version.com.puppycrawl.tools.checkstyle>9.3</version.com.puppycrawl.tools.checkstyle>
+        <version.com.puppycrawl.tools.checkstyle>10.0</version.com.puppycrawl.tools.checkstyle>
 
         <!-- Asciidoctor -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
         <version.com.google.code.gson>2.9.0</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.17.94</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, the AWS SDK and in tests (wiremock, ...) -->
-        <version.com.fasterxml.jackson>2.13.1</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.13.2</version.com.fasterxml.jackson>
         <!--
              In the past, there has been jackson-databind bugfix releases without any jackson-core release,
              so we had to use different versions, e.g. jackson-core 2.9.9 and jackson-databind 2.9.9.3.

--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
              That's why we have two separate properties for jackson versions,
              even though they may have the same value from time to time.
          -->
-        <version.com.fasterxml.jackson.databind>2.13.1</version.com.fasterxml.jackson.databind>
+        <version.com.fasterxml.jackson.databind>2.13.2</version.com.fasterxml.jackson.databind>
         <!-- Reactive-streams: used by the AWS SDK -->
         <version.org.reactivestreams.reactive-streams>1.0.3</version.org.reactivestreams.reactive-streams>
         <!-- slf4j: used by the AWS SDK -->


### PR DESCRIPTION
* [HSEARCH-4502](https://hibernate.atlassian.net/browse/HSEARCH-4502): Upgrade to Jackson 2.13.2
* [HSEARCH-4484](https://hibernate.atlassian.net/browse/HSEARCH-4484): Upgrade build dependencies to the latest version

