### PR TITLE
[6.1] HSEARCH-4588 Fix mention of Hibernate Search requiring ORM 5.5 instead of 5.6 in the migration guide

### DIFF
--- a/documentation/src/main/asciidoc/migration/index.asciidoc
+++ b/documentation/src/main/asciidoc/migration/index.asciidoc
@@ -25,7 +25,7 @@ following the migration guide of link:https://hibernate.org/search/documentation
 [[requirements]]
 == Requirements
 
-Hibernate Search {hibernateSearchVersion} now requires using Hibernate ORM versions from the 5.5.x family.
+Hibernate Search {hibernateSearchVersion} now requires using Hibernate ORM versions from the 5.6.x family.
 
 [[data-format]]
 == Data format and schema changes


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4588
