### PR TITLE
Backport HSEARCH-4544 to branch 6.1 - OutOfMemoryError when defining aggregation on text field with .maxTermCount(<very large value>)

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/facet/impl/TextMultiValueFacetCounts.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/facet/impl/TextMultiValueFacetCounts.java
@@ -73,6 +73,12 @@ public class TextMultiValueFacetCounts extends Facets {
 	}
 
 	private FacetResult getTopChildrenSortByCount(int topN) throws IOException {
+		if ( topN > ordCount ) {
+			// HSEARCH-4544 Avoid OutOfMemoryError when passing crazy high topN values
+			// We know there will never be more than "ordCount" values anyway.
+			topN = ordCount;
+		}
+
 		TopOrdAndIntQueue q = null;
 
 		int bottomCount = 0;


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4544

Backport of #3011 to branch 6.1.