### PR TITLE
Backport HSEARCH-4536 to branch 6.1 - .flags(Collections.emptySet()) doesn't disable all flags as expected for SimpleQueryPredicate

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSimpleQueryStringPredicate.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSimpleQueryStringPredicate.java
@@ -88,14 +88,7 @@ public class ElasticsearchSimpleQueryStringPredicate extends AbstractElasticsear
 		}
 
 		if ( flags != null ) {
-			StringBuilder flagsMask = new StringBuilder();
-			for ( SimpleQueryFlag flag : flags ) {
-				if ( flagsMask.length() > 0 ) {
-					flagsMask.append( "|" );
-				}
-				flagsMask.append( getFlagName( flag ) );
-			}
-			FLAGS_ACCESSOR.set( innerObject, flagsMask.toString() );
+			FLAGS_ACCESSOR.set( innerObject, toFlagsMask( flags ) );
 		}
 
 		SIMPLE_QUERY_STRING_ACCESSOR.set( outerObject, innerObject );
@@ -113,11 +106,25 @@ public class ElasticsearchSimpleQueryStringPredicate extends AbstractElasticsear
 		return fieldPaths;
 	}
 
+	private static String toFlagsMask(Set<SimpleQueryFlag> flags) {
+		if ( flags.isEmpty() ) {
+			return "NONE";
+		}
+		StringBuilder flagsMask = new StringBuilder();
+		for ( SimpleQueryFlag flag : flags ) {
+			if ( flagsMask.length() > 0 ) {
+				flagsMask.append( "|" );
+			}
+			flagsMask.append( getFlagName( flag ) );
+		}
+		return flagsMask.toString();
+	}
+
 	/**
 	 * @param flag The flag as defined in Hibernate Search.
 	 * @return The name of this flag in Elasticsearch (might be different from flag.name()).
 	 */
-	private String getFlagName(SimpleQueryFlag flag) {
+	private static String getFlagName(SimpleQueryFlag flag) {
 		switch ( flag ) {
 			case AND:
 				return "AND";

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSimpleQueryStringPredicate.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSimpleQueryStringPredicate.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.backend.elasticsearch.search.predicate.impl;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -49,7 +50,7 @@ public class ElasticsearchSimpleQueryStringPredicate extends AbstractElasticsear
 	private final JsonPrimitive defaultOperator;
 	private final String simpleQueryString;
 	private final String analyzer;
-	private final EnumSet<SimpleQueryFlag> flags;
+	private final Set<SimpleQueryFlag> flags;
 
 	ElasticsearchSimpleQueryStringPredicate(Builder builder) {
 		super( builder );
@@ -150,7 +151,7 @@ public class ElasticsearchSimpleQueryStringPredicate extends AbstractElasticsear
 		private JsonPrimitive defaultOperator = OR_OPERATOR_KEYWORD_JSON;
 		private String simpleQueryString;
 		private String analyzer;
-		private EnumSet<SimpleQueryFlag> flags;
+		private Set<SimpleQueryFlag> flags;
 
 		Builder(ElasticsearchSearchIndexScope<?> scope) {
 			super( scope );
@@ -170,7 +171,7 @@ public class ElasticsearchSimpleQueryStringPredicate extends AbstractElasticsear
 
 		@Override
 		public void flags(Set<SimpleQueryFlag> flags) {
-			this.flags = EnumSet.copyOf( flags );
+			this.flags = flags.isEmpty() ? Collections.emptySet() : EnumSet.copyOf( flags );
 		}
 
 		@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextRegexpPredicate.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextRegexpPredicate.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.backend.elasticsearch.types.predicate.impl;
 
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
 
@@ -35,7 +36,7 @@ public class ElasticsearchTextRegexpPredicate extends AbstractElasticsearchSingl
 	private static final String NO_OPTIONAL_OPERATORS_FLAG_MARK = "NONE";
 
 	private final JsonPrimitive pattern;
-	private final EnumSet<RegexpQueryFlag> flags;
+	private final Set<RegexpQueryFlag> flags;
 
 	public ElasticsearchTextRegexpPredicate(Builder builder) {
 		super( builder );
@@ -69,7 +70,7 @@ public class ElasticsearchTextRegexpPredicate extends AbstractElasticsearchSingl
 
 	private static class Builder extends AbstractBuilder implements RegexpPredicateBuilder {
 		private JsonPrimitive pattern;
-		private EnumSet<RegexpQueryFlag> flags;
+		private Set<RegexpQueryFlag> flags;
 
 		private Builder(ElasticsearchSearchIndexScope<?> scope, ElasticsearchSearchIndexValueFieldContext<String> field) {
 			super( scope, field );
@@ -82,7 +83,7 @@ public class ElasticsearchTextRegexpPredicate extends AbstractElasticsearchSingl
 
 		@Override
 		public void flags(Set<RegexpQueryFlag> flags) {
-			this.flags = EnumSet.copyOf( flags );
+			this.flags = flags.isEmpty() ? Collections.emptySet() : EnumSet.copyOf( flags );
 		}
 
 		@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextRegexpPredicate.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextRegexpPredicate.java
@@ -50,7 +50,7 @@ public class ElasticsearchTextRegexpPredicate extends AbstractElasticsearchSingl
 		VALUE_ACCESSOR.set( innerObject, pattern );
 
 		// set no optional flag as default
-		FLAGS_ACCESSOR.set( innerObject, buildFlag( flags ) );
+		FLAGS_ACCESSOR.set( innerObject, toFlagsMask( flags ) );
 
 		JsonObject middleObject = new JsonObject();
 		middleObject.add( absoluteFieldPath, innerObject );
@@ -92,7 +92,7 @@ public class ElasticsearchTextRegexpPredicate extends AbstractElasticsearchSingl
 		}
 	}
 
-	private static String buildFlag(Set<RegexpQueryFlag> flags) {
+	private static String toFlagsMask(Set<RegexpQueryFlag> flags) {
 		if ( flags == null || flags.isEmpty() ) {
 			return NO_OPTIONAL_OPERATORS_FLAG_MARK;
 		}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneSimpleQueryStringPredicate.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneSimpleQueryStringPredicate.java
@@ -8,7 +8,6 @@ package org.hibernate.search.backend.lucene.search.predicate.impl;
 
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -73,7 +72,7 @@ public class LuceneSimpleQueryStringPredicate extends AbstractLuceneNestablePred
 		private String simpleQueryString;
 		private Analyzer overrideAnalyzer;
 		private boolean ignoreAnalyzer = false;
-		private EnumSet<SimpleQueryFlag> flags;
+		private int flags = -1;
 
 		Builder(LuceneSearchIndexScope<?> scope) {
 			super( scope );
@@ -94,7 +93,7 @@ public class LuceneSimpleQueryStringPredicate extends AbstractLuceneNestablePred
 
 		@Override
 		public void flags(Set<SimpleQueryFlag> flags) {
-			this.flags = EnumSet.copyOf( flags );
+			this.flags = toFlagsMask( flags );
 		}
 
 		@Override
@@ -137,7 +136,7 @@ public class LuceneSimpleQueryStringPredicate extends AbstractLuceneNestablePred
 		}
 
 		private Query buildQuery() {
-			SimpleQueryParser queryParser = new SimpleQueryParser( buildAnalyzer(), buildWeights(), buildFlag() );
+			SimpleQueryParser queryParser = new SimpleQueryParser( buildAnalyzer(), buildWeights(), flags );
 			queryParser.setDefaultOperator( defaultOperator );
 			return queryParser.parse( simpleQueryString );
 		}
@@ -191,7 +190,7 @@ public class LuceneSimpleQueryStringPredicate extends AbstractLuceneNestablePred
 			return weights;
 		}
 
-		private int buildFlag() {
+		private static int toFlagsMask(Set<SimpleQueryFlag> flags) {
 			int flag = -1;
 			if ( flags != null ) {
 				flag = 0;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextRegexpPredicate.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextRegexpPredicate.java
@@ -50,7 +50,7 @@ public class LuceneTextRegexpPredicate extends AbstractLuceneLeafSingleFieldPred
 
 		@Override
 		public void flags(Set<RegexpQueryFlag> flags) {
-			this.flags = buildFlag( flags );
+			this.flags = toFlagsMask( flags );
 		}
 
 		@Override
@@ -65,7 +65,7 @@ public class LuceneTextRegexpPredicate extends AbstractLuceneLeafSingleFieldPred
 		}
 	}
 
-	private static int buildFlag(Set<RegexpQueryFlag> flags) {
+	private static int toFlagsMask(Set<RegexpQueryFlag> flags) {
 		int flag = 0;
 		if ( flags == null || flags.isEmpty() ) {
 			return RegExp.NONE;

--- a/documentation/src/main/asciidoc/reference/search-dsl-predicate.asciidoc
+++ b/documentation/src/main/asciidoc/reference/search-dsl-predicate.asciidoc
@@ -1101,6 +1101,16 @@ include::{sourcedir}/org/hibernate/search/documentation/search/predicate/Predica
 ----
 ====
 
+If you wish, you can disable all syntax constructs:
+
+.Matching a simple query string: disabling all syntax constructs
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java[tags=simpleQueryString-flags-none]
+----
+====
+
 [[search-dsl-predicate-simpleQueryString-multiple-fields]]
 === Targeting multiple fields
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
@@ -9,6 +9,7 @@ package org.hibernate.search.documentation.search.predicate;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import javax.persistence.EntityManagerFactory;
@@ -686,6 +687,19 @@ public class PredicateDslIT {
 							.flags( SimpleQueryFlag.AND, SimpleQueryFlag.OR, SimpleQueryFlag.NOT ) )
 					.fetchHits( 20 );
 			// end::simpleQueryString-flags[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK3_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::simpleQueryString-flags-none[]
+			List<Book> hits = searchSession.search( Book.class )
+					.where( f -> f.simpleQueryString().field( "title" )
+							.matching( "**robot**" )
+							.flags( Collections.emptySet() ) )
+					.fetchHits( 20 );
+			// end::simpleQueryString-flags-none[]
 			assertThat( hits )
 					.extracting( Book::getId )
 					.containsExactlyInAnyOrder( BOOK1_ID, BOOK3_ID );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/RegexpPredicateSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/RegexpPredicateSpecificsIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.integrationtest.backend.tck.search.predicate;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
 
+import java.util.Collections;
 import java.util.function.Function;
 
 import org.hibernate.search.engine.backend.common.DocumentReference;
@@ -165,6 +166,13 @@ public class RegexpPredicateSpecificsIT {
 						.matching( TEXT_COMPLEMENT ) ) )
 				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
 
+		// no flag at all (same as default)
+		assertThatQuery( scope.query()
+				.where( f -> f.regexp().field( absoluteFieldPath )
+						.matching( TEXT_COMPLEMENT )
+						.flags( Collections.emptySet() ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+
 		// alone
 		assertThatQuery( scope.query()
 				.where( f -> f.regexp().field( absoluteFieldPath )
@@ -199,6 +207,13 @@ public class RegexpPredicateSpecificsIT {
 		assertThatQuery( scope.query()
 				.where( f -> f.regexp().field( absoluteFieldPath )
 						.matching( TEXT_INTERVAL ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+
+		// no flag at all (same as default)
+		assertThatQuery( scope.query()
+				.where( f -> f.regexp().field( absoluteFieldPath )
+						.matching( TEXT_INTERVAL )
+						.flags( Collections.emptySet() ) ) )
 				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
 
 		// alone
@@ -237,6 +252,13 @@ public class RegexpPredicateSpecificsIT {
 						.matching( TEXT_INTERSECTION ) ) )
 				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
 
+		// no flag at all (same as default)
+		assertThatQuery( scope.query()
+				.where( f -> f.regexp().field( absoluteFieldPath )
+						.matching( TEXT_INTERSECTION )
+						.flags( Collections.emptySet() ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+
 		// alone
 		assertThatQuery( scope.query()
 				.where( f -> f.regexp().field( absoluteFieldPath )
@@ -271,6 +293,13 @@ public class RegexpPredicateSpecificsIT {
 		assertThatQuery( scope.query()
 				.where( f -> f.regexp().field( absoluteFieldPath )
 						.matching( TEXT_ANYSTRING ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+
+		// no flag at all (same as default)
+		assertThatQuery( scope.query()
+				.where( f -> f.regexp().field( absoluteFieldPath )
+						.matching( TEXT_ANYSTRING )
+						.flags( Collections.emptySet() ) ) )
 				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
 
 		// alone


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4536

Backport of #2993 to branch 6.1.