### PR TITLE
HSEARCH-4533 Introduce customizing properties for outbox polling

### DIFF
--- a/documentation/src/main/asciidoc/reference/coordination.asciidoc
+++ b/documentation/src/main/asciidoc/reference/coordination.asciidoc
@@ -253,7 +253,7 @@ but it will remain asynchronous.
 
 [[coordination-outbox-polling-schema]]
 === [[coordination-database-polling-schema]] Impact on the database schema
-
+==== Basics
 The `outbox-polling` coordination strategy needs to store data in additional tables in the application database,
 so that this data can be consumed by background threads.
 
@@ -276,6 +276,68 @@ See link:{hibernateDocUrl}#configurations-hbmddl[automatic schema generation],
 in particular the Hibernate ORM properties `javax.persistence.schema-generation.scripts.action`,
 `javax.persistence.schema-generation.scripts.create-target`
 and `javax.persistence.schema-generation.scripts.drop-target`.
+
+==== Custom schema/table name/etc.
+By default, outbox and agent tables, mentioned in the previous section, are expected to be found
+in the default catalog/schema, and are using uppercased table names prefixed with `HSEARCH_`.
+Identity generator names used for these tables are prefixed with `HSEARCH_` and suffixed with `_GENERATOR`.
+Sometimes there are specific naming conventions for database objects, or a need to separate the domain
+and technical tables.
+
+To allow some flexibility in this area, Hibernate Search provides a set of configuration properties
+to specify catalog/schema/table/identity generator names for outbox event and agent tables:
+
+[source]
+----
+# Configure the agent mapping:
+hibernate.search.coordination.entity.mapping.agent.catalog=CUSTOM_CATALOG
+hibernate.search.coordination.entity.mapping.agent.schema=CUSTOM_SCHEMA
+hibernate.search.coordination.entity.mapping.agent.generator=CUSTOM_AGENT_GENERATOR
+hibernate.search.coordination.entity.mapping.agent.table=CUSTOM_AGENT_TABLE
+# Configure the outbox event mapping:
+hibernate.search.coordination.entity.mapping.outboxevent.catalog=CUSTOM_CATALOG
+hibernate.search.coordination.entity.mapping.outboxevent.schema=CUSTOM_SCHEMA
+hibernate.search.coordination.entity.mapping.outboxevent.generator=CUSTOM_OUTBOX_GENERATOR
+hibernate.search.coordination.entity.mapping.outboxevent.table=CUSTOM_OUTBOX_TABLE
+----
+
+* `agent.catalog` defines the database catalog to use for the agent table.
++
+Defaults to the default catalog configured in Hibernate ORM.
+* `agent.schema` defines the database schema to use for the agent table.
++
+Defaults to the default schema configured in Hibernate ORM.
+* `agent.generator` defines the identifier generator used for the agent table .
++
+Defaults to `HSEARCH_AGENT_GENERATOR`.
+* `agent.table` defines the database table name for the agent table.
++
+Defaults to `HSEARCH_AGENT`.
+
+* `outboxevent.catalog` defines the database catalog to use for the outbox event table.
++
+Defaults to the default catalog configured in Hibernate ORM.
+* `outboxevent.schema` defines the database schema to use for the outbox event table.
++
+Defaults to the default schema configured in Hibernate ORM.
+* `outboxevent.generator` defines the identifier generator used for the outbox event table.
++
+Defaults to `HSEARCH_OUTBOX_EVENT_GENERATOR`.
+* `outboxevent.table` defines the database table name for the outbox events table.
++
+Defaults to `HSEARCH_OUTBOX_EVENT`.
+
+[TIP]
+====
+If your application relies on autogeneration, make sure that the underlying database supports catalogs/schemas
+when specifying them. Also check if there are any constraints on name length and case sensitivity.
+====
+
+[TIP]
+====
+It is not required to provide all properties at the same time. For example, you can customize the schema only.
+Unspecified properties will use their defaults.
+====
 
 [[coordination-outbox-polling-sharding]]
 === [[coordination-database-polling-sharding]] [[coordination-outbox-polling-sharding-basics]] Sharding and pulse

--- a/documentation/src/main/asciidoc/reference/coordination.asciidoc
+++ b/documentation/src/main/asciidoc/reference/coordination.asciidoc
@@ -281,9 +281,9 @@ and `javax.persistence.schema-generation.scripts.drop-target`.
 By default, outbox and agent tables, mentioned in the previous section, are expected to be found
 in the default catalog/schema, and are using uppercased table names prefixed with `HSEARCH_`.
 Identity generator names used for these tables are prefixed with `HSEARCH_` and suffixed with `_GENERATOR`.
+
 Sometimes there are specific naming conventions for database objects, or a need to separate the domain
 and technical tables.
-
 To allow some flexibility in this area, Hibernate Search provides a set of configuration properties
 to specify catalog/schema/table/identity generator names for outbox event and agent tables:
 
@@ -307,12 +307,12 @@ Defaults to the default catalog configured in Hibernate ORM.
 * `agent.schema` defines the database schema to use for the agent table.
 +
 Defaults to the default schema configured in Hibernate ORM.
-* `agent.generator` defines the identifier generator used for the agent table .
-+
-Defaults to `HSEARCH_AGENT_GENERATOR`.
-* `agent.table` defines the database table name for the agent table.
+* `agent.table` defines the name of the agent table.
 +
 Defaults to `HSEARCH_AGENT`.
+* `agent.generator` defines the name of the identifier generator used for the agent table .
++
+Defaults to `HSEARCH_AGENT_GENERATOR`.
 
 * `outboxevent.catalog` defines the database catalog to use for the outbox event table.
 +
@@ -320,16 +320,17 @@ Defaults to the default catalog configured in Hibernate ORM.
 * `outboxevent.schema` defines the database schema to use for the outbox event table.
 +
 Defaults to the default schema configured in Hibernate ORM.
-* `outboxevent.generator` defines the identifier generator used for the outbox event table.
-+
-Defaults to `HSEARCH_OUTBOX_EVENT_GENERATOR`.
-* `outboxevent.table` defines the database table name for the outbox events table.
+* `outboxevent.table` defines the name of the outbox events table.
 +
 Defaults to `HSEARCH_OUTBOX_EVENT`.
+* `outboxevent.generator` defines the name of the identifier generator used for the outbox event table.
++
+Defaults to `HSEARCH_OUTBOX_EVENT_GENERATOR`.
 
 [TIP]
 ====
-If your application relies on autogeneration, make sure that the underlying database supports catalogs/schemas
+If your application relies on link:{hibernateDocUrl}#configurations-hbmddl[automatic database schema generation],
+make sure that the underlying database supports catalogs/schemas
 when specifying them. Also check if there are any constraints on name length and case sensitivity.
 ====
 

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingCustomEntityMappingIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingCustomEntityMappingIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.integrationtest.mapper.orm.coordination.outboxpolli
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 import static org.junit.Assume.assumeTrue;
 
 import java.util.ArrayList;
@@ -35,7 +36,6 @@ import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.CoordinationStrategyExpectations;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -89,8 +89,7 @@ public class OutboxPollingCustomEntityMappingIT {
 	public void wrongOutboxEventMapping() {
 		assertThatThrownBy( () -> ormSetupHelper.start()
 				.withProperty( "hibernate.search.coordination.outboxevent.entity.mapping", "<ciao></ciao>" )
-				.setup( IndexedEntity.class )
-		)
+				.setup( IndexedEntity.class ) )
 				.isInstanceOf( MappingException.class )
 				.hasMessageContainingAll( "Unable to perform unmarshalling", "unexpected element" );
 	}
@@ -99,8 +98,7 @@ public class OutboxPollingCustomEntityMappingIT {
 	public void wrongAgentMapping() {
 		assertThatThrownBy( () -> ormSetupHelper.start()
 				.withProperty( "hibernate.search.coordination.agent.entity.mapping", "<ciao></ciao>" )
-				.setup( IndexedEntity.class )
-		)
+				.setup( IndexedEntity.class ) )
 				.isInstanceOf( MappingException.class )
 				.hasMessageContainingAll( "Unable to perform unmarshalling", "unexpected element" );
 	}
@@ -116,15 +114,15 @@ public class OutboxPollingCustomEntityMappingIT {
 				.setup( IndexedEntity.class );
 		backendMock.verifyExpectationsMet();
 
-		backendMock.expectWorks( IndexedEntity.INDEX )
-				.add( "1", f -> f.field( "indexedField", "value for the field" ) );
-
 		int id = 1;
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity = new IndexedEntity();
 			entity.setId( id );
 			entity.setIndexedField( "value for the field" );
 			session.persist( entity );
+
+			backendMock.expectWorks( IndexedEntity.INDEX )
+					.add( "1", f -> f.field( "indexedField", "value for the field" ) );
 		} );
 
 		backendMock.verifyExpectationsMet();
@@ -156,15 +154,15 @@ public class OutboxPollingCustomEntityMappingIT {
 				.setup( IndexedEntity.class );
 		backendMock.verifyExpectationsMet();
 
-		backendMock.expectWorks( IndexedEntity.INDEX )
-				.add( "1", f -> f.field( "indexedField", "value for the field" ) );
-
 		int id = 1;
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity = new IndexedEntity();
 			entity.setId( id );
 			entity.setIndexedField( "value for the field" );
 			session.persist( entity );
+
+			backendMock.expectWorks( IndexedEntity.INDEX )
+					.add( "1", f -> f.field( "indexedField", "value for the field" ) );
 		} );
 
 		backendMock.verifyExpectationsMet();
@@ -190,8 +188,7 @@ public class OutboxPollingCustomEntityMappingIT {
 		assertThatThrownBy( () -> ormSetupHelper.start()
 				.withProperty( "hibernate.search.coordination.agent.entity.mapping", VALID_AGENT_EVENT_MAPPING )
 				.withProperty( "hibernate.search.coordination.entity.mapping.agent.table", "break_it_all" )
-				.setup( IndexedEntity.class )
-		)
+				.setup( IndexedEntity.class ) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContaining( "Outbox polling agent configuration property conflict." );
 	}
@@ -201,8 +198,7 @@ public class OutboxPollingCustomEntityMappingIT {
 		assertThatThrownBy( () -> ormSetupHelper.start()
 				.withProperty( "hibernate.search.coordination.outboxevent.entity.mapping", VALID_OUTBOX_EVENT_MAPPING )
 				.withProperty( "hibernate.search.coordination.entity.mapping.outboxevent.table", "break_it_all" )
-				.setup( IndexedEntity.class )
-		)
+				.setup( IndexedEntity.class ) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContaining( "Outbox event configuration property conflict." );
 	}
@@ -221,17 +217,16 @@ public class OutboxPollingCustomEntityMappingIT {
 				.setup( IndexedEntity.class );
 		backendMock.verifyExpectationsMet();
 
-		backendMock.expectWorks( IndexedEntity.INDEX )
-				.add( "1", f -> f.field( "indexedField", "value for the field" ) );
-
 		int id = 1;
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity = new IndexedEntity();
 			entity.setId( id );
 			entity.setIndexedField( "value for the field" );
 			session.persist( entity );
-		} );
 
+			backendMock.expectWorks( IndexedEntity.INDEX )
+					.add( "1", f -> f.field( "indexedField", "value for the field" ) );
+		} );
 		backendMock.verifyExpectationsMet();
 
 		assertThat( statementInspector.countByKey( ORIGINAL_OUTBOX_EVENT_TABLE_NAME ) ).isZero();
@@ -273,17 +268,16 @@ public class OutboxPollingCustomEntityMappingIT {
 		assumeTrue( "This test only makes sense if the dialect supports creating schemas",
 				getDialect().canCreateSchema() );
 
-		backendMock.expectWorks( IndexedEntity.INDEX )
-				.add( "1", f -> f.field( "indexedField", "value for the field" ) );
-
 		int id = 1;
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity = new IndexedEntity();
 			entity.setId( id );
 			entity.setIndexedField( "value for the field" );
 			session.persist( entity );
-		} );
 
+			backendMock.expectWorks( IndexedEntity.INDEX )
+					.add( "1", f -> f.field( "indexedField", "value for the field" ) );
+		} );
 		backendMock.verifyExpectationsMet();
 
 		assertThat( statementInspector.countByKey( ORIGINAL_OUTBOX_EVENT_TABLE_NAME ) ).isZero();

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingCustomEntityMappingIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingCustomEntityMappingIT.java
@@ -41,12 +41,12 @@ import org.junit.Test;
 public class OutboxPollingCustomEntityMappingIT {
 
 	private static final String CUSTOM_SCHEMA = "CUSTOM_SCHEMA";
-	private static final String ORIGINAL_OUTBOX_EVENT_TABLE_NAME = HibernateOrmMapperOutboxPollingSettings.Defaults.ENTITY_MAPPING_OUTBOX_EVENT_TABLE;
+	private static final String ORIGINAL_OUTBOX_EVENT_TABLE_NAME = HibernateOrmMapperOutboxPollingSettings.Defaults.COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_TABLE;
 	private static final String CUSTOM_OUTBOX_EVENT_TABLE_NAME = "CUSTOM_OUTBOX_EVENT";
 	private static final String ORIGINAL_OUTBOX_EVENT_GENERATOR_NAME = ORIGINAL_OUTBOX_EVENT_TABLE_NAME + "_GENERATOR";
 	private static final String CUSTOM_OUTBOX_EVENT_GENERATOR_NAME = CUSTOM_OUTBOX_EVENT_TABLE_NAME + "_GENERATOR";
 
-	private static final String ORIGINAL_AGENT_TABLE_NAME = HibernateOrmMapperOutboxPollingSettings.Defaults.ENTITY_MAPPING_AGENT_TABLE;
+	private static final String ORIGINAL_AGENT_TABLE_NAME = HibernateOrmMapperOutboxPollingSettings.Defaults.COORDINATION_ENTITY_MAPPING_AGENT_TABLE;
 	private static final String CUSTOM_AGENT_TABLE_NAME = "CUSTOM_AGENT";
 	private static final String ORIGINAL_AGENT_GENERATOR_NAME = ORIGINAL_AGENT_TABLE_NAME + "_GENERATOR";
 	private static final String CUSTOM_AGENT_GENERATOR_NAME = CUSTOM_AGENT_TABLE_NAME + "_GENERATOR";

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingCustomEntityMappingIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingCustomEntityMappingIT.java
@@ -358,7 +358,7 @@ public class OutboxPollingCustomEntityMappingIT {
 		@Override
 		public String inspect(String sql) {
 			for ( String key : SQL_KEYS ) {
-				if ( Arrays.stream( sql.split( "[. ]" ) ).anyMatch( token -> key.equals( token ) ) ) {
+				if ( Arrays.stream( sql.split( "[^A-Za-z0-9_-]" ) ).anyMatch( token -> key.equals( token ) ) ) {
 					sqlByKey.get( key ).add( sql );
 				}
 			}

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/HibernateOrmMapperOutboxPollingSettings.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/HibernateOrmMapperOutboxPollingSettings.java
@@ -357,7 +357,8 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	 * <p>
 	 * Defaults to the default catalog configured in Hibernate ORM. See {@link org.hibernate.cfg.AvailableSettings#DEFAULT_CATALOG}.
 	 */
-	public static final String ENTITY_MAPPING_OUTBOXEVENT_CATALOG = PREFIX + Radicals.ENTITY_MAPPING_OUTBOXEVENT_CATALOG;
+	public static final String COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_CATALOG =
+			PREFIX + Radicals.COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_CATALOG;
 
 	/**
 	 * The database schema to use for the outbox event table.
@@ -367,7 +368,8 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	 * <p>
 	 * Defaults to the default schema configured in Hibernate ORM. See {@link org.hibernate.cfg.AvailableSettings#DEFAULT_SCHEMA}.
 	 */
-	public static final String ENTITY_MAPPING_OUTBOXEVENT_SCHEMA = PREFIX + Radicals.ENTITY_MAPPING_OUTBOXEVENT_SCHEMA;
+	public static final String COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_SCHEMA =
+			PREFIX + Radicals.COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_SCHEMA;
 
 	/**
 	 * The name of the outbox event table.
@@ -375,9 +377,10 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value HibernateOrmMapperOutboxPollingSettings#COORDINATION_STRATEGY_NAME}.
 	 * <p>
-	 * The default for this value is {@value Defaults#ENTITY_MAPPING_OUTBOX_EVENT_TABLE}.
+	 * The default for this value is {@value Defaults#COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_TABLE}.
 	 */
-	public static final String ENTITY_MAPPING_OUTBOXEVENT_TABLE = PREFIX + Radicals.ENTITY_MAPPING_OUTBOXEVENT_TABLE;
+	public static final String COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_TABLE =
+			PREFIX + Radicals.COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_TABLE;
 
 	/**
 	 * The name of the identifier generator used for the outbox event table.
@@ -385,10 +388,11 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value HibernateOrmMapperOutboxPollingSettings#COORDINATION_STRATEGY_NAME}.
 	 * <p>
-	 * The default for this value is {@value Defaults#ENTITY_MAPPING_OUTBOX_EVENT_GENERATOR}.
+	 * The default for this value is {@value Defaults#COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_GENERATOR}.
 	 */
 
-	public static final String ENTITY_MAPPING_OUTBOXEVENT_GENERATOR = PREFIX + Radicals.ENTITY_MAPPING_OUTBOXEVENT_GENERATOR;
+	public static final String COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_GENERATOR =
+			PREFIX + Radicals.COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_GENERATOR;
 	/**
 	 * The database catalog to use for the agent table.
 	 * <p>
@@ -397,7 +401,8 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	 * <p>
 	 * Defaults to the default catalog configured in Hibernate ORM. See {@link org.hibernate.cfg.AvailableSettings#DEFAULT_CATALOG}.
 	 */
-	public static final String ENTITY_MAPPING_AGENT_CATALOG = PREFIX + Radicals.ENTITY_MAPPING_AGENT_CATALOG;
+	public static final String COORDINATION_ENTITY_MAPPING_AGENT_CATALOG =
+			PREFIX + Radicals.COORDINATION_ENTITY_MAPPING_AGENT_CATALOG;
 
 	/**
 	 * The database schema to use for the agent table.
@@ -407,7 +412,8 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	 * <p>
 	 * Defaults to the default schema configured in Hibernate ORM. See {@link org.hibernate.cfg.AvailableSettings#DEFAULT_SCHEMA}.
 	 */
-	public static final String ENTITY_MAPPING_AGENT_SCHEMA = PREFIX + Radicals.ENTITY_MAPPING_AGENT_SCHEMA;
+	public static final String COORDINATION_ENTITY_MAPPING_AGENT_SCHEMA =
+			PREFIX + Radicals.COORDINATION_ENTITY_MAPPING_AGENT_SCHEMA;
 
 	/**
 	 * The name of the agent table.
@@ -415,9 +421,10 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value HibernateOrmMapperOutboxPollingSettings#COORDINATION_STRATEGY_NAME}.
 	 * <p>
-	 * The default for this value is {@value Defaults#ENTITY_MAPPING_AGENT_TABLE}.
+	 * The default for this value is {@value Defaults#COORDINATION_ENTITY_MAPPING_AGENT_TABLE}.
 	 */
-	public static final String ENTITY_MAPPING_AGENT_TABLE = PREFIX + Radicals.ENTITY_MAPPING_AGENT_TABLE;
+	public static final String COORDINATION_ENTITY_MAPPING_AGENT_TABLE =
+			PREFIX + Radicals.COORDINATION_ENTITY_MAPPING_AGENT_TABLE;
 
 	/**
 	 * The name of the identifier generator used for the agent table.
@@ -425,10 +432,10 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value HibernateOrmMapperOutboxPollingSettings#COORDINATION_STRATEGY_NAME}.
 	 * <p>
-	 * The default for this value is {@value Defaults#ENTITY_MAPPING_AGENT_GENERATOR}.
+	 * The default for this value is {@value Defaults#COORDINATION_ENTITY_MAPPING_AGENT_GENERATOR}.
 	 */
-	public static final String ENTITY_MAPPING_AGENT_GENERATOR = PREFIX + Radicals.ENTITY_MAPPING_AGENT_GENERATOR;
-
+	public static final String COORDINATION_ENTITY_MAPPING_AGENT_GENERATOR =
+			PREFIX + Radicals.COORDINATION_ENTITY_MAPPING_AGENT_GENERATOR;
 
 	/**
 	 * Configuration property keys without the {@link #PREFIX prefix}.
@@ -452,15 +459,14 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 		public static final String COORDINATION_MASS_INDEXER_POLLING_INTERVAL = COORDINATION_PREFIX + CoordinationRadicals.MASS_INDEXER_POLLING_INTERVAL;
 		public static final String COORDINATION_MASS_INDEXER_PULSE_INTERVAL = COORDINATION_PREFIX + CoordinationRadicals.MASS_INDEXER_PULSE_INTERVAL;
 		public static final String COORDINATION_MASS_INDEXER_PULSE_EXPIRATION = COORDINATION_PREFIX + CoordinationRadicals.MASS_INDEXER_PULSE_EXPIRATION;
-
-		public static final String ENTITY_MAPPING_OUTBOXEVENT_CATALOG = COORDINATION_PREFIX + OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_OUTBOXEVENT_CATALOG;
-		public static final String ENTITY_MAPPING_OUTBOXEVENT_SCHEMA = COORDINATION_PREFIX + OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_OUTBOXEVENT_SCHEMA;
-		public static final String ENTITY_MAPPING_OUTBOXEVENT_TABLE = COORDINATION_PREFIX + OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_OUTBOXEVENT_TABLE;
-		public static final String ENTITY_MAPPING_OUTBOXEVENT_GENERATOR = COORDINATION_PREFIX + OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_OUTBOXEVENT_GENERATOR;
-		public static final String ENTITY_MAPPING_AGENT_CATALOG = COORDINATION_PREFIX + OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_AGENT_CATALOG;
-		public static final String ENTITY_MAPPING_AGENT_SCHEMA = COORDINATION_PREFIX + OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_AGENT_SCHEMA;
-		public static final String ENTITY_MAPPING_AGENT_TABLE = COORDINATION_PREFIX + OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_AGENT_TABLE;
-		public static final String ENTITY_MAPPING_AGENT_GENERATOR = COORDINATION_PREFIX + OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_AGENT_GENERATOR;
+		public static final String COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_CATALOG = COORDINATION_PREFIX + CoordinationRadicals.ENTITY_MAPPING_OUTBOXEVENT_CATALOG;
+		public static final String COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_SCHEMA = COORDINATION_PREFIX + CoordinationRadicals.ENTITY_MAPPING_OUTBOXEVENT_SCHEMA;
+		public static final String COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_TABLE = COORDINATION_PREFIX + CoordinationRadicals.ENTITY_MAPPING_OUTBOXEVENT_TABLE;
+		public static final String COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_GENERATOR = COORDINATION_PREFIX + CoordinationRadicals.ENTITY_MAPPING_OUTBOXEVENT_GENERATOR;
+		public static final String COORDINATION_ENTITY_MAPPING_AGENT_CATALOG = COORDINATION_PREFIX + CoordinationRadicals.ENTITY_MAPPING_AGENT_CATALOG;
+		public static final String COORDINATION_ENTITY_MAPPING_AGENT_SCHEMA = COORDINATION_PREFIX + CoordinationRadicals.ENTITY_MAPPING_AGENT_SCHEMA;
+		public static final String COORDINATION_ENTITY_MAPPING_AGENT_TABLE = COORDINATION_PREFIX + CoordinationRadicals.ENTITY_MAPPING_AGENT_TABLE;
+		public static final String COORDINATION_ENTITY_MAPPING_AGENT_GENERATOR = COORDINATION_PREFIX + CoordinationRadicals.ENTITY_MAPPING_AGENT_GENERATOR;
 	}
 
 	/**
@@ -486,24 +492,18 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 		public static final String MASS_INDEXER_POLLING_INTERVAL = MASS_INDEXER_PREFIX + "polling_interval";
 		public static final String MASS_INDEXER_PULSE_INTERVAL = MASS_INDEXER_PREFIX + "pulse_interval";
 		public static final String MASS_INDEXER_PULSE_EXPIRATION = MASS_INDEXER_PREFIX + "pulse_expiration";
-	}
 
-	public static final class OutboxPollingEntityMappingRadicals {
-		private OutboxPollingEntityMappingRadicals() {
-		}
-
-		private static final String EVENT_MAPPING = "entity.mapping.";
-		private static final String ENTITY_MAPPING_OUTBOXEVENT = EVENT_MAPPING + "outboxevent.";
-		public static final String ENTITY_MAPPING_OUTBOXEVENT_CATALOG = ENTITY_MAPPING_OUTBOXEVENT + "catalog";
-		public static final String ENTITY_MAPPING_OUTBOXEVENT_SCHEMA = ENTITY_MAPPING_OUTBOXEVENT + "schema";
-		public static final String ENTITY_MAPPING_OUTBOXEVENT_TABLE = ENTITY_MAPPING_OUTBOXEVENT + "table";
-		public static final String ENTITY_MAPPING_OUTBOXEVENT_GENERATOR = ENTITY_MAPPING_OUTBOXEVENT + "generator";
-
-		private static final String ENTITY_MAPPING_AGENT = EVENT_MAPPING + "agent.";
-		public static final String ENTITY_MAPPING_AGENT_CATALOG = ENTITY_MAPPING_AGENT + "catalog";
-		public static final String ENTITY_MAPPING_AGENT_SCHEMA = ENTITY_MAPPING_AGENT + "schema";
-		public static final String ENTITY_MAPPING_AGENT_TABLE = ENTITY_MAPPING_AGENT + "table";
-		public static final String ENTITY_MAPPING_AGENT_GENERATOR = ENTITY_MAPPING_AGENT + "generator";
+		public static final String ENTITY_MAPPING_PREFIX = "entity.mapping.";
+		public static final String ENTITY_MAPPING_AGENT_PREFIX = ENTITY_MAPPING_PREFIX + "agent.";
+		public static final String ENTITY_MAPPING_AGENT_GENERATOR = ENTITY_MAPPING_AGENT_PREFIX + "generator";
+		public static final String ENTITY_MAPPING_AGENT_TABLE = ENTITY_MAPPING_AGENT_PREFIX + "table";
+		public static final String ENTITY_MAPPING_AGENT_SCHEMA = ENTITY_MAPPING_AGENT_PREFIX + "schema";
+		public static final String ENTITY_MAPPING_AGENT_CATALOG = ENTITY_MAPPING_AGENT_PREFIX + "catalog";
+		public static final String ENTITY_MAPPING_OUTBOXEVENT_PREFIX = ENTITY_MAPPING_PREFIX + "outboxevent.";
+		public static final String ENTITY_MAPPING_OUTBOXEVENT_GENERATOR = ENTITY_MAPPING_OUTBOXEVENT_PREFIX + "generator";
+		public static final String ENTITY_MAPPING_OUTBOXEVENT_TABLE = ENTITY_MAPPING_OUTBOXEVENT_PREFIX + "table";
+		public static final String ENTITY_MAPPING_OUTBOXEVENT_SCHEMA = ENTITY_MAPPING_OUTBOXEVENT_PREFIX + "schema";
+		public static final String ENTITY_MAPPING_OUTBOXEVENT_CATALOG = ENTITY_MAPPING_OUTBOXEVENT_PREFIX + "catalog";
 	}
 
 	/**
@@ -529,12 +529,12 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 		public static final String HSEARCH_PREFIX = "HSEARCH_";
 
 		// Must not be longer than 20 characters, so that the generator does not exceed the 30 characters for Oracle11g
-		public static final String ENTITY_MAPPING_AGENT_TABLE = HSEARCH_PREFIX + "AGENT";
-		public static final String ENTITY_MAPPING_AGENT_GENERATOR = ENTITY_MAPPING_AGENT_TABLE + "_GENERATOR";
+		public static final String COORDINATION_ENTITY_MAPPING_AGENT_TABLE = HSEARCH_PREFIX + "AGENT";
+		public static final String COORDINATION_ENTITY_MAPPING_AGENT_GENERATOR = COORDINATION_ENTITY_MAPPING_AGENT_TABLE + "_GENERATOR";
 
 		// Must not be longer than 20 characters, so that the generator does not exceed the 30 characters for Oracle11g
-		public static final String ENTITY_MAPPING_OUTBOX_EVENT_TABLE = HSEARCH_PREFIX + "OUTBOX_EVENT";
-		public static final String ENTITY_MAPPING_OUTBOX_EVENT_GENERATOR = ENTITY_MAPPING_OUTBOX_EVENT_TABLE + "_GENERATOR";
+		public static final String COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_TABLE = HSEARCH_PREFIX + "OUTBOX_EVENT";
+		public static final String COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_GENERATOR = COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_TABLE + "_GENERATOR";
 	}
 
 	/**

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/HibernateOrmMapperOutboxPollingSettings.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/HibernateOrmMapperOutboxPollingSettings.java
@@ -46,7 +46,7 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	/**
 	 * Whether the application will process entity change events.
 	 * <p>
-	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value #COORDINATION_STRATEGY_NAME}.
 	 * <p>
 	 * Expects a Boolean value such as {@code true} or {@code false},
@@ -69,7 +69,7 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	 * Failing that, some events may not be processed or may be processed twice or in the wrong order,
 	 * resulting in errors and/or out-of-sync indexes.
 	 * <p>
-	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value #COORDINATION_STRATEGY_NAME}.
 	 * <p>
 	 * When this property is set, {@value #COORDINATION_EVENT_PROCESSOR_SHARDS_ASSIGNED} must also be set.
@@ -88,7 +88,7 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	 * Failing that, some events may not be processed or may be processed twice or in the wrong order,
 	 * resulting in errors and/or out-of-sync indexes.
 	 * <p>
-	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value #COORDINATION_STRATEGY_NAME}.
 	 * <p>
 	 * When this property is set, {@value #COORDINATION_EVENT_PROCESSOR_SHARDS_TOTAL_COUNT} must also be set.
@@ -107,7 +107,7 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	 * In the event processor, how long to wait for another query to the outbox events table
 	 * after a query didn't return any event, in milliseconds.
 	 * <p>
-	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value #COORDINATION_STRATEGY_NAME}.
 	 * <p>
 	 * Hibernate Search will wait that long before polling again if the last polling didn't return any event:
@@ -130,7 +130,7 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	 * How long, in milliseconds, the event processor can poll for events
 	 * before it must perform a "pulse".
 	 * <p>
-	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value #COORDINATION_STRATEGY_NAME}.
 	 * <p>
 	 * Every agent registers itself in a database table.
@@ -173,7 +173,7 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	 * How long, in milliseconds, an event processor "pulse" remains valid
 	 * before considering the agent disconnected and forcibly removing it from the cluster.
 	 * <p>
-	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value #COORDINATION_STRATEGY_NAME}.
 	 * <p>
 	 * Every agent registers itself in a database table.
@@ -209,7 +209,7 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	/**
 	 * In the event processor, how many outbox events, at most, are processed in a single transaction.
 	 * <p>
-	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value #COORDINATION_STRATEGY_NAME}.
 	 * <p>
 	 * Expects a positive Integer value, such as {@code 50},
@@ -223,7 +223,7 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	/**
 	 * In the event processor, the timeout for transactions processing outbox events.
 	 * <p>
-	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value #COORDINATION_STRATEGY_NAME}.
 	 * <p>
 	 * Only effective when a JTA transaction manager is configured.
@@ -240,7 +240,7 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	/**
 	 * How long the event processor must wait before re-processing an event after its processing failed.
 	 * <p>
-	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value #COORDINATION_STRATEGY_NAME}.
 	 * <p>
 	 * Expects a positive integer value in seconds, such as {@code 10},
@@ -257,7 +257,7 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	 * In the mass indexer, how long to wait for another query to the agent table
 	 * when actively waiting for event processors to suspend themselves, in milliseconds.
 	 * <p>
-	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value #COORDINATION_STRATEGY_NAME}.
 	 * <p>
 	 * Hibernate Search will wait that long before polling again when it finds other agents haven't suspended yet:
@@ -279,7 +279,7 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	/**
 	 * How long, in milliseconds, the mass indexer can wait before it must perform a "pulse".
 	 * <p>
-	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value #COORDINATION_STRATEGY_NAME}.
 	 * <p>
 	 * Every agent registers itself in a database table.
@@ -315,7 +315,7 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	 * How long, in milliseconds, a mass indexer agent "pulse" remains valid
 	 * before considering the agent disconnected and forcibly removing it from the cluster.
 	 * <p>
-	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value #COORDINATION_STRATEGY_NAME}.
 	 * <p>
 	 * Every agent registers itself in a database table.
@@ -348,6 +348,88 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	public static final String COORDINATION_MASS_INDEXER_PULSE_EXPIRATION =
 			PREFIX + Radicals.COORDINATION_MASS_INDEXER_PULSE_EXPIRATION;
 
+
+	/**
+	 * The database catalog to use for the outbox event table.
+	 * <p>
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * {@value HibernateOrmMapperOutboxPollingSettings#COORDINATION_STRATEGY_NAME}.
+	 * <p>
+	 * Defaults to the default catalog configured in Hibernate ORM. See {@link org.hibernate.cfg.AvailableSettings#DEFAULT_CATALOG}.
+	 */
+	public static final String ENTITY_MAPPING_OUTBOXEVENT_CATALOG = PREFIX + Radicals.ENTITY_MAPPING_OUTBOXEVENT_CATALOG;
+
+	/**
+	 * The database schema to use for the outbox event table.
+	 * <p>
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * {@value HibernateOrmMapperOutboxPollingSettings#COORDINATION_STRATEGY_NAME}.
+	 * <p>
+	 * Defaults to the default schema configured in Hibernate ORM. See {@link org.hibernate.cfg.AvailableSettings#DEFAULT_SCHEMA}.
+	 */
+	public static final String ENTITY_MAPPING_OUTBOXEVENT_SCHEMA = PREFIX + Radicals.ENTITY_MAPPING_OUTBOXEVENT_SCHEMA;
+
+	/**
+	 * The name of the database table used to store the outbox events.
+	 * <p>
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * {@value HibernateOrmMapperOutboxPollingSettings#COORDINATION_STRATEGY_NAME}.
+	 * <p>
+	 * The default for this value is {@value Defaults#ENTITY_MAPPING_OUTBOX_EVENT_TABLE}.
+	 */
+	public static final String ENTITY_MAPPING_OUTBOXEVENT_TABLE = PREFIX + Radicals.ENTITY_MAPPING_OUTBOXEVENT_TABLE;
+
+	/**
+	 * The name of the identifier generator used for the outbox event table.
+	 * <p>
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * {@value HibernateOrmMapperOutboxPollingSettings#COORDINATION_STRATEGY_NAME}.
+	 * <p>
+	 * The default for this value is {@value Defaults#ENTITY_MAPPING_OUTBOX_EVENT_GENERATOR}.
+	 */
+
+	public static final String ENTITY_MAPPING_OUTBOXEVENT_GENERATOR = PREFIX + Radicals.ENTITY_MAPPING_OUTBOXEVENT_GENERATOR;
+	/**
+	 * The database catalog to use for the agent table.
+	 * <p>
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * {@value HibernateOrmMapperOutboxPollingSettings#COORDINATION_STRATEGY_NAME}.
+	 * <p>
+	 * Defaults to the default catalog configured in Hibernate ORM. See {@link org.hibernate.cfg.AvailableSettings#DEFAULT_CATALOG}.
+	 */
+	public static final String ENTITY_MAPPING_AGENT_CATALOG = PREFIX + Radicals.ENTITY_MAPPING_AGENT_CATALOG;
+
+	/**
+	 * The database schema to use for the agent table.
+	 * <p>
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * {@value HibernateOrmMapperOutboxPollingSettings#COORDINATION_STRATEGY_NAME}.
+	 * <p>
+	 * Defaults to the default schema configured in Hibernate ORM. See {@link org.hibernate.cfg.AvailableSettings#DEFAULT_SCHEMA}.
+	 */
+	public static final String ENTITY_MAPPING_AGENT_SCHEMA = PREFIX + Radicals.ENTITY_MAPPING_AGENT_SCHEMA;
+
+	/**
+	 * The name of the database table used to store the agents.
+	 * <p>
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * {@value HibernateOrmMapperOutboxPollingSettings#COORDINATION_STRATEGY_NAME}.
+	 * <p>
+	 * The default for this value is {@value Defaults#ENTITY_MAPPING_AGENT_TABLE}.
+	 */
+	public static final String ENTITY_MAPPING_AGENT_TABLE = PREFIX + Radicals.ENTITY_MAPPING_AGENT_TABLE;
+
+	/**
+	 * The name of the identifier generator used for the agent table.
+	 * <p>
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * {@value HibernateOrmMapperOutboxPollingSettings#COORDINATION_STRATEGY_NAME}.
+	 * <p>
+	 * The default for this value is {@value Defaults#ENTITY_MAPPING_AGENT_GENERATOR}.
+	 */
+	public static final String ENTITY_MAPPING_AGENT_GENERATOR = PREFIX + Radicals.ENTITY_MAPPING_AGENT_GENERATOR;
+
+
 	/**
 	 * Configuration property keys without the {@link #PREFIX prefix}.
 	 */
@@ -370,6 +452,15 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 		public static final String COORDINATION_MASS_INDEXER_POLLING_INTERVAL = COORDINATION_PREFIX + CoordinationRadicals.MASS_INDEXER_POLLING_INTERVAL;
 		public static final String COORDINATION_MASS_INDEXER_PULSE_INTERVAL = COORDINATION_PREFIX + CoordinationRadicals.MASS_INDEXER_PULSE_INTERVAL;
 		public static final String COORDINATION_MASS_INDEXER_PULSE_EXPIRATION = COORDINATION_PREFIX + CoordinationRadicals.MASS_INDEXER_PULSE_EXPIRATION;
+
+		public static final String ENTITY_MAPPING_OUTBOXEVENT_CATALOG = COORDINATION_PREFIX + OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_OUTBOXEVENT_CATALOG;
+		public static final String ENTITY_MAPPING_OUTBOXEVENT_SCHEMA = COORDINATION_PREFIX + OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_OUTBOXEVENT_SCHEMA;
+		public static final String ENTITY_MAPPING_OUTBOXEVENT_TABLE = COORDINATION_PREFIX + OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_OUTBOXEVENT_TABLE;
+		public static final String ENTITY_MAPPING_OUTBOXEVENT_GENERATOR = COORDINATION_PREFIX + OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_OUTBOXEVENT_GENERATOR;
+		public static final String ENTITY_MAPPING_AGENT_CATALOG = COORDINATION_PREFIX + OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_AGENT_CATALOG;
+		public static final String ENTITY_MAPPING_AGENT_SCHEMA = COORDINATION_PREFIX + OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_AGENT_SCHEMA;
+		public static final String ENTITY_MAPPING_AGENT_TABLE = COORDINATION_PREFIX + OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_AGENT_TABLE;
+		public static final String ENTITY_MAPPING_AGENT_GENERATOR = COORDINATION_PREFIX + OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_AGENT_GENERATOR;
 	}
 
 	/**
@@ -397,6 +488,24 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 		public static final String MASS_INDEXER_PULSE_EXPIRATION = MASS_INDEXER_PREFIX + "pulse_expiration";
 	}
 
+	public static final class OutboxPollingEntityMappingRadicals {
+		private OutboxPollingEntityMappingRadicals() {
+		}
+
+		private static final String EVENT_MAPPING = "entity.mapping.";
+		private static final String ENTITY_MAPPING_OUTBOXEVENT = EVENT_MAPPING + "outboxevent.";
+		public static final String ENTITY_MAPPING_OUTBOXEVENT_CATALOG = ENTITY_MAPPING_OUTBOXEVENT + "catalog";
+		public static final String ENTITY_MAPPING_OUTBOXEVENT_SCHEMA = ENTITY_MAPPING_OUTBOXEVENT + "schema";
+		public static final String ENTITY_MAPPING_OUTBOXEVENT_TABLE = ENTITY_MAPPING_OUTBOXEVENT + "table";
+		public static final String ENTITY_MAPPING_OUTBOXEVENT_GENERATOR = ENTITY_MAPPING_OUTBOXEVENT + "generator";
+
+		private static final String ENTITY_MAPPING_AGENT = EVENT_MAPPING + "agent.";
+		public static final String ENTITY_MAPPING_AGENT_CATALOG = ENTITY_MAPPING_AGENT + "catalog";
+		public static final String ENTITY_MAPPING_AGENT_SCHEMA = ENTITY_MAPPING_AGENT + "schema";
+		public static final String ENTITY_MAPPING_AGENT_TABLE = ENTITY_MAPPING_AGENT + "table";
+		public static final String ENTITY_MAPPING_AGENT_GENERATOR = ENTITY_MAPPING_AGENT + "generator";
+	}
+
 	/**
 	 * Default values for the different settings if no values are given.
 	 */
@@ -414,6 +523,18 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 		public static final int COORDINATION_MASS_INDEXER_POLLING_INTERVAL = 100;
 		public static final int COORDINATION_MASS_INDEXER_PULSE_INTERVAL = 2000;
 		public static final int COORDINATION_MASS_INDEXER_PULSE_EXPIRATION = 30000;
+
+		// WARNING: Always use this prefix for all tables added by Hibernate Search:
+		// we guarantee that in the documentation.
+		public static final String HSEARCH_PREFIX = "HSEARCH_";
+
+		// Must not be longer than 20 characters, so that the generator does not exceed the 30 characters for Oracle11g
+		public static final String ENTITY_MAPPING_AGENT_TABLE = HSEARCH_PREFIX + "AGENT";
+		public static final String ENTITY_MAPPING_AGENT_GENERATOR = ENTITY_MAPPING_AGENT_TABLE + "_GENERATOR";
+
+		// Must not be longer than 20 characters, so that the generator does not exceed the 30 characters for Oracle11g
+		public static final String ENTITY_MAPPING_OUTBOX_EVENT_TABLE = HSEARCH_PREFIX + "OUTBOX_EVENT";
+		public static final String ENTITY_MAPPING_OUTBOX_EVENT_GENERATOR = ENTITY_MAPPING_OUTBOX_EVENT_TABLE + "_GENERATOR";
 	}
 
 	/**

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/HibernateOrmMapperOutboxPollingSettings.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/HibernateOrmMapperOutboxPollingSettings.java
@@ -370,7 +370,7 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	public static final String ENTITY_MAPPING_OUTBOXEVENT_SCHEMA = PREFIX + Radicals.ENTITY_MAPPING_OUTBOXEVENT_SCHEMA;
 
 	/**
-	 * The name of the database table used to store the outbox events.
+	 * The name of the outbox event table.
 	 * <p>
 	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value HibernateOrmMapperOutboxPollingSettings#COORDINATION_STRATEGY_NAME}.
@@ -410,7 +410,7 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 	public static final String ENTITY_MAPPING_AGENT_SCHEMA = PREFIX + Radicals.ENTITY_MAPPING_AGENT_SCHEMA;
 
 	/**
-	 * The name of the database table used to store the agents.
+	 * The name of the agent table.
 	 * <p>
 	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value HibernateOrmMapperOutboxPollingSettings#COORDINATION_STRATEGY_NAME}.

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/spi/HibernateOrmMapperOutboxPollingSpiSettings.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/spi/HibernateOrmMapperOutboxPollingSpiSettings.java
@@ -39,10 +39,10 @@ public final class HibernateOrmMapperOutboxPollingSpiSettings {
 	 * <p>
 	 * As this configuration entirely overrides the entity mapping it cannot be used in combination with any properties
 	 * that define names of catalog/schema/table/identity generator for the outbox event table (
-	 * {@link HibernateOrmMapperOutboxPollingSettings#ENTITY_MAPPING_OUTBOXEVENT_CATALOG},
-	 * {@link HibernateOrmMapperOutboxPollingSettings#ENTITY_MAPPING_OUTBOXEVENT_SCHEMA},
-	 * {@link HibernateOrmMapperOutboxPollingSettings#ENTITY_MAPPING_OUTBOXEVENT_TABLE},
-	 * {@link HibernateOrmMapperOutboxPollingSettings#ENTITY_MAPPING_OUTBOXEVENT_GENERATOR}).
+	 * {@link HibernateOrmMapperOutboxPollingSettings#COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_CATALOG},
+	 * {@link HibernateOrmMapperOutboxPollingSettings#COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_SCHEMA},
+	 * {@link HibernateOrmMapperOutboxPollingSettings#COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_TABLE},
+	 * {@link HibernateOrmMapperOutboxPollingSettings#COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_GENERATOR}).
 	 * An exception ({@link org.hibernate.search.util.common.SearchException} will be thrown in case of such misconfiguration.
 	 */
 	public static final String OUTBOXEVENT_ENTITY_MAPPING = PREFIX + Radicals.OUTBOXEVENT_ENTITY_MAPPING;
@@ -59,10 +59,10 @@ public final class HibernateOrmMapperOutboxPollingSpiSettings {
 	 * <p>
 	 * As this configuration entirely overrides the entity mapping it cannot be used in combination with any properties
 	 * that define names of catalog/schema/table/identity generator for the agent table (
-	 * {@link HibernateOrmMapperOutboxPollingSettings#ENTITY_MAPPING_AGENT_CATALOG},
-	 * {@link HibernateOrmMapperOutboxPollingSettings#ENTITY_MAPPING_AGENT_SCHEMA},
-	 * {@link HibernateOrmMapperOutboxPollingSettings#ENTITY_MAPPING_AGENT_TABLE},
-	 * {@link HibernateOrmMapperOutboxPollingSettings#ENTITY_MAPPING_AGENT_GENERATOR}).
+	 * {@link HibernateOrmMapperOutboxPollingSettings#COORDINATION_ENTITY_MAPPING_AGENT_CATALOG},
+	 * {@link HibernateOrmMapperOutboxPollingSettings#COORDINATION_ENTITY_MAPPING_AGENT_SCHEMA},
+	 * {@link HibernateOrmMapperOutboxPollingSettings#COORDINATION_ENTITY_MAPPING_AGENT_TABLE},
+	 * {@link HibernateOrmMapperOutboxPollingSettings#COORDINATION_ENTITY_MAPPING_AGENT_GENERATOR}).
 	 * An exception ({@link org.hibernate.search.util.common.SearchException} will be thrown in case of such misconfiguration.
 	 */
 	public static final String AGENT_ENTITY_MAPPING = PREFIX + Radicals.AGENT_ENTITY_MAPPING;

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/spi/HibernateOrmMapperOutboxPollingSpiSettings.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/spi/HibernateOrmMapperOutboxPollingSpiSettings.java
@@ -8,9 +8,7 @@ package org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.spi;
 
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.HibernateOrmMapperOutboxPollingSettings;
-import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.Agent;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.OutboxPollingAgentAdditionalJaxbMappingProducer;
-import org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl.OutboxEvent;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl.OutboxPollingOutboxEventAdditionalJaxbMappingProducer;
 import org.hibernate.search.util.common.annotation.Incubating;
 
@@ -30,26 +28,42 @@ public final class HibernateOrmMapperOutboxPollingSpiSettings {
 	public static final String PREFIX = HibernateOrmMapperSettings.PREFIX;
 
 	/**
-	 * Allows the user to define a specific Hibernate mapping for the {@link OutboxEvent} entity.
+	 * Allows the user to define a specific Hibernate mapping for the outbox event table.
 	 * <p>
-	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value HibernateOrmMapperOutboxPollingSettings#COORDINATION_STRATEGY_NAME}.
 	 * <p>
 	 * Expects a String value containing the xml expressing the Hibernate mapping for the entity.
 	 * <p>
 	 * The default for this value is {@link OutboxPollingOutboxEventAdditionalJaxbMappingProducer#ENTITY_DEFINITION}
+	 * <p>
+	 * As this configuration entirely overrides the entity mapping it cannot be used in combination with any properties
+	 * that define names of catalog/schema/table/identity generator for the outbox event table (
+	 * {@link HibernateOrmMapperOutboxPollingSettings#ENTITY_MAPPING_OUTBOXEVENT_CATALOG},
+	 * {@link HibernateOrmMapperOutboxPollingSettings#ENTITY_MAPPING_OUTBOXEVENT_SCHEMA},
+	 * {@link HibernateOrmMapperOutboxPollingSettings#ENTITY_MAPPING_OUTBOXEVENT_TABLE},
+	 * {@link HibernateOrmMapperOutboxPollingSettings#ENTITY_MAPPING_OUTBOXEVENT_GENERATOR}).
+	 * An exception ({@link org.hibernate.search.util.common.SearchException} will be thrown in case of such misconfiguration.
 	 */
 	public static final String OUTBOXEVENT_ENTITY_MAPPING = PREFIX + Radicals.OUTBOXEVENT_ENTITY_MAPPING;
 
 	/**
-	 * Allows the user to define a specific Hibernate mapping for the {@link Agent} entity.
+	 * Allows the user to define a specific Hibernate mapping for the agent table.
 	 * <p>
-	 * Only available when {@link HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
 	 * {@value HibernateOrmMapperOutboxPollingSettings#COORDINATION_STRATEGY_NAME}.
 	 * <p>
 	 * Expects a String value containing the xml expressing the Hibernate mapping for the entity.
 	 * <p>
 	 * The default for this value is {@link OutboxPollingAgentAdditionalJaxbMappingProducer#ENTITY_DEFINITION}
+	 * <p>
+	 * As this configuration entirely overrides the entity mapping it cannot be used in combination with any properties
+	 * that define names of catalog/schema/table/identity generator for the agent table (
+	 * {@link HibernateOrmMapperOutboxPollingSettings#ENTITY_MAPPING_AGENT_CATALOG},
+	 * {@link HibernateOrmMapperOutboxPollingSettings#ENTITY_MAPPING_AGENT_SCHEMA},
+	 * {@link HibernateOrmMapperOutboxPollingSettings#ENTITY_MAPPING_AGENT_TABLE},
+	 * {@link HibernateOrmMapperOutboxPollingSettings#ENTITY_MAPPING_AGENT_GENERATOR}).
+	 * An exception ({@link org.hibernate.search.util.common.SearchException} will be thrown in case of such misconfiguration.
 	 */
 	public static final String AGENT_ENTITY_MAPPING = PREFIX + Radicals.AGENT_ENTITY_MAPPING;
 
@@ -62,8 +76,10 @@ public final class HibernateOrmMapperOutboxPollingSpiSettings {
 		}
 
 		public static final String COORDINATION_PREFIX = HibernateOrmMapperSettings.Radicals.COORDINATION_PREFIX;
+
 		public static final String OUTBOXEVENT_ENTITY_MAPPING = COORDINATION_PREFIX + CoordinationRadicals.OUTBOXEVENT_ENTITY_MAPPING;
 		public static final String AGENT_ENTITY_MAPPING = COORDINATION_PREFIX + CoordinationRadicals.AGENT_ENTITY_MAPPING;
+
 	}
 
 	public static final class CoordinationRadicals {
@@ -73,6 +89,7 @@ public final class HibernateOrmMapperOutboxPollingSpiSettings {
 
 		public static final String OUTBOXEVENT_ENTITY_MAPPING = "outboxevent.entity.mapping";
 		public static final String AGENT_ENTITY_MAPPING = "agent.entity.mapping";
+
 	}
 
 }

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cluster/impl/OutboxPollingAgentAdditionalJaxbMappingProducer.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cluster/impl/OutboxPollingAgentAdditionalJaxbMappingProducer.java
@@ -76,7 +76,9 @@ public class OutboxPollingAgentAdditionalJaxbMappingProducer
 			"</hibernate-mapping>\n";
 
 	public static final String ENTITY_DEFINITION = String.format(
-			Locale.ROOT, ENTITY_DEFINITION_TEMPLATE, "", "", HibernateOrmMapperOutboxPollingSettings.Defaults.ENTITY_MAPPING_AGENT_TABLE, HibernateOrmMapperOutboxPollingSettings.Defaults.ENTITY_MAPPING_AGENT_GENERATOR
+			Locale.ROOT, ENTITY_DEFINITION_TEMPLATE, "", "",
+			HibernateOrmMapperOutboxPollingSettings.Defaults.COORDINATION_ENTITY_MAPPING_AGENT_TABLE,
+			HibernateOrmMapperOutboxPollingSettings.Defaults.COORDINATION_ENTITY_MAPPING_AGENT_GENERATOR
 	);
 
 	private static final OptionalConfigurationProperty<String> AGENT_ENTITY_MAPPING =
@@ -87,25 +89,25 @@ public class OutboxPollingAgentAdditionalJaxbMappingProducer
 
 	private static final OptionalConfigurationProperty<String> ENTITY_MAPPING_AGENT_SCHEMA =
 			ConfigurationProperty.forKey(
-							HibernateOrmMapperOutboxPollingSettings.OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_AGENT_SCHEMA )
+							HibernateOrmMapperOutboxPollingSettings.CoordinationRadicals.ENTITY_MAPPING_AGENT_SCHEMA )
 					.asString()
 					.build();
 
 	private static final OptionalConfigurationProperty<String> ENTITY_MAPPING_AGENT_CATALOG =
 			ConfigurationProperty.forKey(
-							HibernateOrmMapperOutboxPollingSettings.OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_AGENT_CATALOG )
+							HibernateOrmMapperOutboxPollingSettings.CoordinationRadicals.ENTITY_MAPPING_AGENT_CATALOG )
 					.asString()
 					.build();
 
 	private static final OptionalConfigurationProperty<String> ENTITY_MAPPING_AGENT_TABLE =
 			ConfigurationProperty.forKey(
-							HibernateOrmMapperOutboxPollingSettings.OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_AGENT_TABLE )
+							HibernateOrmMapperOutboxPollingSettings.CoordinationRadicals.ENTITY_MAPPING_AGENT_TABLE )
 					.asString()
 					.build();
 
 	private static final OptionalConfigurationProperty<String> ENTITY_MAPPING_AGENT_GENERATOR =
 			ConfigurationProperty.forKey(
-							HibernateOrmMapperOutboxPollingSettings.OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_AGENT_GENERATOR )
+							HibernateOrmMapperOutboxPollingSettings.CoordinationRadicals.ENTITY_MAPPING_AGENT_GENERATOR )
 					.asString()
 					.build();
 
@@ -140,8 +142,8 @@ public class OutboxPollingAgentAdditionalJaxbMappingProducer
 						ENTITY_DEFINITION_TEMPLATE,
 						schema.orElse( "" ),
 						catalog.orElse( "" ),
-						table.orElse( HibernateOrmMapperOutboxPollingSettings.Defaults.ENTITY_MAPPING_AGENT_TABLE ),
-						generator.orElse( HibernateOrmMapperOutboxPollingSettings.Defaults.ENTITY_MAPPING_AGENT_GENERATOR )
+						table.orElse( HibernateOrmMapperOutboxPollingSettings.Defaults.COORDINATION_ENTITY_MAPPING_AGENT_TABLE ),
+						generator.orElse( HibernateOrmMapperOutboxPollingSettings.Defaults.COORDINATION_ENTITY_MAPPING_AGENT_GENERATOR )
 
 				)
 		);

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingOutboxEventAdditionalJaxbMappingProducer.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingOutboxEventAdditionalJaxbMappingProducer.java
@@ -11,6 +11,8 @@ import java.io.ByteArrayInputStream;
 import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Locale;
+import java.util.Optional;
 
 import org.hibernate.boot.jaxb.Origin;
 import org.hibernate.boot.jaxb.SourceType;
@@ -21,9 +23,10 @@ import org.hibernate.boot.model.source.internal.hbm.MappingDocument;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
 import org.hibernate.search.engine.cfg.spi.ConfigurationProperty;
+import org.hibernate.search.engine.cfg.spi.OptionalConfigurationProperty;
 import org.hibernate.search.mapper.orm.bootstrap.spi.HibernateSearchOrmMappingProducer;
+import org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.HibernateOrmMapperOutboxPollingSettings;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.spi.HibernateOrmMapperOutboxPollingSpiSettings;
-import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.OutboxPollingAgentAdditionalJaxbMappingProducer;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.logging.impl.Log;
 import org.hibernate.search.util.common.annotation.impl.SuppressForbiddenApis;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
@@ -32,11 +35,6 @@ public final class OutboxPollingOutboxEventAdditionalJaxbMappingProducer
 		implements HibernateSearchOrmMappingProducer {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
-
-	private static final String HSEARCH_PREFIX = OutboxPollingAgentAdditionalJaxbMappingProducer.HSEARCH_PREFIX;
-
-	// Must not be longer than 20 characters, so that the generator does not exceed the 30 characters for Oracle11g
-	public static final String TABLE_NAME = HSEARCH_PREFIX + "OUTBOX_EVENT";
 
 	private static final String CLASS_NAME = OutboxEvent.class.getName();
 
@@ -47,13 +45,13 @@ public final class OutboxPollingOutboxEventAdditionalJaxbMappingProducer
 	// because our override actually matches the default for the native entity name.
 	public static final String ENTITY_NAME = CLASS_NAME;
 
-	public static final String ENTITY_DEFINITION = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-			"<hibernate-mapping>\n" +
-			"    <class name=\"" + CLASS_NAME + "\" entity-name=\"" + ENTITY_NAME + "\" table=\"" + TABLE_NAME + "\">\n" +
+	public static final String ENTITY_DEFINITION_TEMPLATE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+			"<hibernate-mapping schema=\"%1$s\" catalog=\"%2$s\">\n" +
+			"    <class name=\"" + CLASS_NAME + "\" entity-name=\"" + ENTITY_NAME + "\" table=\"%3$s\">\n" +
 			"        <id name=\"id\" type=\"long\">\n" +
 			"            <generator class=\"org.hibernate.id.enhanced.SequenceStyleGenerator\">\n" +
-			"                <param name=\"sequence_name\">" + TABLE_NAME + "_GENERATOR</param>\n" +
-			"                <param name=\"table_name\">" + TABLE_NAME + "_GENERATOR</param>\n" +
+			"                <param name=\"sequence_name\">%4$s</param>\n" +
+			"                <param name=\"table_name\">%4$s</param>\n" +
 			"                <param name=\"initial_value\">1</param>\n" +
 			"                <param name=\"increment_size\">1</param>\n" +
 			"            </generator>\n" +
@@ -72,10 +70,38 @@ public final class OutboxPollingOutboxEventAdditionalJaxbMappingProducer
 			"    </class>\n" +
 			"</hibernate-mapping>\n";
 
-	private static final ConfigurationProperty<String> OUTBOXEVENT_ENTITY_MAPPING =
-			ConfigurationProperty.forKey( HibernateOrmMapperOutboxPollingSpiSettings.CoordinationRadicals.OUTBOXEVENT_ENTITY_MAPPING )
+	public static final String ENTITY_DEFINITION = String.format(
+			Locale.ROOT, ENTITY_DEFINITION_TEMPLATE, "", "", HibernateOrmMapperOutboxPollingSettings.Defaults.ENTITY_MAPPING_OUTBOX_EVENT_TABLE, HibernateOrmMapperOutboxPollingSettings.Defaults.ENTITY_MAPPING_OUTBOX_EVENT_GENERATOR
+	);
+
+	private static final OptionalConfigurationProperty<String> OUTBOXEVENT_ENTITY_MAPPING =
+			ConfigurationProperty.forKey(
+							HibernateOrmMapperOutboxPollingSpiSettings.CoordinationRadicals.OUTBOXEVENT_ENTITY_MAPPING )
 					.asString()
-					.withDefault( ENTITY_DEFINITION )
+					.build();
+
+	private static final OptionalConfigurationProperty<String> ENTITY_MAPPING_OUTBOXEVENT_SCHEMA =
+			ConfigurationProperty.forKey(
+							HibernateOrmMapperOutboxPollingSettings.OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_OUTBOXEVENT_SCHEMA )
+					.asString()
+					.build();
+
+	private static final OptionalConfigurationProperty<String> ENTITY_MAPPING_OUTBOXEVENT_CATALOG =
+			ConfigurationProperty.forKey(
+							HibernateOrmMapperOutboxPollingSettings.OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_OUTBOXEVENT_CATALOG )
+					.asString()
+					.build();
+
+	private static final OptionalConfigurationProperty<String> ENTITY_MAPPING_OUTBOXEVENT_TABLE =
+			ConfigurationProperty.forKey(
+							HibernateOrmMapperOutboxPollingSettings.OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_OUTBOXEVENT_TABLE )
+					.asString()
+					.build();
+
+	private static final OptionalConfigurationProperty<String> ENTITY_MAPPING_OUTBOXEVENT_GENERATOR =
+			ConfigurationProperty.forKey(
+							HibernateOrmMapperOutboxPollingSettings.OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_OUTBOXEVENT_GENERATOR )
+					.asString()
 					.build();
 
 	@Override
@@ -83,7 +109,37 @@ public final class OutboxPollingOutboxEventAdditionalJaxbMappingProducer
 			+ " and there's nothing we can do about it")
 	public Collection<MappingDocument> produceMappings(ConfigurationPropertySource propertySource,
 			MappingBinder mappingBinder, MetadataBuildingContext buildingContext) {
-		String entityDefinition = OUTBOXEVENT_ENTITY_MAPPING.get( propertySource );
+
+		Optional<String> mapping = OUTBOXEVENT_ENTITY_MAPPING.get( propertySource );
+		Optional<String> schema = ENTITY_MAPPING_OUTBOXEVENT_SCHEMA.get( propertySource );
+		Optional<String> catalog = ENTITY_MAPPING_OUTBOXEVENT_CATALOG.get( propertySource );
+		Optional<String> table = ENTITY_MAPPING_OUTBOXEVENT_TABLE.get( propertySource );
+		Optional<String> generator = ENTITY_MAPPING_OUTBOXEVENT_GENERATOR.get( propertySource );
+
+		// only allow configuring the entire mapping or table/catalog/schema/generator names
+		if ( mapping.isPresent() && ( schema.isPresent() || catalog.isPresent() || table.isPresent() || generator.isPresent() ) ) {
+			throw log.outboxEventConfigurationPropertyConflict(
+					OUTBOXEVENT_ENTITY_MAPPING.resolveOrRaw( propertySource ),
+					new String[] {
+							ENTITY_MAPPING_OUTBOXEVENT_SCHEMA.resolveOrRaw( propertySource ),
+							ENTITY_MAPPING_OUTBOXEVENT_CATALOG.resolveOrRaw( propertySource ),
+							ENTITY_MAPPING_OUTBOXEVENT_TABLE.resolveOrRaw( propertySource ),
+							ENTITY_MAPPING_OUTBOXEVENT_GENERATOR.resolveOrRaw( propertySource )
+					}
+			);
+		}
+
+		String entityDefinition = mapping.orElseGet( () ->
+				String.format(
+						Locale.ROOT,
+						ENTITY_DEFINITION_TEMPLATE,
+						schema.orElse( "" ),
+						catalog.orElse( "" ),
+						table.orElse( HibernateOrmMapperOutboxPollingSettings.Defaults.ENTITY_MAPPING_OUTBOX_EVENT_TABLE ),
+						generator.orElse( HibernateOrmMapperOutboxPollingSettings.Defaults.ENTITY_MAPPING_OUTBOX_EVENT_GENERATOR )
+
+				)
+		);
 
 		log.outboxEventGeneratedEntityMapping( entityDefinition );
 		Origin origin = new Origin( SourceType.OTHER, "search" );

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingOutboxEventAdditionalJaxbMappingProducer.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingOutboxEventAdditionalJaxbMappingProducer.java
@@ -71,7 +71,9 @@ public final class OutboxPollingOutboxEventAdditionalJaxbMappingProducer
 			"</hibernate-mapping>\n";
 
 	public static final String ENTITY_DEFINITION = String.format(
-			Locale.ROOT, ENTITY_DEFINITION_TEMPLATE, "", "", HibernateOrmMapperOutboxPollingSettings.Defaults.ENTITY_MAPPING_OUTBOX_EVENT_TABLE, HibernateOrmMapperOutboxPollingSettings.Defaults.ENTITY_MAPPING_OUTBOX_EVENT_GENERATOR
+			Locale.ROOT, ENTITY_DEFINITION_TEMPLATE, "", "",
+			HibernateOrmMapperOutboxPollingSettings.Defaults.COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_TABLE,
+			HibernateOrmMapperOutboxPollingSettings.Defaults.COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_GENERATOR
 	);
 
 	private static final OptionalConfigurationProperty<String> OUTBOXEVENT_ENTITY_MAPPING =
@@ -82,25 +84,25 @@ public final class OutboxPollingOutboxEventAdditionalJaxbMappingProducer
 
 	private static final OptionalConfigurationProperty<String> ENTITY_MAPPING_OUTBOXEVENT_SCHEMA =
 			ConfigurationProperty.forKey(
-							HibernateOrmMapperOutboxPollingSettings.OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_OUTBOXEVENT_SCHEMA )
+							HibernateOrmMapperOutboxPollingSettings.CoordinationRadicals.ENTITY_MAPPING_OUTBOXEVENT_SCHEMA )
 					.asString()
 					.build();
 
 	private static final OptionalConfigurationProperty<String> ENTITY_MAPPING_OUTBOXEVENT_CATALOG =
 			ConfigurationProperty.forKey(
-							HibernateOrmMapperOutboxPollingSettings.OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_OUTBOXEVENT_CATALOG )
+							HibernateOrmMapperOutboxPollingSettings.CoordinationRadicals.ENTITY_MAPPING_OUTBOXEVENT_CATALOG )
 					.asString()
 					.build();
 
 	private static final OptionalConfigurationProperty<String> ENTITY_MAPPING_OUTBOXEVENT_TABLE =
 			ConfigurationProperty.forKey(
-							HibernateOrmMapperOutboxPollingSettings.OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_OUTBOXEVENT_TABLE )
+							HibernateOrmMapperOutboxPollingSettings.CoordinationRadicals.ENTITY_MAPPING_OUTBOXEVENT_TABLE )
 					.asString()
 					.build();
 
 	private static final OptionalConfigurationProperty<String> ENTITY_MAPPING_OUTBOXEVENT_GENERATOR =
 			ConfigurationProperty.forKey(
-							HibernateOrmMapperOutboxPollingSettings.OutboxPollingEntityMappingRadicals.ENTITY_MAPPING_OUTBOXEVENT_GENERATOR )
+							HibernateOrmMapperOutboxPollingSettings.CoordinationRadicals.ENTITY_MAPPING_OUTBOXEVENT_GENERATOR )
 					.asString()
 					.build();
 
@@ -135,8 +137,8 @@ public final class OutboxPollingOutboxEventAdditionalJaxbMappingProducer
 						ENTITY_DEFINITION_TEMPLATE,
 						schema.orElse( "" ),
 						catalog.orElse( "" ),
-						table.orElse( HibernateOrmMapperOutboxPollingSettings.Defaults.ENTITY_MAPPING_OUTBOX_EVENT_TABLE ),
-						generator.orElse( HibernateOrmMapperOutboxPollingSettings.Defaults.ENTITY_MAPPING_OUTBOX_EVENT_GENERATOR )
+						table.orElse( HibernateOrmMapperOutboxPollingSettings.Defaults.COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_TABLE ),
+						generator.orElse( HibernateOrmMapperOutboxPollingSettings.Defaults.COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_GENERATOR )
 
 				)
 		);

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/logging/impl/Log.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/logging/impl/Log.java
@@ -160,4 +160,12 @@ public interface Log extends BasicLogger {
 			value = "Multi-tenancy is not enabled but a tenant id is specified. Trying to use the tenant id: '%1$s'.")
 	SearchException multiTenancyNotEnabled(String tenantId);
 
+	@Message(id = ID_OFFSET + 26, value = "Outbox polling agent configuration property conflict."
+			+ " Either mapping property %1$s or subset of name adjustment properties %2$s should be provided at the same time.")
+	SearchException agentConfigurationPropertyConflict(String mappingPropertyName, String[] nameAdjustmentProperties);
+
+	@Message(id = ID_OFFSET + 27, value = "Outbox event configuration property conflict."
+			+ " Either mapping property %1$s or subset of name adjustment properties %2$s should be provided at the same time.")
+	SearchException outboxEventConfigurationPropertyConflict(String mappingPropertyName, String[] nameAdjustmentProperties);
+
 }

--- a/orm6/integrationtest/mapper/orm/ant-src-changes.patch
+++ b/orm6/integrationtest/mapper/orm/ant-src-changes.patch
@@ -903,7 +903,7 @@ index 798418f3a9..bbfc99e232 100644
  				.contains( "_containingIndexBackref" );
  
 diff --git a/test/java/org/hibernate/search/integrationtest/mapper/orm/model/GenericPropertyIT.java b/test/java/org/hibernate/search/integrationtest/mapper/orm/model/GenericPropertyIT.java
-index d110dbb171..0796b95350 100644
+index aa24c725e1..66c2063aea 100644
 --- a/test/java/org/hibernate/search/integrationtest/mapper/orm/model/GenericPropertyIT.java
 +++ b/test/java/org/hibernate/search/integrationtest/mapper/orm/model/GenericPropertyIT.java
 @@ -6,6 +6,7 @@
@@ -914,7 +914,7 @@ index d110dbb171..0796b95350 100644
  import java.util.ArrayList;
  import java.util.List;
  import jakarta.persistence.Basic;
-@@ -121,25 +122,17 @@ public void setGenericProperty(GenericEntity<String> genericProperty) {
+@@ -117,25 +118,17 @@ public void setGenericProperty(GenericEntity<String> genericProperty) {
  	}
  
  	@Entity(name = "generic")

--- a/orm6/mapper/orm-coordination-outbox-polling/ant-src-changes.patch
+++ b/orm6/mapper/orm-coordination-outbox-polling/ant-src-changes.patch
@@ -1,17 +1,17 @@
 diff --git a/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cluster/impl/OutboxPollingAgentAdditionalJaxbMappingProducer.java b/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cluster/impl/OutboxPollingAgentAdditionalJaxbMappingProducer.java
-index 37a19e2b97..c2255a15ae 100644
+index 84efb07e7d..33447ee586 100644
 --- a/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cluster/impl/OutboxPollingAgentAdditionalJaxbMappingProducer.java
 +++ b/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cluster/impl/OutboxPollingAgentAdditionalJaxbMappingProducer.java
-@@ -32,6 +32,8 @@
+@@ -36,6 +36,8 @@
  
  	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
  
 +	public static final String HIBERNATE_SEARCH = "hibernate-search";
 +
- 	// WARNING: Always use this prefix for all tables added by Hibernate Search:
- 	// we guarantee that in the documentation.
- 	public static final String HSEARCH_PREFIX = "HSEARCH_";
-@@ -100,7 +102,7 @@ public Collection<MappingDocument> produceMappings(ConfigurationPropertySource p
+ 	private static final String CLASS_NAME = Agent.class.getName();
+ 
+ 	// Setting both the JPA entity name and the native entity name to the FQCN so that:
+@@ -157,7 +159,7 @@ public Collection<MappingDocument> produceMappings(ConfigurationPropertySource p
  
  		JaxbHbmHibernateMapping root = (JaxbHbmHibernateMapping) binding.getRoot();
  
@@ -21,19 +21,27 @@ index 37a19e2b97..c2255a15ae 100644
  	}
  }
 diff --git a/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingOutboxEventAdditionalJaxbMappingProducer.java b/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingOutboxEventAdditionalJaxbMappingProducer.java
-index 085409d2b8..3f497919bb 100644
+index 6a28818314..0060583360 100644
 --- a/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingOutboxEventAdditionalJaxbMappingProducer.java
 +++ b/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingOutboxEventAdditionalJaxbMappingProducer.java
-@@ -33,6 +33,8 @@
+@@ -27,6 +27,7 @@
+ import org.hibernate.search.mapper.orm.bootstrap.spi.HibernateSearchOrmMappingProducer;
+ import org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.HibernateOrmMapperOutboxPollingSettings;
+ import org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.spi.HibernateOrmMapperOutboxPollingSpiSettings;
++import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.OutboxPollingAgentAdditionalJaxbMappingProducer;
+ import org.hibernate.search.mapper.orm.coordination.outboxpolling.logging.impl.Log;
+ import org.hibernate.search.util.common.annotation.impl.SuppressForbiddenApis;
+ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
+@@ -36,6 +37,8 @@
  
  	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
  
 +	private static final String HIBERNATE_SEARCH = OutboxPollingAgentAdditionalJaxbMappingProducer.HIBERNATE_SEARCH;
 +
- 	private static final String HSEARCH_PREFIX = OutboxPollingAgentAdditionalJaxbMappingProducer.HSEARCH_PREFIX;
+ 	private static final String CLASS_NAME = OutboxEvent.class.getName();
  
- 	// Must not be longer than 20 characters, so that the generator does not exceed the 30 characters for Oracle11g
-@@ -63,7 +65,7 @@
+ 	// Setting both the JPA entity name and the native entity name to the FQCN so that:
+@@ -61,7 +64,7 @@
  			"        <property name=\"entityIdHash\" type=\"integer\" index=\"entityIdHash\" nullable=\"false\" />\n" +
  			"        <property name=\"payload\" type=\"materialized_blob\" nullable=\"false\" />\n" +
  			"        <property name=\"retries\" type=\"integer\" nullable=\"false\" />\n" +
@@ -42,8 +50,8 @@ index 085409d2b8..3f497919bb 100644
  			"        <property name=\"status\" index=\"status\" nullable=\"false\">\n" +
  			"            <type name=\"org.hibernate.type.EnumType\">\n" +
  			"                <param name=\"enumClass\">" + OutboxEvent.Status.class.getName() + "</param>\n" +
-@@ -86,7 +88,7 @@ public Collection<MappingDocument> produceMappings(ConfigurationPropertySource p
- 		String entityDefinition = OUTBOXEVENT_ENTITY_MAPPING.get( propertySource );
+@@ -144,7 +147,7 @@ public Collection<MappingDocument> produceMappings(ConfigurationPropertySource p
+ 		);
  
  		log.outboxEventGeneratedEntityMapping( entityDefinition );
 -		Origin origin = new Origin( SourceType.OTHER, "search" );
@@ -51,7 +59,7 @@ index 085409d2b8..3f497919bb 100644
  
  		ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream( entityDefinition.getBytes() );
  		BufferedInputStream bufferedInputStream = new BufferedInputStream( byteArrayInputStream );
-@@ -94,7 +96,7 @@ public Collection<MappingDocument> produceMappings(ConfigurationPropertySource p
+@@ -152,7 +155,7 @@ public Collection<MappingDocument> produceMappings(ConfigurationPropertySource p
  
  		JaxbHbmHibernateMapping root = (JaxbHbmHibernateMapping) binding.getRoot();
  


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4533

- define a set of properties for catalog/schema/tables names for
agent and outbox events
- make mapping producers to consider introduced properties
- make sure that statement inspector doesn't pick up keys on partial matches

I didn't find any "programmatic configuration" capability, only through the properties, or have I missed something ?
Also, I wasn't sure how to test with the custom schema/catalog. Simply specifying something doesn't work out of the box as it throws an exception that the underlying H2 doesn't have such schema. And I haven't yet dug deep to figure out how the `backendMock` and `ormSetupHelper` internals are working. Could you maybe point me to a sample where tests are using various schemas? 