### PR TITLE
Backport HSEARCH-4512 to branch 6.1 - Upgrade to Hibernate ORM 5.6.7.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
         <version.org.slf4j>1.7.35</version.org.slf4j>
 
         <!-- >>> ORM -->
-        <version.org.hibernate>5.6.5.Final</version.org.hibernate>
+        <version.org.hibernate>5.6.7.Final</version.org.hibernate>
         <javadoc.org.hibernate.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.majorVersion}.${parsed-version.org.hibernate.minorVersion}/javadocs/</javadoc.org.hibernate.url>
         <documentation.org.hibernate.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.majorVersion}.${parsed-version.org.hibernate.minorVersion}/userguide/html_single/Hibernate_User_Guide.html</documentation.org.hibernate.url>
         <version.org.hibernate.commons.annotations>5.1.2.Final</version.org.hibernate.commons.annotations>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4512

Backport of #2947 to branch 6.1.