### PR TITLE
HSEARCH-4483 Update mass-indexing log message format

### DIFF
--- a/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/LibraryShowcaseMassIndexingIT.java
+++ b/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/LibraryShowcaseMassIndexingIT.java
@@ -110,8 +110,14 @@ public class LibraryShowcaseMassIndexingIT {
 			int batchSize = 49;
 			indexer.batchSizeToLoadObjects( batchSize );
 			int expectedNumberOfLogs = NUMBER_OF_BOOKS / MASS_INDEXING_MONITOR_LOG_PERIOD;
+
+			// Example:
+			// Mass indexing progress: indexed 151 entities in 21 ms.
 			logged.expectEvent( Level.INFO, "Mass indexing progress: indexed", "entities in", "ms" ).times( expectedNumberOfLogs );
-			logged.expectEvent( Level.INFO, "Mass indexing progress:", "%", "documents/second" ).times( expectedNumberOfLogs );
+
+			// Example:
+			// Mass indexing progress: 26.50%. Mass indexing speed: 2765.605713 documents/second since last message, 2765.605713 documents/second since start.
+			logged.expectEvent( Level.INFO, "Mass indexing progress:", "%", "Mass indexing speed:", "documents/second since last message", "documents/second since start" ).times( expectedNumberOfLogs );
 
 			indexer.startAndWait();
 		}

--- a/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/LibraryShowcaseMassIndexingIT.java
+++ b/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/LibraryShowcaseMassIndexingIT.java
@@ -93,7 +93,11 @@ public class LibraryShowcaseMassIndexingIT {
 	@Test
 	public void testMassIndexingMonitor() {
 		assertThat( documentService.countIndexed() ).isEqualTo( 0 );
-		MassIndexer indexer = adminService.createMassIndexer();
+		MassIndexer indexer = adminService.createMassIndexer()
+				// Concurrency leads to an unpredictable number of log events,
+				// because we skip logging in some cases where it's triggered concurrently.
+				// So, for this test which needs assertions on the number of log events, we avoid concurrency.
+				.threadsToLoadObjects( 1 );
 		try {
 			/*
 			 * The default period for logging in the default mass indexing monitor is 50.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
@@ -88,8 +88,8 @@ public interface Log extends BasicLogger {
 	void indexingProgressRaw(long doneCount, long elapsedMs);
 
 	@LogMessage(level = INFO)
-	@Message(id = ID_OFFSET_LEGACY_ENGINE + 31, value = "Mass indexing progress: %2$.2f%% [%1$f documents/second].")
-	void indexingProgressStats(float estimateSpeed, float estimatePercentileComplete);
+	@Message(id = ID_OFFSET_LEGACY_ENGINE + 31, value = "Mass indexing progress: %3$.2f%%. Mass indexing speed: %1$f documents/second since last message, %2$f documents/second since start.")
+	void indexingProgressStats(float currentSpeed, float estimateSpeed, float estimatePercentileComplete);
 
 	@LogMessage(level = ERROR)
 	@Message(id = ID_OFFSET_LEGACY_ENGINE + 62, value = "Mass indexing received interrupt signal: aborting.")

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingLoggingMonitor.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingLoggingMonitor.java
@@ -55,8 +55,10 @@ public class PojoMassIndexingLoggingMonitor implements MassIndexingMonitor {
 		if ( startTime == 0 ) {
 			synchronized (this) {
 				if ( startTime == 0 ) {
-					startTime = System.nanoTime();
+					long theStartTime = System.nanoTime();
 					lastMessageInfo.set( new StatusMessageInfo( startTime, 0 ) );
+					// Do this last, so other threads will block until we're done initializing lastMessageInfo.
+					startTime = theStartTime;
 				}
 			}
 		}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4483

- include the "between-iterations" speed as part of logged info

