### PR TITLE
HSEARCH-4571 Follow-up to fix tests

### DIFF
--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/sync/OutOfSyncIndexIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/sync/OutOfSyncIndexIT.java
@@ -7,17 +7,17 @@
 package org.hibernate.search.integrationtest.mapper.orm.realbackend.sync;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 import static org.hibernate.search.integrationtest.mapper.orm.realbackend.util.BookCreatorUtils.prepareBooks;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
-import java.time.Duration;
 import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.search.integrationtest.mapper.orm.realbackend.testsupport.BackendConfigurations;
 import org.hibernate.search.integrationtest.mapper.orm.realbackend.util.Book;
 import org.hibernate.search.integrationtest.mapper.orm.realbackend.util.BookCreatorUtils;
 import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.automaticindexing.session.AutomaticIndexingSynchronizationStrategyNames;
+import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
@@ -39,18 +39,11 @@ public class OutOfSyncIndexIT {
 	@Before
 	public void before() {
 		entityManagerFactory = setupHelper.start()
+				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_SYNCHRONIZATION_STRATEGY,
+						AutomaticIndexingSynchronizationStrategyNames.READ_SYNC )
 				.setup( Book.class );
 
 		prepareBooks( entityManagerFactory );
-
-		await( "Waiting for docs to appear" )
-				.pollDelay( Duration.ZERO )
-				.pollInterval( Duration.ofMillis( 5 ) )
-				.atMost( Duration.ofSeconds( 5 ) )
-				.untilAsserted( () -> {
-					assertThat( BookCreatorUtils.documentsCount( entityManagerFactory ) )
-							.isPositive();
-				} );
 	}
 
 	@Test

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/sync/OutOfSyncIndexIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/sync/OutOfSyncIndexIT.java
@@ -31,6 +31,8 @@ import org.junit.Test;
  */
 public class OutOfSyncIndexIT {
 
+	private static final int NUMBER_OF_BOOKS = 8;
+
 	@Rule
 	public OrmSetupHelper setupHelper = OrmSetupHelper.withSingleBackend( BackendConfigurations.simple() );
 
@@ -43,7 +45,7 @@ public class OutOfSyncIndexIT {
 						AutomaticIndexingSynchronizationStrategyNames.READ_SYNC )
 				.setup( Book.class );
 
-		prepareBooks( entityManagerFactory );
+		prepareBooks( entityManagerFactory, NUMBER_OF_BOOKS );
 	}
 
 	@Test

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/util/BookCreatorUtils.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/util/BookCreatorUtils.java
@@ -18,10 +18,6 @@ public final class BookCreatorUtils {
 	private BookCreatorUtils() {
 	}
 
-	public static void prepareBooks(EntityManagerFactory entityManagerFactory) {
-		prepareBooks( entityManagerFactory, 8 );
-	}
-
 	public static void prepareBooks(EntityManagerFactory entityManagerFactory, int numberOfBooks) {
 		withinJPATransaction( entityManagerFactory, entityManager -> {
 			for ( int i = 0; i < numberOfBooks; i++ ) {


### PR DESCRIPTION
Follows up on #3054 .

@marko-bekhta You may be interested in the first commit. I missed that during my review, otherwise I would have told you Hibernate Search has a built-in feature to make indexing synchronous :) We generally only use that in tests, because performance is bad, but it's *very* useful for tests.