### PR TITLE
HSEARCH-4584 Projection and sort on the same nested field fails with the Lucene Backend

### DIFF
--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/nested/ProjectionAndOrderByNestedIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/nested/ProjectionAndOrderByNestedIT.java
@@ -1,0 +1,93 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+package org.hibernate.search.integrationtest.backend.lucene.nested;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.IndexObjectFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
+import org.hibernate.search.engine.backend.types.ObjectStructure;
+import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.engine.search.query.SearchQuery;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ProjectionAndOrderByNestedIT {
+
+	@Rule
+	public final SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private final SimpleMappedIndex<IndexBinding> index = SimpleMappedIndex.of( IndexBinding::new );
+
+	@Before
+	public void before() {
+		setupHelper.start().withIndex( index ).setup();
+	}
+
+	@Test
+	public void test() {
+		index.index( "1", doc -> {
+			doc.addValue( index.binding().year, 1845 );
+
+			DocumentElement author = doc.addObject( index.binding().author );
+			author.addValue( index.binding().name, "Edgar Allen Poe" );
+		} );
+		index.index( "2", doc -> {
+			doc.addValue( index.binding().year, 1890 );
+
+			DocumentElement author = doc.addObject( index.binding().author );
+			author.addValue( index.binding().name, "Emily Dickinson" );
+		} );
+		index.index( "3", doc -> {
+			doc.addValue( index.binding().year, 1883 );
+
+			DocumentElement author = doc.addObject( index.binding().author );
+			author.addValue( index.binding().name, "Emma Lazarus" );
+		} );
+
+		StubMappingScope scope = index.createScope();
+		SearchQuery<Object> query = scope.query()
+				.select( f -> f.field( "author.name" ) )
+				.where( f -> f.range().field( "year" ).lessThan( 1885 ) )
+				.sort( f -> f.field( "author.name" ) )
+				.toQuery();
+
+		List<Object> hits = query.fetchAll().hits();
+		assertThat( hits ).isNotEmpty();
+	}
+
+	private static class IndexBinding {
+		private final IndexFieldReference<Integer> year;
+
+		private final IndexObjectFieldReference author;
+		private final IndexFieldReference<String> name;
+
+		IndexBinding(IndexSchemaElement root) {
+			year = root.field( "year", f -> f.asInteger()
+					.projectable( Projectable.YES ).sortable( Sortable.YES ) ).toReference();
+
+			IndexSchemaObjectField nested = root.objectField( "author", ObjectStructure.NESTED );
+			author = nested.toReference();
+
+			name = nested.field( "name", f -> f.asString()
+					.projectable( Projectable.YES ).sortable( Sortable.YES ) ).toReference();
+		}
+	}
+
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldProjectionAndSortNestedIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldProjectionAndSortNestedIT.java
@@ -5,7 +5,7 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 
-package org.hibernate.search.integrationtest.backend.lucene.nested;
+package org.hibernate.search.integrationtest.backend.tck.search.projection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,12 +23,14 @@ import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class ProjectionAndOrderByNestedIT {
+@TestForIssue(jiraKey = "HSEARCH-4584")
+public class FieldProjectionAndSortNestedIT {
 
 	@Rule
 	public final SearchSetupHelper setupHelper = new SearchSetupHelper();


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4584

Turns out this was already fixed on `main` by #2955 