### PR TITLE
HSEARCH-4484 + HSEARCH-4581 Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,7 @@
         <version.assembly.plugin>3.1.0</version.assembly.plugin>
         <version.buildhelper.plugin>3.3.0</version.buildhelper.plugin>
         <version.checkstyle.plugin>3.1.2</version.checkstyle.plugin>
-        <version.bundle.plugin>5.1.5</version.bundle.plugin>
+        <version.bundle.plugin>5.1.6</version.bundle.plugin>
         <version.clean.plugin>3.2.0</version.clean.plugin>
         <!-- Needing 3.6.2 at least because of MCOMPILER-294 -->
         <version.compiler.plugin>3.10.1</version.compiler.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
              That's why we have two separate properties for jackson versions,
              even though they may have the same value from time to time.
          -->
-        <version.com.fasterxml.jackson.databind>2.13.2.2</version.com.fasterxml.jackson.databind>
+        <version.com.fasterxml.jackson.databind>2.13.3</version.com.fasterxml.jackson.databind>
         <!-- Reactive-streams: used by the AWS SDK -->
         <version.org.reactivestreams.reactive-streams>1.0.3</version.org.reactivestreams.reactive-streams>
         <!-- slf4j: used by the AWS SDK -->

--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
         <version.com.google.code.gson>2.9.0</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.17.94</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, the AWS SDK and in tests (wiremock, ...) -->
-        <version.com.fasterxml.jackson>2.13.2</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.13.3</version.com.fasterxml.jackson>
         <!--
              In the past, there has been jackson-databind bugfix releases without any jackson-core release,
              so we had to use different versions, e.g. jackson-core 2.9.9 and jackson-databind 2.9.9.3.

--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,7 @@
 
         <!-- >>> JSR 352: JBatch runtime -->
         <version.com.ibm.jbatch>1.0</version.com.ibm.jbatch>
-        <version.com.ibm.jbatch.jakarta>2.1.0</version.com.ibm.jbatch.jakarta>
+        <version.com.ibm.jbatch.jakarta>2.1.1</version.com.ibm.jbatch.jakarta>
         <version.org.apache.derby>10.13.1.1</version.org.apache.derby>
 
         <!-- >>> JSR 352: JBeret SE dependencies -->


### PR DESCRIPTION
* [HSEARCH-4581](https://hibernate.atlassian.net/browse/HSEARCH-4581): Upgrade to Jackson 2.13.3
* [HSEARCH-4484](https://hibernate.atlassian.net/browse/HSEARCH-4484): Upgrade build dependencies to the latest version

Follows up on https://github.com/hibernate/hibernate-search/pull/2895, https://github.com/hibernate/hibernate-search/pull/2902, https://github.com/hibernate/hibernate-search/pull/2904, #2913, #2931, #2941, #2954, #2293 #2983, #3021, #3028, #3041