### PR TITLE
HSEARCH-4516 + HSEARCH-4517 Upgrade to Elasticsearch client 8.1.1 and run tests against Elasticsearch 8.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
         <version.org.elasticsearch.compatible.not-regularly-tested.text>7.0 or 8.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest micro of each Elasticsearch branch -->
-        <version.org.elasticsearch.latest-8.1>8.1.0</version.org.elasticsearch.latest-8.1>
+        <version.org.elasticsearch.latest-8.1>8.1.1</version.org.elasticsearch.latest-8.1>
         <version.org.elasticsearch.latest-8.0>8.0.1</version.org.elasticsearch.latest-8.0>
         <version.org.elasticsearch.latest-7.17>7.17.0</version.org.elasticsearch.latest-7.17>
         <version.org.elasticsearch.latest-7.16>7.16.3</version.org.elasticsearch.latest-7.16>

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.1+ -->
-        <version.org.elasticsearch.client>8.1.0</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>8.1.1</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-8.1) becomes the default. -->


### PR DESCRIPTION
* [HSEARCH-4517](https://hibernate.atlassian.net/browse/HSEARCH-4517): Run tests against Elasticsearch 8.1.1
* [HSEARCH-4516](https://hibernate.atlassian.net/browse/HSEARCH-4516): Upgrade to Elasticsearch client 8.1.1

