### PR TITLE
Backport HSEARCH-4540 to branch 6.1 - Upgrade to the latest version of Jakarta dependencies in -orm6/-jakarta artifacts

### DIFF
--- a/jakarta/mapper/orm/pom.xml
+++ b/jakarta/mapper/orm/pom.xml
@@ -39,14 +39,18 @@
             <!-- Use `jakarta.activation:jakarta.activation-api` instead of `com.sun.activation:jakarta.activation` in Jakarta EE 10 -->
             <exclusions>
                 <exclusion>
-                    <groupId>jakarta.activation</groupId>
-                    <artifactId>jakarta.activation-api</artifactId>
+                    <groupId>com.sun.activation</groupId>
+                    <artifactId>jakarta.activation</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.transaction</groupId>

--- a/orm6/mapper/orm/pom.xml
+++ b/orm6/mapper/orm/pom.xml
@@ -39,8 +39,8 @@
             <!-- Use `jakarta.activation:jakarta.activation-api` instead of `com.sun.activation:jakarta.activation` in Jakarta EE 10 -->
             <exclusions>
                 <exclusion>
-                    <groupId>jakarta.activation</groupId>
-                    <artifactId>jakarta.activation-api</artifactId>
+                    <groupId>com.sun.activation</groupId>
+                    <artifactId>jakarta.activation</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -53,6 +53,10 @@
         <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.transaction</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@
         <version.jakarta.xml.bind>3.0.1</version.jakarta.xml.bind>
         <version.jakarta.activation>2.0.1</version.jakarta.activation>
         <version.org.jboss.spec.javax.interceptor.jboss-interceptor-api_1.2_spec>1.0.1.Final</version.org.jboss.spec.javax.interceptor.jboss-interceptor-api_1.2_spec>
-        <version.jakarta.interceptor-api>2.0.1</version.jakarta.interceptor-api>
+        <version.jakarta.interceptor-api>2.1.0</version.jakarta.interceptor-api>
         <!-- This is used to generate a link to the Java EE javadoc -->
         <javadoc.javaee.url>https://javaee.github.io/javaee-spec/javadocs/</javadoc.javaee.url>
         <javadoc.jakarta.batch.url>https://jakarta.ee/specifications/batch/2.0/apidocs/</javadoc.jakarta.batch.url>

--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,7 @@
              Ideally, we should remove this dependency management when the dependencies fix their dependency divergence.
          -->
         <version.jakarta.xml.bind>4.0.0</version.jakarta.xml.bind>
-        <version.jakarta.activation>2.0.1</version.jakarta.activation>
+        <version.jakarta.activation>2.1.0</version.jakarta.activation>
         <version.org.jboss.spec.javax.interceptor.jboss-interceptor-api_1.2_spec>1.0.1.Final</version.org.jboss.spec.javax.interceptor.jboss-interceptor-api_1.2_spec>
         <version.jakarta.interceptor-api>2.1.0</version.jakarta.interceptor-api>
         <!-- This is used to generate a link to the Java EE javadoc -->
@@ -1047,8 +1047,8 @@
                 <version>${version.jakarta.xml.bind}</version>
             </dependency>
             <dependency>
-                <groupId>com.sun.activation</groupId>
-                <artifactId>jakarta.activation</artifactId>
+                <groupId>jakarta.activation</groupId>
+                <artifactId>jakarta.activation-api</artifactId>
                 <version>${version.jakarta.activation}</version>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
              (Hibernate ORM, JBatch, ...).
              Ideally, we should remove this dependency management when the dependencies fix their dependency divergence.
          -->
-        <version.jakarta.xml.bind>3.0.1</version.jakarta.xml.bind>
+        <version.jakarta.xml.bind>4.0.0</version.jakarta.xml.bind>
         <version.jakarta.activation>2.0.1</version.jakarta.activation>
         <version.org.jboss.spec.javax.interceptor.jboss-interceptor-api_1.2_spec>1.0.1.Final</version.org.jboss.spec.javax.interceptor.jboss-interceptor-api_1.2_spec>
         <version.jakarta.interceptor-api>2.1.0</version.jakarta.interceptor-api>

--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
         <javadoc.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/javadocs/</javadoc.org.hibernate.orm.url>
         <documentation.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/userguide/html_single/Hibernate_User_Guide.html</documentation.org.hibernate.orm.url>
         <version.org.hibernate.commons.annotations.orm6>6.0.0.Final</version.org.hibernate.commons.annotations.orm6>
-        <version.jakarta.persistence>3.0.0</version.jakarta.persistence>
+        <version.jakarta.persistence>3.1.0</version.jakarta.persistence>
 
         <!-- >>> JSR 352 -->
         <version.javax.batch>1.0.1</version.javax.batch>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4540

Backport of #3007 to branch 6.1.