### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/simple-build.yml
+++ b/.github/workflows/simple-build.yml
@@ -36,6 +36,9 @@ env:
   #    See https://github.com/apache/pulsar/blob/60ef5e983e5e8956bd0b602b5741bd6255c6258a/.github/workflows/ci-unit.yaml#L30
   #    See https://github.com/apache/pulsar/commit/9405e6bfcba250f014faae6ba0490a8045cb4674
   MAVEN_ARGS: "-e -B --settings .github/mvn-settings.xml -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3"
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and test on Java 11


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
