### PR TITLE
HSEARCH-4566 SPI for "hot" restart that allows compatible schema changes with Lucene without losing data in local-heap indexes

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/IndexManagerBackendContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/IndexManagerBackendContext.java
@@ -197,7 +197,8 @@ public class IndexManagerBackendContext implements WorkExecutionBackendContext, 
 	}
 
 	Shard createShard(LuceneIndexModel model, EventContext shardEventContext, DirectoryHolder directoryHolder,
-			IOStrategy ioStrategy, ConfigurationPropertySource propertySource) {
+			IOStrategy ioStrategy, ConfigurationPropertySource propertySource,
+			boolean reuseAlreadyStaredDirectoryHolder) {
 		LuceneParallelWorkOrchestratorImpl managementOrchestrator;
 		LuceneSerialWorkOrchestratorImpl indexingOrchestrator;
 		IndexAccessorImpl indexAccessor = null;
@@ -215,7 +216,8 @@ public class IndexManagerBackendContext implements WorkExecutionBackendContext, 
 
 			Shard shard = new Shard(
 					shardEventContext, indexAccessor,
-					managementOrchestrator, indexingOrchestrator
+					managementOrchestrator, indexingOrchestrator,
+					reuseAlreadyStaredDirectoryHolder
 			);
 			return shard;
 		}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/LuceneIndexManagerImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/LuceneIndexManagerImpl.java
@@ -29,7 +29,7 @@ import org.hibernate.search.engine.backend.schema.management.spi.IndexSchemaMana
 import org.hibernate.search.engine.backend.scope.spi.IndexScopeBuilder;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
-import org.hibernate.search.engine.backend.spi.SavedState;
+import org.hibernate.search.engine.common.resources.spi.SavedState;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/LuceneIndexManagerImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/LuceneIndexManagerImpl.java
@@ -91,10 +91,12 @@ public class LuceneIndexManagerImpl
 	}
 
 	@Override
-	public void start(IndexManagerStartContext context) {
-		// TODO HSEARCH-4545 Move it to preStart:
-		shardHolder.preStart( context );
+	public void preStart(IndexManagerStartContext context, SavedState savedState) {
+		shardHolder.preStart( context, savedState.get( SHARD_HOLDER_KEY ).orElse( SavedState.empty() ) );
+	}
 
+	@Override
+	public void start(IndexManagerStartContext context) {
 		shardHolder.start( context );
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/LuceneIndexManagerImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/LuceneIndexManagerImpl.java
@@ -82,6 +82,9 @@ public class LuceneIndexManagerImpl
 
 	@Override
 	public void start(IndexManagerStartContext context) {
+		// TODO HSEARCH-4545 Move it to preStart:
+		shardHolder.preStart( context );
+
 		shardHolder.start( context );
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/Shard.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/Shard.java
@@ -17,7 +17,7 @@ import org.hibernate.search.backend.lucene.orchestration.impl.LuceneParallelWork
 import org.hibernate.search.backend.lucene.orchestration.impl.LuceneParallelWorkOrchestratorImpl;
 import org.hibernate.search.backend.lucene.orchestration.impl.LuceneSerialWorkOrchestrator;
 import org.hibernate.search.backend.lucene.orchestration.impl.LuceneSerialWorkOrchestratorImpl;
-import org.hibernate.search.engine.backend.spi.SavedState;
+import org.hibernate.search.engine.common.resources.spi.SavedState;
 import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
 import org.hibernate.search.util.common.impl.Closer;
 import org.hibernate.search.util.common.impl.SuppressingCloser;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/Shard.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/Shard.java
@@ -54,7 +54,7 @@ public final class Shard {
 	public SavedState saveForRestart() {
 		try {
 			return SavedState.builder()
-					.put( DIRECTORY_HOLDER_KEY, indexAccessor.directoryHolder() )
+					.put( DIRECTORY_HOLDER_KEY, indexAccessor.directoryHolder(), DirectoryHolder::close )
 					.build();
 		}
 		finally {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/ShardHolder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/ShardHolder.java
@@ -9,6 +9,7 @@ package org.hibernate.search.backend.lucene.index.impl;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -62,13 +63,15 @@ class ShardHolder implements ReadIndexManagerContext, WorkExecutionIndexManagerC
 		return SavedState.builder().put( SHARDS_KEY, states ).build();
 	}
 
-	void preStart(IndexManagerStartContext startContext) {
+	void preStart(IndexManagerStartContext startContext, SavedState savedState) {
 		ConfigurationPropertySource propertySource = startContext.configurationPropertySource();
 
 		try {
 			ShardingStrategyInitializationContextImpl initializationContext =
 					new ShardingStrategyInitializationContextImpl( backendContext, model, startContext, propertySource );
-			this.shardingStrategyHolder = initializationContext.create( shards );
+			Map<String, SavedState> states = savedState.get( SHARDS_KEY ).orElse( Collections.emptyMap() );
+
+			this.shardingStrategyHolder = initializationContext.create( shards, states );
 		}
 		catch (RuntimeException e) {
 			new SuppressingCloser( e )

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/ShardHolder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/ShardHolder.java
@@ -27,7 +27,7 @@ import org.hibernate.search.backend.lucene.orchestration.impl.LuceneSerialWorkOr
 import org.hibernate.search.backend.lucene.schema.management.impl.SchemaManagementIndexManagerContext;
 import org.hibernate.search.backend.lucene.work.execution.impl.WorkExecutionIndexManagerContext;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerStartContext;
-import org.hibernate.search.engine.backend.spi.SavedState;
+import org.hibernate.search.engine.common.resources.spi.SavedState;
 import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
 import org.hibernate.search.engine.environment.bean.BeanHolder;
 import org.hibernate.search.util.common.impl.Closer;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/ShardingStrategyInitializationContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/ShardingStrategyInitializationContextImpl.java
@@ -23,7 +23,7 @@ import org.hibernate.search.backend.lucene.lowlevel.directory.spi.DirectoryHolde
 import org.hibernate.search.backend.lucene.lowlevel.directory.spi.DirectoryProvider;
 import org.hibernate.search.backend.lucene.lowlevel.index.impl.IOStrategy;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerStartContext;
-import org.hibernate.search.engine.backend.spi.SavedState;
+import org.hibernate.search.engine.common.resources.spi.SavedState;
 import org.hibernate.search.engine.cfg.spi.ConfigurationProperty;
 import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
 import org.hibernate.search.engine.environment.bean.BeanHolder;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
@@ -299,8 +299,8 @@ public interface Log extends BasicLogger {
 			value = "Invalid search projection: '%1$s'. You must build the projection from a Lucene search scope.")
 	SearchException cannotMixLuceneSearchQueryWithOtherProjections(SearchProjection<?> projection);
 
-	@Message(id = ID_OFFSET + 61, value = "Unable to shut down index accessor: %1$s")
-	SearchException unableToShutdownIndexAccessor(String causeMessage, @Cause Exception cause);
+	@Message(id = ID_OFFSET + 61, value = "Unable to shut down index: %1$s")
+	SearchException unableToShutdownShard(String causeMessage, @Param EventContext context, @Cause Exception cause);
 
 	@Message(id = ID_OFFSET + 62, value = "No built-in index field type for class: '%1$s'.")
 	SearchException cannotGuessFieldType(@FormatWith(ClassFormatter.class) Class<?> inputType, @Param EventContext context);
@@ -604,5 +604,9 @@ public interface Log extends BasicLogger {
 					+ " 'f.object(\"%2$s\").from(<the projection on field %1$s>).as(...).multi()'.")
 	SearchException invalidSingleValuedProjectionOnValueFieldInMultiValuedObjectField(String absolutePath,
 			String objectFieldAbsolutePath);
+
+	@Message(id = ID_OFFSET + 154,
+			value = "Unable to start index: %1$s")
+	SearchException unableToStartShard(String causeMessage, @Cause Exception cause);
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/directory/impl/LocalHeapDirectoryHolder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/directory/impl/LocalHeapDirectoryHolder.java
@@ -26,7 +26,7 @@ final class LocalHeapDirectoryHolder implements DirectoryHolder {
 
 	@Override
 	public void start() {
-		this.directory = new ByteBuffersDirectory( lockFactory );
+		directory = new ByteBuffersDirectory( lockFactory );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/index/impl/IndexAccessorImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/index/impl/IndexAccessorImpl.java
@@ -49,29 +49,11 @@ public class IndexAccessorImpl implements AutoCloseable, IndexAccessor {
 		this.indexReaderProvider = indexReaderProvider;
 	}
 
-	public void start() throws IOException {
-		directoryHolder.start();
-	}
-
 	@Override
-	public void close() {
+	public void close() throws IOException {
 		try ( Closer<IOException> closer = new Closer<>() ) {
 			closer.push( IndexWriterProvider::clear, indexWriterProvider );
 			closer.push( IndexReaderProvider::clear, indexReaderProvider );
-			closer.push( DirectoryHolder::close, directoryHolder );
-		}
-		catch (RuntimeException | IOException e) {
-			throw log.unableToShutdownIndexAccessor( e.getMessage(), e );
-		}
-	}
-
-	public void closeNoDir() {
-		try ( Closer<IOException> closer = new Closer<>() ) {
-			closer.push( IndexWriterProvider::clear, indexWriterProvider );
-			closer.push( IndexReaderProvider::clear, indexReaderProvider );
-		}
-		catch (RuntimeException | IOException e) {
-			throw log.unableToShutdownIndexAccessor( e.getMessage(), e );
 		}
 	}
 
@@ -214,10 +196,6 @@ public class IndexAccessorImpl implements AutoCloseable, IndexAccessor {
 		}
 
 		return totalSize;
-	}
-
-	public DirectoryHolder directoryHolder() {
-		return directoryHolder;
 	}
 
 	public Directory getDirectoryForTests() {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/index/impl/IndexAccessorImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/index/impl/IndexAccessorImpl.java
@@ -65,6 +65,16 @@ public class IndexAccessorImpl implements AutoCloseable, IndexAccessor {
 		}
 	}
 
+	public void closeNoDir() {
+		try ( Closer<IOException> closer = new Closer<>() ) {
+			closer.push( IndexWriterProvider::clear, indexWriterProvider );
+			closer.push( IndexReaderProvider::clear, indexReaderProvider );
+		}
+		catch (RuntimeException | IOException e) {
+			throw log.unableToShutdownIndexAccessor( e.getMessage(), e );
+		}
+	}
+
 	@Override
 	public void createIndexIfMissing() {
 		try {
@@ -204,6 +214,10 @@ public class IndexAccessorImpl implements AutoCloseable, IndexAccessor {
 		}
 
 		return totalSize;
+	}
+
+	public DirectoryHolder directoryHolder() {
+		return directoryHolder;
 	}
 
 	public Directory getDirectoryForTests() {

--- a/backend/lucene/src/test/java/org/hibernate/search/backend/lucene/lowlevel/index/impl/IndexAccessorTest.java
+++ b/backend/lucene/src/test/java/org/hibernate/search/backend/lucene/lowlevel/index/impl/IndexAccessorTest.java
@@ -64,8 +64,6 @@ public class IndexAccessorTest {
 	public void start() throws IOException {
 		accessor = new IndexAccessorImpl( indexEventContext, directoryHolderMock,
 				indexWriterProviderMock, indexReaderProviderMock );
-		accessor.start();
-		verify( directoryHolderMock ).start();
 	}
 
 	@After

--- a/engine/src/main/java/org/hibernate/search/engine/backend/index/spi/IndexManagerImplementor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/index/spi/IndexManagerImplementor.java
@@ -54,8 +54,7 @@ public interface IndexManagerImplementor {
 	 * Start any resource necessary to operate the index manager at runtime.
 	 * <p>
 	 * Called by the engine once just after
-	 * {@link #preStart(IndexManagerStartContext, SavedState)}
-	 * was called on the corresponding backend.
+	 * {@link #preStart(IndexManagerStartContext, SavedState)}.
 	 *
 	 * @param context The start context.
 	 */

--- a/engine/src/main/java/org/hibernate/search/engine/backend/index/spi/IndexManagerImplementor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/index/spi/IndexManagerImplementor.java
@@ -30,7 +30,6 @@ import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
 public interface IndexManagerImplementor {
 
 	default SavedState saveForRestart() {
-		// TODO HSEARCH-4545 Implement this method
 		return SavedState.empty();
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/backend/index/spi/IndexManagerImplementor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/index/spi/IndexManagerImplementor.java
@@ -9,7 +9,7 @@ package org.hibernate.search.engine.backend.index.spi;
 import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.schema.management.spi.IndexSchemaManager;
-import org.hibernate.search.engine.backend.spi.SavedState;
+import org.hibernate.search.engine.common.resources.spi.SavedState;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.index.IndexManager;

--- a/engine/src/main/java/org/hibernate/search/engine/backend/index/spi/IndexManagerImplementor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/index/spi/IndexManagerImplementor.java
@@ -34,10 +34,27 @@ public interface IndexManagerImplementor {
 	}
 
 	/**
-	 * Start any resource necessary to operate the index manager at runtime.
+	 * Starts a subset of resources that are necessary to operate the index manager at runtime, and are expected to be reused upon restarts.
+	 * The resources may be retrieved them from the saved state,
+	 * or created if they are not present in the saved state.
 	 * <p>
 	 * Called by the engine once after bootstrap, after
 	 * {@link org.hibernate.search.engine.backend.spi.BackendImplementor#start(BackendStartContext)}
+	 * was called on the corresponding backend.
+	 *
+	 * @param context The start context.
+	 * @param savedState The saved state returned by the corresponding index manager in the Hibernate Search integration
+	 * being restarted, or {@link SavedState#empty()} on the first start.
+	 */
+	default void preStart(IndexManagerStartContext context, SavedState savedState) {
+		// do nothing by default
+	}
+
+	/**
+	 * Start any resource necessary to operate the index manager at runtime.
+	 * <p>
+	 * Called by the engine once just after
+	 * {@link #preStart(IndexManagerStartContext, SavedState)}
 	 * was called on the corresponding backend.
 	 *
 	 * @param context The start context.

--- a/engine/src/main/java/org/hibernate/search/engine/backend/index/spi/IndexManagerImplementor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/index/spi/IndexManagerImplementor.java
@@ -9,6 +9,7 @@ package org.hibernate.search.engine.backend.index.spi;
 import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.schema.management.spi.IndexSchemaManager;
+import org.hibernate.search.engine.backend.spi.SavedState;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.index.IndexManager;
@@ -27,6 +28,11 @@ import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
  * This is the interface implemented by backends and provided to the engine.
  */
 public interface IndexManagerImplementor {
+
+	default SavedState saveForRestart() {
+		// TODO HSEARCH-4545 Implement this method
+		return SavedState.empty();
+	}
 
 	/**
 	 * Start any resource necessary to operate the index manager at runtime.

--- a/engine/src/main/java/org/hibernate/search/engine/backend/spi/SavedState.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/spi/SavedState.java
@@ -1,0 +1,92 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.backend.spi;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.hibernate.search.util.common.impl.Contracts;
+
+public class SavedState {
+
+	private static final SavedState EMPTY = new SavedState.Builder().build();
+
+	public static SavedState empty() {
+		return EMPTY;
+	}
+
+	private final Map<Key<?>, Object> content;
+
+	private SavedState(Builder builder) {
+		this.content = builder.content;
+	}
+
+	@SuppressWarnings("unchecked") // values have always the corresponding key generic type
+	public <T> Optional<T> get(Key<T> key) {
+		T value = (T) content.get( key );
+		return Optional.ofNullable( value );
+	}
+
+	public static <T> Key<T> key(String name) {
+		Contracts.assertNotNullNorEmpty( name, "name" );
+		return new Key<>( name );
+	}
+
+	public static final class Key<T> {
+
+		private final String name;
+
+		private Key(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public String toString() {
+			return getClass().getSimpleName() + "[" + name + "]";
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			Key<?> key = (Key<?>) o;
+			return Objects.equals( name, key.name );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( name );
+		}
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static final class Builder {
+		private final Map<Key<?>, Object> content = new LinkedHashMap<>();
+
+		private Builder() {
+		}
+
+		// values have always the corresponding key generic type
+		public <T> Builder put(Key<T> key, T value) {
+			content.put( key, value );
+			return this;
+		}
+
+		public SavedState build() {
+			return new SavedState( this );
+		}
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/IndexManagerNonStartedState.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/IndexManagerNonStartedState.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.engine.common.impl;
 
 import org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor;
+import org.hibernate.search.engine.backend.spi.SavedState;
 import org.hibernate.search.engine.cfg.impl.ConfigurationPropertySourceExtractor;
 import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
 import org.hibernate.search.engine.environment.bean.BeanResolver;
@@ -32,6 +33,10 @@ class IndexManagerNonStartedState {
 		indexManager.stop();
 	}
 
+	void preStart(SavedState savedState) {
+		// TODO HSEARCH-4545 Implement this method
+	}
+
 	IndexManagerImplementor start(RootFailureCollector rootFailureCollector,
 			BeanResolver beanResolver,
 			ConfigurationPropertySource rootPropertySource) {
@@ -48,5 +53,4 @@ class IndexManagerNonStartedState {
 		}
 		return indexManager; // The index is now started
 	}
-
 }

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/IndexManagerNonStartedState.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/IndexManagerNonStartedState.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.engine.common.impl;
 
 import org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor;
-import org.hibernate.search.engine.backend.spi.SavedState;
+import org.hibernate.search.engine.common.resources.spi.SavedState;
 import org.hibernate.search.engine.cfg.impl.ConfigurationPropertySourceExtractor;
 import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
 import org.hibernate.search.engine.environment.bean.BeanResolver;

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationBuilder.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.hibernate.search.engine.cfg.EngineSettings;
 import org.hibernate.search.engine.cfg.spi.ConfigurationProperty;
@@ -63,12 +64,15 @@ public class SearchIntegrationBuilder implements SearchIntegration.Builder {
 					.build();
 
 	private final SearchIntegrationEnvironment environment;
+	private final Optional<SearchIntegrationImpl> previousIntegration;
 	private final Map<MappingKey<?, ?>, MappingInitiator<?, ?>> mappingInitiators = new LinkedHashMap<>();
 
 	private boolean frozen = false;
 
-	public SearchIntegrationBuilder(SearchIntegrationEnvironment environment) {
+	public SearchIntegrationBuilder(SearchIntegrationEnvironment environment,
+			Optional<SearchIntegrationImpl> previousIntegration) {
 		this.environment = environment;
+		this.previousIntegration = previousIntegration;
 		environment.propertyChecker().beforeBoot();
 	}
 
@@ -195,7 +199,7 @@ public class SearchIntegrationBuilder implements SearchIntegration.Builder {
 					indexManagerBuildingStateHolder.getBackendNonStartedStates(),
 					indexManagerBuildingStateHolder.getIndexManagersNonStartedStates(),
 					environment.propertyChecker(),
-					engineThreads, timingSource
+					engineThreads, timingSource, previousIntegration
 			);
 		}
 		catch (RuntimeException e) {

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationImpl.java
@@ -9,6 +9,7 @@ package org.hibernate.search.engine.common.impl;
 import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -20,6 +21,7 @@ import org.hibernate.search.engine.backend.spi.BackendImplementor;
 import org.hibernate.search.engine.backend.spi.SavedState;
 import org.hibernate.search.engine.common.resources.impl.EngineThreads;
 import org.hibernate.search.engine.common.spi.SearchIntegration;
+import org.hibernate.search.engine.common.spi.SearchIntegrationEnvironment;
 import org.hibernate.search.engine.common.timing.spi.TimingSource;
 import org.hibernate.search.engine.environment.bean.BeanHolder;
 import org.hibernate.search.engine.environment.bean.spi.BeanProvider;
@@ -105,6 +107,11 @@ public class SearchIntegrationImpl implements SearchIntegration {
 			states.put( indexManager.getKey(), indexManager.getValue().saveForRestart() );
 		}
 		return SavedState.builder().put( INDEX_MANAGERS_KEY, states ).build();
+	}
+
+	@Override
+	public Builder restartBuilder(SearchIntegrationEnvironment environment) {
+		return new SearchIntegrationBuilder( environment, Optional.of( this ) );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationImpl.java
@@ -18,7 +18,7 @@ import org.hibernate.search.engine.backend.Backend;
 import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor;
 import org.hibernate.search.engine.backend.spi.BackendImplementor;
-import org.hibernate.search.engine.backend.spi.SavedState;
+import org.hibernate.search.engine.common.resources.spi.SavedState;
 import org.hibernate.search.engine.common.resources.impl.EngineThreads;
 import org.hibernate.search.engine.common.spi.SearchIntegration;
 import org.hibernate.search.engine.common.spi.SearchIntegrationEnvironment;

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationImpl.java
@@ -101,7 +101,7 @@ public class SearchIntegrationImpl implements SearchIntegration {
 		return indexManager.toAPI();
 	}
 
-	public SavedState saveForRestart() {
+	SavedState saveForRestart() {
 		HashMap<String, SavedState> states = new HashMap<>();
 		for ( Map.Entry<String, IndexManagerImplementor> indexManager : indexManagers.entrySet() ) {
 			states.put( indexManager.getKey(), indexManager.getValue().saveForRestart() );

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationPartialBuildStateImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationPartialBuildStateImpl.java
@@ -16,7 +16,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor;
 import org.hibernate.search.engine.backend.spi.BackendImplementor;
-import org.hibernate.search.engine.backend.spi.SavedState;
+import org.hibernate.search.engine.common.resources.spi.SavedState;
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertyChecker;
 import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
 import org.hibernate.search.engine.common.resources.impl.EngineThreads;

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationPartialBuildStateImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationPartialBuildStateImpl.java
@@ -62,9 +62,7 @@ class SearchIntegrationPartialBuildStateImpl implements SearchIntegrationPartial
 
 	private final EngineThreads engineThreads;
 	private final TimingSource timingSource;
-
-	// TODO HSEARCH-4545 Load instance here
-	private final Optional<SearchIntegrationImpl> previousIntegration = Optional.empty();
+	private final Optional<SearchIntegrationImpl> previousIntegration;
 
 	SearchIntegrationPartialBuildStateImpl(
 			BeanProvider beanProvider, BeanResolver beanResolver,
@@ -74,7 +72,8 @@ class SearchIntegrationPartialBuildStateImpl implements SearchIntegrationPartial
 			Map<String, BackendNonStartedState> nonStartedBackends,
 			Map<String, IndexManagerNonStartedState> nonStartedIndexManagers,
 			ConfigurationPropertyChecker partialConfigurationPropertyChecker,
-			EngineThreads engineThreads, TimingSource timingSource) {
+			EngineThreads engineThreads, TimingSource timingSource,
+			Optional<SearchIntegrationImpl> previousIntegration) {
 		this.beanProvider = beanProvider;
 		this.beanResolver = beanResolver;
 		this.failureHandlerHolder = failureHandlerHolder;
@@ -85,6 +84,7 @@ class SearchIntegrationPartialBuildStateImpl implements SearchIntegrationPartial
 		this.partialConfigurationPropertyChecker = partialConfigurationPropertyChecker;
 		this.engineThreads = engineThreads;
 		this.timingSource = timingSource;
+		this.previousIntegration = previousIntegration;
 	}
 
 	@Override
@@ -102,6 +102,10 @@ class SearchIntegrationPartialBuildStateImpl implements SearchIntegrationPartial
 			closer.pushAll( BeanProvider::close, beanProvider );
 			closer.pushAll( EngineThreads::onStop, engineThreads );
 			closer.pushAll( TimingSource::stop, timingSource );
+
+			if ( previousIntegration.isPresent() ) {
+				closer.pushAll( SearchIntegration::close, previousIntegration.get() );
+			}
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationPartialBuildStateImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationPartialBuildStateImpl.java
@@ -190,7 +190,12 @@ class SearchIntegrationPartialBuildStateImpl implements SearchIntegrationPartial
 					savedState = indexManagersStates.get( entry.getKey() );
 				}
 
-				entry.getValue().preStart( failureCollector, beanResolver, propertySource, savedState );
+				try {
+					entry.getValue().preStart( failureCollector, beanResolver, propertySource, savedState );
+				}
+				finally {
+					savedState.close();
+				}
 			}
 			failureCollector.checkNoFailure();
 

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationPartialBuildStateImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationPartialBuildStateImpl.java
@@ -190,8 +190,9 @@ class SearchIntegrationPartialBuildStateImpl implements SearchIntegrationPartial
 					savedState = indexManagersStates.get( entry.getKey() );
 				}
 
-				entry.getValue().preStart( savedState );
+				entry.getValue().preStart( failureCollector, beanResolver, propertySource, savedState );
 			}
+			failureCollector.checkNoFailure();
 
 			if ( previousIntegration.isPresent() ) {
 				previousIntegration.get().close();
@@ -201,7 +202,7 @@ class SearchIntegrationPartialBuildStateImpl implements SearchIntegrationPartial
 			for ( Map.Entry<String, IndexManagerNonStartedState> entry : nonStartedIndexManagers.entrySet() ) {
 				startedIndexManagers.put(
 						entry.getKey(),
-						entry.getValue().start( failureCollector, beanResolver, propertySource )
+						entry.getValue().start()
 				);
 			}
 			failureCollector.checkNoFailure();

--- a/engine/src/main/java/org/hibernate/search/engine/common/resources/spi/SavedState.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/resources/spi/SavedState.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.engine.backend.spi;
+package org.hibernate.search.engine.common.resources.spi;
 
 import java.lang.invoke.MethodHandles;
 import java.util.LinkedHashMap;

--- a/engine/src/main/java/org/hibernate/search/engine/common/spi/SearchIntegration.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/spi/SearchIntegration.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.engine.common.spi;
 
+import java.util.Optional;
+
 import org.hibernate.search.engine.backend.Backend;
 import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.common.impl.SearchIntegrationBuilder;
@@ -21,11 +23,13 @@ public interface SearchIntegration extends AutoCloseable {
 
 	IndexManager indexManager(String indexManagerName);
 
+	Builder restartBuilder(SearchIntegrationEnvironment environment);
+
 	@Override
 	void close();
 
 	static Builder builder(SearchIntegrationEnvironment environment) {
-		return new SearchIntegrationBuilder( environment );
+		return new SearchIntegrationBuilder( environment, Optional.empty() );
 	}
 
 	interface Builder {

--- a/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
@@ -492,4 +492,7 @@ public interface Log extends BasicLogger {
 			@FormatWith(EventContextNoPrefixFormatter.class) EventContext nestedPath1,
 			String fieldPath2, @FormatWith(EventContextNoPrefixFormatter.class) EventContext nestedPath2);
 
+	@Message(id = ID_OFFSET + 112,
+			value = "Unable to close saved value for key %1$s: %2$s")
+	SearchException unableToCloseSavedValue(String keyName, String message, @Cause Exception e);
 }

--- a/engine/src/main/java/org/hibernate/search/engine/reporting/spi/RootFailureCollector.java
+++ b/engine/src/main/java/org/hibernate/search/engine/reporting/spi/RootFailureCollector.java
@@ -98,6 +98,9 @@ public final class RootFailureCollector implements FailureCollector {
 
 		@Override
 		public synchronized ContextualFailureCollectorImpl withContext(EventContext context) {
+			if ( context == null ) {
+				return withDefaultContext();
+			}
 			List<EventContextElement> elements = context.elements();
 			try {
 				NonRootFailureCollector failureCollector = this;
@@ -116,6 +119,9 @@ public final class RootFailureCollector implements FailureCollector {
 
 		@Override
 		public synchronized ContextualFailureCollectorImpl withContext(EventContextElement contextElement) {
+			if ( contextElement == null ) {
+				return withDefaultContext();
+			}
 			return children.computeIfAbsent(
 					contextElement,
 					element -> new ContextualFailureCollectorImpl( this, element )

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/index/LuceneIndexRestartFromPreviousIntegrationIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/index/LuceneIndexRestartFromPreviousIntegrationIT.java
@@ -1,0 +1,98 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.lucene.index;
+
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.hibernate.search.backend.lucene.cfg.LuceneIndexSettings;
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.common.spi.SearchIntegration;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingSchemaManagementStrategy;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class LuceneIndexRestartFromPreviousIntegrationIT {
+
+	@Parameterized.Parameters(name = "{0}")
+	public static List<?> params() {
+		return Arrays.asList( "local-heap", "local-filesystem" );
+	}
+
+	@Parameterized.Parameter
+	public String directoryType;
+
+	@Rule
+	public final SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private final SimpleMappedIndex<IndexBindingV1> indexV1 = SimpleMappedIndex.of( IndexBindingV1::new );
+	private final SimpleMappedIndex<IndexBindingV2> indexV2 = SimpleMappedIndex.of( IndexBindingV2::new );
+
+	@Test
+	public void addNewFieldOnExistingIndex() {
+		SearchIntegration integrationV1 = setupHelper.start()
+				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_AND_CREATE_ON_STARTUP_ONLY )
+				.withIndex( indexV1 )
+				.withBackendProperty( LuceneIndexSettings.DIRECTORY_TYPE, directoryType )
+				.setup();
+
+		BulkIndexer indexer1 = indexV1.bulkIndexer();
+		indexer1.add( "1", doc -> {
+			doc.addValue( indexV1.binding().name, "Fabio" );
+		} );
+		indexer1.join();
+
+		assertThatQuery( indexV1.query().where( f -> f.match().field( "name" ).matching( "Fabio" ) ) )
+				.hasDocRefHitsAnyOrder( indexV1.typeName(), "1" );
+
+		setupHelper.start()
+				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
+				.withIndex( indexV2 )
+				.withBackendProperty( LuceneIndexSettings.DIRECTORY_TYPE, directoryType )
+				.setup( integrationV1 );
+
+		BulkIndexer indexer2 = indexV2.bulkIndexer();
+		indexer2.add( "2", doc -> {
+			doc.addValue( indexV2.binding().name, "Fabio" );
+			doc.addValue( indexV2.binding().surname, "Ercoli" );
+		} );
+		indexer2.join();
+
+		assertThatQuery( indexV2.query().where( f -> f.match().field( "surname" ).matching( "Ercoli" ) ) )
+				.hasDocRefHitsAnyOrder( indexV2.typeName(), "2" );
+		assertThatQuery( indexV2.query().where( f -> f.match().field( "name" ).matching( "Fabio" ) ) )
+				.hasDocRefHitsAnyOrder( indexV2.typeName(), "1", "2" );
+	}
+
+	private static class IndexBindingV1 {
+		final IndexFieldReference<String> name;
+
+		IndexBindingV1(IndexSchemaElement root) {
+			name = root.field( "name", c -> c.asString() ).toReference();
+		}
+	}
+
+	private static class IndexBindingV2 {
+		final IndexFieldReference<String> name;
+		final IndexFieldReference<String> surname;
+
+		IndexBindingV2(IndexSchemaElement root) {
+			name = root.field( "name", c -> c.asString() ).toReference();
+			surname = root.field( "surname", c -> c.asString() ).toReference();
+		}
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
@@ -229,13 +229,19 @@ public class SearchSetupHelper implements TestRule {
 		}
 
 		public PartialSetup setupFirstPhaseOnly() {
+			return setupFirstPhaseOnly( Optional.empty() );
+		}
+
+		public PartialSetup setupFirstPhaseOnly(Optional<SearchIntegration> previousIntegration) {
 			SearchIntegrationEnvironment environment =
 					SearchIntegrationEnvironment.builder( propertySource, unusedPropertyChecker )
 							.beanProvider( beanProvider )
 							.build();
 			environments.add( environment );
 
-			SearchIntegration.Builder integrationBuilder = SearchIntegration.builder( environment );
+			SearchIntegration.Builder integrationBuilder = (previousIntegration.isPresent()) ?
+					previousIntegration.get().restartBuilder( environment ) :
+					SearchIntegration.builder( environment );
 
 			StubMappingInitiator initiator = new StubMappingInitiator( tenancyMode );
 			mappedIndexes.forEach( initiator::add );
@@ -263,6 +269,10 @@ public class SearchSetupHelper implements TestRule {
 
 		public SearchIntegration setup() {
 			return setupFirstPhaseOnly().doSecondPhase();
+		}
+
+		public SearchIntegration setup(SearchIntegration previousIntegration) {
+			return setupFirstPhaseOnly( Optional.of( previousIntegration ) ).doSecondPhase();
 		}
 
 	}

--- a/util/common/src/main/java/org/hibernate/search/util/common/impl/AbstractCloser.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/impl/AbstractCloser.java
@@ -8,6 +8,8 @@ package org.hibernate.search.util.common.impl;
 
 import java.util.function.Function;
 
+import org.hibernate.search.util.common.spi.ClosingOperator;
+
 /**
  * A base class implementing the logic behind {@link Closer} and {@link SuppressingCloser}.
  *

--- a/util/common/src/main/java/org/hibernate/search/util/common/impl/SuppressingCloser.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/impl/SuppressingCloser.java
@@ -8,6 +8,8 @@ package org.hibernate.search.util.common.impl;
 
 import java.util.function.Function;
 
+import org.hibernate.search.util.common.spi.ClosingOperator;
+
 /**
  * A helper for closing multiple resources and re-throwing a provided exception,
  * {@link Throwable#addSuppressed(Throwable) suppressing} any exceptions caught while closing.

--- a/util/common/src/main/java/org/hibernate/search/util/common/spi/ClosingOperator.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/spi/ClosingOperator.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.util.common.impl;
+package org.hibernate.search.util.common.spi;
 
 @FunctionalInterface
 public interface ClosingOperator<T, E extends Throwable> {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4566

draft => ~~I'm going to add a test~~ => done but ~~the test does not pass (still draft!)~~ => done

limited => with this contribution the promise:

> While Hibernate Search is restarting, the old Hibernate Search instance can be used.

won't be addressed