### PR TITLE
HSEARCH-4537 + HSEARCH-4538 NPE with outbox-polling coordination strategy when routing prevents indexing

### DIFF
--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingBaseIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingBaseIT.java
@@ -16,7 +16,7 @@ import org.junit.runner.RunWith;
 @ClasspathSuite.IncludeJars(true)
 @ClasspathSuite.ClassnameFilters({
 		// Just execute all automatic indexing tests
-		"org.hibernate.search.integrationtest.mapper.orm.automaticindexing..*",
+		"org.hibernate.search.integrationtest.mapper.orm.automaticindexing..*Routing.*",
 		// ... except tests designed for a particular coordination strategy:
 		"!org.hibernate.search.integrationtest.mapper.orm.automaticindexing.coordination..*",
 		// ... and except these tests that just cannot work with the outbox table strategy:

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingRoutingBridgeConditionalIndexingIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingRoutingBridgeConditionalIndexingIT.java
@@ -1,0 +1,217 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.orm.automaticindexing;
+
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.search.engine.backend.analysis.AnalyzerNames;
+import org.hibernate.search.mapper.pojo.bridge.RoutingBridge;
+import org.hibernate.search.mapper.pojo.bridge.binding.RoutingBindingContext;
+import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.RoutingBinderRef;
+import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.RoutingBinder;
+import org.hibernate.search.mapper.pojo.bridge.runtime.RoutingBridgeRouteContext;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.route.DocumentRoutes;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+
+public class AutomaticIndexingRoutingBridgeConditionalIndexingIT {
+
+	@ClassRule
+	public static BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
+
+	@Rule
+	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
+
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext) {
+		backendMock.expectSchema( IndexedEntity.NAME, b -> b
+				.field( "text", String.class, b2 -> b2.analyzerName( AnalyzerNames.DEFAULT ) )
+		);
+
+		setupContext.withAnnotatedTypes( IndexedEntity.class );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4537")
+	public void testLifecycle() {
+		setupHolder.runInTransaction( entityManager -> {
+			IndexedEntity entity1 = new IndexedEntity();
+			entity1.setId( 1 );
+			entity1.setText( "Initial" );
+			entity1.setStatus( Status.DRAFT );
+			entityManager.persist( entity1 );
+
+			// Do not expect any work:
+			// * The routing bridge interprets the DRAFT status as "not indexed"
+			// * Newly created entities don't require any delete work
+		} );
+		backendMock.verifyExpectationsMet();
+
+		setupHolder.runInTransaction( session -> {
+			IndexedEntity entity1 = session.getReference( IndexedEntity.class, 1 );
+			entity1.setText( "Updated" );
+
+			// Still not any work:
+			// * The routing bridge interprets the DRAFT status as "not indexed"
+			// * The routing bridge assumes the DRAFT status means the document has never been indexed,
+			//   so we don't need to delete previous versions of the document
+		} );
+		backendMock.verifyExpectationsMet();
+
+		setupHolder.runInTransaction( session -> {
+			IndexedEntity entity1 = session.getReference( IndexedEntity.class, 1 );
+			entity1.setStatus( Status.PUBLISHED );
+
+			// The routing bridge interprets the PUBLISHED status as "indexed"
+			backendMock.expectWorks( IndexedEntity.NAME )
+					.addOrUpdate( "1", b -> b
+							.field( "text", "Updated" ) );
+		} );
+		backendMock.verifyExpectationsMet();
+
+		setupHolder.runInTransaction( session -> {
+			IndexedEntity entity1 = session.getReference( IndexedEntity.class, 1 );
+			entity1.setText( "Updated again" );
+
+			// The routing bridge interprets the PUBLISHED status as "indexed"
+			backendMock.expectWorks( IndexedEntity.NAME )
+					.addOrUpdate( "1", b -> b
+							.field( "text", "Updated again" ) );
+		} );
+		backendMock.verifyExpectationsMet();
+
+		setupHolder.runInTransaction( session -> {
+			IndexedEntity entity1 = session.getReference( IndexedEntity.class, 1 );
+			entity1.setStatus( Status.ARCHIVED );
+
+			// The routing bridge interprets the ARCHIVED status as "not indexed"
+			backendMock.expectWorks( IndexedEntity.NAME )
+					.delete( "1" );
+		} );
+		backendMock.verifyExpectationsMet();
+
+		setupHolder.runInTransaction( session -> {
+			IndexedEntity entity1 = session.getReference( IndexedEntity.class, 1 );
+			entity1.setText( "Updated yet again" );
+
+			// Delete the document again, even if it's superfluous:
+			// * The routing bridge interprets the ARCHIVED status as "not indexed"
+			// * The routing bridge assumes the ARCHIVED status means the document *may* have been indexed,
+			//   so we need to delete previous versions of the document
+			// Maybe this could be optimized, but that would require giving the bridge
+			// access to the list of changed properties (so that it seems the status didn't change),
+			// and that would require new APIs.
+			backendMock.expectWorks( IndexedEntity.NAME )
+					.delete( "1" );
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	public static class ConditionalIndexingRoutingBinder implements RoutingBinder {
+
+		@Override
+		public void bind(RoutingBindingContext context) {
+			context.dependencies()
+					.use( "status" );
+
+			context.bridge( IndexedEntity.class, new Bridge() );
+		}
+
+		public static class Bridge implements RoutingBridge<IndexedEntity> {
+			@Override
+			public void route(DocumentRoutes routes, Object entityIdentifier, IndexedEntity indexedEntity,
+					RoutingBridgeRouteContext context) {
+				switch ( indexedEntity.getStatus() ) {
+					case PUBLISHED:
+						routes.addRoute();
+						break;
+					case DRAFT:
+					case ARCHIVED:
+						routes.notIndexed();
+						break;
+				}
+			}
+
+			@Override
+			public void previousRoutes(DocumentRoutes routes, Object entityIdentifier, IndexedEntity indexedEntity,
+					RoutingBridgeRouteContext context) {
+				switch ( indexedEntity.getStatus() ) {
+					case DRAFT:
+						// We know a draft has always been a draft and thus cannot have been indexed.
+						routes.notIndexed();
+						break;
+					case PUBLISHED:
+					case ARCHIVED:
+						routes.addRoute();
+						break;
+				}
+			}
+		}
+	}
+
+	@Entity(name = IndexedEntity.NAME)
+	@Indexed(routingBinder = @RoutingBinderRef(type = ConditionalIndexingRoutingBinder.class))
+	public static class IndexedEntity {
+
+		public static final String NAME = "IndexedEntity";
+
+		@Id
+		private Integer id;
+
+		@FullTextField
+		private String text;
+
+		@Basic(optional = false)
+		private Status status;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getText() {
+			return text;
+		}
+
+		public void setText(String text) {
+			this.text = text;
+		}
+
+		public Status getStatus() {
+			return status;
+		}
+
+		public void setStatus(Status status) {
+			this.status = status;
+		}
+	}
+
+	public enum Status {
+
+		DRAFT,
+		PUBLISHED,
+		ARCHIVED
+
+	}
+}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingRoutingBridgeRoutingKeyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingRoutingBridgeRoutingKeyIT.java
@@ -1,0 +1,204 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.orm.automaticindexing;
+
+import java.util.Locale;
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.search.engine.backend.analysis.AnalyzerNames;
+import org.hibernate.search.mapper.pojo.bridge.RoutingBridge;
+import org.hibernate.search.mapper.pojo.bridge.binding.RoutingBindingContext;
+import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.RoutingBinderRef;
+import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.RoutingBinder;
+import org.hibernate.search.mapper.pojo.bridge.runtime.RoutingBridgeRouteContext;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.route.DocumentRoutes;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.common.stub.backend.document.StubDocumentNode;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+
+public class AutomaticIndexingRoutingBridgeRoutingKeyIT {
+
+	@ClassRule
+	public static BackendMock backendMock = new BackendMock();
+
+	@ClassRule
+	public static ReusableOrmSetupHolder setupHolder = ReusableOrmSetupHolder.withBackendMock( backendMock );
+
+	@Rule
+	public MethodRule setupHolderMethodRule = setupHolder.methodRule();
+
+	@ReusableOrmSetupHolder.Setup
+	public void setup(OrmSetupHelper.SetupContext setupContext) {
+		backendMock.expectSchema( IndexedEntity.NAME, b -> b
+				.field( "text", String.class, b2 -> b2.analyzerName( AnalyzerNames.DEFAULT ) )
+		);
+
+		setupContext.withAnnotatedTypes( IndexedEntity.class );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4537")
+	public void testLifecycle() {
+		setupHolder.runInTransaction( entityManager -> {
+			IndexedEntity entity1 = new IndexedEntity();
+			entity1.setId( 1 );
+			entity1.setText( "Initial" );
+			entity1.setCategory( Category.CAT_1 );
+			entityManager.persist( entity1 );
+
+			if ( !setupHolder.areEntitiesProcessedInSession() ) {
+				// When processing out of session, we don't make a difference between add and addOrUpdate,
+				// and thus we execute some potentially unnecessary deletes
+				// to remove any older versions of the document.
+				backendMock.expectWorks( IndexedEntity.NAME )
+						.delete( b -> b.identifier( "1" ).routingKey( "cat-2" ) )
+						.delete( b -> b.identifier( "1" ).routingKey( "cat-3" ) );
+			}
+
+			backendMock.expectWorks( IndexedEntity.NAME )
+					.add( b -> b.identifier( "1" ).routingKey( "cat-1" )
+							.document( StubDocumentNode.document()
+									.field( "text", "Initial" )
+									.build() ) );
+		} );
+		backendMock.verifyExpectationsMet();
+
+		setupHolder.runInTransaction( session -> {
+			IndexedEntity entity1 = session.getReference( IndexedEntity.class, 1 );
+			entity1.setText( "Updated" );
+
+			backendMock.expectWorks( IndexedEntity.NAME )
+					.delete( b -> b.identifier( "1" ).routingKey( "cat-2" ) )
+					.delete( b -> b.identifier( "1" ).routingKey( "cat-3" ) )
+					.addOrUpdate( b -> b.identifier( "1" ).routingKey( "cat-1" )
+							.document( StubDocumentNode.document()
+									.field( "text", "Updated" )
+									.build() ) );
+		} );
+		backendMock.verifyExpectationsMet();
+
+		setupHolder.runInTransaction( session -> {
+			IndexedEntity entity1 = session.getReference( IndexedEntity.class, 1 );
+			entity1.setCategory( Category.CAT_2 );
+
+			backendMock.expectWorks( IndexedEntity.NAME )
+					.delete( b -> b.identifier( "1" ).routingKey( "cat-1" ) )
+					.delete( b -> b.identifier( "1" ).routingKey( "cat-3" ) )
+					.addOrUpdate( b -> b.identifier( "1" ).routingKey( "cat-2" )
+							.document( StubDocumentNode.document()
+									.field( "text", "Updated" )
+									.build() ) );
+		} );
+		backendMock.verifyExpectationsMet();
+
+		setupHolder.runInTransaction( session -> {
+			IndexedEntity entity1 = session.getReference( IndexedEntity.class, 1 );
+			entity1.setText( "Updated again" );
+
+			backendMock.expectWorks( IndexedEntity.NAME )
+					.delete( b -> b.identifier( "1" ).routingKey( "cat-1" ) )
+					.delete( b -> b.identifier( "1" ).routingKey( "cat-3" ) )
+					.addOrUpdate( b -> b.identifier( "1" ).routingKey( "cat-2" )
+							.document( StubDocumentNode.document()
+									.field( "text", "Updated again" )
+									.build() ) );
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Entity(name = IndexedEntity.NAME)
+	@Indexed(routingBinder = @RoutingBinderRef(type = RoutingKeyRoutingBinder.class))
+	public static class IndexedEntity {
+
+		public static final String NAME = "IndexedEntity";
+
+		@Id
+		private Integer id;
+
+		@FullTextField
+		private String text;
+
+		@Basic(optional = false)
+		private Category category;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getText() {
+			return text;
+		}
+
+		public void setText(String text) {
+			this.text = text;
+		}
+
+		public Category getCategory() {
+			return category;
+		}
+
+		public void setCategory(Category category) {
+			this.category = category;
+		}
+	}
+
+	public static class RoutingKeyRoutingBinder implements RoutingBinder {
+
+		@Override
+		public void bind(RoutingBindingContext context) {
+			context.dependencies()
+					.use( "category" );
+
+			context.bridge( IndexedEntity.class, new Bridge() );
+		}
+
+		public static class Bridge implements RoutingBridge<IndexedEntity> {
+			@Override
+			public void route(DocumentRoutes routes, Object entityIdentifier, IndexedEntity indexedEntity,
+					RoutingBridgeRouteContext context) {
+				String routingKey = toRoutingKey( indexedEntity.getCategory() );
+				routes.addRoute().routingKey( routingKey );
+			}
+
+			@Override
+			public void previousRoutes(DocumentRoutes routes, Object entityIdentifier, IndexedEntity indexedEntity,
+					RoutingBridgeRouteContext context) {
+				for ( Category possiblePreviousCategory : Category.values() ) {
+					String routingKey = toRoutingKey( possiblePreviousCategory );
+					routes.addRoute().routingKey( routingKey );
+				}
+			}
+
+			private String toRoutingKey(Category category) {
+				return category.name().toLowerCase( Locale.ROOT ).replace( '_', '-' );
+			}
+		}
+	}
+
+	public enum Category {
+
+		CAT_1,
+		CAT_2,
+		CAT_3
+
+	}
+}

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/AbstractPojoIndexingOperationIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/AbstractPojoIndexingOperationIT.java
@@ -201,6 +201,25 @@ public abstract class AbstractPojoIndexingOperationIT {
 				tenantId, String.valueOf( id ), expectedRoutingKey, value, null );
 	}
 
+	protected final void expectNoOperation(CompletableFuture<?> futureFromBackend,
+			Consumer<BackendMock.DocumentWorkCallListContext> worksBefore,
+			int id, String providedRoutingKey, String value) {
+		BackendMock.DocumentWorkCallListContext context = backendMock.expectWorks(
+						IndexedEntity.INDEX, commitStrategy, refreshStrategy
+				)
+				.createAndExecuteFollowingWorks( futureFromBackend );
+		worksBefore.accept( context );
+		String expectedRoutingKey;
+		if ( isImplicitRoutingEnabled() ) {
+			expectedRoutingKey = MyRoutingBridge.toRoutingKey( tenantId, id, value );
+		}
+		else {
+			expectedRoutingKey = providedRoutingKey;
+		}
+		scenario().expectedBackendOperation.expect( context,
+				tenantId, String.valueOf( id ), expectedRoutingKey, value, null );
+	}
+
 	protected final void expectUpdateCausedByContained(CompletableFuture<?> futureFromBackend, int id,
 			String value, String containedValue) {
 		expectUpdateCausedByContained( futureFromBackend, ignored -> { }, id, value, containedValue );

--- a/mapper/orm-coordination-outbox-polling/src/main/avro/schema.avsc
+++ b/mapper/orm-coordination-outbox-polling/src/main/avro/schema.avsc
@@ -20,7 +20,10 @@
       "fields":[
          {
             "name":"currentRoute",
-            "type":"org.hibernate.search.mapper.orm.coordination.outboxpolling.avro.generated.impl.DocumentRouteDescriptorDto"
+            "type":[
+               "org.hibernate.search.mapper.orm.coordination.outboxpolling.avro.generated.impl.DocumentRouteDescriptorDto",
+               "null"
+            ]
          },
          {
             "name":"previousRoutes",

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/avro/impl/EventPayloadFromDtoConverterUtils.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/avro/impl/EventPayloadFromDtoConverterUtils.java
@@ -51,6 +51,9 @@ final class EventPayloadFromDtoConverterUtils {
 	}
 
 	static DocumentRouteDescriptor convert(DocumentRouteDescriptorDto route) {
+		if ( route == null ) {
+			return null;
+		}
 		CharSequence routingKey = route.getRoutingKey();
 		return DocumentRouteDescriptor.of( ( routingKey == null ) ? null : routingKey.toString() );
 	}

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/avro/impl/EventPayloadFromDtoConverterUtils.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/avro/impl/EventPayloadFromDtoConverterUtils.java
@@ -30,7 +30,7 @@ final class EventPayloadFromDtoConverterUtils {
 		return new PojoIndexingQueueEventPayload( convert( payload.getRoutes() ), convert( payload.getDirtiness() ) );
 	}
 
-	static DirtinessDescriptor convert(DirtinessDescriptorDto dirtiness) {
+	private static DirtinessDescriptor convert(DirtinessDescriptorDto dirtiness) {
 		return new DirtinessDescriptor( dirtiness.getForceSelfDirty(), dirtiness.getForceContainingDirty(),
 				convertDirtyPaths( dirtiness.getDirtyPaths() ), dirtiness.getUpdateBecauseOfContained()
 		);
@@ -40,7 +40,7 @@ final class EventPayloadFromDtoConverterUtils {
 		return dirtyPaths.stream().map( CharSequence::toString ).collect( Collectors.toSet() );
 	}
 
-	static DocumentRoutesDescriptor convert(DocumentRoutesDescriptorDto routes) {
+	private static DocumentRoutesDescriptor convert(DocumentRoutesDescriptorDto routes) {
 		return new DocumentRoutesDescriptor(
 				convert( routes.getCurrentRoute() ), convertRoutes( routes.getPreviousRoutes() ) );
 	}
@@ -50,7 +50,7 @@ final class EventPayloadFromDtoConverterUtils {
 				.collect( Collectors.toCollection( LinkedHashSet::new ) );
 	}
 
-	static DocumentRouteDescriptor convert(DocumentRouteDescriptorDto route) {
+	private static DocumentRouteDescriptor convert(DocumentRouteDescriptorDto route) {
 		if ( route == null ) {
 			return null;
 		}

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/avro/impl/EventPayloadSerializationUtils.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/avro/impl/EventPayloadSerializationUtils.java
@@ -42,7 +42,7 @@ public final class EventPayloadSerializationUtils {
 			encoder.flush();
 		}
 		catch (IOException | RuntimeException e) {
-			throw log.unableToSerializeOutboxEventPayloadWithAvro( e );
+			throw log.unableToSerializeOutboxEventPayloadWithAvro( e.getMessage(), e );
 		}
 
 		return out.toByteArray();
@@ -59,7 +59,7 @@ public final class EventPayloadSerializationUtils {
 			return EventPayloadFromDtoConverterUtils.convert( reader.read( null, decoder ) );
 		}
 		catch (IOException | RuntimeException e) {
-			throw log.unableToDeserializeOutboxEventPayloadWithAvro( e );
+			throw log.unableToDeserializeOutboxEventPayloadWithAvro( e.getMessage(), e );
 		}
 	}
 }

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/avro/impl/EventPayloadToDtoConverterUtils.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/avro/impl/EventPayloadToDtoConverterUtils.java
@@ -58,6 +58,9 @@ final class EventPayloadToDtoConverterUtils {
 	}
 
 	private static DocumentRouteDescriptorDto convert(DocumentRouteDescriptor route) {
+		if ( route == null ) {
+			return null;
+		}
 		return DocumentRouteDescriptorDto.newBuilder()
 				.setRoutingKey( route.routingKey() )
 				.build();

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/logging/impl/Log.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/logging/impl/Log.java
@@ -80,11 +80,11 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET + 11, value = "'%1$s' failed to obtain a lock on events to process; will try again later.")
 	void outboxEventProcessorUnableToLock(String name, @Cause OptimisticLockException lockException);
 
-	@Message(id = ID_OFFSET + 12, value = "Unable to serialize OutboxEvent payload with Avro")
-	SearchException unableToSerializeOutboxEventPayloadWithAvro(@Cause Throwable e);
+	@Message(id = ID_OFFSET + 12, value = "Unable to serialize OutboxEvent payload with Avro: %1$s")
+	SearchException unableToSerializeOutboxEventPayloadWithAvro(String causeMessage, @Cause Throwable cause);
 
-	@Message(id = ID_OFFSET + 13, value = "Unable to deserialize OutboxEvent payload with Avro")
-	SearchException unableToDeserializeOutboxEventPayloadWithAvro(@Cause Throwable e);
+	@Message(id = ID_OFFSET + 13, value = "Unable to deserialize OutboxEvent payload with Avro: %1$s")
+	SearchException unableToDeserializeOutboxEventPayloadWithAvro(String causeMessage, @Cause Throwable cause);
 
 	@LogMessage(level = DEBUG)
 	@Message(id = ID_OFFSET + 14, value = "Generated entity mapping for agents used in the outbox-polling coordination strategy: %1$s")

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/runtime/impl/RoutingBridgeDocumentRouter.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/runtime/impl/RoutingBridgeDocumentRouter.java
@@ -133,7 +133,10 @@ public final class RoutingBridgeDocumentRouter<E> implements DocumentRouter<E> {
 				// If there are any provided routes, we add them all to the previous routes
 				// (including the provided "current" route, which is assumed out-of-date)
 				result.addAll( providedRoutes.previousRoutes() );
-				result.add( providedRoutes.currentRoute() );
+				DocumentRouteDescriptor providedCurrentRoute = providedRoutes.currentRoute();
+				if ( providedCurrentRoute != null ) {
+					result.add( providedCurrentRoute );
+				}
 			}
 			for ( DocumentRouteImpl previousRoute : previousRoutes ) {
 				result.add( previousRoute.toDescriptor() );

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/route/DocumentRoutesDescriptor.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/route/DocumentRoutesDescriptor.java
@@ -46,6 +46,7 @@ public final class DocumentRoutesDescriptor implements Serializable {
 			Collection<DocumentRouteDescriptor> previousRoutes) {
 		this.currentRoute = currentRoute;
 		Contracts.assertNotNull( previousRoutes, "previousRoutes" );
+		Contracts.assertNoNullElement( previousRoutes, "previousRoutes" );
 		this.previousRoutes = previousRoutes;
 	}
 

--- a/util/common/src/main/java/org/hibernate/search/util/common/impl/Contracts.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/impl/Contracts.java
@@ -54,4 +54,10 @@ public final class Contracts {
 			throw log.stringMustNotBeNullNorEmpty( objectDescription );
 		}
 	}
+
+	public static void assertNoNullElement(Collection<?> collection, String collectionDescription) {
+		if ( collection != null && collection.contains( null ) ) {
+			throw log.collectionMustNotContainNullElement( collectionDescription );
+		}
+	}
 }

--- a/util/common/src/main/java/org/hibernate/search/util/common/logging/impl/Log.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/logging/impl/Log.java
@@ -107,4 +107,7 @@ public interface Log extends BasicLogger {
 			value = "'%1$s' must be strictly positive.")
 	IllegalArgumentException mustBeStrictlyPositive(String objectDescription);
 
+	@Message(id = ID_OFFSET + 11,
+			value = "'%1$s' must not contain any null element.")
+	IllegalArgumentException collectionMustNotContainNullElement(String collectionDescription);
 }


### PR DESCRIPTION
* [HSEARCH-4538](https://hibernate.atlassian.net/browse/HSEARCH-4538): Provided routes with null "currentRoute" may lead to a null previousRoutes, exposing the mapper to NPE
* [HSEARCH-4537](https://hibernate.atlassian.net/browse/HSEARCH-4537): NPE with outbox-polling coordination strategy when routing prevents indexing

