### PR TITLE
HSEARCH-4561 + HSEARCH-4562 + HSEARCH-4564 Add compatibility with OpenSearch 1.3 + 2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,8 +288,7 @@ The following profiles are available:
   * `elasticsearch-8.0` for 8.0
   * `elasticsearch-8.1` for 8.1+ (**the default**)
 * [OpenSearch](https://www.opensearch.org/)
-  * `opensearch-1.0` for 1.0
-  * `opensearch-1.2` for 1.2+
+  * `opensearch-1.0` for 1.0+
 
 Alternatively, you can prevent the build from launching an Elasticsearch server automatically
 and run Elasticsearch-related tests against your own server using the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,7 +288,8 @@ The following profiles are available:
   * `elasticsearch-8.0` for 8.0
   * `elasticsearch-8.1` for 8.1+ (**the default**)
 * [OpenSearch](https://www.opensearch.org/)
-  * `opensearch-1.0` for 1.0+
+  * `opensearch-1.0` for 1.0 and later 1.x
+  * `opensearch-2.0` for 2.0+
 
 Alternatively, you can prevent the build from launching an Elasticsearch server automatically
 and run Elasticsearch-related tests against your own server using the

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -259,9 +259,12 @@ stage('Configure') {
 
 					// --------------------------------------------
 					// OpenSearch
+					// Not testing 1.0 - 1.2 to make the build quicker.
 					new OpenSearchEsLocalBuildEnvironment(version: '1.0', mavenProfile: 'opensearch-1.0',
-							condition: TestCondition.AFTER_MERGE),
-					new OpenSearchEsLocalBuildEnvironment(version: '1.2', mavenProfile: 'opensearch-1.2',
+							condition: TestCondition.ON_DEMAND),
+					new OpenSearchEsLocalBuildEnvironment(version: '1.2', mavenProfile: 'opensearch-1.0',
+							condition: TestCondition.ON_DEMAND),
+					new OpenSearchEsLocalBuildEnvironment(version: '1.3', mavenProfile: 'opensearch-1.0',
 							condition: TestCondition.AFTER_MERGE)
 			],
 			esAws: [
@@ -302,7 +305,6 @@ stage('Configure') {
 					// AWS OpenSearch service
 					new OpenSearchEsAwsBuildEnvironment(version: '1.1', mavenProfile: 'opensearch-1.0',
 							condition: TestCondition.AFTER_MERGE),
-
 					// Also test static credentials, but only for the latest version
 					new OpenSearchEsAwsBuildEnvironment(version: '1.1', mavenProfile: 'opensearch-1.0',
 							staticCredentials: true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -265,6 +265,8 @@ stage('Configure') {
 					new OpenSearchEsLocalBuildEnvironment(version: '1.2', mavenProfile: 'opensearch-1.0',
 							condition: TestCondition.ON_DEMAND),
 					new OpenSearchEsLocalBuildEnvironment(version: '1.3', mavenProfile: 'opensearch-1.0',
+							condition: TestCondition.AFTER_MERGE),
+					new OpenSearchEsLocalBuildEnvironment(version: '2.0', mavenProfile: 'opensearch-2.0',
 							condition: TestCondition.AFTER_MERGE)
 			],
 			esAws: [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -306,9 +306,11 @@ stage('Configure') {
 					// --------------------------------------------
 					// AWS OpenSearch service
 					new OpenSearchEsAwsBuildEnvironment(version: '1.1', mavenProfile: 'opensearch-1.0',
+							condition: TestCondition.ON_DEMAND),
+					new OpenSearchEsAwsBuildEnvironment(version: '1.2', mavenProfile: 'opensearch-1.0',
 							condition: TestCondition.AFTER_MERGE),
 					// Also test static credentials, but only for the latest version
-					new OpenSearchEsAwsBuildEnvironment(version: '1.1', mavenProfile: 'opensearch-1.0',
+					new OpenSearchEsAwsBuildEnvironment(version: '1.2', mavenProfile: 'opensearch-1.0',
 							staticCredentials: true,
 							condition: TestCondition.AFTER_MERGE)
 			]

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
@@ -177,17 +177,29 @@ public class ElasticsearchDialectFactory {
 
 	private ElasticsearchProtocolDialect createProtocolDialectOpenSearch(ElasticsearchVersion version) {
 		int major = version.major();
-
+		OptionalInt minorOptional = version.minor();
+		if ( !minorOptional.isPresent() ) {
+			// The version is supposed to be fetched from the cluster itself, so it should be complete
+			throw new AssertionFailure( "The Elasticsearch version is incomplete when creating the protocol dialect." );
+		}
+		int minor = minorOptional.getAsInt();
 		if ( major < 1 ) {
 			throw log.unsupportedElasticsearchVersion( version );
 		}
 		else if ( major == 1 ) {
-			return new Elasticsearch70ProtocolDialect();
+			return createProtocolDialectOpenSearchV1( version, minor );
 		}
 		else {
 			log.unknownElasticsearchVersion( version );
 			return new Elasticsearch70ProtocolDialect();
 		}
+	}
+
+	private ElasticsearchProtocolDialect createProtocolDialectOpenSearchV1(ElasticsearchVersion version, int minor) {
+		if ( minor > 3 ) {
+			log.unknownElasticsearchVersion( version );
+		}
+		return new Elasticsearch70ProtocolDialect();
 	}
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
@@ -189,6 +189,9 @@ public class ElasticsearchDialectFactory {
 		else if ( major == 1 ) {
 			return createProtocolDialectOpenSearchV1( version, minor );
 		}
+		else if ( major == 2 ) {
+			return createProtocolDialectOpenSearchV2( version, minor );
+		}
 		else {
 			log.unknownElasticsearchVersion( version );
 			return new Elasticsearch70ProtocolDialect();
@@ -197,6 +200,13 @@ public class ElasticsearchDialectFactory {
 
 	private ElasticsearchProtocolDialect createProtocolDialectOpenSearchV1(ElasticsearchVersion version, int minor) {
 		if ( minor > 3 ) {
+			log.unknownElasticsearchVersion( version );
+		}
+		return new Elasticsearch70ProtocolDialect();
+	}
+
+	private ElasticsearchProtocolDialect createProtocolDialectOpenSearchV2(ElasticsearchVersion version, int minor) {
+		if ( minor > 0 ) {
 			log.unknownElasticsearchVersion( version );
 		}
 		return new Elasticsearch70ProtocolDialect();

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -768,28 +768,55 @@ public class ElasticsearchDialectFactoryTest {
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4212")
+	@TestForIssue(jiraKey = "HSEARCH-4562")
 	public void openSearch_2() {
-		testSuccessWithWarning(
+		testSuccess(
 				ElasticsearchDistributionName.OPENSEARCH, "2", "2.0.0",
 				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
 		);
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4212")
+	@TestForIssue(jiraKey = "HSEARCH-4562")
 	public void openSearch_2_0() {
-		testSuccessWithWarning(
+		testSuccess(
 				ElasticsearchDistributionName.OPENSEARCH, "2.0", "2.0.0",
 				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
 		);
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4212")
+	@TestForIssue(jiraKey = "HSEARCH-4562")
 	public void openSearch_2_0_0() {
-		testSuccessWithWarning(
+		testSuccess(
 				ElasticsearchDistributionName.OPENSEARCH, "2.0.0", "2.0.0",
+				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4562")
+	public void openSearch_3() {
+		testSuccessWithWarning(
+				ElasticsearchDistributionName.OPENSEARCH, "3", "3.0.0",
+				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4562")
+	public void openSearch_3_0() {
+		testSuccessWithWarning(
+				ElasticsearchDistributionName.OPENSEARCH, "3.0", "3.0.0",
+				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4562")
+	public void openSearch_3_0_0() {
+		testSuccessWithWarning(
+				ElasticsearchDistributionName.OPENSEARCH, "3.0.0", "3.0.0",
 				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
 		);
 	}

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -723,6 +723,51 @@ public class ElasticsearchDialectFactoryTest {
 	}
 
 	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4561")
+	public void openSearch_1_3() {
+		testSuccess(
+				ElasticsearchDistributionName.OPENSEARCH, "1.3", "1.3.1",
+				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4561")
+	public void openSearch_1_3_0() {
+		testSuccess(
+				ElasticsearchDistributionName.OPENSEARCH, "1.3.0", "1.3.0",
+				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4561")
+	public void openSearch_1_3_1() {
+		testSuccess(
+				ElasticsearchDistributionName.OPENSEARCH, "1.3.1", "1.3.1",
+				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4561")
+	public void openSearch_1_4() {
+		testSuccessWithWarning(
+				ElasticsearchDistributionName.OPENSEARCH, "1.4", "1.4.0",
+				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4561")
+	public void openSearch_1_4_0() {
+		testSuccessWithWarning(
+				ElasticsearchDistributionName.OPENSEARCH, "1.4.0", "1.4.0",
+				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+		);
+	}
+
+	@Test
 	@TestForIssue(jiraKey = "HSEARCH-4212")
 	public void openSearch_2() {
 		testSuccessWithWarning(

--- a/integrationtest/backend/elasticsearch/pom.xml
+++ b/integrationtest/backend/elasticsearch/pom.xml
@@ -283,9 +283,19 @@
             </properties>
         </profile>
 
-        <!-- OpenSearch 1.0+ test environment -->
+        <!-- OpenSearch 1.0 to 1.3 test environment -->
         <profile>
             <id>opensearch-1.0</id>
+            <properties>
+                <failsafe.excludedGroups.elasticsearch.version>
+                    <!-- Nothing here -->
+                </failsafe.excludedGroups.elasticsearch.version>
+            </properties>
+        </profile>
+
+        <!-- OpenSearch 2.0+ test environment -->
+        <profile>
+            <id>opensearch-2.0</id>
             <properties>
                 <failsafe.excludedGroups.elasticsearch.version>
                     <!-- Nothing here -->

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -613,18 +613,7 @@
             <properties>
                 <test.elasticsearch.run.opensearch.skip>${test.elasticsearch.run.skip}</test.elasticsearch.run.opensearch.skip>
                 <test.elasticsearch.connection.distribution>opensearch</test.elasticsearch.connection.distribution>
-                <test.elasticsearch.connection.version>${version.org.opensearch.latest-1.0}</test.elasticsearch.connection.version>
-                <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch710TestDialect</test.elasticsearch.testdialect>
-            </properties>
-        </profile>
-
-        <!-- OpenSearch 1.2+ test environment -->
-        <profile>
-            <id>opensearch-1.2</id>
-            <properties>
-                <test.elasticsearch.run.opensearch.skip>${test.elasticsearch.run.skip}</test.elasticsearch.run.opensearch.skip>
-                <test.elasticsearch.connection.distribution>opensearch</test.elasticsearch.connection.distribution>
-                <test.elasticsearch.connection.version>${version.org.opensearch.latest-1.2}</test.elasticsearch.connection.version>
+                <test.elasticsearch.connection.version>${version.org.opensearch.latest-1.3}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch710TestDialect</test.elasticsearch.testdialect>
             </properties>
         </profile>

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -607,13 +607,24 @@
             </properties>
         </profile>
 
-        <!-- OpenSearch 1.0+ test environment -->
+        <!-- OpenSearch 1.0 to 1.3 test environment -->
         <profile>
             <id>opensearch-1.0</id>
             <properties>
                 <test.elasticsearch.run.opensearch.skip>${test.elasticsearch.run.skip}</test.elasticsearch.run.opensearch.skip>
                 <test.elasticsearch.connection.distribution>opensearch</test.elasticsearch.connection.distribution>
                 <test.elasticsearch.connection.version>${version.org.opensearch.latest-1.3}</test.elasticsearch.connection.version>
+                <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch710TestDialect</test.elasticsearch.testdialect>
+            </properties>
+        </profile>
+
+        <!-- OpenSearch 2.0+ test environment -->
+        <profile>
+            <id>opensearch-2.0</id>
+            <properties>
+                <test.elasticsearch.run.opensearch.skip>${test.elasticsearch.run.skip}</test.elasticsearch.run.opensearch.skip>
+                <test.elasticsearch.connection.distribution>opensearch</test.elasticsearch.connection.distribution>
+                <test.elasticsearch.connection.version>${version.org.opensearch.latest-2.0}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch710TestDialect</test.elasticsearch.testdialect>
             </properties>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,7 @@
         <version.org.elasticsearch.latest-6.2>6.2.4</version.org.elasticsearch.latest-6.2>
         <version.org.elasticsearch.latest-5.6>5.6.16</version.org.elasticsearch.latest-5.6>
         <!-- The latest micro of other Elasticsearch distributions -->
+        <version.org.opensearch.latest-2.0>2.0.0-rc1</version.org.opensearch.latest-2.0>
         <version.org.opensearch.latest-1.3>1.3.1</version.org.opensearch.latest-1.3>
         <version.org.opensearch.latest-1.2>1.2.1</version.org.opensearch.latest-1.2>
         <version.org.opensearch.latest-1.0>1.0.0</version.org.opensearch.latest-1.0>

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,7 @@
         <version.org.elasticsearch.latest-6.2>6.2.4</version.org.elasticsearch.latest-6.2>
         <version.org.elasticsearch.latest-5.6>5.6.16</version.org.elasticsearch.latest-5.6>
         <!-- The latest micro of other Elasticsearch distributions -->
+        <version.org.opensearch.latest-1.3>1.3.1</version.org.opensearch.latest-1.3>
         <version.org.opensearch.latest-1.2>1.2.1</version.org.opensearch.latest-1.2>
         <version.org.opensearch.latest-1.0>1.0.0</version.org.opensearch.latest-1.0>
         <version.com.google.code.gson>2.9.0</version.com.google.code.gson>


### PR DESCRIPTION
* [HSEARCH-4564](https://hibernate.atlassian.net/browse/HSEARCH-4564): Run tests against AWS OpenSearch Service 1.2 instead of 1.1
* [HSEARCH-4562](https://hibernate.atlassian.net/browse/HSEARCH-4562): Add compatibility with OpenSearch 2.0
* [HSEARCH-4561](https://hibernate.atlassian.net/browse/HSEARCH-4561): Add compatibility with OpenSearch 1.3

