### PR TITLE
HSEARCH-4559 + HSEARCH-4560 Add compatibility with Elasticsearch 8.2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -285,8 +285,7 @@ The following profiles are available:
   * `elasticsearch-7.10` for 7.10
   * `elasticsearch-7.11` for 7.11 ([not open-source starting with this version](https://opensource.org/node/1099))
   * `elasticsearch-7.12` for 7.12 to 7.17
-  * `elasticsearch-8.0` for 8.0
-  * `elasticsearch-8.1` for 8.1+ (**the default**)
+  * `elasticsearch-8.0` for 8.0+ (**the default**)
 * [OpenSearch](https://www.opensearch.org/)
   * `opensearch-1.0` for 1.0
   * `opensearch-1.2` for 1.2+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -253,7 +253,10 @@ stage('Configure') {
 					// Not testing 8.0 because we know there are problems in 8.0.1 (see https://hibernate.atlassian.net/browse/HSEARCH-4497)
 					new EsLocalBuildEnvironment(versionRange: '[8.0,8.1)', mavenProfile: 'elasticsearch-8.0',
 							condition: TestCondition.ON_DEMAND),
-					new EsLocalBuildEnvironment(versionRange: '[8.1,8.x)', mavenProfile: 'elasticsearch-8.1',
+					// Not testing 8.1 to make the build quicker.
+					new EsLocalBuildEnvironment(versionRange: '[8.1,8.2)', mavenProfile: 'elasticsearch-8.0',
+							condition: TestCondition.ON_DEMAND),
+					new EsLocalBuildEnvironment(versionRange: '[8.2,8.x)', mavenProfile: 'elasticsearch-8.0',
 							condition: TestCondition.BEFORE_MERGE,
 							isDefault: true),
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
@@ -166,7 +166,7 @@ public class ElasticsearchDialectFactory {
 	}
 
 	private ElasticsearchProtocolDialect createProtocolDialectElasticV8(ElasticsearchVersion version, int minor) {
-		if ( minor > 1 ) {
+		if ( minor > 2 ) {
 			log.unknownElasticsearchVersion( version );
 		}
 		else if ( minor == 0 ) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/lowlevel/syntax/search/impl/Elasticsearch81SearchSyntax.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/lowlevel/syntax/search/impl/Elasticsearch81SearchSyntax.java
@@ -17,7 +17,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 
 /**
- * The search syntax for ES7.0 and later.
+ * The search syntax for ES8.1 and later.
  */
 public class Elasticsearch81SearchSyntax implements ElasticsearchSearchSyntax {
 

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -583,7 +583,7 @@ public class ElasticsearchDialectFactoryTest {
 	@TestForIssue(jiraKey = "HSEARCH-4475")
 	public void elastic_8() {
 		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "8", "8.1.0",
+				ElasticsearchDistributionName.ELASTIC, "8", "8.2.0",
 				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
 		);
 	}
@@ -625,19 +625,37 @@ public class ElasticsearchDialectFactoryTest {
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4505")
+	@TestForIssue(jiraKey = "HSEARCH-4559")
 	public void elastic_8_2() {
-		testSuccessWithWarning(
+		testSuccess(
 				ElasticsearchDistributionName.ELASTIC, "8.2", "8.2.0",
 				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
 		);
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4505")
+	@TestForIssue(jiraKey = "HSEARCH-4559")
 	public void elastic_8_2_0() {
-		testSuccessWithWarning(
+		testSuccess(
 				ElasticsearchDistributionName.ELASTIC, "8.2.0", "8.2.0",
+				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4559")
+	public void elastic_8_3() {
+		testSuccessWithWarning(
+				ElasticsearchDistributionName.ELASTIC, "8.3", "8.3.0",
+				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4559")
+	public void elastic_8_3_0() {
+		testSuccessWithWarning(
+				ElasticsearchDistributionName.ELASTIC, "8.3.0", "8.3.0",
 				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
 		);
 	}

--- a/integrationtest/backend/elasticsearch/pom.xml
+++ b/integrationtest/backend/elasticsearch/pom.xml
@@ -256,19 +256,9 @@
             </properties>
         </profile>
 
-        <!-- Elasticsearch 8.0 test environment -->
+        <!-- Elasticsearch 8.0+ test environment -->
         <profile>
             <id>elasticsearch-8.0</id>
-            <properties>
-                <failsafe.excludedGroups.elasticsearch.version>
-                    <!-- Nothing here -->
-                </failsafe.excludedGroups.elasticsearch.version>
-            </properties>
-        </profile>
-
-        <!-- Elasticsearch 8.1+ test environment -->
-        <profile>
-            <id>elasticsearch-8.1</id>
             <activation>
                 <!-- This must be re-defined here: the activation defined in the parent pom is not enough -->
                 <!-- Activate by default, i.e. if test.elasticsearch.connection.version has not been defined explicitly -->

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -579,20 +579,9 @@
             </properties>
         </profile>
 
-        <!-- Elasticsearch 8.0 test environment -->
+        <!-- Elasticsearch 8.0+ test environment -->
         <profile>
             <id>elasticsearch-8.0</id>
-            <properties>
-                <test.elasticsearch.run.elastic.skip>${test.elasticsearch.run.skip}</test.elasticsearch.run.elastic.skip>
-                <test.elasticsearch.connection.distribution>elastic</test.elasticsearch.connection.distribution>
-                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-8.0}</test.elasticsearch.connection.version>
-                <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch712TestDialect</test.elasticsearch.testdialect>
-            </properties>
-        </profile>
-
-        <!-- Elasticsearch 8.1+ test environment -->
-        <profile>
-            <id>elasticsearch-8.1</id>
             <activation>
                 <!-- Activate by default, i.e. if test.elasticsearch.connection.version has not been defined explicitly -->
                 <property>
@@ -602,7 +591,7 @@
             <properties>
                 <test.elasticsearch.run.elastic.skip>${test.elasticsearch.run.skip}</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.distribution>elastic</test.elasticsearch.connection.distribution>
-                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-8.1}</test.elasticsearch.connection.version>
+                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-8.2}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch712TestDialect</test.elasticsearch.testdialect>
             </properties>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -202,8 +202,8 @@
 
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
-        <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.1+ -->
-        <version.org.elasticsearch.client>8.1.3</version.org.elasticsearch.client>
+        <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.2+ -->
+        <version.org.elasticsearch.client>8.2.0</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-8.1) becomes the default. -->

--- a/pom.xml
+++ b/pom.xml
@@ -206,16 +206,17 @@
         <version.org.elasticsearch.client>8.2.0</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
-             to make sure the corresponding profile (e.g. elasticsearch-8.1) becomes the default. -->
-        <version.org.elasticsearch.compatible.main>${version.org.elasticsearch.latest-8.1}</version.org.elasticsearch.compatible.main>
+             to make sure the corresponding profile (e.g. elasticsearch-8.3) becomes the default. -->
+        <version.org.elasticsearch.compatible.main>${version.org.elasticsearch.latest-8.2}</version.org.elasticsearch.compatible.main>
         <documentation.org.elasticsearch.url>https://www.elastic.co/guide/en/elasticsearch/reference/${parsed-version.org.elasticsearch.compatible.main.majorVersion}.${parsed-version.org.elasticsearch.compatible.main.minorVersion}</documentation.org.elasticsearch.url>
         <!-- The versions of Elasticsearch/OpenSearch advertised as compatible with Hibernate Search -->
         <!-- Make sure that 7.10 stays explicitly mentioned here, because that's the last open-source version -->
-        <version.org.elasticsearch.compatible.regularly-tested.text>5.6, 6.8, 7.10, 7.17 or 8.1</version.org.elasticsearch.compatible.regularly-tested.text>
+        <version.org.elasticsearch.compatible.regularly-tested.text>5.6, 6.8, 7.10, 7.17 or 8.2</version.org.elasticsearch.compatible.regularly-tested.text>
         <version.org.opensearch.compatible.regularly-tested.text>1.0 or 1.2</version.org.opensearch.compatible.regularly-tested.text>
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
         <version.org.elasticsearch.compatible.not-regularly-tested.text>7.0 or 8.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest micro of each Elasticsearch branch -->
+        <version.org.elasticsearch.latest-8.2>8.2.0</version.org.elasticsearch.latest-8.2>
         <version.org.elasticsearch.latest-8.1>8.1.3</version.org.elasticsearch.latest-8.1>
         <version.org.elasticsearch.latest-8.0>8.0.1</version.org.elasticsearch.latest-8.0>
         <version.org.elasticsearch.latest-7.17>7.17.0</version.org.elasticsearch.latest-7.17>


### PR DESCRIPTION
* [HSEARCH-4560](https://hibernate.atlassian.net/browse/HSEARCH-4560): Upgrade to Elasticsearch client 8.2.0
* [HSEARCH-4559](https://hibernate.atlassian.net/browse/HSEARCH-4559): Add compatibility with Elasticsearch 8.2.0

