### PR TITLE
Backport HSEARCH-4523 to branch 6.1 - Upgrade -orm6 artifacts to Hibernate ORM 6.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
         <version.javax.persistence>2.2</version.javax.persistence>
 
         <!-- >>> ORM 6 / Jakarta Persistence -->
-        <version.org.hibernate.orm>6.0.0.CR2</version.org.hibernate.orm>
+        <version.org.hibernate.orm>6.0.0.Final</version.org.hibernate.orm>
         <javadoc.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/javadocs/</javadoc.org.hibernate.orm.url>
         <documentation.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/userguide/html_single/Hibernate_User_Guide.html</documentation.org.hibernate.orm.url>
         <version.org.hibernate.commons.annotations.orm6>6.0.0.CR1</version.org.hibernate.commons.annotations.orm6>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4523

Backport of #2970 to branch 6.1.