### PR TITLE
HSEARCH-4489 Add matchNone() predicate

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchMatchNonePredicate.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchMatchNonePredicate.java
@@ -1,0 +1,49 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.search.predicate.impl;
+
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonAccessor;
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonObjectAccessor;
+import org.hibernate.search.backend.elasticsearch.search.common.impl.ElasticsearchSearchIndexScope;
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.engine.search.predicate.spi.MatchNonePredicateBuilder;
+
+import com.google.gson.JsonObject;
+
+
+class ElasticsearchMatchNonePredicate extends AbstractElasticsearchPredicate {
+
+	private static final JsonObjectAccessor MATCH_NONE_ACCESSOR = JsonAccessor.root().property( "match_none" )
+			.asObject();
+
+	private ElasticsearchMatchNonePredicate(Builder builder) {
+		super( builder );
+	}
+
+	@Override
+	public void checkNestableWithin(String expectedParentNestedPath) {
+		// Nothing to do
+	}
+
+	@Override
+	protected JsonObject doToJsonQuery(PredicateRequestContext context,
+			JsonObject outerObject, JsonObject innerObject) {
+		MATCH_NONE_ACCESSOR.set( outerObject, innerObject );
+		return outerObject;
+	}
+
+	static class Builder extends AbstractBuilder implements MatchNonePredicateBuilder {
+		Builder(ElasticsearchSearchIndexScope<?> scope) {
+			super( scope );
+		}
+
+		@Override
+		public SearchPredicate build() {
+			return new ElasticsearchMatchNonePredicate( this );
+		}
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactory.java
@@ -10,6 +10,7 @@ import org.hibernate.search.backend.elasticsearch.search.common.impl.Elasticsear
 import org.hibernate.search.engine.search.predicate.spi.BooleanPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchAllPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchIdPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.MatchNonePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
 import org.hibernate.search.engine.search.predicate.spi.SimpleQueryStringPredicateBuilder;
 
@@ -26,6 +27,11 @@ public class ElasticsearchSearchPredicateBuilderFactory implements SearchPredica
 	@Override
 	public MatchAllPredicateBuilder matchAll() {
 		return new ElasticsearchMatchAllPredicate.Builder( scope );
+	}
+
+	@Override
+	public MatchNonePredicateBuilder matchNone() {
+		return new ElasticsearchMatchNonePredicate.Builder( scope );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneMatchNonePredicate.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneMatchNonePredicate.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.search.predicate.impl;
+
+import org.hibernate.search.backend.lucene.search.common.impl.LuceneSearchIndexScope;
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.engine.search.predicate.spi.MatchNonePredicateBuilder;
+
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+
+
+class LuceneMatchNonePredicate extends AbstractLuceneSearchPredicate {
+
+	private LuceneMatchNonePredicate(Builder builder) {
+		super( builder );
+	}
+
+	@Override
+	public void checkNestableWithin(String expectedParentNestedPath) {
+		// Nothing to do
+	}
+
+	@Override
+	protected Query doToQuery(PredicateRequestContext context) {
+		return new MatchNoDocsQuery();
+	}
+
+	static class Builder extends AbstractBuilder implements MatchNonePredicateBuilder {
+		Builder(LuceneSearchIndexScope<?> scope) {
+			super( scope );
+		}
+
+		@Override
+		public SearchPredicate build() {
+			return new LuceneMatchNonePredicate( this );
+		}
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneSearchPredicateBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneSearchPredicateBuilderFactory.java
@@ -10,6 +10,7 @@ import org.hibernate.search.backend.lucene.search.common.impl.LuceneSearchIndexS
 import org.hibernate.search.engine.search.predicate.spi.BooleanPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchAllPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchIdPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.MatchNonePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
 import org.hibernate.search.engine.search.predicate.spi.SimpleQueryStringPredicateBuilder;
 
@@ -27,6 +28,11 @@ public class LuceneSearchPredicateBuilderFactory implements SearchPredicateBuild
 	@Override
 	public MatchAllPredicateBuilder matchAll() {
 		return new LuceneMatchAllPredicate.Builder( scope );
+	}
+
+	@Override
+	public MatchNonePredicateBuilder matchNone() {
+		return new LuceneMatchNonePredicate.Builder( scope );
 	}
 
 	@Override

--- a/documentation/src/main/asciidoc/reference/search-dsl-predicate.asciidoc
+++ b/documentation/src/main/asciidoc/reference/search-dsl-predicate.asciidoc
@@ -67,6 +67,19 @@ include::{sourcedir}/org/hibernate/search/documentation/search/predicate/Predica
 * The score of a `matchAll` predicate is constant and equal to 1 by default,
 but can be <<search-dsl-predicate-common-boost,boosted with `.boost(...)`>>.
 
+[[search-dsl-predicate-match-none]]
+== `matchNone`: match no documents
+
+The `matchNone` predicate is the inverse of `matchAll` and matches no documents.
+
+.Matching no documents
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java[tags=matchNone]
+----
+====
+
 [[search-dsl-predicate-id]]
 == `id`: match a document identifier
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
@@ -116,6 +116,20 @@ public class PredicateDslIT {
 	}
 
 	@Test
+	public void matchNone() {
+		withinSearchSession( searchSession -> {
+			// tag::matchNone[]
+			List<Book> hits = searchSession.search( Book.class )
+					.where( f -> f.matchNone() )
+					.fetchHits( 20 );
+			// end::matchNone[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.isEmpty();
+		} );
+	}
+
+	@Test
 	public void id() {
 		// DO NOT USE THE BOOKX_ID CONSTANTS INSIDE TAGS BELOW:
 		// we don't want the constants to appear in the documentation.

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/MatchNonePredicateFinalStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/MatchNonePredicateFinalStep.java
@@ -1,0 +1,13 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.predicate.dsl;
+
+/**
+ * The initial and final step in "match none" predicate definition.
+ */
+public interface MatchNonePredicateFinalStep extends PredicateFinalStep {
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/SearchPredicateFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/SearchPredicateFactory.java
@@ -44,6 +44,14 @@ public interface SearchPredicateFactory {
 	MatchAllPredicateOptionsStep<?> matchAll();
 
 	/**
+	 * Match none of the documents.
+	 *
+	 * @return The initial step of a DSL where the "match none" predicate can be defined.
+	 * @see MatchNonePredicateFinalStep
+	 */
+	MatchNonePredicateFinalStep matchNone();
+
+	/**
 	 * Match documents where the identifier is among the given values.
 	 *
 	 * @return The initial step of a DSL allowing the definition of an "id" predicate.

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/impl/MatchNonePredicateFinalStepImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/impl/MatchNonePredicateFinalStepImpl.java
@@ -1,0 +1,30 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.predicate.dsl.impl;
+
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.engine.search.predicate.dsl.MatchNonePredicateFinalStep;
+import org.hibernate.search.engine.search.predicate.dsl.spi.AbstractPredicateFinalStep;
+import org.hibernate.search.engine.search.predicate.dsl.spi.SearchPredicateDslContext;
+import org.hibernate.search.engine.search.predicate.spi.MatchNonePredicateBuilder;
+
+
+public final class MatchNonePredicateFinalStepImpl extends AbstractPredicateFinalStep
+		implements MatchNonePredicateFinalStep {
+
+	private final MatchNonePredicateBuilder matchNoneBuilder;
+
+	public MatchNonePredicateFinalStepImpl(SearchPredicateDslContext<?> dslContext) {
+		super( dslContext );
+		this.matchNoneBuilder = dslContext.scope().predicateBuilders().matchNone();
+	}
+
+	@Override
+	protected SearchPredicate build() {
+		return matchNoneBuilder.build();
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/spi/AbstractSearchPredicateFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/spi/AbstractSearchPredicateFactory.java
@@ -15,6 +15,7 @@ import org.hibernate.search.engine.search.predicate.dsl.ExistsPredicateFieldStep
 import org.hibernate.search.engine.search.predicate.dsl.ExtendedSearchPredicateFactory;
 import org.hibernate.search.engine.search.predicate.dsl.MatchAllPredicateOptionsStep;
 import org.hibernate.search.engine.search.predicate.dsl.MatchIdPredicateMatchingStep;
+import org.hibernate.search.engine.search.predicate.dsl.MatchNonePredicateFinalStep;
 import org.hibernate.search.engine.search.predicate.dsl.MatchPredicateFieldStep;
 import org.hibernate.search.engine.search.predicate.dsl.NamedPredicateOptionsStep;
 import org.hibernate.search.engine.search.predicate.dsl.NestedPredicateFieldStep;
@@ -32,6 +33,7 @@ import org.hibernate.search.engine.search.predicate.dsl.impl.BooleanPredicateCla
 import org.hibernate.search.engine.search.predicate.dsl.impl.ExistsPredicateFieldStepImpl;
 import org.hibernate.search.engine.search.predicate.dsl.impl.MatchAllPredicateOptionsStepImpl;
 import org.hibernate.search.engine.search.predicate.dsl.impl.MatchIdPredicateMatchingStepImpl;
+import org.hibernate.search.engine.search.predicate.dsl.impl.MatchNonePredicateFinalStepImpl;
 import org.hibernate.search.engine.search.predicate.dsl.impl.MatchPredicateFieldStepImpl;
 import org.hibernate.search.engine.search.predicate.dsl.impl.NamedPredicateOptionsStepImpl;
 import org.hibernate.search.engine.search.predicate.dsl.impl.NestedPredicateFieldStepImpl;
@@ -62,6 +64,11 @@ public abstract class AbstractSearchPredicateFactory<
 	@Override
 	public MatchAllPredicateOptionsStep<?> matchAll() {
 		return new MatchAllPredicateOptionsStepImpl( dslContext, this );
+	}
+
+	@Override
+	public MatchNonePredicateFinalStep matchNone() {
+		return new MatchNonePredicateFinalStepImpl( dslContext );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/MatchNonePredicateBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/MatchNonePredicateBuilder.java
@@ -1,0 +1,11 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.predicate.spi;
+
+public interface MatchNonePredicateBuilder extends SearchPredicateBuilder {
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/SearchPredicateBuilderFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/SearchPredicateBuilderFactory.java
@@ -16,6 +16,8 @@ public interface SearchPredicateBuilderFactory {
 
 	MatchAllPredicateBuilder matchAll();
 
+	MatchNonePredicateBuilder matchNone();
+
 	MatchIdPredicateBuilder id();
 
 	BooleanPredicateBuilder bool();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchNonePredicateSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchNonePredicateSpecificsIT.java
@@ -1,0 +1,87 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.search.predicate;
+
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
+
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactory;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class MatchNonePredicateSpecificsIT {
+
+	private static final String DOCUMENT_1 = "1";
+	private static final String STRING_1 = "aaa";
+
+	private static final String DOCUMENT_2 = "2";
+	private static final String STRING_2 = "bbb";
+
+	private static final String DOCUMENT_3 = "3";
+	private static final String STRING_3 = "ccc";
+
+	@ClassRule
+	public static final SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private static final SimpleMappedIndex<IndexBinding> index = SimpleMappedIndex.of( IndexBinding::new );
+
+	@BeforeClass
+	public static void setup() {
+		setupHelper.start().withIndex( index ).setup();
+
+		initData();
+	}
+
+	@Test
+	public void matchNone() {
+		assertThatQuery( index.query()
+				.where( SearchPredicateFactory::matchNone ) )
+				.hasNoHits();
+	}
+
+	@Test
+	public void matchNoneWithinBoolPredicate() {
+		//check that we will find something with a single match predicate
+		assertThatQuery( index.query()
+				.where(
+						f -> f.bool()
+								.must( f.match().field( "string" ).matching( STRING_1 ).toPredicate() )
+				)
+		).hasTotalHitCount( 1 );
+
+		// make sure that matchNone will "override" the other matching predicate
+		assertThatQuery( index.query()
+				.where(
+						f -> f.bool()
+								.must( f.match().field( "string" ).matching( STRING_1 ).toPredicate() )
+								.must( f.matchNone() )
+				)
+		).hasNoHits();
+	}
+
+	private static void initData() {
+		index.bulkIndexer()
+				.add( DOCUMENT_1, document -> document.addValue( index.binding().string, STRING_1 ) )
+				.add( DOCUMENT_2, document -> document.addValue( index.binding().string, STRING_2 ) )
+				.add( DOCUMENT_3, document -> document.addValue( index.binding().string, STRING_3 ) )
+				.join();
+	}
+
+	private static class IndexBinding {
+		final IndexFieldReference<String> string;
+
+		IndexBinding(IndexSchemaElement root) {
+			string = root.field( "string", IndexFieldTypeFactory::asString ).toReference();
+		}
+	}
+}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubSearchPredicate.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubSearchPredicate.java
@@ -19,6 +19,7 @@ import org.hibernate.search.engine.search.predicate.spi.BooleanPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.ExistsPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchAllPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchIdPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.MatchNonePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.NamedPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.NestedPredicateBuilder;
@@ -101,6 +102,7 @@ public class StubSearchPredicate implements SearchPredicate {
 	}
 
 	public static class Builder implements MatchAllPredicateBuilder,
+			MatchNonePredicateBuilder,
 			BooleanPredicateBuilder,
 			MatchIdPredicateBuilder,
 			MatchPredicateBuilder,

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubSearchPredicateBuilderFactory.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubSearchPredicateBuilderFactory.java
@@ -9,6 +9,7 @@ package org.hibernate.search.util.impl.integrationtest.common.stub.backend.searc
 import org.hibernate.search.engine.search.predicate.spi.BooleanPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchAllPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchIdPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.MatchNonePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
 import org.hibernate.search.engine.search.predicate.spi.SimpleQueryStringPredicateBuilder;
 
@@ -22,6 +23,11 @@ public class StubSearchPredicateBuilderFactory
 
 	@Override
 	public MatchAllPredicateBuilder matchAll() {
+		return new StubSearchPredicate.Builder();
+	}
+
+	@Override
+	public MatchNonePredicateBuilder matchNone() {
 		return new StubSearchPredicate.Builder();
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4489

- add matchNone() to DSL
- update documentation to mention new predicate

I wasn't able to think of some simple yet, at the same time, meaningful use case for this new predicate, hence if anyone has some suggestions would be happy to add more tests around it.