### PR TITLE
Backport HSEARCH-4569 + HSEARCH-4570 to branch 6.1 - Upgrade -orm6 artifacts to Hibernate ORM 6.0.1.Final

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
     # so we can safely use a high limit here.
     open-pull-requests-limit: 20
     ignore:
+      # These dependencies are updated manually
+      - dependency-name: "org.hibernate:*"
+      - dependency-name: "org.hibernate.*:*"
       # AWS SDK releases way too often (every week?); ignore all patch updates
       - dependency-name: "software.amazon.awssdk:*"
         update-types: ["version-update:semver-patch"]

--- a/pom.xml
+++ b/pom.xml
@@ -271,7 +271,7 @@
         <version.org.hibernate.orm>6.0.1.Final</version.org.hibernate.orm>
         <javadoc.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/javadocs/</javadoc.org.hibernate.orm.url>
         <documentation.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/userguide/html_single/Hibernate_User_Guide.html</documentation.org.hibernate.orm.url>
-        <version.org.hibernate.commons.annotations.orm6>6.0.0.Final</version.org.hibernate.commons.annotations.orm6>
+        <version.org.hibernate.commons.annotations.orm6>6.0.1.Final</version.org.hibernate.commons.annotations.orm6>
         <version.jakarta.persistence>3.1.0</version.jakarta.persistence>
 
         <!-- >>> JSR 352 -->

--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
         <version.javax.persistence>2.2</version.javax.persistence>
 
         <!-- >>> ORM 6 / Jakarta Persistence -->
-        <version.org.hibernate.orm>6.0.0.Final</version.org.hibernate.orm>
+        <version.org.hibernate.orm>6.0.1.Final</version.org.hibernate.orm>
         <javadoc.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/javadocs/</javadoc.org.hibernate.orm.url>
         <documentation.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/userguide/html_single/Hibernate_User_Guide.html</documentation.org.hibernate.orm.url>
         <version.org.hibernate.commons.annotations.orm6>6.0.0.Final</version.org.hibernate.commons.annotations.orm6>


### PR DESCRIPTION
* [HSEARCH-4570](https://hibernate.atlassian.net/browse/HSEARCH-4570): Upgrade -orm6 artifacts to HCANN 6.0.1.Final
* [HSEARCH-4569](https://hibernate.atlassian.net/browse/HSEARCH-4569): Upgrade -orm6 artifacts to Hibernate ORM 6.0.1.Final

Backport of #3039 to branch 6.1