### PR TITLE
HSEARCH-4575 Make fields projectable by default for ES

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/AbstractElasticsearchStandardIndexFieldTypeOptionsStep.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/AbstractElasticsearchStandardIndexFieldTypeOptionsStep.java
@@ -27,10 +27,10 @@ abstract class AbstractElasticsearchStandardIndexFieldTypeOptionsStep<S extends 
 	protected static boolean resolveDefault(Projectable projectable) {
 		switch ( projectable ) {
 			case DEFAULT:
-			case NO:
-				return false;
 			case YES:
 				return true;
+			case NO:
+				return false;
 			default:
 				throw new AssertionFailure( "Unexpected value for Projectable: " + projectable );
 		}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchGeoPointIndexFieldTypeOptionsStep.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchGeoPointIndexFieldTypeOptionsStep.java
@@ -33,8 +33,13 @@ class ElasticsearchGeoPointIndexFieldTypeOptionsStep
 		ElasticsearchGeoPointFieldCodec codec = ElasticsearchGeoPointFieldCodec.INSTANCE;
 		builder.codec( codec );
 
+		// Since docs values are going to be available as soon as the filed is either sortable or projectable
+		// it would open the other capability automatically. Hence:
+		resolvedSortable = resolvedSortable || resolvedProjectable;
+		resolvedProjectable = resolvedSortable;
+
 		// We need doc values for the projection script when not sorting on the same field
-		builder.mapping().setDocValues( resolvedSortable || resolvedProjectable );
+		builder.mapping().setDocValues( resolvedProjectable );
 
 		if ( resolvedSearchable ) {
 			builder.searchable( true );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchGeoPointIndexFieldTypeOptionsStep.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchGeoPointIndexFieldTypeOptionsStep.java
@@ -8,16 +8,16 @@ package org.hibernate.search.backend.elasticsearch.types.dsl.impl;
 
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.DataTypes;
 import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchExistsPredicate;
-import org.hibernate.search.engine.search.predicate.spi.PredicateTypeKeys;
 import org.hibernate.search.backend.elasticsearch.search.projection.impl.ElasticsearchDistanceToFieldProjection;
 import org.hibernate.search.backend.elasticsearch.search.projection.impl.ElasticsearchFieldProjection;
-import org.hibernate.search.engine.search.projection.spi.ProjectionTypeKeys;
-import org.hibernate.search.engine.search.sort.spi.SortTypeKeys;
 import org.hibernate.search.backend.elasticsearch.types.codec.impl.ElasticsearchGeoPointFieldCodec;
 import org.hibernate.search.backend.elasticsearch.types.predicate.impl.ElasticsearchGeoPointSpatialWithinBoundingBoxPredicate;
 import org.hibernate.search.backend.elasticsearch.types.predicate.impl.ElasticsearchGeoPointSpatialWithinCirclePredicate;
 import org.hibernate.search.backend.elasticsearch.types.predicate.impl.ElasticsearchGeoPointSpatialWithinPolygonPredicate;
 import org.hibernate.search.backend.elasticsearch.types.sort.impl.ElasticsearchDistanceSort;
+import org.hibernate.search.engine.search.predicate.spi.PredicateTypeKeys;
+import org.hibernate.search.engine.search.projection.spi.ProjectionTypeKeys;
+import org.hibernate.search.engine.search.sort.spi.SortTypeKeys;
 import org.hibernate.search.engine.spatial.GeoPoint;
 
 

--- a/documentation/src/main/asciidoc/migration/index.asciidoc
+++ b/documentation/src/main/asciidoc/migration/index.asciidoc
@@ -33,6 +33,14 @@ Hibernate Search's requirements did not change in version {hibernateSearchVersio
 Indexes created with Hibernate Search {hibernateSearchPreviousStableVersionShort}
 can be read from and written to with Hibernate Search {hibernateSearchVersion}.
 
+If your Hibernate Search mapping includes `GeoPoint` fields that are using the default value for the `projectable` option,
+and are using either the default value or `Sortable.NO` for the `sortable` option, Elasticsearch schema validation
+will fail on startup because of missing docvalues on those fields.
+To address that, either:
+
+* Revert to the previous defaults by adding `projectable = Projectable.NO` to the mapping annotation of relevant `GeoPoint` fields.
+* Or recreate your Elasticsearch indexes and reindex your database. The easiest way to do so is to use link:{hibernateSearchDocUrl}#mapper-orm-indexing-massindexer[the the `MassIndexer`] with link:{hibernateSearchDocUrl}#mapper-orm-indexing-massindexer-parameters-drop-and-create-schema[`dropAndCreateSchemaOnStart(true)`].
+
 [[configuration]]
 == Configuration changes
 

--- a/documentation/src/main/asciidoc/reference/mapper-orm-mapping-directfieldmapping.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapper-orm-mapping-directfieldmapping.asciidoc
@@ -159,6 +159,9 @@ Whether the field can be <<search-dsl-projection, projected on>>,
 i.e. whether the field value is stored in the index to allow retrieval later when querying.
 +
 Value: `Projectable.YES`, `Projectable.NO`, `Projectable.DEFAULT`.
++
+The defaults are different for the <<backend-lucene,Lucene>> and <<backend-elasticsearch,Elasticsearch>> backends:
+with Lucene, the default is `Projectable.NO`, while with Elasticsearch it's `Projectable.YES`.
 
 [[mapper-orm-directfieldmapping-aggregable]] `aggregable`::
 Whether the field can be <<search-dsl-aggregation, aggregated>>,

--- a/documentation/src/main/asciidoc/reference/mapper-orm-mapping-directfieldmapping.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapper-orm-mapping-directfieldmapping.asciidoc
@@ -162,6 +162,12 @@ Value: `Projectable.YES`, `Projectable.NO`, `Projectable.DEFAULT`.
 +
 The defaults are different for the <<backend-lucene,Lucene>> and <<backend-elasticsearch,Elasticsearch>> backends:
 with Lucene, the default is `Projectable.NO`, while with Elasticsearch it's `Projectable.YES`.
++
+[NOTE]
+====
+For <<backend-elasticsearch,Elasticsearch>> if any of `projectable` or `sortable` properties are resolved to `YES`
+on a `GeoPoint` field then this field automatically becomes both `projectable` and `sortable` even if one of them was explicitly set to `NO`.
+====
 
 [[mapper-orm-directfieldmapping-aggregable]] `aggregable`::
 Whether the field can be <<search-dsl-aggregation, aggregated>>,

--- a/documentation/src/main/asciidoc/reference/search-dsl-projection.asciidoc
+++ b/documentation/src/main/asciidoc/reference/search-dsl-projection.asciidoc
@@ -36,7 +36,8 @@ include::{sourcedir}/org/hibernate/search/documentation/search/projection/Projec
 [NOTE]
 ====
 There are a few constraints regarding `field` projections.
-In particular, in order for a field to be "projectable", it must be <<mapper-orm-directfieldmapping-projectable,marked as such in the mapping>>,
+In particular, in order for a field to be "projectable", it must either be <<mapper-orm-directfieldmapping-projectable,explicitly marked as such in the mapping>>,
+or be implicitly projectable based on the underlying backend (Elasticsearch),
 so that it is correctly stored in the index.
 ====
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedentities/SearchMappingIndexedEntitiesIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedentities/SearchMappingIndexedEntitiesIT.java
@@ -24,6 +24,7 @@ import org.hibernate.search.engine.backend.metamodel.IndexValueFieldTypeDescript
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.mapping.SearchMapping;
 import org.hibernate.search.mapper.orm.entity.SearchIndexedEntity;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -97,7 +98,7 @@ public class SearchMappingIndexedEntitiesIT {
 				Optional<String> normalizerName = type.normalizerName();
 				// Etc.
 				//end::indexMetamodel[]
-				assertThat( projectable ).isFalse();
+				assertThat( projectable ).isEqualTo( BackendConfiguration.isElasticsearch() ? true : false );
 				assertThat( dslArgumentClass ).isEqualTo( Date.class );
 				assertThat( projectedValueClass ).isEqualTo( Date.class );
 				assertThat( analyzerName ).isEmpty();

--- a/engine/src/main/java/org/hibernate/search/engine/backend/types/Projectable.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/types/Projectable.java
@@ -15,6 +15,10 @@ package org.hibernate.search.engine.backend.types;
 public enum Projectable {
 	/**
 	 * Use the backend-specific default.
+	 * <ul>
+	 *     <li>Lucene's default value is {@code YES} </li>
+	 *     <li>Elasticsearch's default value is {@code NO} </li>
+	 * </ul>
 	 */
 	DEFAULT,
 	/**

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -114,6 +114,11 @@ class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 	}
 
 	@Override
+	public boolean fieldsProjectableByDefault() {
+		return true;
+	}
+
+	@Override
 	public boolean supportsTotalHitsThresholdForSearch() {
 		return dialect.supportsSkipOrLimitingTotalHitCount();
 	}

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/LuceneTckBackendFeatures.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/LuceneTckBackendFeatures.java
@@ -22,6 +22,11 @@ class LuceneTckBackendFeatures extends TckBackendFeatures {
 	}
 
 	@Override
+	public boolean fieldsProjectableByDefault() {
+		return false;
+	}
+
+	@Override
 	public boolean reliesOnNestedDocumentsForObjectProjection() {
 		return true;
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/metamodel/IndexValueFieldTypeDescriptorBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/metamodel/IndexValueFieldTypeDescriptorBaseIT.java
@@ -24,6 +24,7 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.configuratio
 import org.hibernate.search.integrationtest.backend.tck.testsupport.operations.TermsAggregationDescriptor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.AnalyzedStringFieldTypeDescriptor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.GeoPointFieldTypeDescriptor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.NormalizedStringFieldTypeDescriptor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ValueWrapper;
@@ -80,14 +81,16 @@ public class IndexValueFieldTypeDescriptorBaseIT {
 
 	@Test
 	public void isSortable() {
+		boolean projectable = TckConfiguration.get().getBackendFeatures().fieldsProjectableByDefault();
+
 		assertThat( getTypeDescriptor( "default" ) )
-				.returns( false, IndexValueFieldTypeDescriptor::sortable );
+				.returns( GeoPointFieldTypeDescriptor.INSTANCE.equals( fieldType ) ? projectable : false, IndexValueFieldTypeDescriptor::sortable );
 		if ( isSortSupported() ) {
 			assertThat( getTypeDescriptor( "sortable" ) )
 					.returns( true, IndexValueFieldTypeDescriptor::sortable );
 		}
 		assertThat( getTypeDescriptor( "nonSortable" ) )
-				.returns( false, IndexValueFieldTypeDescriptor::sortable );
+				.returns( GeoPointFieldTypeDescriptor.INSTANCE.equals( fieldType ) ? projectable : false, IndexValueFieldTypeDescriptor::sortable );
 	}
 
 	@Test

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/metamodel/IndexValueFieldTypeDescriptorBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/metamodel/IndexValueFieldTypeDescriptorBaseIT.java
@@ -25,6 +25,7 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.operations.T
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.AnalyzedStringFieldTypeDescriptor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.NormalizedStringFieldTypeDescriptor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ValueWrapper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
@@ -91,8 +92,9 @@ public class IndexValueFieldTypeDescriptorBaseIT {
 
 	@Test
 	public void isProjectable() {
+		boolean projectable = TckConfiguration.get().getBackendFeatures().fieldsProjectableByDefault();
 		assertThat( getTypeDescriptor( "default" ) )
-				.returns( false, IndexValueFieldTypeDescriptor::projectable );
+				.returns( projectable, IndexValueFieldTypeDescriptor::projectable );
 		assertThat( getTypeDescriptor( "projectable" ) )
 				.returns( true, IndexValueFieldTypeDescriptor::projectable );
 		assertThat( getTypeDescriptor( "nonProjectable" ) )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/DistanceProjectionMultiValuedBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/DistanceProjectionMultiValuedBaseIT.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.integrationtest.backend.tck.search.projection;
 
+import static org.hibernate.search.integrationtest.backend.tck.testsupport.model.singlefield.SingleFieldIndexBinding.NO_ADDITIONAL_CONFIGURATION;
 import static org.hibernate.search.integrationtest.backend.tck.testsupport.types.values.IndexableGeoPointWithDistanceFromCenterValues.CENTER_POINT_1;
 import static org.hibernate.search.integrationtest.backend.tck.testsupport.types.values.IndexableGeoPointWithDistanceFromCenterValues.CENTER_POINT_2;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
@@ -28,6 +29,7 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldT
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.GeoPointFieldTypeDescriptor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values.AscendingUniqueDistanceFromCenterValues;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values.IndexableGeoPointWithDistanceFromCenterValues;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TestedFieldStructure;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.TestComparators;
@@ -83,16 +85,26 @@ public class DistanceProjectionMultiValuedBaseIT {
 	public static SearchSetupHelper setupHelper = new SearchSetupHelper();
 
 	private static final SimpleMappedIndex<SingleFieldIndexBinding> mainIndex =
-			SimpleMappedIndex.of( root -> SingleFieldIndexBinding.create(
-					root, supportedFieldTypes,
-					c -> c.projectable( Projectable.YES )
-			) )
+			SimpleMappedIndex.of(
+							root -> SingleFieldIndexBinding.create(
+									root,
+									supportedFieldTypes,
+									TckConfiguration.get().getBackendFeatures().fieldsProjectableByDefault() ?
+											NO_ADDITIONAL_CONFIGURATION :
+											c -> c.projectable( Projectable.YES )
+							)
+					)
 					.name( "main" );
 	private static final SimpleMappedIndex<SingleFieldIndexBinding> sortableIndex =
-			SimpleMappedIndex.of( root -> SingleFieldIndexBinding.create(
-					root, supportedFieldTypes,
-					c -> c.projectable( Projectable.YES ).sortable( Sortable.YES )
-			) )
+			SimpleMappedIndex.of(
+							root -> SingleFieldIndexBinding.create(
+									root,
+									supportedFieldTypes,
+									TckConfiguration.get().getBackendFeatures().fieldsProjectableByDefault() ?
+											c -> c.sortable( Sortable.YES ) :
+											c -> c.projectable( Projectable.YES ).sortable( Sortable.YES )
+							)
+					)
 					.name( "sortable" );
 
 	@BeforeClass

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/DistanceProjectionMultiValuedBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/DistanceProjectionMultiValuedBaseIT.java
@@ -101,7 +101,7 @@ public class DistanceProjectionMultiValuedBaseIT {
 									root,
 									supportedFieldTypes,
 									TckConfiguration.get().getBackendFeatures().fieldsProjectableByDefault() ?
-											c -> c.sortable( Sortable.YES ) :
+											NO_ADDITIONAL_CONFIGURATION :
 											c -> c.projectable( Projectable.YES ).sortable( Sortable.YES )
 							)
 					)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/DistanceProjectionSingleValuedBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/DistanceProjectionSingleValuedBaseIT.java
@@ -95,7 +95,7 @@ public class DistanceProjectionSingleValuedBaseIT {
 									root,
 									supportedFieldTypes,
 									TckConfiguration.get().getBackendFeatures().fieldsProjectableByDefault() ?
-											c -> c.sortable( Sortable.YES ) :
+											NO_ADDITIONAL_CONFIGURATION :
 											c -> c.projectable( Projectable.YES ).sortable( Sortable.YES )
 							)
 					)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/DistanceProjectionSingleValuedBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/DistanceProjectionSingleValuedBaseIT.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.integrationtest.backend.tck.search.projection;
 
+import static org.hibernate.search.integrationtest.backend.tck.testsupport.model.singlefield.SingleFieldIndexBinding.NO_ADDITIONAL_CONFIGURATION;
 import static org.hibernate.search.integrationtest.backend.tck.testsupport.types.values.IndexableGeoPointWithDistanceFromCenterValues.CENTER_POINT_1;
 import static org.hibernate.search.integrationtest.backend.tck.testsupport.types.values.IndexableGeoPointWithDistanceFromCenterValues.CENTER_POINT_2;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
@@ -78,16 +79,26 @@ public class DistanceProjectionSingleValuedBaseIT {
 	public static SearchSetupHelper setupHelper = new SearchSetupHelper();
 
 	private static final SimpleMappedIndex<SingleFieldIndexBinding> mainIndex =
-			SimpleMappedIndex.of( root -> SingleFieldIndexBinding.createWithSingleValuedNestedFields(
-					root, supportedFieldTypes,
-					c -> c.projectable( Projectable.YES )
-			) )
+			SimpleMappedIndex.of(
+							root -> SingleFieldIndexBinding.createWithSingleValuedNestedFields(
+									root,
+									supportedFieldTypes,
+									TckConfiguration.get().getBackendFeatures().fieldsProjectableByDefault() ?
+											NO_ADDITIONAL_CONFIGURATION :
+											c -> c.projectable( Projectable.YES )
+							)
+					)
 					.name( "main" );
 	private static final SimpleMappedIndex<SingleFieldIndexBinding> sortableIndex =
-			SimpleMappedIndex.of( root -> SingleFieldIndexBinding.createWithSingleValuedNestedFields(
-					root, supportedFieldTypes,
-					c -> c.projectable( Projectable.YES ).sortable( Sortable.YES )
-			) )
+			SimpleMappedIndex.of(
+							root -> SingleFieldIndexBinding.createWithSingleValuedNestedFields(
+									root,
+									supportedFieldTypes,
+									TckConfiguration.get().getBackendFeatures().fieldsProjectableByDefault() ?
+											c -> c.sortable( Sortable.YES ) :
+											c -> c.projectable( Projectable.YES ).sortable( Sortable.YES )
+							)
+					)
 					.name( "sortable" );
 
 	@BeforeClass

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldProjectionMultiValuedBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldProjectionMultiValuedBaseIT.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.integrationtest.backend.tck.search.projection;
 
+import static org.hibernate.search.integrationtest.backend.tck.testsupport.model.singlefield.SingleFieldIndexBinding.NO_ADDITIONAL_CONFIGURATION;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
 import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.documentProvider;
 
@@ -19,6 +20,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.model.singlefield.SingleFieldIndexBinding;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TestedFieldStructure;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
@@ -65,7 +67,13 @@ public class FieldProjectionMultiValuedBaseIT<F> {
 	public static SearchSetupHelper setupHelper = new SearchSetupHelper();
 
 	private static final Function<IndexSchemaElement, SingleFieldIndexBinding> bindingFactory =
-			root -> SingleFieldIndexBinding.create( root, supportedFieldTypes, c -> c.projectable( Projectable.YES ) );
+			root -> SingleFieldIndexBinding.create(
+					root,
+					supportedFieldTypes,
+					TckConfiguration.get().getBackendFeatures().fieldsProjectableByDefault() ?
+							NO_ADDITIONAL_CONFIGURATION :
+							c -> c.projectable( Projectable.YES )
+			);
 
 	private static final SimpleMappedIndex<SingleFieldIndexBinding> index = SimpleMappedIndex.of( bindingFactory );
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldProjectionSingleValuedBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldProjectionSingleValuedBaseIT.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.integrationtest.backend.tck.search.projection;
 
+import static org.hibernate.search.integrationtest.backend.tck.testsupport.model.singlefield.SingleFieldIndexBinding.NO_ADDITIONAL_CONFIGURATION;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
 import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.documentProvider;
 import static org.junit.Assume.assumeTrue;
@@ -67,8 +68,13 @@ public class FieldProjectionSingleValuedBaseIT<F> {
 	public static SearchSetupHelper setupHelper = new SearchSetupHelper();
 
 	private static final Function<IndexSchemaElement, SingleFieldIndexBinding> bindingFactory =
-			root -> SingleFieldIndexBinding.createWithSingleValuedNestedFields( root, supportedFieldTypes,
-					c -> c.projectable( Projectable.YES ) );
+			root -> SingleFieldIndexBinding.createWithSingleValuedNestedFields(
+					root,
+					supportedFieldTypes,
+					TckConfiguration.get().getBackendFeatures().fieldsProjectableByDefault() ?
+							NO_ADDITIONAL_CONFIGURATION :
+							c -> c.projectable( Projectable.YES )
+			);
 
 	private static final SimpleMappedIndex<SingleFieldIndexBinding> index = SimpleMappedIndex.of( bindingFactory );
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/DistanceSortTypeCheckingAndConversionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/DistanceSortTypeCheckingAndConversionIT.java
@@ -9,6 +9,7 @@ package org.hibernate.search.integrationtest.backend.tck.search.sort;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hibernate.search.integrationtest.backend.tck.testsupport.types.values.AscendingUniqueDistanceFromCenterValues.CENTER_POINT;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 import java.util.function.Consumer;
@@ -96,6 +97,10 @@ public class DistanceSortTypeCheckingAndConversionIT {
 
 	@Test
 	public void unsortable() {
+		assumeFalse(
+				"Skipping test for ES GeoPoint as those would become sortable by default in this case.",
+				TckConfiguration.get().getBackendFeatures().fieldsProjectableByDefault()
+		);
 		StubMappingScope scope = mainIndex.createScope();
 		String fieldPath = getNonSortableFieldPath();
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/model/singlefield/SingleFieldIndexBinding.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/model/singlefield/SingleFieldIndexBinding.java
@@ -28,6 +28,8 @@ public class SingleFieldIndexBinding extends AbstractObjectBinding {
 	public static final String DISCRIMINATOR_VALUE_INCLUDED = "included";
 	public static final String DISCRIMINATOR_VALUE_EXCLUDED = "excluded";
 
+	public static final Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> NO_ADDITIONAL_CONFIGURATION = c -> { };
+
 	public static SingleFieldIndexBinding create(IndexSchemaElement root,
 			Collection<? extends FieldTypeDescriptor<?>> supportedFieldTypes,
 			Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
@@ -59,6 +59,8 @@ public abstract class TckBackendFeatures {
 		return true;
 	}
 
+	public abstract boolean fieldsProjectableByDefault();
+
 	public boolean supportsTotalHitsThresholdForSearch() {
 		return true;
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4575

- change the default behavior of projectable for ES
- extend Tck helper to expose the projectable defaults for backends
- update documentation

Haven't seen anything "updatable" on `SearchProjectionFactory` javadoc. 