### PR TITLE
Backport HSEARCH-4513 to branch 6.1 - Using a SearchSort instance in multiple queries with the Lucene backend has side effects and leads to unexpected results

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/collector/impl/CollectorExecutionContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/collector/impl/CollectorExecutionContext.java
@@ -12,7 +12,6 @@ import org.hibernate.search.backend.lucene.lowlevel.join.impl.NestedDocsProvider
 import org.hibernate.search.backend.lucene.lowlevel.reader.impl.IndexReaderMetadataResolver;
 
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.Query;
 
 public final class CollectorExecutionContext {
 
@@ -20,17 +19,13 @@ public final class CollectorExecutionContext {
 
 	private final IndexSearcher indexSearcher;
 
-	private final Query luceneQuery;
-
 	private final int maxDocs;
 
 	public CollectorExecutionContext(IndexReaderMetadataResolver metadataResolver,
 			IndexSearcher indexSearcher,
-			Query luceneQuery,
 			int maxDocs) {
 		this.metadataResolver = metadataResolver;
 		this.indexSearcher = indexSearcher;
-		this.luceneQuery = luceneQuery;
 		this.maxDocs = maxDocs;
 	}
 
@@ -43,11 +38,11 @@ public final class CollectorExecutionContext {
 	}
 
 	public NestedDocsProvider createNestedDocsProvider(String nestedDocumentPath) {
-		return new NestedDocsProvider( nestedDocumentPath, luceneQuery );
+		return new NestedDocsProvider( nestedDocumentPath );
 	}
 
 	public NestedDocsProvider createNestedDocsProvider(Set<String> nestedDocumentPaths) {
-		return new NestedDocsProvider( nestedDocumentPaths, luceneQuery );
+		return new NestedDocsProvider( nestedDocumentPaths );
 	}
 
 	public int getMaxDocs() {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/query/impl/Queries.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/query/impl/Queries.java
@@ -17,7 +17,6 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.join.BitSetProducer;
-import org.apache.lucene.search.join.QueryBitSetProducer;
 import org.apache.lucene.search.join.ToChildBlockJoinQuery;
 
 public class Queries {
@@ -76,25 +75,22 @@ public class Queries {
 		return queryBuilder.build();
 	}
 
-	public static BitSetProducer parentFilter(String parentNestedDocumentPath) {
-		Query parentQuery;
+	public static Query parentsFilterQuery(String parentNestedDocumentPath) {
 		if ( parentNestedDocumentPath == null ) {
-			parentQuery = Queries.mainDocumentQuery();
+			return Queries.mainDocumentQuery();
 		}
 		else {
-			parentQuery = Queries.nestedDocumentPathQuery( parentNestedDocumentPath );
+			return Queries.nestedDocumentPathQuery( parentNestedDocumentPath );
 		}
-		return new QueryBitSetProducer( parentQuery );
 	}
 
-	public static BooleanQuery findChildQuery(BitSetProducer parentFilter,
-				Set<String> nestedDocumentPaths, Query originalParentQuery,
-				Query nestedFilter) {
-		ToChildBlockJoinQuery parentQuery = new ToChildBlockJoinQuery( originalParentQuery, parentFilter );
+	public static BooleanQuery findChildQuery(Query parentQuery, BitSetProducer parentFilter,
+			Set<String> nestedDocumentPaths, Query nestedFilter) {
+		ToChildBlockJoinQuery childQuery = new ToChildBlockJoinQuery( parentQuery, parentFilter );
 
 		BooleanQuery.Builder builder = new BooleanQuery.Builder();
 
-		builder.add( parentQuery, Occur.MUST )
+		builder.add( childQuery, Occur.MUST )
 				.add( createNestedDocumentPathSubQuery( nestedDocumentPaths ), Occur.FILTER )
 				.add( childDocumentQuery(), Occur.FILTER );
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/aggregation/impl/AggregationExtractContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/aggregation/impl/AggregationExtractContext.java
@@ -18,15 +18,13 @@ import org.apache.lucene.search.Query;
 public class AggregationExtractContext {
 
 	private final IndexReader indexReader;
-	private final Query luceneQuery;
 	private final FromDocumentValueConvertContext fromDocumentValueConvertContext;
 	private final CollectorSet collectors;
 
-	public AggregationExtractContext(IndexReader indexReader, Query luceneQuery,
+	public AggregationExtractContext(IndexReader indexReader,
 			FromDocumentValueConvertContext fromDocumentValueConvertContext,
 			CollectorSet collectors) {
 		this.indexReader = indexReader;
-		this.luceneQuery = luceneQuery;
 		this.fromDocumentValueConvertContext = fromDocumentValueConvertContext;
 		this.collectors = collectors;
 	}
@@ -44,6 +42,6 @@ public class AggregationExtractContext {
 	}
 
 	public NestedDocsProvider createNestedDocsProvider(String nestedDocumentPath, Query nestedFilter) {
-		return new NestedDocsProvider( nestedDocumentPath, luceneQuery, nestedFilter );
+		return new NestedDocsProvider( nestedDocumentPath, nestedFilter );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/ExtractionRequirements.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/ExtractionRequirements.java
@@ -68,7 +68,7 @@ public final class ExtractionRequirements {
 		boolean requireFieldDocRescoring = false;
 
 		CollectorExecutionContext executionContext =
-				new CollectorExecutionContext( metadataResolver, indexSearcher, rewrittenLuceneQuery, maxDocs );
+				new CollectorExecutionContext( metadataResolver, indexSearcher, maxDocs );
 
 		CollectorSet.Builder collectorsForAllMatchingDocsBuilder =
 				new CollectorSet.Builder( executionContext, timeoutManager );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/LuceneCollectors.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/LuceneCollectors.java
@@ -162,7 +162,7 @@ public class LuceneCollectors {
 		try {
 			ScoreDoc[] scoreDocs = topDocs.scoreDocs;
 			ExplicitDocIdsQuery topDocsQuery = new ExplicitDocIdsQuery( scoreDocs, startInclusive, endExclusive );
-			this.collectorsForTopDocs = buildTopdDocsDataCollectors( topDocsQuery );
+			this.collectorsForTopDocs = buildTopdDocsDataCollectors();
 			indexSearcher.search( topDocsQuery, collectorsForTopDocs.getComposed() );
 		}
 		catch (TimeLimitingCollector.TimeExceededException e) {
@@ -225,11 +225,9 @@ public class LuceneCollectors {
 		}
 	}
 
-	private CollectorSet buildTopdDocsDataCollectors(Query topDocsQuery) throws IOException {
+	private CollectorSet buildTopdDocsDataCollectors() throws IOException {
 		CollectorExecutionContext executionContext = new CollectorExecutionContext(
 				metadataResolver, indexSearcher,
-				// Only join nested documents for the top documents (not for all documents matching this.luceneQuery).
-				topDocsQuery,
 				// Allocate just enough memory to handle the top documents.
 				topDocs.scoreDocs.length
 		);

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/LuceneCollectors.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/LuceneCollectors.java
@@ -162,7 +162,7 @@ public class LuceneCollectors {
 		try {
 			ScoreDoc[] scoreDocs = topDocs.scoreDocs;
 			ExplicitDocIdsQuery topDocsQuery = new ExplicitDocIdsQuery( scoreDocs, startInclusive, endExclusive );
-			this.collectorsForTopDocs = buildTopdDocsDataCollectors();
+			this.collectorsForTopDocs = buildTopDocsDataCollectors();
 			indexSearcher.search( topDocsQuery, collectorsForTopDocs.getComposed() );
 		}
 		catch (TimeLimitingCollector.TimeExceededException e) {
@@ -225,7 +225,7 @@ public class LuceneCollectors {
 		}
 	}
 
-	private CollectorSet buildTopdDocsDataCollectors() throws IOException {
+	private CollectorSet buildTopDocsDataCollectors() throws IOException {
 		CollectorExecutionContext executionContext = new CollectorExecutionContext(
 				metadataResolver, indexSearcher,
 				// Allocate just enough memory to handle the top documents.

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneNestedPredicate.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneNestedPredicate.java
@@ -17,6 +17,7 @@ import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.BitSetProducer;
+import org.apache.lucene.search.join.QueryBitSetProducer;
 import org.apache.lucene.search.join.ScoreMode;
 import org.apache.lucene.search.join.ToParentBlockJoinQuery;
 
@@ -48,7 +49,7 @@ public class LuceneNestedPredicate extends AbstractLuceneSingleFieldPredicate {
 		// Note: this filter should include *all* parents, not just the matched ones.
 		// Otherwise we will not "see" non-matched parents,
 		// and we will consider its matching children as children of the next matching parent.
-		BitSetProducer parentFilter = Queries.parentFilter( parentNestedDocumentPath );
+		BitSetProducer parentFilter = new QueryBitSetProducer( Queries.parentsFilterQuery( parentNestedDocumentPath ) );
 
 		// TODO HSEARCH-3090 at some point we should have a parameter for the score mode
 		return new ToParentBlockJoinQuery( childQueryBuilder.build(), parentFilter, ScoreMode.Avg );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneExtractableSearchResult.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneExtractableSearchResult.java
@@ -136,7 +136,7 @@ public class LuceneExtractableSearchResult<H> {
 
 	private Map<AggregationKey<?>, ?> extractAggregations() throws IOException {
 		AggregationExtractContext aggregationExtractContext = new AggregationExtractContext(
-				indexSearcher.getIndexReader(), requestContext.getLuceneQuery(),
+				indexSearcher.getIndexReader(),
 				fromDocumentValueConvertContext,
 				luceneCollectors.getCollectorsForAllMatchingDocs()
 		);

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilder.java
@@ -64,8 +64,6 @@ public class LuceneSearchQueryBuilder<H> implements SearchQueryBuilder<H>, Lucen
 	private final SearchLoadingContextBuilder<?, ?, ?> loadingContextBuilder;
 	private final LuceneSearchProjection<?, H> rootProjection;
 
-	private List<LuceneFieldComparatorSource> nestedFieldSorts;
-
 	private Query luceneQuery;
 	private List<SortField> sortFields;
 	private Map<AggregationKey<?>, LuceneSearchAggregation<?>> aggregations;
@@ -163,14 +161,6 @@ public class LuceneSearchQueryBuilder<H> implements SearchQueryBuilder<H>, Lucen
 	@Override
 	public void collectSortField(SortField sortField, LuceneFieldComparatorSource nestedFieldSort) {
 		collectSortField( sortField );
-		if ( nestedFieldSort == null ) {
-			return;
-		}
-
-		if ( nestedFieldSorts == null ) {
-			nestedFieldSorts = new ArrayList<>( 5 );
-		}
-		nestedFieldSorts.add( nestedFieldSort );
 	}
 
 	@Override
@@ -210,12 +200,6 @@ public class LuceneSearchQueryBuilder<H> implements SearchQueryBuilder<H>, Lucen
 		Sort luceneSort = null;
 		if ( sortFields != null && !sortFields.isEmpty() ) {
 			luceneSort = new Sort( sortFields.toArray( new SortField[0] ) );
-		}
-
-		if ( nestedFieldSorts != null ) {
-			for ( LuceneFieldComparatorSource nestedField : nestedFieldSorts ) {
-				nestedField.setOriginalParentQuery( definitiveLuceneQuery );
-			}
 		}
 
 		LuceneSearchQueryRequestContext requestContext = new LuceneSearchQueryRequestContext(

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/comparatorsource/impl/LuceneFieldComparatorSource.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/comparatorsource/impl/LuceneFieldComparatorSource.java
@@ -13,17 +13,11 @@ import org.apache.lucene.search.Query;
 
 public abstract class LuceneFieldComparatorSource extends FieldComparatorSource {
 
-	protected final String nestedDocumentPath;
-	protected final Query filter;
-
 	protected NestedDocsProvider nestedDocsProvider;
 
 	public LuceneFieldComparatorSource(String nestedDocumentPath, Query filter) {
-		this.nestedDocumentPath = nestedDocumentPath;
-		this.filter = filter;
+		this.nestedDocsProvider = nestedDocumentPath == null ? null
+				: new NestedDocsProvider( nestedDocumentPath, filter );
 	}
 
-	public void setOriginalParentQuery(Query luceneQuery) {
-		this.nestedDocsProvider = new NestedDocsProvider( nestedDocumentPath, luceneQuery, filter );
-	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/AbstractLuceneDocumentValueSort.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/AbstractLuceneDocumentValueSort.java
@@ -33,18 +33,16 @@ public abstract class AbstractLuceneDocumentValueSort extends AbstractLuceneReve
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	protected final SortField sortField;
-	protected final LuceneFieldComparatorSource nestedFieldSort;
 
 	protected AbstractLuceneDocumentValueSort(AbstractBuilder builder) {
 		super( builder );
 		LuceneFieldComparatorSource fieldComparatorSource = builder.toFieldComparatorSource();
 		sortField = new SortField( builder.absoluteFieldPath, fieldComparatorSource, order == SortOrder.DESC );
-		nestedFieldSort = builder.nestedDocumentPath != null ? fieldComparatorSource : null;
 	}
 
 	@Override
 	public void toSortFields(LuceneSearchSortCollector collector) {
-		collector.collectSortField( sortField, nestedFieldSort );
+		collector.collectSortField( sortField );
 	}
 
 	public abstract static class AbstractBuilder extends AbstractLuceneReversibleSort.AbstractBuilder {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/DistanceSearchSortBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/DistanceSearchSortBaseIT.java
@@ -14,6 +14,7 @@ import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -24,6 +25,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement
 import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.engine.search.common.SortMode;
 import org.hibernate.search.engine.search.query.SearchQuery;
+import org.hibernate.search.engine.search.sort.SearchSort;
 import org.hibernate.search.engine.search.sort.dsl.DistanceSortOptionsStep;
 import org.hibernate.search.engine.search.sort.dsl.SearchSortFactory;
 import org.hibernate.search.engine.spatial.GeoPoint;
@@ -38,6 +40,7 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.Se
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.BeforeClass;
@@ -370,6 +373,37 @@ public class DistanceSearchSortBaseIT {
 						} ) ) )
 				.hasDocRefHitsExactOrder( index.typeName(),
 						dataSet.doc1Id, dataSet.doc2Id, dataSet.doc3Id, dataSet.emptyDoc1Id );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = { "HSEARCH-4513" })
+	public void concurrentQueriesUsingSameSort() {
+		assumeTestParametersWork();
+
+		DataSet dataSet;
+		String fieldPath = getFieldPath();
+
+		StubMappingScope scope = index.createScope();
+
+		SearchSort sort = applyFilter( applySortMode( scope.sort().distance( fieldPath, CENTER_POINT ) ) ).toSort();
+
+		dataSet = dataSetForAsc;
+		SearchQuery<DocumentReference> query1 = scope.query()
+				.where( f -> f.id().matchingAny( Arrays.asList( dataSet.doc1Id, dataSet.doc2Id ) ) )
+				.routing( dataSet.routingKey )
+				// Reuse the same sort in multiple queries
+				.sort( sort )
+				.toQuery();
+		SearchQuery<DocumentReference> query2 = scope.query()
+				.where( f -> f.id().matching( "NOT_MATCHING_ANYTHING" ) )
+				.routing( dataSet.routingKey )
+				// Reuse the same sort in multiple queries
+				.sort( sort )
+				.toQuery();
+		assertThatQuery( query1 )
+				.hasDocRefHitsExactOrder( index.typeName(), dataSet.doc1Id, dataSet.doc2Id );
+		assertThatQuery( query2 )
+				.hasNoHits();
 	}
 
 	private void assumeTestParametersWork() {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortBaseIT.java
@@ -31,6 +31,7 @@ import org.hibernate.search.engine.search.common.SortMode;
 import org.hibernate.search.engine.search.predicate.dsl.PredicateFinalStep;
 import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
 import org.hibernate.search.engine.search.query.SearchQuery;
+import org.hibernate.search.engine.search.sort.SearchSort;
 import org.hibernate.search.engine.search.sort.dsl.FieldSortOptionsStep;
 import org.hibernate.search.engine.search.sort.dsl.SearchSortFactory;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.model.singlefield.AbstractObjectBinding;
@@ -426,6 +427,37 @@ public class FieldSearchSortBaseIT<F> {
 							}
 						} ) ) )
 				.hasDocRefHitsExactOrder( index.typeName(), dataSet.doc1Id, dataSet.doc2Id, dataSet.doc3Id );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = { "HSEARCH-4513" })
+	public void concurrentQueriesUsingSameSort() {
+		assumeTestParametersWork();
+
+		DataSet<F> dataSet;
+		String fieldPath = getFieldPath();
+
+		StubMappingScope scope = index.createScope();
+
+		SearchSort sort = applyFilter( applySortMode( scope.sort().field( fieldPath ) ) ).toSort();
+
+		dataSet = dataSetForAsc;
+		SearchQuery<DocumentReference> query1 = scope.query()
+				.where( f -> f.id().matchingAny( Arrays.asList( dataSet.doc1Id, dataSet.doc2Id ) ) )
+				.routing( dataSet.routingKey )
+				// Reuse the same sort in multiple queries
+				.sort( sort )
+				.toQuery();
+		SearchQuery<DocumentReference> query2 = scope.query()
+				.where( f -> f.id().matching( "NOT_MATCHING_ANYTHING" ) )
+				.routing( dataSet.routingKey )
+				// Reuse the same sort in multiple queries
+				.sort( sort )
+				.toQuery();
+		assertThatQuery( query1 )
+				.hasDocRefHitsExactOrder( index.typeName(), dataSet.doc1Id, dataSet.doc2Id );
+		assertThatQuery( query2 )
+				.hasNoHits();
 	}
 
 	private SearchQuery<DocumentReference> matchNonEmptyQuery(DataSet<F> dataSet,


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4513

Backport of #2949 to branch 6.1.