### PR TITLE
HSEARCH-4497 + HSEARCH-4505 Add compatibility with Elasticsearch 8.1.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,7 +238,8 @@ The following profiles are available:
   * `elasticsearch-7.10` for 7.10
   * `elasticsearch-7.11` for 7.11 ([not open-source starting with this version](https://opensource.org/node/1099))
   * `elasticsearch-7.12` for 7.12 to 7.17
-  * `elasticsearch-8.0` for 8.0+ (**the default**)
+  * `elasticsearch-8.0` for 8.0
+  * `elasticsearch-8.1` for 8.1+ (**the default**)
 * [OpenSearch](https://www.opensearch.org/)
   * `opensearch-1.0` for 1.0
   * `opensearch-1.2` for 1.2+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -256,8 +256,9 @@ stage('Configure') {
 							condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(versionRange: '[7.12,8.0)', mavenProfile: 'elasticsearch-7.12',
 							condition: TestCondition.AFTER_MERGE),
+					// Not testing 8.0 because we know there are problems in 8.0.1 (see https://hibernate.atlassian.net/browse/HSEARCH-4497)
 					new EsLocalBuildEnvironment(versionRange: '[8.0,8.1)', mavenProfile: 'elasticsearch-8.0',
-							condition: TestCondition.AFTER_MERGE),
+							condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(versionRange: '[8.1,8.x)', mavenProfile: 'elasticsearch-8.1',
 							condition: TestCondition.BEFORE_MERGE,
 							isDefault: true),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -256,7 +256,9 @@ stage('Configure') {
 							condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(versionRange: '[7.12,8.0)', mavenProfile: 'elasticsearch-7.12',
 							condition: TestCondition.AFTER_MERGE),
-					new EsLocalBuildEnvironment(versionRange: '[8.0,8.x)', mavenProfile: 'elasticsearch-8.0',
+					new EsLocalBuildEnvironment(versionRange: '[8.0,8.1)', mavenProfile: 'elasticsearch-8.0',
+							condition: TestCondition.AFTER_MERGE),
+					new EsLocalBuildEnvironment(versionRange: '[8.1,8.x)', mavenProfile: 'elasticsearch-8.1',
 							condition: TestCondition.BEFORE_MERGE,
 							isDefault: true),
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
@@ -22,6 +22,7 @@ import org.hibernate.search.backend.elasticsearch.dialect.protocol.impl.Elastics
 import org.hibernate.search.backend.elasticsearch.dialect.protocol.impl.Elasticsearch67ProtocolDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.protocol.impl.Elasticsearch70ProtocolDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.protocol.impl.Elasticsearch80ProtocolDialect;
+import org.hibernate.search.backend.elasticsearch.dialect.protocol.impl.Elasticsearch81ProtocolDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.protocol.impl.ElasticsearchProtocolDialect;
 import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.util.common.AssertionFailure;
@@ -125,7 +126,7 @@ public class ElasticsearchDialectFactory {
 		}
 		else {
 			log.unknownElasticsearchVersion( version );
-			return new Elasticsearch80ProtocolDialect();
+			return new Elasticsearch81ProtocolDialect();
 		}
 	}
 
@@ -165,10 +166,13 @@ public class ElasticsearchDialectFactory {
 	}
 
 	private ElasticsearchProtocolDialect createProtocolDialectElasticV8(ElasticsearchVersion version, int minor) {
-		if ( minor > 0 ) {
+		if ( minor > 1 ) {
 			log.unknownElasticsearchVersion( version );
 		}
-		return new Elasticsearch80ProtocolDialect();
+		else if ( minor == 0 ) {
+			return new Elasticsearch80ProtocolDialect();
+		}
+		return new Elasticsearch81ProtocolDialect();
 	}
 
 	private ElasticsearchProtocolDialect createProtocolDialectOpenSearch(ElasticsearchVersion version) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/Elasticsearch81ProtocolDialect.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/Elasticsearch81ProtocolDialect.java
@@ -9,7 +9,7 @@ package org.hibernate.search.backend.elasticsearch.dialect.protocol.impl;
 import org.hibernate.search.backend.elasticsearch.gson.spi.GsonProvider;
 import org.hibernate.search.backend.elasticsearch.lowlevel.syntax.metadata.impl.Elasticsearch64IndexMetadataSyntax;
 import org.hibernate.search.backend.elasticsearch.lowlevel.syntax.metadata.impl.ElasticsearchIndexMetadataSyntax;
-import org.hibernate.search.backend.elasticsearch.lowlevel.syntax.search.impl.Elasticsearch7SearchSyntax;
+import org.hibernate.search.backend.elasticsearch.lowlevel.syntax.search.impl.Elasticsearch81SearchSyntax;
 import org.hibernate.search.backend.elasticsearch.lowlevel.syntax.search.impl.ElasticsearchSearchSyntax;
 import org.hibernate.search.backend.elasticsearch.search.query.impl.Elasticsearch7SearchResultExtractorFactory;
 import org.hibernate.search.backend.elasticsearch.search.query.impl.ElasticsearchSearchResultExtractorFactory;
@@ -17,9 +17,9 @@ import org.hibernate.search.backend.elasticsearch.work.builder.factory.impl.Elas
 import org.hibernate.search.backend.elasticsearch.work.builder.factory.impl.ElasticsearchWorkBuilderFactory;
 
 /**
- * The protocol dialect for Elasticsearch 8.0.
+ * The protocol dialect for Elasticsearch 8.1 and later 8.x.
  */
-public class Elasticsearch80ProtocolDialect implements ElasticsearchProtocolDialect {
+public class Elasticsearch81ProtocolDialect implements ElasticsearchProtocolDialect {
 
 	@Override
 	public ElasticsearchIndexMetadataSyntax createIndexMetadataSyntax() {
@@ -28,7 +28,7 @@ public class Elasticsearch80ProtocolDialect implements ElasticsearchProtocolDial
 
 	@Override
 	public ElasticsearchSearchSyntax createSearchSyntax() {
-		return new Elasticsearch7SearchSyntax();
+		return new Elasticsearch81SearchSyntax();
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/lowlevel/syntax/search/impl/Elasticsearch7SearchSyntax.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/lowlevel/syntax/search/impl/Elasticsearch7SearchSyntax.java
@@ -6,60 +6,17 @@
  */
 package org.hibernate.search.backend.elasticsearch.lowlevel.syntax.search.impl;
 
-import java.util.List;
-
-import org.hibernate.search.backend.elasticsearch.gson.impl.JsonAccessor;
-import org.hibernate.search.backend.elasticsearch.gson.impl.JsonArrayAccessor;
-
 import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
+import com.google.gson.LongSerializationPolicy;
 
 /**
- * The search syntax for ES7.0 and later.
+ * The search syntax for ES7.0 to ES8.0.
  */
-public class Elasticsearch7SearchSyntax implements ElasticsearchSearchSyntax {
-
-	private static final JsonArrayAccessor DOCVALUE_FIELDS_ACCESSOR =
-			JsonAccessor.root().property( "docvalue_fields" ).asArray();
-
-	private static final JsonAccessor<JsonElement> NESTED_ACCESSOR = JsonAccessor.root().property( "nested" );
-	private static final JsonAccessor<JsonElement> PATH_ACCESSOR = JsonAccessor.root().property( "path" );
-	private static final JsonAccessor<JsonElement> FILTER_ACCESSOR = JsonAccessor.root().property( "filter" );
-	private static final JsonAccessor<Boolean> IGNORE_UNMAPPED_ACCESSOR =
-			JsonAccessor.root().property( "ignore_unmapped" ).asBoolean();
+public class Elasticsearch7SearchSyntax extends Elasticsearch81SearchSyntax {
 
 	@Override
-	public String getTermAggregationOrderByTermToken() {
-		return "_key";
-	}
-
-	@Override
-	public void requestDocValues(JsonObject requestBody, JsonPrimitive fieldName) {
-		// The default format is the format defined in the mapping, which is what we want
-		DOCVALUE_FIELDS_ACCESSOR.addElementIfAbsent( requestBody, fieldName );
-	}
-
-	@Override
-	public void requestNestedSort(List<String> nestedPathHierarchy, JsonObject innerObject, JsonObject filterOrNull) {
-		JsonObject nextNestedObjectTarget = innerObject;
-		for ( int i = 0; i < nestedPathHierarchy.size(); i++ ) {
-			String nestedPath = nestedPathHierarchy.get( i );
-
-			JsonObject nestedObject = new JsonObject();
-			PATH_ACCESSOR.set( nestedObject, new JsonPrimitive( nestedPath ) );
-			NESTED_ACCESSOR.set( nextNestedObjectTarget, nestedObject );
-			if ( i == (nestedPathHierarchy.size() - 1) && filterOrNull != null ) {
-				FILTER_ACCESSOR.set( nestedObject, filterOrNull );
-			}
-
-			// the new api requires a recursion on the path hierarchy
-			nextNestedObjectTarget = nestedObject;
-		}
-	}
-
-	@Override
-	public void requestGeoDistanceSortIgnoreUnmapped(JsonObject innerObject) {
-		IGNORE_UNMAPPED_ACCESSOR.set( innerObject, true );
+	public JsonElement encodeLongForAggregation(Long value) {
+		// Workaround for https://github.com/elastic/elasticsearch/issues/81529
+		return LongSerializationPolicy.STRING.serialize( value );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/lowlevel/syntax/search/impl/Elasticsearch81SearchSyntax.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/lowlevel/syntax/search/impl/Elasticsearch81SearchSyntax.java
@@ -1,0 +1,72 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.lowlevel.syntax.search.impl;
+
+import java.util.List;
+
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonAccessor;
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonArrayAccessor;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+/**
+ * The search syntax for ES7.0 and later.
+ */
+public class Elasticsearch81SearchSyntax implements ElasticsearchSearchSyntax {
+
+	private static final JsonArrayAccessor DOCVALUE_FIELDS_ACCESSOR =
+			JsonAccessor.root().property( "docvalue_fields" ).asArray();
+
+	private static final JsonAccessor<JsonElement> NESTED_ACCESSOR = JsonAccessor.root().property( "nested" );
+	private static final JsonAccessor<JsonElement> PATH_ACCESSOR = JsonAccessor.root().property( "path" );
+	private static final JsonAccessor<JsonElement> FILTER_ACCESSOR = JsonAccessor.root().property( "filter" );
+	private static final JsonAccessor<Boolean> IGNORE_UNMAPPED_ACCESSOR =
+			JsonAccessor.root().property( "ignore_unmapped" ).asBoolean();
+
+	@Override
+	public String getTermAggregationOrderByTermToken() {
+		return "_key";
+	}
+
+	@Override
+	public void requestDocValues(JsonObject requestBody, JsonPrimitive fieldName) {
+		// The default format is the format defined in the mapping, which is what we want
+		DOCVALUE_FIELDS_ACCESSOR.addElementIfAbsent( requestBody, fieldName );
+	}
+
+	@Override
+	public void requestNestedSort(List<String> nestedPathHierarchy, JsonObject innerObject, JsonObject filterOrNull) {
+		JsonObject nextNestedObjectTarget = innerObject;
+		for ( int i = 0; i < nestedPathHierarchy.size(); i++ ) {
+			String nestedPath = nestedPathHierarchy.get( i );
+
+			JsonObject nestedObject = new JsonObject();
+			PATH_ACCESSOR.set( nestedObject, new JsonPrimitive( nestedPath ) );
+			NESTED_ACCESSOR.set( nextNestedObjectTarget, nestedObject );
+			if ( i == (nestedPathHierarchy.size() - 1) && filterOrNull != null ) {
+				FILTER_ACCESSOR.set( nestedObject, filterOrNull );
+			}
+
+			// the new api requires a recursion on the path hierarchy
+			nextNestedObjectTarget = nestedObject;
+		}
+	}
+
+	@Override
+	public void requestGeoDistanceSortIgnoreUnmapped(JsonObject innerObject) {
+		IGNORE_UNMAPPED_ACCESSOR.set( innerObject, true );
+	}
+
+	@Override
+	public JsonElement encodeLongForAggregation(Long value) {
+		// https://github.com/elastic/elasticsearch/issues/81529 was solved in ES8.1
+		return value == null ? JsonNull.INSTANCE : new JsonPrimitive( value );
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/lowlevel/syntax/search/impl/ElasticsearchSearchSyntax.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/lowlevel/syntax/search/impl/ElasticsearchSearchSyntax.java
@@ -8,6 +8,7 @@ package org.hibernate.search.backend.elasticsearch.lowlevel.syntax.search.impl;
 
 import java.util.List;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 
@@ -20,5 +21,7 @@ public interface ElasticsearchSearchSyntax {
 	void requestNestedSort(List<String> nestedPathHierarchy, JsonObject innerObject, JsonObject filterOrNull);
 
 	void requestGeoDistanceSortIgnoreUnmapped(JsonObject innerObject);
+
+	JsonElement encodeLongForAggregation(Long value);
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/ElasticsearchRangeAggregation.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/ElasticsearchRangeAggregation.java
@@ -153,7 +153,7 @@ public class ElasticsearchRangeAggregation<F, K>
 		private JsonElement convertToFieldValue(K value) {
 			try {
 				F converted = toFieldValueConverter.toDocumentValue( value, scope.toDocumentValueConvertContext() );
-				return codec.encodeForAggregation( converted );
+				return codec.encodeForAggregation( scope.searchSyntax(), converted );
 			}
 			catch (RuntimeException e) {
 				throw log.cannotConvertDslParameter( e.getMessage(), e, field.eventContext() );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchFieldCodec.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.backend.elasticsearch.types.codec.impl;
 
+import org.hibernate.search.backend.elasticsearch.lowlevel.syntax.search.impl.ElasticsearchSearchSyntax;
+
 import com.google.gson.JsonElement;
 
 /**
@@ -26,10 +28,12 @@ public interface ElasticsearchFieldCodec<F> {
 	/**
 	 * Encodes a value for inclusion in an aggregation request.
 	 *
+	 *
+	 * @param searchSyntax The search syntax.
 	 * @param value The value to encode.
 	 * @return The encoded value.
 	 */
-	default JsonElement encodeForAggregation(F value) {
+	default JsonElement encodeForAggregation(ElasticsearchSearchSyntax searchSyntax, F value) {
 		return encode( value );
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchLongFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchLongFieldCodec.java
@@ -7,11 +7,11 @@
 package org.hibernate.search.backend.elasticsearch.types.codec.impl;
 
 import org.hibernate.search.backend.elasticsearch.gson.impl.JsonElementTypes;
+import org.hibernate.search.backend.elasticsearch.lowlevel.syntax.search.impl.ElasticsearchSearchSyntax;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonPrimitive;
-import com.google.gson.LongSerializationPolicy;
 
 public class ElasticsearchLongFieldCodec implements ElasticsearchFieldCodec<Long> {
 	public static final ElasticsearchLongFieldCodec INSTANCE = new ElasticsearchLongFieldCodec();
@@ -28,9 +28,8 @@ public class ElasticsearchLongFieldCodec implements ElasticsearchFieldCodec<Long
 	}
 
 	@Override
-	public JsonElement encodeForAggregation(Long value) {
-		// Workaround for https://github.com/elastic/elasticsearch/issues/81529
-		return LongSerializationPolicy.STRING.serialize( value );
+	public JsonElement encodeForAggregation(ElasticsearchSearchSyntax searchSyntax, Long value) {
+		return searchSyntax.encodeLongForAggregation( value );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -23,6 +23,7 @@ import org.hibernate.search.backend.elasticsearch.dialect.protocol.impl.Elastics
 import org.hibernate.search.backend.elasticsearch.dialect.protocol.impl.Elasticsearch67ProtocolDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.protocol.impl.Elasticsearch70ProtocolDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.protocol.impl.Elasticsearch80ProtocolDialect;
+import org.hibernate.search.backend.elasticsearch.dialect.protocol.impl.Elasticsearch81ProtocolDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.protocol.impl.ElasticsearchProtocolDialect;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
@@ -582,8 +583,8 @@ public class ElasticsearchDialectFactoryTest {
 	@TestForIssue(jiraKey = "HSEARCH-4475")
 	public void elastic_8() {
 		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "8", "8.0.0",
-				Elasticsearch8ModelDialect.class, Elasticsearch80ProtocolDialect.class
+				ElasticsearchDistributionName.ELASTIC, "8", "8.1.0",
+				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
 		);
 	}
 
@@ -606,20 +607,38 @@ public class ElasticsearchDialectFactoryTest {
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4475")
+	@TestForIssue(jiraKey = "HSEARCH-4505")
 	public void elastic_8_1() {
-		testSuccessWithWarning(
+		testSuccess(
 				ElasticsearchDistributionName.ELASTIC, "8.1", "8.1.0",
-				Elasticsearch8ModelDialect.class, Elasticsearch80ProtocolDialect.class
+				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
 		);
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4475")
+	@TestForIssue(jiraKey = "HSEARCH-4505")
 	public void elastic_8_1_0() {
-		testSuccessWithWarning(
+		testSuccess(
 				ElasticsearchDistributionName.ELASTIC, "8.1.0", "8.1.0",
-				Elasticsearch8ModelDialect.class, Elasticsearch80ProtocolDialect.class
+				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4505")
+	public void elastic_8_2() {
+		testSuccessWithWarning(
+				ElasticsearchDistributionName.ELASTIC, "8.2", "8.2.0",
+				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4505")
+	public void elastic_8_2_0() {
+		testSuccessWithWarning(
+				ElasticsearchDistributionName.ELASTIC, "8.2.0", "8.2.0",
+				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
 		);
 	}
 
@@ -627,7 +646,7 @@ public class ElasticsearchDialectFactoryTest {
 	public void elastic_9_0_0() {
 		testSuccessWithWarning(
 				ElasticsearchDistributionName.ELASTIC, "9.0.0", "9.0.0",
-				Elasticsearch8ModelDialect.class, Elasticsearch80ProtocolDialect.class
+				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
 		);
 	}
 

--- a/integrationtest/backend/elasticsearch/pom.xml
+++ b/integrationtest/backend/elasticsearch/pom.xml
@@ -256,9 +256,19 @@
             </properties>
         </profile>
 
-        <!-- Elasticsearch 8.0+ test environment -->
+        <!-- Elasticsearch 8.0 test environment -->
         <profile>
             <id>elasticsearch-8.0</id>
+            <properties>
+                <failsafe.excludedGroups.elasticsearch.version>
+                    <!-- Nothing here -->
+                </failsafe.excludedGroups.elasticsearch.version>
+            </properties>
+        </profile>
+
+        <!-- Elasticsearch 8.1+ test environment -->
+        <profile>
+            <id>elasticsearch-8.1</id>
             <activation>
                 <!-- This must be re-defined here: the activation defined in the parent pom is not enough -->
                 <!-- Activate by default, i.e. if test.elasticsearch.connection.version has not been defined explicitly -->

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateCustomMappingIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateCustomMappingIT.java
@@ -161,12 +161,12 @@ public class ElasticsearchIndexSchemaManagerUpdateCustomMappingIT {
 		elasticsearchClient.index( index.name() ).type().putMapping(
 				" { " +
 				"    '_source':{ " +
-				"       'enabled':true " +
+				"       'enabled': false " +
 				"    } " +
 				" } "
 		);
 
-		assertThatThrownBy( () -> setupAndUpdateIndex( "no-overlapping.json" ) )
+		assertThatThrownBy( () -> setupAndUpdateIndex( "source-enabled.json" ) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll( "conflicts", "_source" );
 	}

--- a/integrationtest/backend/elasticsearch/src/test/resources/custom-index-mapping/source-enabled.json
+++ b/integrationtest/backend/elasticsearch/src/test/resources/custom-index-mapping/source-enabled.json
@@ -1,0 +1,5 @@
+{
+  "_source": {
+    "enabled": true
+  }
+}

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -579,9 +579,20 @@
             </properties>
         </profile>
 
-        <!-- Elasticsearch 8.0+ test environment -->
+        <!-- Elasticsearch 8.0 test environment -->
         <profile>
             <id>elasticsearch-8.0</id>
+            <properties>
+                <test.elasticsearch.run.elastic.skip>${test.elasticsearch.run.skip}</test.elasticsearch.run.elastic.skip>
+                <test.elasticsearch.connection.distribution>elastic</test.elasticsearch.connection.distribution>
+                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-8.0}</test.elasticsearch.connection.version>
+                <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch712TestDialect</test.elasticsearch.testdialect>
+            </properties>
+        </profile>
+
+        <!-- Elasticsearch 8.1+ test environment -->
+        <profile>
+            <id>elasticsearch-8.1</id>
             <activation>
                 <!-- Activate by default, i.e. if test.elasticsearch.connection.version has not been defined explicitly -->
                 <property>
@@ -591,7 +602,7 @@
             <properties>
                 <test.elasticsearch.run.elastic.skip>${test.elasticsearch.run.skip}</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.distribution>elastic</test.elasticsearch.connection.distribution>
-                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-8.0}</test.elasticsearch.connection.version>
+                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-8.1}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch712TestDialect</test.elasticsearch.testdialect>
             </properties>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -206,16 +206,17 @@
         <version.org.elasticsearch.client>8.1.0</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
-             to make sure the corresponding profile (e.g. elasticsearch-8.0) becomes the default. -->
-        <version.org.elasticsearch.compatible.main>${version.org.elasticsearch.latest-8.0}</version.org.elasticsearch.compatible.main>
+             to make sure the corresponding profile (e.g. elasticsearch-8.1) becomes the default. -->
+        <version.org.elasticsearch.compatible.main>${version.org.elasticsearch.latest-8.1}</version.org.elasticsearch.compatible.main>
         <documentation.org.elasticsearch.url>https://www.elastic.co/guide/en/elasticsearch/reference/${parsed-version.org.elasticsearch.compatible.main.majorVersion}.${parsed-version.org.elasticsearch.compatible.main.minorVersion}</documentation.org.elasticsearch.url>
         <!-- The versions of Elasticsearch/OpenSearch advertised as compatible with Hibernate Search -->
         <!-- Make sure that 7.10 stays explicitly mentioned here, because that's the last open-source version -->
-        <version.org.elasticsearch.compatible.regularly-tested.text>5.6, 6.8, 7.10, 7.17 or 8.0</version.org.elasticsearch.compatible.regularly-tested.text>
+        <version.org.elasticsearch.compatible.regularly-tested.text>5.6, 6.8, 7.10, 7.17 or 8.1</version.org.elasticsearch.compatible.regularly-tested.text>
         <version.org.opensearch.compatible.regularly-tested.text>1.0 or 1.2</version.org.opensearch.compatible.regularly-tested.text>
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
-        <version.org.elasticsearch.compatible.not-regularly-tested.text>6.0 or 7.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
+        <version.org.elasticsearch.compatible.not-regularly-tested.text>7.0 or 8.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest micro of each Elasticsearch branch -->
+        <version.org.elasticsearch.latest-8.1>8.1.0</version.org.elasticsearch.latest-8.1>
         <version.org.elasticsearch.latest-8.0>8.0.1</version.org.elasticsearch.latest-8.0>
         <version.org.elasticsearch.latest-7.17>7.17.0</version.org.elasticsearch.latest-7.17>
         <version.org.elasticsearch.latest-7.16>7.16.3</version.org.elasticsearch.latest-7.16>

--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
         <version.org.elasticsearch.compatible.not-regularly-tested.text>6.0 or 7.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest micro of each Elasticsearch branch -->
-        <version.org.elasticsearch.latest-8.0>8.0.0</version.org.elasticsearch.latest-8.0>
+        <version.org.elasticsearch.latest-8.0>8.0.1</version.org.elasticsearch.latest-8.0>
         <version.org.elasticsearch.latest-7.17>7.17.0</version.org.elasticsearch.latest-7.17>
         <version.org.elasticsearch.latest-7.16>7.16.3</version.org.elasticsearch.latest-7.16>
         <!-- 7.14 and 7.15 have annoying bugs that make almost all of our test suite fail, so we don't test them


### PR DESCRIPTION
* [HSEARCH-4497](https://hibernate.atlassian.net/browse/HSEARCH-4497): Run tests against Elasticsearch 8.0.1
* [HSEARCH-4505](https://hibernate.atlassian.net/browse/HSEARCH-4505): Add compatibility with Elasticsearch 8.1.0

