### PR TITLE
HSEARCH-4503 Disable version logging through system properties

### DIFF
--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/bootstrap/impl/HibernateSearchPreIntegrationService.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/bootstrap/impl/HibernateSearchPreIntegrationService.java
@@ -30,6 +30,7 @@ import org.hibernate.search.engine.environment.bean.BeanResolver;
 import org.hibernate.search.engine.environment.bean.spi.BeanProvider;
 import org.hibernate.search.mapper.orm.bootstrap.spi.HibernateOrmIntegrationBooterBehavior;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
+import org.hibernate.search.mapper.orm.cfg.spi.HibernateOrmMapperSpiSettings;
 import org.hibernate.search.mapper.orm.common.impl.HibernateOrmUtils;
 import org.hibernate.search.mapper.orm.coordination.impl.CoordinationConfigurationContextImpl;
 import org.hibernate.search.mapper.orm.logging.impl.Log;
@@ -63,6 +64,12 @@ public abstract class HibernateSearchPreIntegrationService implements Service, A
 					.withDefault( HibernateOrmMapperSettings.Defaults.ENABLED )
 					.build();
 
+	private static final ConfigurationProperty<Boolean> LOG_VERSION =
+			ConfigurationProperty.forKey( HibernateOrmMapperSpiSettings.JBOSS_LOG_VERSION )
+					.asBoolean()
+					.withDefault( HibernateOrmMapperSpiSettings.Defaults.JBOSS_LOG_VERSIONS )
+					.build();
+
 	public static class Contributor implements ServiceContributor {
 		@Override
 		public void contribute(StandardServiceRegistryBuilder serviceRegistryBuilder) {
@@ -88,7 +95,10 @@ public abstract class HibernateSearchPreIntegrationService implements Service, A
 				return null;
 			}
 			initiated = true;
-			log.version( Version.versionString() );
+
+			if ( LOG_VERSION.get( AllAwareConfigurationPropertySource.system() ) ) {
+				log.version( Version.versionString() );
+			}
 
 			ConfigurationPropertyChecker propertyChecker = ConfigurationPropertyChecker.create();
 			@SuppressWarnings("unchecked")

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/cfg/spi/HibernateOrmMapperSpiSettings.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/cfg/spi/HibernateOrmMapperSpiSettings.java
@@ -18,6 +18,10 @@ public final class HibernateOrmMapperSpiSettings {
 	public static final String INTEGRATION_PARTIAL_BUILD_STATE =
 			PREFIX + Radicals.INTEGRATION_PARTIAL_BUILD_STATE;
 
+	public static final String JBOSS_LOG_VERSION =
+			// No Hibernate-specific prefix here; this controls the behavior of multiple JBoss libraries.
+			"jboss.log-version";
+
 	public static class Radicals {
 
 		private Radicals() {
@@ -33,6 +37,8 @@ public final class HibernateOrmMapperSpiSettings {
 
 		private Defaults() {
 		}
+
+		public static final boolean JBOSS_LOG_VERSIONS = true;
 
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4503

~~Draft until we know for sure which property key we'll want to use; see https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/INFO.20messages.20on.20native-image~~ => Jboss-threads went with `jboss.log-version`, so we're going to go with that. See https://github.com/jbossas/jboss-threads/pull/120/files#diff-f7179ffcce5656c32a94e972f59059723d7d9d1c53bc3274c1d7bdda0b6a212aR61