### PR TITLE
HSEARCH-4534 Fix random failures for tests involving dynamic BigDecimal/BigInteger fields with Elasticsearch

### DIFF
--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -102,9 +102,10 @@ class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 			return ! dialect.hasBugForBigIntegerValuesForDynamicField();
 		}
 		else if ( BigDecimal.class.equals( javaType ) ) {
-			// For some reason, ES 5.6 sometimes fails to index BigDecimal values
+			// For some reason, ES 5.6 and 6.x sometimes fails to index BigDecimal values
 			// in dynamic fields.
-			// See https://hibernate.atlassian.net/browse/HSEARCH-4310.
+			// See https://hibernate.atlassian.net/browse/HSEARCH-4310,
+			// https://hibernate.atlassian.net/browse/HSEARCH-4310
 			return ! dialect.hasBugForBigDecimalValuesForDynamicField();
 		}
 		else {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSortDynamicFieldIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSortDynamicFieldIT.java
@@ -37,10 +37,11 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class FieldSortDynamicFieldIT<F> {
 
-	private static final List<FieldTypeDescriptor<?>> supportedFieldTypes = new ArrayList<>();
+	private static List<FieldTypeDescriptor<?>> supportedFieldTypes;
 
 	@Parameterized.Parameters(name = "{0}")
 	public static Object[][] parameters() {
+		supportedFieldTypes = new ArrayList<>();
 		List<Object[]> parameters = new ArrayList<>();
 		for ( FieldTypeDescriptor<?> fieldType : FieldTypeDescriptor.getAll() ) {
 			if ( fieldType.isFieldSortSupported() ) {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSortDynamicFieldIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSortDynamicFieldIT.java
@@ -44,7 +44,9 @@ public class FieldSortDynamicFieldIT<F> {
 		supportedFieldTypes = new ArrayList<>();
 		List<Object[]> parameters = new ArrayList<>();
 		for ( FieldTypeDescriptor<?> fieldType : FieldTypeDescriptor.getAll() ) {
-			if ( fieldType.isFieldSortSupported() ) {
+			if ( fieldType.isFieldSortSupported()
+					&& TckConfiguration.get().getBackendFeatures()
+							.supportsValuesForDynamicField( fieldType.getJavaType() ) ) {
 				supportedFieldTypes.add( fieldType );
 				parameters.add( new Object[] { fieldType } );
 			}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSortTypeCheckingAndConversionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSortTypeCheckingAndConversionIT.java
@@ -60,10 +60,11 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class FieldSortTypeCheckingAndConversionIT<F> {
 
-	private static final List<FieldTypeDescriptor<?>> supportedFieldTypes = new ArrayList<>();
+	private static List<FieldTypeDescriptor<?>> supportedFieldTypes;
 
 	@Parameterized.Parameters(name = "{0}")
 	public static Object[][] parameters() {
+		supportedFieldTypes = new ArrayList<>();
 		List<Object[]> parameters = new ArrayList<>();
 		for ( FieldTypeDescriptor<?> fieldType : FieldTypeDescriptor.getAll() ) {
 			if ( fieldType.isFieldSortSupported() ) {

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/Elasticsearch5TestDialect.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/Elasticsearch5TestDialect.java
@@ -26,11 +26,6 @@ public class Elasticsearch5TestDialect extends Elasticsearch60TestDialect {
 	}
 
 	@Override
-	public boolean hasBugForBigDecimalValuesForDynamicField() {
-		return true;
-	}
-
-	@Override
 	public boolean supportMoreThan1024Terms() {
 		return false;
 	}

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/Elasticsearch68TestDialect.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/Elasticsearch68TestDialect.java
@@ -48,6 +48,13 @@ public class Elasticsearch68TestDialect extends Elasticsearch70TestDialect {
 	}
 
 	@Override
+	public boolean hasBugForBigDecimalValuesForDynamicField() {
+		// See https://hibernate.atlassian.net/browse/HSEARCH-4310,
+		// https://hibernate.atlassian.net/browse/HSEARCH-4310
+		return true;
+	}
+
+	@Override
 	public boolean supportsSkipOrLimitingTotalHitCount() {
 		return false;
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4534

I managed to reproduce the problem on Elasticsearch 6.8, but not on 7.2 or 8.1. So I'll go ahead and assume this was a bug in 6.x that was fixed in 7.0, 7.1 or 7.2.

Though I couldn't find the relevant issue/PR on Elasticsearch's GitHub repository...