### PR TITLE
HSEARCH-4484 + HSEARCH-4518 Upgrade build dependencies + Jackson-databind to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1833,18 +1833,12 @@
                                     <!-- The jdk-reflection is not yet something we can avoid -->
                                     <!--<bundledSignature>jdk-reflection</bundledSignature>-->
 
-                                    <!-- All following signatures should be replicated for each target JDK version we intend to support -->
-                                    <bundledSignature>jdk-unsafe-1.8</bundledSignature>
-                                    <bundledSignature>jdk-unsafe-9</bundledSignature>
-                                    <bundledSignature>jdk-unsafe-10</bundledSignature>
-                                    <bundledSignature>jdk-unsafe-11</bundledSignature>
-                                    <bundledSignature>jdk-unsafe-12</bundledSignature>
-                                    <bundledSignature>jdk-unsafe-13</bundledSignature>
-                                    <bundledSignature>jdk-unsafe-14</bundledSignature>
-                                    <bundledSignature>jdk-unsafe-15</bundledSignature>
-                                    <bundledSignature>jdk-unsafe-16</bundledSignature>
-                                    <bundledSignature>jdk-unsafe-17</bundledSignature>
+                                    <!-- These signatures can safely be limited to the current JDK;
+                                         see https://github.com/policeman-tools/forbidden-apis/issues/197#issuecomment-1080370368
+                                     -->
+                                    <bundledSignature>jdk-unsafe</bundledSignature>
 
+                                    <!-- All following signatures should be replicated for each target JDK version we intend to support -->
                                     <bundledSignature>jdk-deprecated-1.8</bundledSignature>
                                     <bundledSignature>jdk-deprecated-9</bundledSignature>
                                     <bundledSignature>jdk-deprecated-10</bundledSignature>

--- a/pom.xml
+++ b/pom.xml
@@ -353,7 +353,7 @@
         <version.compiler.plugin>3.10.1</version.compiler.plugin>
         <version.dependency.plugin>3.3.0</version.dependency.plugin>
         <!-- Check dependencies for security vulnerabilities -->
-        <version.dependency-check.plugin>7.0.0</version.dependency-check.plugin>
+        <version.dependency-check.plugin>7.0.1</version.dependency-check.plugin>
         <version.deploy.plugin>2.8.2</version.deploy.plugin>
         <version.org.eclipse.m2e.lifecycle-mapping>1.0.0</version.org.eclipse.m2e.lifecycle-mapping>
         <version.enforcer.plugin>3.0.0</version.enforcer.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
              That's why we have two separate properties for jackson versions,
              even though they may have the same value from time to time.
          -->
-        <version.com.fasterxml.jackson.databind>2.13.2</version.com.fasterxml.jackson.databind>
+        <version.com.fasterxml.jackson.databind>2.13.2.1</version.com.fasterxml.jackson.databind>
         <!-- Reactive-streams: used by the AWS SDK -->
         <version.org.reactivestreams.reactive-streams>1.0.3</version.org.reactivestreams.reactive-streams>
         <!-- slf4j: used by the AWS SDK -->

--- a/pom.xml
+++ b/pom.xml
@@ -358,7 +358,7 @@
         <version.org.eclipse.m2e.lifecycle-mapping>1.0.0</version.org.eclipse.m2e.lifecycle-mapping>
         <version.enforcer.plugin>3.0.0</version.enforcer.plugin>
         <version.exec.plugin>3.0.0</version.exec.plugin>
-        <version.forbiddenapis.plugin>3.2</version.forbiddenapis.plugin>
+        <version.forbiddenapis.plugin>3.3</version.forbiddenapis.plugin>
         <version.help.plugin>3.2.0</version.help.plugin>
         <version.install.plugin>2.5.2</version.install.plugin>
         <version.io.takari.maven>0.7.7</version.io.takari.maven>

--- a/pom.xml
+++ b/pom.xml
@@ -387,7 +387,7 @@
         <version.scripting.plugin>3.0.0</version.scripting.plugin>
         <version.gpg.plugin>3.0.1</version.gpg.plugin>
         <version.org.codehaus.groovy-jsr223>3.0.10</version.org.codehaus.groovy-jsr223>
-        <version.com.puppycrawl.tools.checkstyle>10.0</version.com.puppycrawl.tools.checkstyle>
+        <version.com.puppycrawl.tools.checkstyle>10.1</version.com.puppycrawl.tools.checkstyle>
 
         <!-- Asciidoctor -->
 


### PR DESCRIPTION
* [HSEARCH-4518](https://hibernate.atlassian.net/browse/HSEARCH-4518): Upgrade to Jackson-databind 2.13.2.1
* [HSEARCH-4484](https://hibernate.atlassian.net/browse/HSEARCH-4484): Upgrade build dependencies to the latest version


Follows up on https://github.com/hibernate/hibernate-search/pull/2895, https://github.com/hibernate/hibernate-search/pull/2902, https://github.com/hibernate/hibernate-search/pull/2904, #2913, #2931, #2941, #2954