### PR TITLE
HSEARCH-4586 Use clean, consistent utils for all in-session code execution in ORM sessions

### DIFF
--- a/build/config/src/main/resources/checkstyle.xml
+++ b/build/config/src/main/resources/checkstyle.xml
@@ -88,6 +88,12 @@
             <property name="ignoreComments" value="true" />
         </module>
 
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="(?&lt;!^import static)\s[\w\.]*\bOrmUtils\.[a-z]\w*\(" />
+            <property name="message" value="Always use static imports for OrmUtils" />
+            <property name="ignoreComments" value="true" />
+        </module>
+
        <!-- Checks for imports -->
         <module name="AvoidStarImport" />
         <module name="RedundantImport" />

--- a/documentation/src/test/java/org/hibernate/search/documentation/analysis/AnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/analysis/AnalysisIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.analysis;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration.isLucene;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import javax.persistence.Entity;
 import javax.persistence.EntityManagerFactory;
@@ -50,14 +50,14 @@ public class AnalysisIT {
 				)
 				.setup( IndexedEntity.class );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			IndexedEntity entity = new IndexedEntity();
 			// Mix French and English to test multiple analyzers with different stemmers
 			entity.setText( "THE <strong>châtié</strong> wording" );
 			entityManager.persist( entity );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			assertThat(

--- a/documentation/src/test/java/org/hibernate/search/documentation/analysis/AnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/analysis/AnalysisIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.analysis;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration.isLucene;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import javax.persistence.Entity;
 import javax.persistence.EntityManagerFactory;
@@ -21,7 +22,6 @@ import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.mapper.orm.mapping.HibernateOrmSearchMappingConfigurer;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -50,14 +50,14 @@ public class AnalysisIT {
 				)
 				.setup( IndexedEntity.class );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			IndexedEntity entity = new IndexedEntity();
 			// Mix French and English to test multiple analyzers with different stemmers
 			entity.setText( "THE <strong>châtié</strong> wording" );
 			entityManager.persist( entity );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			assertThat(

--- a/documentation/src/test/java/org/hibernate/search/documentation/analysis/ElasticsearchAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/analysis/ElasticsearchAnalysisIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.analysis;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import javax.persistence.Entity;
 import javax.persistence.EntityManagerFactory;
@@ -21,7 +22,6 @@ import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.mapper.orm.mapping.HibernateOrmSearchMappingConfigurer;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,13 +47,13 @@ public class ElasticsearchAnalysisIT {
 				)
 				.setup( IndexedEntity.class );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			IndexedEntity entity = new IndexedEntity();
 			entity.setText( "the Wording" );
 			entityManager.persist( entity );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			assertThat(

--- a/documentation/src/test/java/org/hibernate/search/documentation/analysis/ElasticsearchAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/analysis/ElasticsearchAnalysisIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.analysis;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import javax.persistence.Entity;
 import javax.persistence.EntityManagerFactory;
@@ -47,13 +47,13 @@ public class ElasticsearchAnalysisIT {
 				)
 				.setup( IndexedEntity.class );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			IndexedEntity entity = new IndexedEntity();
 			entity.setText( "the Wording" );
 			entityManager.persist( entity );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			assertThat(

--- a/documentation/src/test/java/org/hibernate/search/documentation/analysis/LuceneAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/analysis/LuceneAnalysisIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.analysis;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import javax.persistence.Entity;
 import javax.persistence.EntityManagerFactory;
@@ -21,7 +22,6 @@ import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.mapper.orm.mapping.HibernateOrmSearchMappingConfigurer;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,13 +47,13 @@ public class LuceneAnalysisIT {
 				)
 				.setup( IndexedEntity.class );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			IndexedEntity entity = new IndexedEntity();
 			entity.setText( "the Wording" );
 			entityManager.persist( entity );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			assertThat(
@@ -84,13 +84,13 @@ public class LuceneAnalysisIT {
 				)
 				.setup( IndexedEntity.class );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			IndexedEntity entity = new IndexedEntity();
 			entity.setText( "the Wording" );
 			entityManager.persist( entity );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			assertThat( searchSession.search( IndexedEntity.class )
@@ -118,13 +118,13 @@ public class LuceneAnalysisIT {
 				)
 				.setup( IndexedEntity.class );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			IndexedEntity entity = new IndexedEntity();
 			entity.setText( "the Wording" );
 			entityManager.persist( entity );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			assertThat(

--- a/documentation/src/test/java/org/hibernate/search/documentation/analysis/LuceneAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/analysis/LuceneAnalysisIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.analysis;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import javax.persistence.Entity;
 import javax.persistence.EntityManagerFactory;
@@ -47,13 +47,13 @@ public class LuceneAnalysisIT {
 				)
 				.setup( IndexedEntity.class );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			IndexedEntity entity = new IndexedEntity();
 			entity.setText( "the Wording" );
 			entityManager.persist( entity );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			assertThat(
@@ -84,13 +84,13 @@ public class LuceneAnalysisIT {
 				)
 				.setup( IndexedEntity.class );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			IndexedEntity entity = new IndexedEntity();
 			entity.setText( "the Wording" );
 			entityManager.persist( entity );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			assertThat( searchSession.search( IndexedEntity.class )
@@ -118,13 +118,13 @@ public class LuceneAnalysisIT {
 				)
 				.setup( IndexedEntity.class );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			IndexedEntity entity = new IndexedEntity();
 			entity.setText( "the Wording" );
 			entityManager.persist( entity );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			assertThat(

--- a/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/layout/ElasticsearchCustomLayoutStrategyIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/layout/ElasticsearchCustomLayoutStrategyIT.java
@@ -9,7 +9,7 @@ package org.hibernate.search.documentation.backend.elasticsearch.layout;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.ElasticsearchIndexMetadataTestUtils.encodeName;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -56,13 +56,13 @@ public class ElasticsearchCustomLayoutStrategyIT {
 				JSONCompareMode.LENIENT
 		);
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setTitle( "The Robots Of Dawn" );
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/layout/ElasticsearchCustomLayoutStrategyIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/layout/ElasticsearchCustomLayoutStrategyIT.java
@@ -9,6 +9,7 @@ package org.hibernate.search.documentation.backend.elasticsearch.layout;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.ElasticsearchIndexMetadataTestUtils.encodeName;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -21,7 +22,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.rule.TestElasticsearchClient;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.JsonHelper;
 
 import org.junit.Rule;
@@ -56,13 +56,13 @@ public class ElasticsearchCustomLayoutStrategyIT {
 				JSONCompareMode.LENIENT
 		);
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setTitle( "The Robots Of Dawn" );
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/mapping/ElasticsearchCustomIndexMappingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/mapping/ElasticsearchCustomIndexMappingIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.backend.elasticsearch.mapping;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 import static org.hibernate.search.util.impl.test.JsonHelper.assertJsonEquals;
 
 import java.io.InputStream;
@@ -50,13 +50,13 @@ public class ElasticsearchCustomIndexMappingIT {
 		String mapping = elasticsearchClient.index( Book.NAME ).type().getMapping();
 		assertJsonEquals( expectedMergedMapping(), mapping );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setTitle( "The Robots Of Dawn" );
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/mapping/ElasticsearchCustomIndexMappingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/mapping/ElasticsearchCustomIndexMappingIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.backend.elasticsearch.mapping;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 import static org.hibernate.search.util.impl.test.JsonHelper.assertJsonEquals;
 
 import java.io.InputStream;
@@ -22,7 +23,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.rule.TestElasticsearchClient;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -50,13 +50,13 @@ public class ElasticsearchCustomIndexMappingIT {
 		String mapping = elasticsearchClient.index( Book.NAME ).type().getMapping();
 		assertJsonEquals( expectedMergedMapping(), mapping );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setTitle( "The Robots Of Dawn" );
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/setting/ElasticsearchCustomIndexSettingsIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/setting/ElasticsearchCustomIndexSettingsIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.backend.elasticsearch.setting;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -18,7 +19,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,13 +38,13 @@ public class ElasticsearchCustomIndexSettingsIT {
 				)
 				.setup( Book.class );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setTitle( "The Robots Of Dawn" );
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/setting/ElasticsearchCustomIndexSettingsIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/setting/ElasticsearchCustomIndexSettingsIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.backend.elasticsearch.setting;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -38,13 +38,13 @@ public class ElasticsearchCustomIndexSettingsIT {
 				)
 				.setup( Book.class );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setTitle( "The Robots Of Dawn" );
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/type/asnative/ElasticsearchNativeTypeIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/type/asnative/ElasticsearchNativeTypeIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.backend.elasticsearch.type.asnative;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,13 +36,13 @@ public class ElasticsearchNativeTypeIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			CompanyServer companyServer = new CompanyServer();
 			companyServer.setIpAddress( "192.168.10.2" );
 			entityManager.persist( companyServer );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<CompanyServer> result = searchSession.search( CompanyServer.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/type/asnative/ElasticsearchNativeTypeIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/type/asnative/ElasticsearchNativeTypeIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.backend.elasticsearch.type.asnative;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -36,13 +36,13 @@ public class ElasticsearchNativeTypeIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			CompanyServer companyServer = new CompanyServer();
 			companyServer.setIpAddress( "192.168.10.2" );
 			entityManager.persist( companyServer );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<CompanyServer> result = searchSession.search( CompanyServer.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/backend/lucene/type/asnative/LuceneNativeTypeIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/backend/lucene/type/asnative/LuceneNativeTypeIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.backend.lucene.type.asnative;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -38,7 +38,7 @@ public class LuceneNativeTypeIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			WebPage webPage1 = new WebPage();
 			webPage1.setId( 1 );
 			webPage1.setPageRank( 2.0f );
@@ -53,7 +53,7 @@ public class LuceneNativeTypeIT {
 			entityManager.persist( webPage3 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Result> result = searchSession.search( WebPage.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/backend/lucene/type/asnative/LuceneNativeTypeIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/backend/lucene/type/asnative/LuceneNativeTypeIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.backend.lucene.type.asnative;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -38,7 +38,7 @@ public class LuceneNativeTypeIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			WebPage webPage1 = new WebPage();
 			webPage1.setId( 1 );
 			webPage1.setPageRank( 2.0f );
@@ -53,7 +53,7 @@ public class LuceneNativeTypeIT {
 			entityManager.persist( webPage3 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Result> result = searchSession.search( WebPage.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/customanalysis/GettingStartedCustomAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/customanalysis/GettingStartedCustomAnalysisIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.gettingstarted.withhsearch.customanal
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration.BACKEND_TYPE;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.concurrent.atomic.AtomicReference;
 import javax.persistence.EntityManagerFactory;
@@ -51,7 +51,7 @@ public class GettingStartedCustomAnalysisIT {
 	public void test() {
 		AtomicReference<Integer> bookIdHolder = new AtomicReference<>();
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Author author = new Author();
 			author.setName( "John Doe" );
 
@@ -68,7 +68,7 @@ public class GettingStartedCustomAnalysisIT {
 			bookIdHolder.set( book.getId() );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// tag::searching[]
 			// Not shown: get the entity manager and open a transaction
 			SearchSession searchSession = Search.session( entityManager );
@@ -86,7 +86,7 @@ public class GettingStartedCustomAnalysisIT {
 		} );
 
 		// Also test the other terms mentioned in the getting started guide
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			for ( String term : new String[] { "Refactor", "refactors", "refactor", "refactoring" } ) {

--- a/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/customanalysis/GettingStartedCustomAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/customanalysis/GettingStartedCustomAnalysisIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.gettingstarted.withhsearch.customanal
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration.BACKEND_TYPE;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.concurrent.atomic.AtomicReference;
 import javax.persistence.EntityManagerFactory;
@@ -18,7 +19,6 @@ import org.hibernate.search.engine.search.query.SearchResult;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.util.impl.integrationtest.common.TestConfigurationProvider;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.After;
 import org.junit.Before;
@@ -51,7 +51,7 @@ public class GettingStartedCustomAnalysisIT {
 	public void test() {
 		AtomicReference<Integer> bookIdHolder = new AtomicReference<>();
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Author author = new Author();
 			author.setName( "John Doe" );
 
@@ -68,7 +68,7 @@ public class GettingStartedCustomAnalysisIT {
 			bookIdHolder.set( book.getId() );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::searching[]
 			// Not shown: get the entity manager and open a transaction
 			SearchSession searchSession = Search.session( entityManager );
@@ -86,7 +86,7 @@ public class GettingStartedCustomAnalysisIT {
 		} );
 
 		// Also test the other terms mentioned in the getting started guide
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			for ( String term : new String[] { "Refactor", "refactors", "refactor", "refactoring" } ) {

--- a/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/defaultanalysis/GettingStartedDefaultAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/defaultanalysis/GettingStartedDefaultAnalysisIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.gettingstarted.withhsearch.defaultana
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration.BACKEND_TYPE;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
@@ -55,7 +55,7 @@ public class GettingStartedDefaultAnalysisIT {
 	public void test() {
 		AtomicReference<Integer> bookIdHolder = new AtomicReference<>();
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// tag::indexing[]
 			// Not shown: get the entity manager and open a transaction
 			Author author = new Author();
@@ -76,7 +76,7 @@ public class GettingStartedDefaultAnalysisIT {
 			bookIdHolder.set( book.getId() );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			try {
 			// tag::manual-index[]
 				SearchSession searchSession = Search.session( entityManager ); // <1>
@@ -92,7 +92,7 @@ public class GettingStartedDefaultAnalysisIT {
 			}
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// tag::searching-objects[]
 			// Not shown: get the entity manager and open a transaction
 			SearchSession searchSession = Search.session( entityManager ); // <1>
@@ -129,7 +129,7 @@ public class GettingStartedDefaultAnalysisIT {
 					.containsExactlyInAnyOrder( bookIdHolder.get() );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// tag::searching-lambdas[]
 			// Not shown: get the entity manager and open a transaction
 			SearchSession searchSession = Search.session( entityManager ); // <1>
@@ -162,7 +162,7 @@ public class GettingStartedDefaultAnalysisIT {
 					.containsExactlyInAnyOrder( bookIdHolder.get() );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// tag::counting[]
 			// Not shown: get the entity manager and open a transaction
 			SearchSession searchSession = Search.session( entityManager );

--- a/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/defaultanalysis/GettingStartedDefaultAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/defaultanalysis/GettingStartedDefaultAnalysisIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.gettingstarted.withhsearch.defaultana
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration.BACKEND_TYPE;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
@@ -22,7 +23,6 @@ import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
 import org.hibernate.search.mapper.orm.scope.SearchScope;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.util.impl.integrationtest.common.TestConfigurationProvider;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.After;
 import org.junit.Before;
@@ -55,7 +55,7 @@ public class GettingStartedDefaultAnalysisIT {
 	public void test() {
 		AtomicReference<Integer> bookIdHolder = new AtomicReference<>();
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::indexing[]
 			// Not shown: get the entity manager and open a transaction
 			Author author = new Author();
@@ -76,7 +76,7 @@ public class GettingStartedDefaultAnalysisIT {
 			bookIdHolder.set( book.getId() );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			try {
 			// tag::manual-index[]
 				SearchSession searchSession = Search.session( entityManager ); // <1>
@@ -92,7 +92,7 @@ public class GettingStartedDefaultAnalysisIT {
 			}
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::searching-objects[]
 			// Not shown: get the entity manager and open a transaction
 			SearchSession searchSession = Search.session( entityManager ); // <1>
@@ -129,7 +129,7 @@ public class GettingStartedDefaultAnalysisIT {
 					.containsExactlyInAnyOrder( bookIdHolder.get() );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::searching-lambdas[]
 			// Not shown: get the entity manager and open a transaction
 			SearchSession searchSession = Search.session( entityManager ); // <1>
@@ -162,7 +162,7 @@ public class GettingStartedDefaultAnalysisIT {
 					.containsExactlyInAnyOrder( bookIdHolder.get() );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::counting[]
 			// Not shown: get the entity manager and open a transaction
 			SearchSession searchSession = Search.session( entityManager );

--- a/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withouthsearch/GettingStartedWithoutHibernateSearchIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withouthsearch/GettingStartedWithoutHibernateSearchIT.java
@@ -7,14 +7,13 @@
 package org.hibernate.search.documentation.gettingstarted.withouthsearch;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 import javax.persistence.TypedQuery;
-
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.After;
 import org.junit.Before;
@@ -40,7 +39,7 @@ public class GettingStartedWithoutHibernateSearchIT {
 	public void test() {
 		AtomicReference<Integer> bookIdHolder = new AtomicReference<>();
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Author author = new Author();
 			author.setName( "John Doe" );
 
@@ -57,7 +56,7 @@ public class GettingStartedWithoutHibernateSearchIT {
 			bookIdHolder.set( book.getId() );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			TypedQuery<Book> query = entityManager.createQuery( "select b from Book b where title = ?1", Book.class );
 			query.setParameter( 1, "Refactoring: Improving the Design of Existing Code" );
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withouthsearch/GettingStartedWithoutHibernateSearchIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withouthsearch/GettingStartedWithoutHibernateSearchIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.gettingstarted.withouthsearch;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -39,7 +39,7 @@ public class GettingStartedWithoutHibernateSearchIT {
 	public void test() {
 		AtomicReference<Integer> bookIdHolder = new AtomicReference<>();
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Author author = new Author();
 			author.setName( "John Doe" );
 
@@ -56,7 +56,7 @@ public class GettingStartedWithoutHibernateSearchIT {
 			bookIdHolder.set( book.getId() );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			TypedQuery<Book> query = entityManager.createQuery( "select b from Book b where title = ?1", Book.class );
 			query.setParameter( 1, "Refactoring: Improving the Design of Existing Code" );
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/alternative/alternativebinder/AlternativeBinderIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/alternative/alternativebinder/AlternativeBinderIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.alternative.alternativebin
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -59,7 +59,7 @@ public class AlternativeBinderIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			BlogEntry entry1 = new BlogEntry();
 			entry1.setId( 1 );
 			entry1.setLanguage( Language.GERMAN );
@@ -73,7 +73,7 @@ public class AlternativeBinderIT {
 			entityManager.persist( entry2 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			// Only matches the german text, because the word is decomposed

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/alternative/alternativebinder/AlternativeBinderIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/alternative/alternativebinder/AlternativeBinderIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.alternative.alternativebin
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -19,7 +20,6 @@ import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.bridge.builtin.programmatic.AlternativeBinder;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -59,7 +59,7 @@ public class AlternativeBinderIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			BlogEntry entry1 = new BlogEntry();
 			entry1.setId( 1 );
 			entry1.setLanguage( Language.GERMAN );
@@ -73,7 +73,7 @@ public class AlternativeBinderIT {
 			entityManager.persist( entry2 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			// Only matches the german text, because the word is decomposed

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/containers/fromotherentity/DependenciesFromOtherEntityIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/containers/fromotherentity/DependenciesFromOtherEntityIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.dependencies.contai
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import javax.persistence.EntityManagerFactory;
 
@@ -15,7 +16,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -34,7 +34,7 @@ public class DependenciesFromOtherEntityIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			ScientificPaper paper1 = new ScientificPaper( 1 );
 			paper1.setTitle( "Fundamental Ideas of the General Theory of Relativity and the Application of this Theory in Astronomy" );
 			ScientificPaper paper2 = new ScientificPaper( 2 );
@@ -50,7 +50,7 @@ public class DependenciesFromOtherEntityIT {
 			entityManager.persist( paper3 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			assertThat( searchSession.search( ScientificPaper.class )
@@ -72,7 +72,7 @@ public class DependenciesFromOtherEntityIT {
 			)
 					.hasSize( 0 );
 		} );
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			ScientificPaper paper1 = entityManager.find( ScientificPaper.class, 1 );
 			ScientificPaper paper2 = entityManager.find( ScientificPaper.class, 2 );
 			ScientificPaper paper3 = entityManager.find( ScientificPaper.class, 3 );
@@ -85,7 +85,7 @@ public class DependenciesFromOtherEntityIT {
 			entityManager.persist( paper4 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			assertThat( searchSession.search( ScientificPaper.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/containers/fromotherentity/DependenciesFromOtherEntityIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/containers/fromotherentity/DependenciesFromOtherEntityIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.dependencies.contai
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import javax.persistence.EntityManagerFactory;
 
@@ -34,7 +34,7 @@ public class DependenciesFromOtherEntityIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			ScientificPaper paper1 = new ScientificPaper( 1 );
 			paper1.setTitle( "Fundamental Ideas of the General Theory of Relativity and the Application of this Theory in Astronomy" );
 			ScientificPaper paper2 = new ScientificPaper( 2 );
@@ -50,7 +50,7 @@ public class DependenciesFromOtherEntityIT {
 			entityManager.persist( paper3 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			assertThat( searchSession.search( ScientificPaper.class )
@@ -72,7 +72,7 @@ public class DependenciesFromOtherEntityIT {
 			)
 					.hasSize( 0 );
 		} );
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			ScientificPaper paper1 = entityManager.find( ScientificPaper.class, 1 );
 			ScientificPaper paper2 = entityManager.find( ScientificPaper.class, 2 );
 			ScientificPaper paper3 = entityManager.find( ScientificPaper.class, 3 );
@@ -85,7 +85,7 @@ public class DependenciesFromOtherEntityIT {
 			entityManager.persist( paper4 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			assertThat( searchSession.search( ScientificPaper.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/containers/property/DependenciesContainersPropertyIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/containers/property/DependenciesContainersPropertyIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.bridge.dependencies.containers.property;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -36,7 +36,7 @@ public class DependenciesContainersPropertyIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setTitle( "The Caves Of Steel" );
 
@@ -55,7 +55,7 @@ public class DependenciesContainersPropertyIT {
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/containers/property/DependenciesContainersPropertyIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/containers/property/DependenciesContainersPropertyIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.bridge.dependencies.containers.property;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -16,7 +17,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,7 +36,7 @@ public class DependenciesContainersPropertyIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setTitle( "The Caves Of Steel" );
 
@@ -55,7 +55,7 @@ public class DependenciesContainersPropertyIT {
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/containers/simple/DependenciesContainersSimpleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/containers/simple/DependenciesContainersSimpleIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.bridge.dependencies.containers.simple;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -16,7 +17,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,7 +36,7 @@ public class DependenciesContainersSimpleIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setTitle( "The Caves Of Steel" );
 
@@ -55,7 +55,7 @@ public class DependenciesContainersSimpleIT {
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/containers/simple/DependenciesContainersSimpleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/containers/simple/DependenciesContainersSimpleIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.bridge.dependencies.containers.simple;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -36,7 +36,7 @@ public class DependenciesContainersSimpleIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setTitle( "The Caves Of Steel" );
 
@@ -55,7 +55,7 @@ public class DependenciesContainersSimpleIT {
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/simple/DependenciesSimpleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/simple/DependenciesSimpleIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.dependencies.simple
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -35,7 +35,7 @@ public class DependenciesSimpleIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Author author = new Author();
 			author.setFirstName( "Isaac" );
 			author.setLastName( "Asimov" );
@@ -48,7 +48,7 @@ public class DependenciesSimpleIT {
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/simple/DependenciesSimpleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/simple/DependenciesSimpleIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.dependencies.simple
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -16,7 +17,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -35,7 +35,7 @@ public class DependenciesSimpleIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Author author = new Author();
 			author.setFirstName( "Isaac" );
 			author.setLastName( "Asimov" );
@@ -48,7 +48,7 @@ public class DependenciesSimpleIT {
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/dynamic/DocumentModelDslDynamicIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/dynamic/DocumentModelDslDynamicIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.document.model.dsl.
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -35,7 +35,7 @@ public class DocumentModelDslDynamicIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = new Book();
 			book1.setId( 1 );
 			book1.getUserMetadata().put( "note", "I really liked this one" );
@@ -52,7 +52,7 @@ public class DocumentModelDslDynamicIT {
 			entityManager.persist( book2 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result1 = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/dynamic/DocumentModelDslDynamicIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/dynamic/DocumentModelDslDynamicIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.document.model.dsl.
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -16,7 +17,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -35,7 +35,7 @@ public class DocumentModelDslDynamicIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book1 = new Book();
 			book1.setId( 1 );
 			book1.getUserMetadata().put( "note", "I really liked this one" );
@@ -52,7 +52,7 @@ public class DocumentModelDslDynamicIT {
 			entityManager.persist( book2 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result1 = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/object/DocumentModelDslObjectIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/object/DocumentModelDslObjectIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.document.model.dsl.
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,7 +36,7 @@ public class DocumentModelDslObjectIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Invoice invoice = new Invoice();
 			invoice.getLineItems()
 					.add( new InvoiceLineItem( InvoiceLineItemCategory.BOOK, new BigDecimal( "5.99" ) ) );
@@ -49,7 +49,7 @@ public class DocumentModelDslObjectIT {
 			entityManager.persist( invoice );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Invoice> result = searchSession.search( Invoice.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/object/DocumentModelDslObjectIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/object/DocumentModelDslObjectIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.document.model.dsl.
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -36,7 +36,7 @@ public class DocumentModelDslObjectIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Invoice invoice = new Invoice();
 			invoice.getLineItems()
 					.add( new InvoiceLineItem( InvoiceLineItemCategory.BOOK, new BigDecimal( "5.99" ) ) );
@@ -49,7 +49,7 @@ public class DocumentModelDslObjectIT {
 			entityManager.persist( invoice );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Invoice> result = searchSession.search( Invoice.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/simple/DocumentModelDslSimpleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/simple/DocumentModelDslSimpleIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.document.model.dsl.
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.Arrays;
 import java.util.List;
@@ -18,7 +19,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.documentation.testsupport.data.ISBN;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -37,7 +37,7 @@ public class DocumentModelDslSimpleIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setIsbn( ISBN.parse( "978-0-58-600835-5" ) );
 			entityManager.persist( book );
@@ -48,7 +48,7 @@ public class DocumentModelDslSimpleIT {
 			entityManager.persist( author );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Object> result = searchSession.search( Arrays.asList( Book.class, Author.class ) )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/simple/DocumentModelDslSimpleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/simple/DocumentModelDslSimpleIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.document.model.dsl.
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.Arrays;
 import java.util.List;
@@ -37,7 +37,7 @@ public class DocumentModelDslSimpleIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setIsbn( ISBN.parse( "978-0-58-600835-5" ) );
 			entityManager.persist( book );
@@ -48,7 +48,7 @@ public class DocumentModelDslSimpleIT {
 			entityManager.persist( author );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Object> result = searchSession.search( Arrays.asList( Book.class, Author.class ) )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/binder/IdentifierBinderIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/binder/IdentifierBinderIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.identifierbridge.bi
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -54,7 +54,7 @@ public class IdentifierBinderIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 
 			Book book = new Book();
 			book.getId().setPublisherId( 1L );
@@ -62,7 +62,7 @@ public class IdentifierBinderIT {
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/binder/IdentifierBinderIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/binder/IdentifierBinderIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.identifierbridge.bi
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -54,7 +54,7 @@ public class IdentifierBinderIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 
 			Book book = new Book();
 			book.getId().setPublisherId( 1L );
@@ -62,7 +62,7 @@ public class IdentifierBinderIT {
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/compatible/IdentifierBridgeCompatibleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/compatible/IdentifierBridgeCompatibleIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.identifierbridge.co
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.Arrays;
 import java.util.List;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,7 +36,7 @@ public class IdentifierBridgeCompatibleIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.getId().setPublisherId( 1L );
 			book.getId().setPublisherSpecificBookId( 42L );
@@ -48,7 +48,7 @@ public class IdentifierBridgeCompatibleIT {
 			entityManager.persist( magazine );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Object> result = searchSession.search( Arrays.asList( Book.class, Magazine.class ) )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/compatible/IdentifierBridgeCompatibleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/compatible/IdentifierBridgeCompatibleIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.identifierbridge.co
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.Arrays;
 import java.util.List;
@@ -36,7 +36,7 @@ public class IdentifierBridgeCompatibleIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.getId().setPublisherId( 1L );
 			book.getId().setPublisherSpecificBookId( 42L );
@@ -48,7 +48,7 @@ public class IdentifierBridgeCompatibleIT {
 			entityManager.persist( magazine );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Object> result = searchSession.search( Arrays.asList( Book.class, Magazine.class ) )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/ormcontext/IdentifierBridgeOrmContextIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/ormcontext/IdentifierBridgeOrmContextIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.identifierbridge.or
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -38,13 +38,13 @@ public class IdentifierBridgeOrmContextIT {
 	public void smoke() {
 		// See MyDataValueBridge
 		entityManagerFactory.getProperties().put( "test.data.indexed", MyData.VALUE1 );
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			MyEntity myEntity = new MyEntity();
 			myEntity.setId( MyData.VALUE3 );
 			entityManager.persist( myEntity );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// See MyDataValueBridge
 			entityManager.setProperty( "test.data.projected", MyData.VALUE2 );
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/ormcontext/IdentifierBridgeOrmContextIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/ormcontext/IdentifierBridgeOrmContextIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.identifierbridge.or
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.common.EntityReference;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -38,13 +38,13 @@ public class IdentifierBridgeOrmContextIT {
 	public void smoke() {
 		// See MyDataValueBridge
 		entityManagerFactory.getProperties().put( "test.data.indexed", MyData.VALUE1 );
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			MyEntity myEntity = new MyEntity();
 			myEntity.setId( MyData.VALUE3 );
 			entityManager.persist( myEntity );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// See MyDataValueBridge
 			entityManager.setProperty( "test.data.projected", MyData.VALUE2 );
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/param/IdentifierBridgeParamIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/param/IdentifierBridgeParamIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.identifierbridge.pa
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.engine.search.common.ValueConvert;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,14 +36,14 @@ public class IdentifierBridgeParamIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book1 = new Book();
 			book1.setId( 0 );
 			book1.setTitle( "The Fellowship Of The Ring" );
 			entityManager.persist( book1 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/param/IdentifierBridgeParamIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/param/IdentifierBridgeParamIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.identifierbridge.pa
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -36,14 +36,14 @@ public class IdentifierBridgeParamIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = new Book();
 			book1.setId( 0 );
 			book1.setTitle( "The Fellowship Of The Ring" );
 			entityManager.persist( book1 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/param/context/IdentifierBridgeParamIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/param/context/IdentifierBridgeParamIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.identifierbridge.pa
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.engine.search.common.ValueConvert;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,14 +36,14 @@ public class IdentifierBridgeParamIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book1 = new Book();
 			book1.setId( 0 );
 			book1.setTitle( "The Fellowship Of The Ring" );
 			entityManager.persist( book1 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/param/context/IdentifierBridgeParamIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/param/context/IdentifierBridgeParamIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.identifierbridge.pa
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -36,14 +36,14 @@ public class IdentifierBridgeParamIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = new Book();
 			book1.setId( 0 );
 			book1.setTitle( "The Fellowship Of The Ring" );
 			entityManager.persist( book1 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/simple/IdentifierBridgeSimpleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/simple/IdentifierBridgeSimpleIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.identifierbridge.si
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -54,7 +54,7 @@ public class IdentifierBridgeSimpleIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 
 			Book book = new Book();
 			book.getId().setPublisherId( 1L );
@@ -62,7 +62,7 @@ public class IdentifierBridgeSimpleIT {
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/simple/IdentifierBridgeSimpleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/identifierbridge/simple/IdentifierBridgeSimpleIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.identifierbridge.si
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -54,7 +54,7 @@ public class IdentifierBridgeSimpleIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 
 			Book book = new Book();
 			book.getId().setPublisherId( 1L );
@@ -62,7 +62,7 @@ public class IdentifierBridgeSimpleIT {
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/namedpredicate/NamedPredicateIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/namedpredicate/NamedPredicateIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.namedpredicate;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -16,7 +17,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -35,7 +35,7 @@ public class NamedPredicateIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			ItemStock unit1 = new ItemStock();
 			unit1.setSkuId( "SHOES.WI2012.4242" );
 			unit1.setAmountInStock( 23 );
@@ -50,7 +50,7 @@ public class NamedPredicateIT {
 			entityManager.persist( unit3 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			// tag::named-predicate[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/namedpredicate/NamedPredicateIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/namedpredicate/NamedPredicateIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.namedpredicate;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -35,7 +35,7 @@ public class NamedPredicateIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			ItemStock unit1 = new ItemStock();
 			unit1.setSkuId( "SHOES.WI2012.4242" );
 			unit1.setAmountInStock( 23 );
@@ -50,7 +50,7 @@ public class NamedPredicateIT {
 			entityManager.persist( unit3 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			// tag::named-predicate[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/bridgedelement/PropertyBridgeBridgedElementIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/bridgedelement/PropertyBridgeBridgedElementIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.propertybridge.brid
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -56,7 +56,7 @@ public class PropertyBridgeBridgedElementIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Invoice invoice = new Invoice();
 			invoice.getLineItems()
 					.add( new InvoiceLineItem( InvoiceLineItemCategory.BOOK, new BigDecimal( "5.99" ) ) );
@@ -69,7 +69,7 @@ public class PropertyBridgeBridgedElementIT {
 			entityManager.persist( invoice );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Invoice> result = searchSession.search( Invoice.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/bridgedelement/PropertyBridgeBridgedElementIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/bridgedelement/PropertyBridgeBridgedElementIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.propertybridge.brid
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -20,7 +21,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -56,7 +56,7 @@ public class PropertyBridgeBridgedElementIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Invoice invoice = new Invoice();
 			invoice.getLineItems()
 					.add( new InvoiceLineItem( InvoiceLineItemCategory.BOOK, new BigDecimal( "5.99" ) ) );
@@ -69,7 +69,7 @@ public class PropertyBridgeBridgedElementIT {
 			entityManager.persist( invoice );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Invoice> result = searchSession.search( Invoice.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/ormcontext/PropertyBridgeOrmContextIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/ormcontext/PropertyBridgeOrmContextIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.propertybridge.ormc
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -36,7 +36,7 @@ public class PropertyBridgeOrmContextIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// See MyDataPropertyBinder
 			entityManager.setProperty( "test.data.indexed", MyData.INDEXED );
 
@@ -44,7 +44,7 @@ public class PropertyBridgeOrmContextIT {
 			entityManager.persist( myEntity );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<MyEntity> result = searchSession.search( MyEntity.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/ormcontext/PropertyBridgeOrmContextIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/ormcontext/PropertyBridgeOrmContextIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.propertybridge.ormc
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.engine.search.common.ValueConvert;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,7 +36,7 @@ public class PropertyBridgeOrmContextIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// See MyDataPropertyBinder
 			entityManager.setProperty( "test.data.indexed", MyData.INDEXED );
 
@@ -44,7 +44,7 @@ public class PropertyBridgeOrmContextIT {
 			entityManager.persist( myEntity );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<MyEntity> result = searchSession.search( MyEntity.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/param/PropertyBridgeParamIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/param/PropertyBridgeParamIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.propertybridge.para
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -18,7 +19,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -55,7 +55,7 @@ public class PropertyBridgeParamIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Invoice invoice = new Invoice();
 			invoice.getLineItems()
 					.add( new InvoiceLineItem( InvoiceLineItemCategory.BOOK, new BigDecimal( "5.99" ) ) );
@@ -68,7 +68,7 @@ public class PropertyBridgeParamIT {
 			entityManager.persist( invoice );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Invoice> result = searchSession.search( Invoice.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/param/PropertyBridgeParamIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/param/PropertyBridgeParamIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.propertybridge.para
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -55,7 +55,7 @@ public class PropertyBridgeParamIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Invoice invoice = new Invoice();
 			invoice.getLineItems()
 					.add( new InvoiceLineItem( InvoiceLineItemCategory.BOOK, new BigDecimal( "5.99" ) ) );
@@ -68,7 +68,7 @@ public class PropertyBridgeParamIT {
 			entityManager.persist( invoice );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Invoice> result = searchSession.search( Invoice.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/param/context/PropertyBridgeParamIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/param/context/PropertyBridgeParamIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.propertybridge.para
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.math.BigDecimal;
 import java.util.Collections;
@@ -58,7 +58,7 @@ public class PropertyBridgeParamIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Invoice invoice = new Invoice();
 			invoice.getLineItems()
 					.add( new InvoiceLineItem( InvoiceLineItemCategory.BOOK, new BigDecimal( "5.99" ) ) );
@@ -71,7 +71,7 @@ public class PropertyBridgeParamIT {
 			entityManager.persist( invoice );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Invoice> result = searchSession.search( Invoice.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/param/context/PropertyBridgeParamIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/param/context/PropertyBridgeParamIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.propertybridge.para
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.math.BigDecimal;
 import java.util.Collections;
@@ -21,7 +22,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -58,7 +58,7 @@ public class PropertyBridgeParamIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Invoice invoice = new Invoice();
 			invoice.getLineItems()
 					.add( new InvoiceLineItem( InvoiceLineItemCategory.BOOK, new BigDecimal( "5.99" ) ) );
@@ -71,7 +71,7 @@ public class PropertyBridgeParamIT {
 			entityManager.persist( invoice );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Invoice> result = searchSession.search( Invoice.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/simple/PropertyBridgeSimpleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/simple/PropertyBridgeSimpleIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.propertybridge.simp
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,7 +36,7 @@ public class PropertyBridgeSimpleIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Invoice invoice = new Invoice();
 			invoice.getLineItems()
 					.add( new InvoiceLineItem( InvoiceLineItemCategory.BOOK, new BigDecimal( "5.99" ) ) );
@@ -49,7 +49,7 @@ public class PropertyBridgeSimpleIT {
 			entityManager.persist( invoice );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Invoice> result = searchSession.search( Invoice.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/simple/PropertyBridgeSimpleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/simple/PropertyBridgeSimpleIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.propertybridge.simp
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -36,7 +36,7 @@ public class PropertyBridgeSimpleIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Invoice invoice = new Invoice();
 			invoice.getLineItems()
 					.add( new InvoiceLineItem( InvoiceLineItemCategory.BOOK, new BigDecimal( "5.99" ) ) );
@@ -49,7 +49,7 @@ public class PropertyBridgeSimpleIT {
 			entityManager.persist( invoice );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Invoice> result = searchSession.search( Invoice.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/resolver/BridgeResolverIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/resolver/BridgeResolverIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.bridge.resolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -18,7 +19,6 @@ import org.hibernate.search.engine.search.common.ValueConvert;
 import org.hibernate.search.engine.spatial.DistanceUnit;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -48,7 +48,7 @@ public class BridgeResolverIT {
 		MyProductId book2Id = new MyProductId( "largevue", "84784-484-44" );
 		ISBN book2Isbn = ISBN.parse( "978-0-58-600824-5" );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book1 = new Book();
 			book1.setId( book1Id );
 			book1.setIsbn( book1Isbn );
@@ -67,7 +67,7 @@ public class BridgeResolverIT {
 			entityManager.persist( book2 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			List<ISBN> result = Search.session( entityManager ).search( Book.class )
 					.select( f -> f.field( "isbn", ISBN.class ) )
 					.where( f -> f.match().field( "genre" ).matching( "science", ValueConvert.NO ) )
@@ -76,7 +76,7 @@ public class BridgeResolverIT {
 					.containsExactly( book1Isbn );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			List<Genre> result = Search.session( entityManager ).search( Book.class )
 					.select( f -> f.field( "genre", Genre.class ) )
 					.where( f -> f.match().field( "title" ).matching( "steel" ) )
@@ -85,7 +85,7 @@ public class BridgeResolverIT {
 					.containsExactly( Genre.SCIFI );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			List<Book> result = Search.session( entityManager ).search( Book.class )
 					.where( f -> f.spatial().within().field( "location" )
 							.circle( 42.0, 41.0, 100, DistanceUnit.KILOMETERS ) )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/resolver/BridgeResolverIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/resolver/BridgeResolverIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.bridge.resolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -48,7 +48,7 @@ public class BridgeResolverIT {
 		MyProductId book2Id = new MyProductId( "largevue", "84784-484-44" );
 		ISBN book2Isbn = ISBN.parse( "978-0-58-600824-5" );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = new Book();
 			book1.setId( book1Id );
 			book1.setIsbn( book1Isbn );
@@ -67,7 +67,7 @@ public class BridgeResolverIT {
 			entityManager.persist( book2 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			List<ISBN> result = Search.session( entityManager ).search( Book.class )
 					.select( f -> f.field( "isbn", ISBN.class ) )
 					.where( f -> f.match().field( "genre" ).matching( "science", ValueConvert.NO ) )
@@ -76,7 +76,7 @@ public class BridgeResolverIT {
 					.containsExactly( book1Isbn );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			List<Genre> result = Search.session( entityManager ).search( Book.class )
 					.select( f -> f.field( "genre", Genre.class ) )
 					.where( f -> f.match().field( "title" ).matching( "steel" ) )
@@ -85,7 +85,7 @@ public class BridgeResolverIT {
 					.containsExactly( Genre.SCIFI );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			List<Book> result = Search.session( entityManager ).search( Book.class )
 					.where( f -> f.spatial().within().field( "location" )
 							.circle( 42.0, 41.0, 100, DistanceUnit.KILOMETERS ) )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/routingbridge/conditionalindexing/RoutingBridgeConditionalIndexingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/routingbridge/conditionalindexing/RoutingBridgeConditionalIndexingIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.bridge.routingbridge.conditionalindexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.engine.search.query.SearchResult;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -61,7 +61,7 @@ public class RoutingBridgeConditionalIndexingIT {
 
 	@Test
 	public void test() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			SearchResult<Book> result = searchSession.search( Book.class )
 					.where( f -> f.matchAll() )
@@ -70,7 +70,7 @@ public class RoutingBridgeConditionalIndexingIT {
 					.containsExactlyInAnyOrder( BOOK1_ID, BOOK3_ID );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book2 = entityManager.find( Book.class, BOOK2_ID );
 			Book book3 = entityManager.find( Book.class, BOOK3_ID );
 
@@ -78,7 +78,7 @@ public class RoutingBridgeConditionalIndexingIT {
 			book3.setStatus( Status.ARCHIVED );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			SearchResult<Book> result = searchSession.search( Book.class )
 					.where( f -> f.matchAll() )
@@ -89,7 +89,7 @@ public class RoutingBridgeConditionalIndexingIT {
 	}
 
 	private void initData() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book1 = new Book();
 			book1.setId( BOOK1_ID );
 			book1.setTitle( "I, Robot" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/routingbridge/conditionalindexing/RoutingBridgeConditionalIndexingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/routingbridge/conditionalindexing/RoutingBridgeConditionalIndexingIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.bridge.routingbridge.conditionalindexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -61,7 +61,7 @@ public class RoutingBridgeConditionalIndexingIT {
 
 	@Test
 	public void test() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			SearchResult<Book> result = searchSession.search( Book.class )
 					.where( f -> f.matchAll() )
@@ -70,7 +70,7 @@ public class RoutingBridgeConditionalIndexingIT {
 					.containsExactlyInAnyOrder( BOOK1_ID, BOOK3_ID );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book2 = entityManager.find( Book.class, BOOK2_ID );
 			Book book3 = entityManager.find( Book.class, BOOK3_ID );
 
@@ -78,7 +78,7 @@ public class RoutingBridgeConditionalIndexingIT {
 			book3.setStatus( Status.ARCHIVED );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			SearchResult<Book> result = searchSession.search( Book.class )
 					.where( f -> f.matchAll() )
@@ -89,7 +89,7 @@ public class RoutingBridgeConditionalIndexingIT {
 	}
 
 	private void initData() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = new Book();
 			book1.setId( BOOK1_ID );
 			book1.setTitle( "I, Robot" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/routingbridge/ormcontext/RoutingBridgeOrmContextIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/routingbridge/ormcontext/RoutingBridgeOrmContextIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.routingbridge.ormco
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -16,7 +17,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -39,7 +39,7 @@ public class RoutingBridgeOrmContextIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// See MyDataPropertyBinder
 			entityManager.setProperty( "test.data.indexed", MyData.INDEXED );
 
@@ -48,7 +48,7 @@ public class RoutingBridgeOrmContextIT {
 			entityManager.persist( myEntity );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<MyEntity> result = searchSession.search( MyEntity.class )
@@ -58,7 +58,7 @@ public class RoutingBridgeOrmContextIT {
 			assertThat( result ).hasSize( 1 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// See MyDataPropertyBinder
 			entityManager.setProperty( "test.data.indexed", MyData.NOT_INDEXED );
 
@@ -67,7 +67,7 @@ public class RoutingBridgeOrmContextIT {
 			Search.session( entityManager ).indexingPlan().addOrUpdate( myEntity );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<MyEntity> result = searchSession.search( MyEntity.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/routingbridge/ormcontext/RoutingBridgeOrmContextIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/routingbridge/ormcontext/RoutingBridgeOrmContextIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.routingbridge.ormco
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -39,7 +39,7 @@ public class RoutingBridgeOrmContextIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// See MyDataPropertyBinder
 			entityManager.setProperty( "test.data.indexed", MyData.INDEXED );
 
@@ -48,7 +48,7 @@ public class RoutingBridgeOrmContextIT {
 			entityManager.persist( myEntity );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<MyEntity> result = searchSession.search( MyEntity.class )
@@ -58,7 +58,7 @@ public class RoutingBridgeOrmContextIT {
 			assertThat( result ).hasSize( 1 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// See MyDataPropertyBinder
 			entityManager.setProperty( "test.data.indexed", MyData.NOT_INDEXED );
 
@@ -67,7 +67,7 @@ public class RoutingBridgeOrmContextIT {
 			Search.session( entityManager ).indexingPlan().addOrUpdate( myEntity );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<MyEntity> result = searchSession.search( MyEntity.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/routingbridge/routingkey/RoutingBridgeRoutingKeyIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/routingbridge/routingkey/RoutingBridgeRoutingKeyIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.bridge.routingbridge.routingkey;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.engine.search.query.SearchResult;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -63,7 +63,7 @@ public class RoutingBridgeRoutingKeyIT {
 
 	@Test
 	public void routing_single() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::routing-single[]
 			SearchResult<Book> result = searchSession.search( Book.class ) // <1>
@@ -81,7 +81,7 @@ public class RoutingBridgeRoutingKeyIT {
 	}
 
 	private void initData() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book1 = new Book();
 			book1.setId( BOOK1_ID );
 			book1.setTitle( "I, Robot" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/routingbridge/routingkey/RoutingBridgeRoutingKeyIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/routingbridge/routingkey/RoutingBridgeRoutingKeyIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.bridge.routingbridge.routingkey;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -63,7 +63,7 @@ public class RoutingBridgeRoutingKeyIT {
 
 	@Test
 	public void routing_single() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::routing-single[]
 			SearchResult<Book> result = searchSession.search( Book.class ) // <1>
@@ -81,7 +81,7 @@ public class RoutingBridgeRoutingKeyIT {
 	}
 
 	private void initData() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = new Book();
 			book1.setId( BOOK1_ID );
 			book1.setTitle( "I, Robot" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/typebridge/ormcontext/TypeBridgeOrmContextIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/typebridge/ormcontext/TypeBridgeOrmContextIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.typebridge.ormconte
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -36,7 +36,7 @@ public class TypeBridgeOrmContextIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// See MyDataPropertyBinder
 			entityManager.setProperty( "test.data.indexed", MyData.INDEXED );
 
@@ -44,7 +44,7 @@ public class TypeBridgeOrmContextIT {
 			entityManager.persist( myEntity );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<MyEntity> result = searchSession.search( MyEntity.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/typebridge/ormcontext/TypeBridgeOrmContextIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/typebridge/ormcontext/TypeBridgeOrmContextIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.typebridge.ormconte
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.engine.search.common.ValueConvert;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,7 +36,7 @@ public class TypeBridgeOrmContextIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// See MyDataPropertyBinder
 			entityManager.setProperty( "test.data.indexed", MyData.INDEXED );
 
@@ -44,7 +44,7 @@ public class TypeBridgeOrmContextIT {
 			entityManager.persist( myEntity );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<MyEntity> result = searchSession.search( MyEntity.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/typebridge/param/TypeBridgeParamIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/typebridge/param/TypeBridgeParamIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.typebridge.param;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -53,7 +53,7 @@ public class TypeBridgeParamIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Author author1 = new Author();
 			author1.setFirstName( "Ty" );
 			author1.setLastName( "Frank" );
@@ -65,7 +65,7 @@ public class TypeBridgeParamIT {
 			entityManager.persist( author2 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Author> result = searchSession.search( Author.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/typebridge/param/TypeBridgeParamIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/typebridge/param/TypeBridgeParamIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.typebridge.param;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -53,7 +53,7 @@ public class TypeBridgeParamIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Author author1 = new Author();
 			author1.setFirstName( "Ty" );
 			author1.setLastName( "Frank" );
@@ -65,7 +65,7 @@ public class TypeBridgeParamIT {
 			entityManager.persist( author2 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Author> result = searchSession.search( Author.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/typebridge/param/context/TypeBridgeParamIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/typebridge/param/context/TypeBridgeParamIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.typebridge.param.co
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.Collections;
 import java.util.List;
@@ -54,7 +54,7 @@ public class TypeBridgeParamIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Author author1 = new Author();
 			author1.setFirstName( "Ty" );
 			author1.setLastName( "Frank" );
@@ -66,7 +66,7 @@ public class TypeBridgeParamIT {
 			entityManager.persist( author2 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Author> result = searchSession.search( Author.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/typebridge/param/context/TypeBridgeParamIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/typebridge/param/context/TypeBridgeParamIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.typebridge.param.co
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.Collections;
 import java.util.List;
@@ -18,7 +19,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -54,7 +54,7 @@ public class TypeBridgeParamIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Author author1 = new Author();
 			author1.setFirstName( "Ty" );
 			author1.setLastName( "Frank" );
@@ -66,7 +66,7 @@ public class TypeBridgeParamIT {
 			entityManager.persist( author2 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Author> result = searchSession.search( Author.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/typebridge/simple/TypeBridgeSimpleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/typebridge/simple/TypeBridgeSimpleIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.typebridge.simple;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -35,14 +35,14 @@ public class TypeBridgeSimpleIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Author author = new Author();
 			author.setFirstName( "Isaac" );
 			author.setLastName( "Asimov" );
 			entityManager.persist( author );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Author> result = searchSession.search( Author.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/typebridge/simple/TypeBridgeSimpleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/typebridge/simple/TypeBridgeSimpleIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.typebridge.simple;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -16,7 +17,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -35,14 +35,14 @@ public class TypeBridgeSimpleIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Author author = new Author();
 			author.setFirstName( "Isaac" );
 			author.setLastName( "Asimov" );
 			entityManager.persist( author );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Author> result = searchSession.search( Author.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/types/dsl/dslconverter/IndexFieldTypeDslDslConverterIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/types/dsl/dslconverter/IndexFieldTypeDslDslConverterIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.types.dsl.dslconver
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -36,13 +36,13 @@ public class IndexFieldTypeDslDslConverterIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setIsbn( ISBN.parse( "978-0-58-600835-5" ) );
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			//tag::include[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/types/dsl/dslconverter/IndexFieldTypeDslDslConverterIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/types/dsl/dslconverter/IndexFieldTypeDslDslConverterIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.types.dsl.dslconver
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.documentation.testsupport.data.ISBN;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,13 +36,13 @@ public class IndexFieldTypeDslDslConverterIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setIsbn( ISBN.parse( "978-0-58-600835-5" ) );
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			//tag::include[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/types/dsl/projectionconverter/IndexFieldTypeDslProjectionConverterIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/types/dsl/projectionconverter/IndexFieldTypeDslProjectionConverterIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.types.dsl.projectio
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.documentation.testsupport.data.ISBN;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,13 +36,13 @@ public class IndexFieldTypeDslProjectionConverterIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setIsbn( ISBN.parse( "978-0-58-600835-5" ) );
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			//tag::include[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/types/dsl/projectionconverter/IndexFieldTypeDslProjectionConverterIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/types/dsl/projectionconverter/IndexFieldTypeDslProjectionConverterIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.types.dsl.projectio
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -36,13 +36,13 @@ public class IndexFieldTypeDslProjectionConverterIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setIsbn( ISBN.parse( "978-0-58-600835-5" ) );
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			//tag::include[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/types/dsl/simple/IndexFieldTypeDslSimpleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/types/dsl/simple/IndexFieldTypeDslSimpleIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.types.dsl.simple;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -36,13 +36,13 @@ public class IndexFieldTypeDslSimpleIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setIsbn( ISBN.parse( "978-0-58-600835-5" ) );
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/types/dsl/simple/IndexFieldTypeDslSimpleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/types/dsl/simple/IndexFieldTypeDslSimpleIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.types.dsl.simple;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.documentation.testsupport.data.ISBN;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,13 +36,13 @@ public class IndexFieldTypeDslSimpleIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setIsbn( ISBN.parse( "978-0-58-600835-5" ) );
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/binder/ValueBridgeBinderIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/binder/ValueBridgeBinderIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.valuebridge.binder;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -19,7 +20,6 @@ import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -58,13 +58,13 @@ public class ValueBridgeBinderIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setIsbn( ISBN.parse( "978-0-58-600835-5" ) );
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/binder/ValueBridgeBinderIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/binder/ValueBridgeBinderIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.valuebridge.binder;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -58,13 +58,13 @@ public class ValueBridgeBinderIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setIsbn( ISBN.parse( "978-0-58-600835-5" ) );
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/compatible/ValueBridgeCompatibleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/compatible/ValueBridgeCompatibleIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.valuebridge.compati
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.Arrays;
 import java.util.List;
@@ -37,7 +37,7 @@ public class ValueBridgeCompatibleIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book1 book1 = new Book1();
 			book1.setIsbn( ISBN.parse( "978-0-58-600835-5" ) );
 			entityManager.persist( book1 );
@@ -47,7 +47,7 @@ public class ValueBridgeCompatibleIT {
 			entityManager.persist( book2 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Object> result = searchSession.search( Arrays.asList( Book1.class, Book2.class ) )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/compatible/ValueBridgeCompatibleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/compatible/ValueBridgeCompatibleIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.valuebridge.compati
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.Arrays;
 import java.util.List;
@@ -18,7 +19,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.documentation.testsupport.data.ISBN;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -37,7 +37,7 @@ public class ValueBridgeCompatibleIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book1 book1 = new Book1();
 			book1.setIsbn( ISBN.parse( "978-0-58-600835-5" ) );
 			entityManager.persist( book1 );
@@ -47,7 +47,7 @@ public class ValueBridgeCompatibleIT {
 			entityManager.persist( book2 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Object> result = searchSession.search( Arrays.asList( Book1.class, Book2.class ) )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/indexnullas/ValueBridgeIndexNullAsIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/indexnullas/ValueBridgeIndexNullAsIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.valuebridge.indexnu
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.documentation.testsupport.data.ISBN;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,13 +36,13 @@ public class ValueBridgeIndexNullAsIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setIsbn( null );
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/indexnullas/ValueBridgeIndexNullAsIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/indexnullas/ValueBridgeIndexNullAsIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.valuebridge.indexnu
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -36,13 +36,13 @@ public class ValueBridgeIndexNullAsIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setIsbn( null );
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/ormcontext/ValueBridgeOrmContextIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/ormcontext/ValueBridgeOrmContextIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.valuebridge.ormcont
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.engine.search.common.ValueConvert;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -38,12 +38,12 @@ public class ValueBridgeOrmContextIT {
 	public void smoke() {
 		// See MyDataValueBridge
 		entityManagerFactory.getProperties().put( "test.data.indexed", MyData.INDEXED );
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			MyEntity myEntity = new MyEntity();
 			entityManager.persist( myEntity );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// See MyDataValueBridge
 			entityManager.setProperty( "test.data.projected", MyData.PROJECTED );
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/ormcontext/ValueBridgeOrmContextIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/ormcontext/ValueBridgeOrmContextIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.valuebridge.ormcont
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -38,12 +38,12 @@ public class ValueBridgeOrmContextIT {
 	public void smoke() {
 		// See MyDataValueBridge
 		entityManagerFactory.getProperties().put( "test.data.indexed", MyData.INDEXED );
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			MyEntity myEntity = new MyEntity();
 			entityManager.persist( myEntity );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// See MyDataValueBridge
 			entityManager.setProperty( "test.data.projected", MyData.PROJECTED );
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/param/ValueBridgeParamIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/param/ValueBridgeParamIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.valuebridge.param;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.time.Year;
 import java.util.List;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,7 +36,7 @@ public class ValueBridgeParamIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book1 = new Book();
 			book1.setTitle( "The Government Is Evil" );
 			book1.setPublished( true );
@@ -52,7 +52,7 @@ public class ValueBridgeParamIT {
 			entityManager.persist( book2 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )
@@ -63,7 +63,7 @@ public class ValueBridgeParamIT {
 			assertThat( result ).hasSize( 1 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/param/ValueBridgeParamIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/param/ValueBridgeParamIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.valuebridge.param;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.time.Year;
 import java.util.List;
@@ -36,7 +36,7 @@ public class ValueBridgeParamIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = new Book();
 			book1.setTitle( "The Government Is Evil" );
 			book1.setPublished( true );
@@ -52,7 +52,7 @@ public class ValueBridgeParamIT {
 			entityManager.persist( book2 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )
@@ -63,7 +63,7 @@ public class ValueBridgeParamIT {
 			assertThat( result ).hasSize( 1 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/param/context/ValueBridgeParamIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/param/context/ValueBridgeParamIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.valuebridge.param.c
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.time.Year;
 import java.util.List;
@@ -36,7 +36,7 @@ public class ValueBridgeParamIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = new Book();
 			book1.setTitle( "The Government Is Evil" );
 			book1.setPublished( true );
@@ -52,7 +52,7 @@ public class ValueBridgeParamIT {
 			entityManager.persist( book2 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )
@@ -63,7 +63,7 @@ public class ValueBridgeParamIT {
 			assertThat( result ).hasSize( 1 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/param/context/ValueBridgeParamIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/param/context/ValueBridgeParamIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.valuebridge.param.c
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.time.Year;
 import java.util.List;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,7 +36,7 @@ public class ValueBridgeParamIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book1 = new Book();
 			book1.setTitle( "The Government Is Evil" );
 			book1.setPublished( true );
@@ -52,7 +52,7 @@ public class ValueBridgeParamIT {
 			entityManager.persist( book2 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )
@@ -63,7 +63,7 @@ public class ValueBridgeParamIT {
 			assertThat( result ).hasSize( 1 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/projection/ValueBridgeProjectionIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/projection/ValueBridgeProjectionIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.valuebridge.project
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -36,13 +36,13 @@ public class ValueBridgeProjectionIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setIsbn( ISBN.parse( "978-0-58-600835-5" ) );
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<ISBN> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/projection/ValueBridgeProjectionIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/projection/ValueBridgeProjectionIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.valuebridge.project
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.documentation.testsupport.data.ISBN;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,13 +36,13 @@ public class ValueBridgeProjectionIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setIsbn( ISBN.parse( "978-0-58-600835-5" ) );
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<ISBN> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/simple/ValueBridgeSimpleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/simple/ValueBridgeSimpleIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.valuebridge.simple;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -18,7 +19,6 @@ import org.hibernate.search.documentation.testsupport.data.ISBN;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -55,13 +55,13 @@ public class ValueBridgeSimpleIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setIsbn( ISBN.parse( "978-0-58-600835-5" ) );
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/simple/ValueBridgeSimpleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/valuebridge/simple/ValueBridgeSimpleIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.bridge.valuebridge.simple;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -55,13 +55,13 @@ public class ValueBridgeSimpleIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setIsbn( ISBN.parse( "978-0-58-600835-5" ) );
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/containerextractor/ContainerExtractorIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/containerextractor/ContainerExtractorIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.containerextractor;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -64,7 +64,7 @@ public class ContainerExtractorIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Author author = new Author();
 			author.setId( 1 );
 			author.setName( "Isaac Asimov" );
@@ -81,7 +81,7 @@ public class ContainerExtractorIT {
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/containerextractor/ContainerExtractorIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/containerextractor/ContainerExtractorIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.containerextractor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -19,7 +20,6 @@ import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.extractor.builtin.BuiltinContainerExtractors;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -64,7 +64,7 @@ public class ContainerExtractorIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Author author = new Author();
 			author.setId( 1 );
 			author.setName( "Isaac Asimov" );
@@ -81,7 +81,7 @@ public class ContainerExtractorIT {
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.directfieldmapping;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -19,7 +20,6 @@ import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -74,7 +74,7 @@ public class HibernateOrmSimpleMappingIT {
 
 	@Test
 	public void sort() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class ) // <1>
@@ -92,7 +92,7 @@ public class HibernateOrmSimpleMappingIT {
 
 	@Test
 	public void projection_simple() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<String> result = searchSession.search( Book.class ) // <1>
@@ -106,7 +106,7 @@ public class HibernateOrmSimpleMappingIT {
 	}
 
 	private void initData() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book1 = new Book();
 			book1.setTitle( BOOK1_TITLE );
 			book1.setPageCount( BOOK1_PAGECOUNT );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.directfieldmapping;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -74,7 +74,7 @@ public class HibernateOrmSimpleMappingIT {
 
 	@Test
 	public void sort() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class ) // <1>
@@ -92,7 +92,7 @@ public class HibernateOrmSimpleMappingIT {
 
 	@Test
 	public void projection_simple() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<String> result = searchSession.search( Book.class ) // <1>
@@ -106,7 +106,7 @@ public class HibernateOrmSimpleMappingIT {
 	}
 
 	private void initData() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = new Book();
 			book1.setTitle( BOOK1_TITLE );
 			book1.setPageCount( BOOK1_PAGECOUNT );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/entityindexmapping/HibernateOrmIndexedIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/entityindexmapping/HibernateOrmIndexedIT.java
@@ -9,6 +9,7 @@ package org.hibernate.search.documentation.mapper.orm.entityindexmapping;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -26,7 +27,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.Programm
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -85,7 +85,7 @@ public class HibernateOrmIndexedIT {
 
 	@Test
 	public void search_separateQueries() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Author> authorResult = searchSession.search( Author.class )
@@ -103,7 +103,7 @@ public class HibernateOrmIndexedIT {
 	@Test
 	public void search_singleQuery() {
 		assertThatThrownBy(
-				() -> OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+				() -> withinJPATransaction( entityManagerFactory, entityManager -> {
 					SearchSession searchSession = Search.session( entityManager );
 
 					// tag::cross-backend-search[]
@@ -120,7 +120,7 @@ public class HibernateOrmIndexedIT {
 	}
 
 	private void initData() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book1 = new Book();
 			book1.setTitle( "Some title" );
 			Author author1 = new Author();

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/entityindexmapping/HibernateOrmIndexedIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/entityindexmapping/HibernateOrmIndexedIT.java
@@ -9,7 +9,7 @@ package org.hibernate.search.documentation.mapper.orm.entityindexmapping;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -85,7 +85,7 @@ public class HibernateOrmIndexedIT {
 
 	@Test
 	public void search_separateQueries() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Author> authorResult = searchSession.search( Author.class )
@@ -103,7 +103,7 @@ public class HibernateOrmIndexedIT {
 	@Test
 	public void search_singleQuery() {
 		assertThatThrownBy(
-				() -> withinJPATransaction( entityManagerFactory, entityManager -> {
+				() -> with( entityManagerFactory ).runInTransaction( entityManager -> {
 					SearchSession searchSession = Search.session( entityManager );
 
 					// tag::cross-backend-search[]
@@ -120,7 +120,7 @@ public class HibernateOrmIndexedIT {
 	}
 
 	private void initData() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = new Book();
 			book1.setTitle( "Some title" );
 			Author author1 = new Author();

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/identifiermapping/customtype/IdentifierMappingCustomTypeIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/identifiermapping/customtype/IdentifierMappingCustomTypeIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.identifiermapping.customty
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -18,7 +19,6 @@ import org.hibernate.search.documentation.testsupport.data.ISBN;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -37,14 +37,14 @@ public class IdentifierMappingCustomTypeIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setIsbn( ISBN.parse( "978-0-58-600835-5" ) );
 
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<DocumentReference> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/identifiermapping/customtype/IdentifierMappingCustomTypeIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/identifiermapping/customtype/IdentifierMappingCustomTypeIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.identifiermapping.customty
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -37,14 +37,14 @@ public class IdentifierMappingCustomTypeIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setIsbn( ISBN.parse( "978-0-58-600835-5" ) );
 
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<DocumentReference> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/identifiermapping/naturalid/IdentifierMappingNaturalIdIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/identifiermapping/naturalid/IdentifierMappingNaturalIdIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.identifiermapping.naturali
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -54,14 +54,14 @@ public class IdentifierMappingNaturalIdIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setIsbn( "9780586008355" );
 
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<DocumentReference> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/identifiermapping/naturalid/IdentifierMappingNaturalIdIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/identifiermapping/naturalid/IdentifierMappingNaturalIdIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.identifiermapping.naturali
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -18,7 +19,6 @@ import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -54,14 +54,14 @@ public class IdentifierMappingNaturalIdIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setIsbn( "9780586008355" );
 
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<DocumentReference> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/includepaths/IndexedEmbeddedIncludePathsIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/includepaths/IndexedEmbeddedIncludePathsIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.indexedembedded.includepat
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -18,7 +19,6 @@ import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.mapping.SearchMapping;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -38,7 +38,7 @@ public class IndexedEmbeddedIncludePathsIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Human human1 = new Human();
 			human1.setId( 1 );
 			human1.setName( "George Bush Senior" );
@@ -71,7 +71,7 @@ public class IndexedEmbeddedIncludePathsIT {
 			entityManager.persist( human4 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Human> result = searchSession.search( Human.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/includepaths/IndexedEmbeddedIncludePathsIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/includepaths/IndexedEmbeddedIncludePathsIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.indexedembedded.includepat
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -38,7 +38,7 @@ public class IndexedEmbeddedIncludePathsIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Human human1 = new Human();
 			human1.setId( 1 );
 			human1.setName( "George Bush Senior" );
@@ -71,7 +71,7 @@ public class IndexedEmbeddedIncludePathsIT {
 			entityManager.persist( human4 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Human> result = searchSession.search( Human.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/includepathsanddepth/IndexedEmbeddedIncludePathsAndDepthIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/includepathsanddepth/IndexedEmbeddedIncludePathsAndDepthIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.indexedembedded.includepat
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -38,7 +38,7 @@ public class IndexedEmbeddedIncludePathsAndDepthIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Human human1 = new Human();
 			human1.setId( 1 );
 			human1.setName( "George Bush Senior" );
@@ -71,7 +71,7 @@ public class IndexedEmbeddedIncludePathsAndDepthIT {
 			entityManager.persist( human4 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Human> result = searchSession.search( Human.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/includepathsanddepth/IndexedEmbeddedIncludePathsAndDepthIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/includepathsanddepth/IndexedEmbeddedIncludePathsAndDepthIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.indexedembedded.includepat
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -18,7 +19,6 @@ import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.mapping.SearchMapping;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -38,7 +38,7 @@ public class IndexedEmbeddedIncludePathsAndDepthIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Human human1 = new Human();
 			human1.setId( 1 );
 			human1.setName( "George Bush Senior" );
@@ -71,7 +71,7 @@ public class IndexedEmbeddedIncludePathsAndDepthIT {
 			entityManager.persist( human4 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Human> result = searchSession.search( Human.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/none/IndexedEmbeddedNoneIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/none/IndexedEmbeddedNoneIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.indexedembedded.none;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -35,7 +35,7 @@ public class IndexedEmbeddedNoneIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setId( 1 );
 			book.setTitle( "Robots Of Dawn" );
@@ -50,7 +50,7 @@ public class IndexedEmbeddedNoneIT {
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/none/IndexedEmbeddedNoneIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/none/IndexedEmbeddedNoneIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.indexedembedded.none;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -15,7 +16,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -35,7 +35,7 @@ public class IndexedEmbeddedNoneIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setId( 1 );
 			book.setTitle( "Robots Of Dawn" );
@@ -50,7 +50,7 @@ public class IndexedEmbeddedNoneIT {
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/onelevel/IndexedEmbeddedOneLevelIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/onelevel/IndexedEmbeddedOneLevelIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.indexedembedded.onelevel;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -16,7 +17,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -59,7 +59,7 @@ public class IndexedEmbeddedOneLevelIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setId( 1 );
 			book.setTitle( "Robots Of Dawn" );
@@ -74,7 +74,7 @@ public class IndexedEmbeddedOneLevelIT {
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/onelevel/IndexedEmbeddedOneLevelIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/onelevel/IndexedEmbeddedOneLevelIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.indexedembedded.onelevel;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -59,7 +59,7 @@ public class IndexedEmbeddedOneLevelIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setId( 1 );
 			book.setTitle( "Robots Of Dawn" );
@@ -74,7 +74,7 @@ public class IndexedEmbeddedOneLevelIT {
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/flattened/IndexedEmbeddedStructureFlattenedIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/flattened/IndexedEmbeddedStructureFlattenedIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.indexedembedded.structure.flattened;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -60,7 +60,7 @@ public class IndexedEmbeddedStructureFlattenedIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setId( 1 );
 			book.setTitle( "Leviathan Wakes" );
@@ -84,7 +84,7 @@ public class IndexedEmbeddedStructureFlattenedIT {
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			// tag::include[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/flattened/IndexedEmbeddedStructureFlattenedIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/flattened/IndexedEmbeddedStructureFlattenedIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.indexedembedded.structure.flattened;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -60,7 +60,7 @@ public class IndexedEmbeddedStructureFlattenedIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setId( 1 );
 			book.setTitle( "Leviathan Wakes" );
@@ -84,7 +84,7 @@ public class IndexedEmbeddedStructureFlattenedIT {
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			// tag::include[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/nested/IndexedEmbeddedStructureNestedIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/nested/IndexedEmbeddedStructureNestedIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.indexedembedded.structure.nested;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -60,7 +60,7 @@ public class IndexedEmbeddedStructureNestedIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setId( 1 );
 			book.setTitle( "Leviathan Wakes" );
@@ -84,7 +84,7 @@ public class IndexedEmbeddedStructureNestedIT {
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			// tag::include[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/nested/IndexedEmbeddedStructureNestedIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/nested/IndexedEmbeddedStructureNestedIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.indexedembedded.structure.nested;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -60,7 +60,7 @@ public class IndexedEmbeddedStructureNestedIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setId( 1 );
 			book.setTitle( "Leviathan Wakes" );
@@ -84,7 +84,7 @@ public class IndexedEmbeddedStructureNestedIT {
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			// tag::include[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/twolevels/IndexedEmbeddedTwoLevelsIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/twolevels/IndexedEmbeddedTwoLevelsIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.indexedembedded.twolevels;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -35,7 +35,7 @@ public class IndexedEmbeddedTwoLevelsIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setId( 1 );
 			book.setTitle( "Robots Of Dawn" );
@@ -55,7 +55,7 @@ public class IndexedEmbeddedTwoLevelsIT {
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/twolevels/IndexedEmbeddedTwoLevelsIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/twolevels/IndexedEmbeddedTwoLevelsIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.indexedembedded.twolevels;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -15,7 +16,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -35,7 +35,7 @@ public class IndexedEmbeddedTwoLevelsIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setId( 1 );
 			book.setTitle( "Robots Of Dawn" );
@@ -55,7 +55,7 @@ public class IndexedEmbeddedTwoLevelsIT {
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmAutomaticIndexingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmAutomaticIndexingIT.java
@@ -9,7 +9,6 @@ package org.hibernate.search.documentation.mapper.orm.indexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -74,7 +73,7 @@ public class HibernateOrmAutomaticIndexingIT {
 	}
 
 	private void initData(EntityManagerFactory entityManagerFactory) {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = new Book();
 			book1.setId( 1 );
 			book1.setTitle( BOOK1_TITLE );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmAutomaticIndexingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmAutomaticIndexingIT.java
@@ -45,7 +45,7 @@ public class HibernateOrmAutomaticIndexingIT {
 				.setup( Book.class, Author.class );
 		initData( entityManagerFactory );
 
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			// tag::automatic-indexing-synchronization-strategy-override[]
 			SearchSession searchSession = Search.session( entityManager ); // <1>
 			searchSession.automaticIndexingSynchronizationStrategy(

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmAutomaticIndexingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmAutomaticIndexingIT.java
@@ -8,6 +8,8 @@ package org.hibernate.search.documentation.mapper.orm.indexing;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -19,7 +21,6 @@ import org.hibernate.search.mapper.orm.automaticindexing.session.AutomaticIndexi
 import org.hibernate.search.mapper.orm.automaticindexing.session.AutomaticIndexingSynchronizationStrategyNames;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,7 +46,7 @@ public class HibernateOrmAutomaticIndexingIT {
 				.setup( Book.class, Author.class );
 		initData( entityManagerFactory );
 
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			// tag::automatic-indexing-synchronization-strategy-override[]
 			SearchSession searchSession = Search.session( entityManager ); // <1>
 			searchSession.automaticIndexingSynchronizationStrategy(
@@ -73,7 +74,7 @@ public class HibernateOrmAutomaticIndexingIT {
 	}
 
 	private void initData(EntityManagerFactory entityManagerFactory) {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book1 = new Book();
 			book1.setId( 1 );
 			book1.setTitle( BOOK1_TITLE );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmBatchJsr352IT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmBatchJsr352IT.java
@@ -64,7 +64,7 @@ public class HibernateOrmBatchJsr352IT {
 		jobExecution = waitForTermination( jobOperator, jobExecution, JOB_TIMEOUT_MS );
 		assertThat( jobExecution.getBatchStatus() ).isEqualTo( BatchStatus.COMPLETED );
 
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			Search.session( entityManager ).workspace().refresh();
 
 			assertBookCount( entityManager, NUMBER_OF_BOOKS );
@@ -88,7 +88,7 @@ public class HibernateOrmBatchJsr352IT {
 		jobExecution = waitForTermination( jobOperator, jobExecution, JOB_TIMEOUT_MS );
 		assertThat( jobExecution.getBatchStatus() ).isEqualTo( BatchStatus.COMPLETED );
 
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			Search.session( entityManager ).workspace().refresh();
 			assertAuthorCount( entityManager, NUMBER_OF_BOOKS / 2 );
 		} );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmBatchJsr352IT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmBatchJsr352IT.java
@@ -11,6 +11,7 @@ import static org.hibernate.search.documentation.mapper.orm.indexing.HibernateOr
 import static org.hibernate.search.documentation.mapper.orm.indexing.HibernateOrmMassIndexerIT.assertAuthorCount;
 import static org.hibernate.search.documentation.mapper.orm.indexing.HibernateOrmMassIndexerIT.assertBookCount;
 import static org.hibernate.search.documentation.mapper.orm.indexing.HibernateOrmMassIndexerIT.initData;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.Properties;
 import javax.batch.operations.JobOperator;
@@ -24,7 +25,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -64,7 +64,7 @@ public class HibernateOrmBatchJsr352IT {
 		jobExecution = waitForTermination( jobOperator, jobExecution, JOB_TIMEOUT_MS );
 		assertThat( jobExecution.getBatchStatus() ).isEqualTo( BatchStatus.COMPLETED );
 
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			Search.session( entityManager ).workspace().refresh();
 
 			assertBookCount( entityManager, NUMBER_OF_BOOKS );
@@ -88,7 +88,7 @@ public class HibernateOrmBatchJsr352IT {
 		jobExecution = waitForTermination( jobOperator, jobExecution, JOB_TIMEOUT_MS );
 		assertThat( jobExecution.getBatchStatus() ).isEqualTo( BatchStatus.COMPLETED );
 
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			Search.session( entityManager ).workspace().refresh();
 			assertAuthorCount( entityManager, NUMBER_OF_BOOKS / 2 );
 		} );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.indexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.Arrays;
 import javax.persistence.EntityManager;
@@ -20,7 +21,6 @@ import org.hibernate.search.mapper.orm.mapping.SearchMapping;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.orm.work.SearchIndexingPlan;
 import org.hibernate.search.mapper.orm.work.SearchWorkspace;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,7 +38,7 @@ public class HibernateOrmManualIndexingIT {
 	public void persist_automaticIndexing_periodicFlushClear() {
 		EntityManagerFactory entityManagerFactory = setup( true );
 
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			assertBookCount( entityManager, 0 );
 
 			// tag::persist-automatic-indexing-periodic-flush-clear[]
@@ -69,7 +69,7 @@ public class HibernateOrmManualIndexingIT {
 	public void persist_automaticIndexing_periodicFlushExecuteClear() {
 		EntityManagerFactory entityManagerFactory = setup( true );
 
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			assertBookCount( entityManager, 0 );
 
 			// tag::persist-automatic-indexing-periodic-flush-execute-clear[]
@@ -104,7 +104,7 @@ public class HibernateOrmManualIndexingIT {
 	public void persist_automaticIndexing_multipleTransactions() {
 		EntityManagerFactory entityManagerFactory = setup( true );
 
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			assertBookCount( entityManager, 0 );
 
 			// tag::persist-automatic-indexing-multiple-transactions[]
@@ -136,7 +136,7 @@ public class HibernateOrmManualIndexingIT {
 		EntityManagerFactory entityManagerFactory = setup( false );
 		initBooksAndAuthors( entityManagerFactory, numberOfBooks );
 
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			assertBookCount( entityManager, 0 );
 
 			// tag::indexing-plan-addOrUpdate[]
@@ -167,7 +167,7 @@ public class HibernateOrmManualIndexingIT {
 		EntityManagerFactory entityManagerFactory = setup( true );
 		initBooksAndAuthors( entityManagerFactory, numberOfBooks );
 
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			assertBookCount( entityManager, numberOfBooks );
 
 			// tag::indexing-plan-delete[]
@@ -208,7 +208,7 @@ public class HibernateOrmManualIndexingIT {
 			// end::workspace-retrieval-mapping[]
 		}
 
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			// tag::workspace-retrieval-session[]
 			SearchSession searchSession = Search.session( entityManager ); // <1>
 			SearchWorkspace allEntitiesWorkspace = searchSession.workspace(); // <2>
@@ -217,7 +217,7 @@ public class HibernateOrmManualIndexingIT {
 			// end::workspace-retrieval-session[]
 		} );
 
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			assertBookCount( entityManager, numberOfBooks );
 			assertAuthorCount( entityManager, numberOfBooks );
 
@@ -233,7 +233,7 @@ public class HibernateOrmManualIndexingIT {
 	}
 
 	private void initBooksAndAuthors(EntityManagerFactory entityManagerFactory, int numberOfBooks) {
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			try {
 				int i = 0;
 				while ( i < numberOfBooks ) {

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java
@@ -38,7 +38,7 @@ public class HibernateOrmManualIndexingIT {
 	public void persist_automaticIndexing_periodicFlushClear() {
 		EntityManagerFactory entityManagerFactory = setup( true );
 
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			assertBookCount( entityManager, 0 );
 
 			// tag::persist-automatic-indexing-periodic-flush-clear[]
@@ -69,7 +69,7 @@ public class HibernateOrmManualIndexingIT {
 	public void persist_automaticIndexing_periodicFlushExecuteClear() {
 		EntityManagerFactory entityManagerFactory = setup( true );
 
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			assertBookCount( entityManager, 0 );
 
 			// tag::persist-automatic-indexing-periodic-flush-execute-clear[]
@@ -104,7 +104,7 @@ public class HibernateOrmManualIndexingIT {
 	public void persist_automaticIndexing_multipleTransactions() {
 		EntityManagerFactory entityManagerFactory = setup( true );
 
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			assertBookCount( entityManager, 0 );
 
 			// tag::persist-automatic-indexing-multiple-transactions[]
@@ -136,7 +136,7 @@ public class HibernateOrmManualIndexingIT {
 		EntityManagerFactory entityManagerFactory = setup( false );
 		initBooksAndAuthors( entityManagerFactory, numberOfBooks );
 
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			assertBookCount( entityManager, 0 );
 
 			// tag::indexing-plan-addOrUpdate[]
@@ -167,7 +167,7 @@ public class HibernateOrmManualIndexingIT {
 		EntityManagerFactory entityManagerFactory = setup( true );
 		initBooksAndAuthors( entityManagerFactory, numberOfBooks );
 
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			assertBookCount( entityManager, numberOfBooks );
 
 			// tag::indexing-plan-delete[]
@@ -208,7 +208,7 @@ public class HibernateOrmManualIndexingIT {
 			// end::workspace-retrieval-mapping[]
 		}
 
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			// tag::workspace-retrieval-session[]
 			SearchSession searchSession = Search.session( entityManager ); // <1>
 			SearchWorkspace allEntitiesWorkspace = searchSession.workspace(); // <2>
@@ -217,7 +217,7 @@ public class HibernateOrmManualIndexingIT {
 			// end::workspace-retrieval-session[]
 		} );
 
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			assertBookCount( entityManager, numberOfBooks );
 			assertAuthorCount( entityManager, numberOfBooks );
 
@@ -233,7 +233,7 @@ public class HibernateOrmManualIndexingIT {
 	}
 
 	private void initBooksAndAuthors(EntityManagerFactory entityManagerFactory, int numberOfBooks) {
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			try {
 				int i = 0;
 				while ( i < numberOfBooks ) {

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmMassIndexerIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmMassIndexerIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.indexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 import static org.hibernate.search.util.impl.test.FutureAssert.assertThatFuture;
 
 import java.lang.invoke.MethodHandles;
@@ -25,7 +26,6 @@ import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.util.common.logging.impl.Log;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -49,7 +49,7 @@ public class HibernateOrmMassIndexerIT {
 				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED, false )
 				.setup( Book.class, Author.class );
 		initData( entityManagerFactory, HibernateOrmMassIndexerIT::newAuthor );
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			assertBookCount( entityManager, 0 );
 			assertAuthorCount( entityManager, 0 );
 		} );
@@ -57,7 +57,7 @@ public class HibernateOrmMassIndexerIT {
 
 	@Test
 	public void simple() {
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			try {
 				// tag::simple[]
 				SearchSession searchSession = Search.session( entityManager ); // <1>
@@ -75,7 +75,7 @@ public class HibernateOrmMassIndexerIT {
 
 	@Test
 	public void reindexOnly() {
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			try {
 				// tag::reindexOnly[]
 				SearchSession searchSession = Search.session( entityManager ); // <1>
@@ -96,7 +96,7 @@ public class HibernateOrmMassIndexerIT {
 
 	@Test
 	public void selectType() {
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			try {
 				SearchSession searchSession = Search.session( entityManager );
 				// tag::select-type[]
@@ -114,7 +114,7 @@ public class HibernateOrmMassIndexerIT {
 
 	@Test
 	public void async_reactive() {
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::async[]
 			searchSession.massIndexer() // <1>
@@ -136,7 +136,7 @@ public class HibernateOrmMassIndexerIT {
 
 	@Test
 	public void async_future() {
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::async[]
 
@@ -154,7 +154,7 @@ public class HibernateOrmMassIndexerIT {
 
 	@Test
 	public void parameters() {
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			try {
 				SearchSession searchSession = Search.session( entityManager );
 				// tag::parameters[]
@@ -194,7 +194,7 @@ public class HibernateOrmMassIndexerIT {
 	}
 
 	static void initData( EntityManagerFactory entityManagerFactory, Function<Integer, Author> authorInit ) {
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			try {
 				int i = 0;
 				while ( i < NUMBER_OF_BOOKS ) {

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmMassIndexerIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmMassIndexerIT.java
@@ -49,7 +49,7 @@ public class HibernateOrmMassIndexerIT {
 				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED, false )
 				.setup( Book.class, Author.class );
 		initData( entityManagerFactory, HibernateOrmMassIndexerIT::newAuthor );
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			assertBookCount( entityManager, 0 );
 			assertAuthorCount( entityManager, 0 );
 		} );
@@ -57,7 +57,7 @@ public class HibernateOrmMassIndexerIT {
 
 	@Test
 	public void simple() {
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			try {
 				// tag::simple[]
 				SearchSession searchSession = Search.session( entityManager ); // <1>
@@ -75,7 +75,7 @@ public class HibernateOrmMassIndexerIT {
 
 	@Test
 	public void reindexOnly() {
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			try {
 				// tag::reindexOnly[]
 				SearchSession searchSession = Search.session( entityManager ); // <1>
@@ -96,7 +96,7 @@ public class HibernateOrmMassIndexerIT {
 
 	@Test
 	public void selectType() {
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			try {
 				SearchSession searchSession = Search.session( entityManager );
 				// tag::select-type[]
@@ -114,7 +114,7 @@ public class HibernateOrmMassIndexerIT {
 
 	@Test
 	public void async_reactive() {
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::async[]
 			searchSession.massIndexer() // <1>
@@ -136,7 +136,7 @@ public class HibernateOrmMassIndexerIT {
 
 	@Test
 	public void async_future() {
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::async[]
 
@@ -154,7 +154,7 @@ public class HibernateOrmMassIndexerIT {
 
 	@Test
 	public void parameters() {
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			try {
 				SearchSession searchSession = Search.session( entityManager );
 				// tag::parameters[]
@@ -194,7 +194,7 @@ public class HibernateOrmMassIndexerIT {
 	}
 
 	static void initData( EntityManagerFactory entityManagerFactory, Function<Integer, Author> authorInit ) {
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			try {
 				int i = 0;
 				while ( i < NUMBER_OF_BOOKS ) {

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/programmatic/simple/ProgrammaticMappingSimpleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/programmatic/simple/ProgrammaticMappingSimpleIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.programmatic.simple;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -41,7 +41,7 @@ public class ProgrammaticMappingSimpleIT {
 
 	@Test
 	public void simple() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setId( 1 );
 			book.setTitle( "The Caves Of Steel" );
@@ -49,7 +49,7 @@ public class ProgrammaticMappingSimpleIT {
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/programmatic/simple/ProgrammaticMappingSimpleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/programmatic/simple/ProgrammaticMappingSimpleIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.programmatic.simple;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -16,7 +17,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -41,7 +41,7 @@ public class ProgrammaticMappingSimpleIT {
 
 	@Test
 	public void simple() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setId( 1 );
 			book.setTitle( "The Caves Of Steel" );
@@ -49,7 +49,7 @@ public class ProgrammaticMappingSimpleIT {
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/associationinverseside/AssociationInverseSideIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/associationinverseside/AssociationInverseSideIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.reindexing.associationinverseside;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -63,7 +63,7 @@ public class AssociationInverseSideIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setTitle( "The Caves Of Steel" );
 
@@ -82,7 +82,7 @@ public class AssociationInverseSideIT {
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/associationinverseside/AssociationInverseSideIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/associationinverseside/AssociationInverseSideIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.reindexing.associationinverseside;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -19,7 +20,6 @@ import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.extractor.builtin.BuiltinContainerExtractors;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
 import org.hibernate.search.mapper.pojo.model.path.PojoModelPath;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -63,7 +63,7 @@ public class AssociationInverseSideIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setTitle( "The Caves Of Steel" );
 
@@ -82,7 +82,7 @@ public class AssociationInverseSideIT {
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/derivedfrom/DerivedFromIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/derivedfrom/DerivedFromIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.reindexing.derivedfrom;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -56,7 +56,7 @@ public class DerivedFromIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book = new Book();
 			book.setTitle( "Leviathan Wakes" );
 
@@ -66,7 +66,7 @@ public class DerivedFromIT {
 			entityManager.persist( book );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/derivedfrom/DerivedFromIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/derivedfrom/DerivedFromIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.reindexing.derivedfrom;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
 import org.hibernate.search.mapper.pojo.model.path.PojoModelPath;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -56,7 +56,7 @@ public class DerivedFromIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book = new Book();
 			book.setTitle( "Leviathan Wakes" );
 
@@ -66,7 +66,7 @@ public class DerivedFromIT {
 			entityManager.persist( book );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/reindexonupdate/no/correct/ReindexOnUpdateNoIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/reindexonupdate/no/correct/ReindexOnUpdateNoIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.reindexing.reindexonupdate.no.correct;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManager;
@@ -60,7 +60,7 @@ public class ReindexOnUpdateNoIT {
 
 	@Test
 	public void reindexOnUpdateNo() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			for ( int i = 0 ; i < 2000 ; ++i ) {
 				Sensor sensor = new Sensor();
 				sensor.setId( i );
@@ -72,39 +72,39 @@ public class ReindexOnUpdateNoIT {
 			}
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			assertThat( countSensorsWithinOperatingParameters( entityManager ) )
 					.isEqualTo( 2000L );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Sensor sensor = entityManager.getReference( Sensor.class, 50 );
 			sensor.setStatus( SensorStatus.OFFLINE );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// The sensor was reindexed, as expected.
 			assertThat( countSensorsWithinOperatingParameters( entityManager ) )
 					.isEqualTo( 1999L );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Sensor sensor = entityManager.getReference( Sensor.class, 70 );
 			sensor.setRollingAverage( 0.5 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// The sensor was *not* been reindexed, as expected.
 			assertThat( countSensorsWithinOperatingParameters( entityManager ) )
 					.isEqualTo( 1999L );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Sensor sensor = entityManager.getReference( Sensor.class, 70 );
 			Search.session( entityManager ).indexingPlan().addOrUpdate( sensor );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// The sensor was reindexed, as expected.
 			assertThat( countSensorsWithinOperatingParameters( entityManager ) )
 					.isEqualTo( 1998L );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/reindexonupdate/no/correct/ReindexOnUpdateNoIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/reindexonupdate/no/correct/ReindexOnUpdateNoIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.reindexing.reindexonupdate.no.correct;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManager;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -60,7 +60,7 @@ public class ReindexOnUpdateNoIT {
 
 	@Test
 	public void reindexOnUpdateNo() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			for ( int i = 0 ; i < 2000 ; ++i ) {
 				Sensor sensor = new Sensor();
 				sensor.setId( i );
@@ -72,39 +72,39 @@ public class ReindexOnUpdateNoIT {
 			}
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			assertThat( countSensorsWithinOperatingParameters( entityManager ) )
 					.isEqualTo( 2000L );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Sensor sensor = entityManager.getReference( Sensor.class, 50 );
 			sensor.setStatus( SensorStatus.OFFLINE );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// The sensor was reindexed, as expected.
 			assertThat( countSensorsWithinOperatingParameters( entityManager ) )
 					.isEqualTo( 1999L );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Sensor sensor = entityManager.getReference( Sensor.class, 70 );
 			sensor.setRollingAverage( 0.5 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// The sensor was *not* been reindexed, as expected.
 			assertThat( countSensorsWithinOperatingParameters( entityManager ) )
 					.isEqualTo( 1999L );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Sensor sensor = entityManager.getReference( Sensor.class, 70 );
 			Search.session( entityManager ).indexingPlan().addOrUpdate( sensor );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// The sensor was reindexed, as expected.
 			assertThat( countSensorsWithinOperatingParameters( entityManager ) )
 					.isEqualTo( 1998L );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/reindexonupdate/no/incorrect/ReindexOnUpdateNoIncorrectIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/reindexonupdate/no/incorrect/ReindexOnUpdateNoIncorrectIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.reindexing.reindexonupdate.no.incorrect;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -14,7 +15,6 @@ import javax.persistence.EntityManagerFactory;
 import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -35,7 +35,7 @@ public class ReindexOnUpdateNoIncorrectIT {
 
 	@Test
 	public void missingReindexOnUpdateNo() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			for ( int i = 0 ; i < 2000 ; ++i ) {
 				Sensor sensor = new Sensor();
 				sensor.setId( i );
@@ -47,28 +47,28 @@ public class ReindexOnUpdateNoIncorrectIT {
 			}
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			assertThat( countSensorsWithinOperatingParameters( entityManager ) )
 					.isEqualTo( 2000L );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Sensor sensor = entityManager.getReference( Sensor.class, 50 );
 			sensor.setStatus( SensorStatus.OFFLINE );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// The sensor was reindexed, as expected.
 			assertThat( countSensorsWithinOperatingParameters( entityManager ) )
 					.isEqualTo( 1999L );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Sensor sensor = entityManager.getReference( Sensor.class, 70 );
 			sensor.setRollingAverage( 0.5 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// The sensor was reindexed! That won't perform well
 			// if we update the rolling average every few milliseconds on all sensors...
 			assertThat( countSensorsWithinOperatingParameters( entityManager ) )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/reindexonupdate/no/incorrect/ReindexOnUpdateNoIncorrectIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/reindexonupdate/no/incorrect/ReindexOnUpdateNoIncorrectIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.reindexing.reindexonupdate.no.incorrect;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -35,7 +35,7 @@ public class ReindexOnUpdateNoIncorrectIT {
 
 	@Test
 	public void missingReindexOnUpdateNo() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			for ( int i = 0 ; i < 2000 ; ++i ) {
 				Sensor sensor = new Sensor();
 				sensor.setId( i );
@@ -47,28 +47,28 @@ public class ReindexOnUpdateNoIncorrectIT {
 			}
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			assertThat( countSensorsWithinOperatingParameters( entityManager ) )
 					.isEqualTo( 2000L );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Sensor sensor = entityManager.getReference( Sensor.class, 50 );
 			sensor.setStatus( SensorStatus.OFFLINE );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// The sensor was reindexed, as expected.
 			assertThat( countSensorsWithinOperatingParameters( entityManager ) )
 					.isEqualTo( 1999L );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Sensor sensor = entityManager.getReference( Sensor.class, 70 );
 			sensor.setRollingAverage( 0.5 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// The sensor was reindexed! That won't perform well
 			// if we update the rolling average every few milliseconds on all sensors...
 			assertThat( countSensorsWithinOperatingParameters( entityManager ) )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/reindexonupdate/shallow/correct/ReindexOnUpdateShallowIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/reindexonupdate/shallow/correct/ReindexOnUpdateShallowIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.reindexing.reindexonupdate.shallow.correct;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManager;
@@ -59,7 +59,7 @@ public class ReindexOnUpdateShallowIT {
 
 	@Test
 	public void reindexOnUpdateShallow() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			BookCategory category = new BookCategory();
 			category.setId( 1 );
 			category.setName( "Science-fiction" );
@@ -74,18 +74,18 @@ public class ReindexOnUpdateShallowIT {
 			}
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			assertThat( countBooksByCategory( entityManager, "science" ) )
 					.isEqualTo( 100L );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			BookCategory category = entityManager.getReference( BookCategory.class, 1 );
 			category.setName( "Anticipation" );
 			entityManager.persist( category );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// The books weren't reindexed, as expected.
 			assertThat( countBooksByCategory( entityManager, "science" ) )
 					.isEqualTo( 100L );
@@ -93,12 +93,12 @@ public class ReindexOnUpdateShallowIT {
 					.isEqualTo( 0L );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			assertThat( countBooksByCategory( entityManager, "crime" ) )
 					.isEqualTo( 0L );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			BookCategory category = new BookCategory();
 			category.setId( 2 );
 			category.setName( "Crime fiction" );
@@ -108,7 +108,7 @@ public class ReindexOnUpdateShallowIT {
 			book.setCategory( category );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// The book was reindexed, as expected.
 			assertThat( countBooksByCategory( entityManager, "crime" ) )
 					.isEqualTo( 1L );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/reindexonupdate/shallow/correct/ReindexOnUpdateShallowIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/reindexonupdate/shallow/correct/ReindexOnUpdateShallowIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.reindexing.reindexonupdate.shallow.correct;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManager;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -59,7 +59,7 @@ public class ReindexOnUpdateShallowIT {
 
 	@Test
 	public void reindexOnUpdateShallow() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			BookCategory category = new BookCategory();
 			category.setId( 1 );
 			category.setName( "Science-fiction" );
@@ -74,18 +74,18 @@ public class ReindexOnUpdateShallowIT {
 			}
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			assertThat( countBooksByCategory( entityManager, "science" ) )
 					.isEqualTo( 100L );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			BookCategory category = entityManager.getReference( BookCategory.class, 1 );
 			category.setName( "Anticipation" );
 			entityManager.persist( category );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// The books weren't reindexed, as expected.
 			assertThat( countBooksByCategory( entityManager, "science" ) )
 					.isEqualTo( 100L );
@@ -93,12 +93,12 @@ public class ReindexOnUpdateShallowIT {
 					.isEqualTo( 0L );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			assertThat( countBooksByCategory( entityManager, "crime" ) )
 					.isEqualTo( 0L );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			BookCategory category = new BookCategory();
 			category.setId( 2 );
 			category.setName( "Crime fiction" );
@@ -108,7 +108,7 @@ public class ReindexOnUpdateShallowIT {
 			book.setCategory( category );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// The book was reindexed, as expected.
 			assertThat( countBooksByCategory( entityManager, "crime" ) )
 					.isEqualTo( 1L );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/schema/management/HibernateOrmSchemaManagerIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/schema/management/HibernateOrmSchemaManagerIT.java
@@ -46,7 +46,7 @@ public class HibernateOrmSchemaManagerIT {
 
 	@Test
 	public void simple() {
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			try {
 				// tag::simple[]
 				SearchSession searchSession = Search.session( entityManager ); // <1>
@@ -65,7 +65,7 @@ public class HibernateOrmSchemaManagerIT {
 
 	@Test
 	public void selectType() {
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			try {
 				SearchSession searchSession = Search.session( entityManager );
 				// tag::select-type[]
@@ -117,7 +117,7 @@ public class HibernateOrmSchemaManagerIT {
 	}
 
 	private void initData() {
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			try {
 				int i = 0;
 				while ( i < NUMBER_OF_BOOKS ) {

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/schema/management/HibernateOrmSchemaManagerIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/schema/management/HibernateOrmSchemaManagerIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.schema.management;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -18,7 +19,6 @@ import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.mapper.orm.schema.management.SchemaManagementStrategyName;
 import org.hibernate.search.mapper.orm.schema.management.SearchSchemaManager;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -46,7 +46,7 @@ public class HibernateOrmSchemaManagerIT {
 
 	@Test
 	public void simple() {
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			try {
 				// tag::simple[]
 				SearchSession searchSession = Search.session( entityManager ); // <1>
@@ -65,7 +65,7 @@ public class HibernateOrmSchemaManagerIT {
 
 	@Test
 	public void selectType() {
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			try {
 				SearchSession searchSession = Search.session( entityManager );
 				// tag::select-type[]
@@ -117,7 +117,7 @@ public class HibernateOrmSchemaManagerIT {
 	}
 
 	private void initData() {
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			try {
 				int i = 0;
 				while ( i < NUMBER_OF_BOOKS ) {

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/spatial/genericfield/GeoPointGenericFieldIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/spatial/genericfield/GeoPointGenericFieldIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.spatial.genericfield;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -17,7 +18,6 @@ import org.hibernate.search.engine.spatial.DistanceUnit;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -55,7 +55,7 @@ public class GeoPointGenericFieldIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Author author = new Author();
 			author.setName( "Isaac Asimov" );
 			author.setPlaceOfBirth( new MyCoordinates( 53.976177, 32.158627 ) );
@@ -63,7 +63,7 @@ public class GeoPointGenericFieldIT {
 			entityManager.persist( author );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Author> result = searchSession.search( Author.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/spatial/genericfield/GeoPointGenericFieldIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/spatial/genericfield/GeoPointGenericFieldIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.spatial.genericfield;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -55,7 +55,7 @@ public class GeoPointGenericFieldIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Author author = new Author();
 			author.setName( "Isaac Asimov" );
 			author.setPlaceOfBirth( new MyCoordinates( 53.976177, 32.158627 ) );
@@ -63,7 +63,7 @@ public class GeoPointGenericFieldIT {
 			entityManager.persist( author );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Author> result = searchSession.search( Author.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/spatial/geopointbinding/multiple/GeoPointBindingMultipleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/spatial/geopointbinding/multiple/GeoPointBindingMultipleIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.spatial.geopointbinding.multiple;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -16,7 +17,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.engine.spatial.DistanceUnit;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,7 +36,7 @@ public class GeoPointBindingMultipleIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Author author = new Author();
 			author.setName( "Isaac Asimov" );
 			author.setPlaceOfBirthLatitude( 53.976177 );
@@ -47,7 +47,7 @@ public class GeoPointBindingMultipleIT {
 			entityManager.persist( author );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Author> result = searchSession.search( Author.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/spatial/geopointbinding/multiple/GeoPointBindingMultipleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/spatial/geopointbinding/multiple/GeoPointBindingMultipleIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.spatial.geopointbinding.multiple;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -36,7 +36,7 @@ public class GeoPointBindingMultipleIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Author author = new Author();
 			author.setName( "Isaac Asimov" );
 			author.setPlaceOfBirthLatitude( 53.976177 );
@@ -47,7 +47,7 @@ public class GeoPointBindingMultipleIT {
 			entityManager.persist( author );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Author> result = searchSession.search( Author.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/spatial/geopointbinding/property/GeoPointBindingPropertyIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/spatial/geopointbinding/property/GeoPointBindingPropertyIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.spatial.geopointbinding.property;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -36,7 +36,7 @@ public class GeoPointBindingPropertyIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Author author = new Author();
 			author.setName( "Isaac Asimov" );
 			author.setPlaceOfBirth( new MyCoordinates( 53.976177, 32.158627 ) );
@@ -44,7 +44,7 @@ public class GeoPointBindingPropertyIT {
 			entityManager.persist( author );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Author> result = searchSession.search( Author.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/spatial/geopointbinding/property/GeoPointBindingPropertyIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/spatial/geopointbinding/property/GeoPointBindingPropertyIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.spatial.geopointbinding.property;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -16,7 +17,6 @@ import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.engine.spatial.DistanceUnit;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,7 +36,7 @@ public class GeoPointBindingPropertyIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Author author = new Author();
 			author.setName( "Isaac Asimov" );
 			author.setPlaceOfBirth( new MyCoordinates( 53.976177, 32.158627 ) );
@@ -44,7 +44,7 @@ public class GeoPointBindingPropertyIT {
 			entityManager.persist( author );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Author> result = searchSession.search( Author.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/spatial/geopointbinding/type/GeoPointBindingTypeIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/spatial/geopointbinding/type/GeoPointBindingTypeIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.spatial.geopointbinding.type;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -59,7 +59,7 @@ public class GeoPointBindingTypeIT {
 
 	@Test
 	public void smoke() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Author author = new Author();
 			author.setName( "Isaac Asimov" );
 			author.setPlaceOfBirthLatitude( 53.976177 );
@@ -68,7 +68,7 @@ public class GeoPointBindingTypeIT {
 			entityManager.persist( author );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Author> result = searchSession.search( Author.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/spatial/geopointbinding/type/GeoPointBindingTypeIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/spatial/geopointbinding/type/GeoPointBindingTypeIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.mapper.orm.spatial.geopointbinding.type;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.EntityManagerFactory;
@@ -18,7 +19,6 @@ import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.bridge.builtin.programmatic.GeoPointBinder;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -59,7 +59,7 @@ public class GeoPointBindingTypeIT {
 
 	@Test
 	public void smoke() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Author author = new Author();
 			author.setName( "Isaac Asimov" );
 			author.setPlaceOfBirthLatitude( 53.976177 );
@@ -68,7 +68,7 @@ public class GeoPointBindingTypeIT {
 			entityManager.persist( author );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Author> result = searchSession.search( Author.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/aggregation/AggregationDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/aggregation/AggregationDslIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.search.aggregation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.sql.Date;
 import java.time.Instant;
@@ -55,7 +55,7 @@ public class AggregationDslIT {
 
 	@Test
 	public void entryPoint() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// tag::entryPoint-lambdas[]
 			SearchSession searchSession = Search.session( entityManager );
 
@@ -76,7 +76,7 @@ public class AggregationDslIT {
 					);
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// tag::entryPoint-objects[]
 			SearchSession searchSession = Search.session( entityManager );
 
@@ -402,14 +402,14 @@ public class AggregationDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = new Book();
 			book1.setId( BOOK1_ID );
 			book1.setTitle( "I, Robot" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/aggregation/AggregationDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/aggregation/AggregationDslIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.search.aggregation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.sql.Date;
 import java.time.Instant;
@@ -29,7 +30,6 @@ import org.hibernate.search.mapper.orm.scope.SearchScope;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.util.common.data.Range;
 import org.hibernate.search.util.common.data.RangeBoundInclusion;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -55,7 +55,7 @@ public class AggregationDslIT {
 
 	@Test
 	public void entryPoint() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::entryPoint-lambdas[]
 			SearchSession searchSession = Search.session( entityManager );
 
@@ -76,7 +76,7 @@ public class AggregationDslIT {
 					);
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::entryPoint-objects[]
 			SearchSession searchSession = Search.session( entityManager );
 
@@ -402,14 +402,14 @@ public class AggregationDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book1 = new Book();
 			book1.setId( BOOK1_ID );
 			book1.setTitle( "I, Robot" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/aggregation/ElasticsearchAggregationDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/aggregation/ElasticsearchAggregationDslIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.documentation.search.aggregation;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 import static org.hibernate.search.util.impl.test.JsonHelper.assertJsonEquals;
 
 import java.sql.Date;
@@ -130,14 +130,14 @@ public class ElasticsearchAggregationDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = new Book();
 			book1.setId( BOOK1_ID );
 			book1.setTitle( "I, Robot" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/aggregation/ElasticsearchAggregationDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/aggregation/ElasticsearchAggregationDslIT.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.documentation.search.aggregation;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 import static org.hibernate.search.util.impl.test.JsonHelper.assertJsonEquals;
 
 import java.sql.Date;
@@ -19,7 +20,6 @@ import org.hibernate.search.engine.search.aggregation.AggregationKey;
 import org.hibernate.search.engine.search.query.SearchResult;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -130,14 +130,14 @@ public class ElasticsearchAggregationDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book1 = new Book();
 			book1.setId( BOOK1_ID );
 			book1.setTitle( "I, Robot" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/converter/DslConverterIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/converter/DslConverterIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.search.converter;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.Basic;
@@ -46,7 +46,7 @@ public class DslConverterIT {
 
 	@Test
 	public void dslConverterEnabled() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			// tag::dsl-converter-enabled[]
@@ -64,7 +64,7 @@ public class DslConverterIT {
 
 	@Test
 	public void dslConverterDisabled() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			// tag::dsl-converter-disabled[]
@@ -81,7 +81,7 @@ public class DslConverterIT {
 	}
 
 	private void initData() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			AuthenticationEvent event1 = new AuthenticationEvent( 1 );
 			event1.setOutcome( AuthenticationOutcome.USER_NOT_FOUND );
 			AuthenticationEvent event2 = new AuthenticationEvent( 2 );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/converter/DslConverterIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/converter/DslConverterIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.search.converter;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import javax.persistence.Basic;
@@ -26,7 +27,6 @@ import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.ValueBridgeRef
 import org.hibernate.search.mapper.pojo.bridge.runtime.ValueBridgeToIndexedValueContext;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -46,7 +46,7 @@ public class DslConverterIT {
 
 	@Test
 	public void dslConverterEnabled() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			// tag::dsl-converter-enabled[]
@@ -64,7 +64,7 @@ public class DslConverterIT {
 
 	@Test
 	public void dslConverterDisabled() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			// tag::dsl-converter-disabled[]
@@ -81,7 +81,7 @@ public class DslConverterIT {
 	}
 
 	private void initData() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			AuthenticationEvent event1 = new AuthenticationEvent( 1 );
 			event1.setOutcome( AuthenticationOutcome.USER_NOT_FOUND );
 			AuthenticationEvent event2 = new AuthenticationEvent( 2 );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/converter/ProjectionConverterIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/converter/ProjectionConverterIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.search.converter;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -26,7 +27,6 @@ import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -46,7 +46,7 @@ public class ProjectionConverterIT {
 
 	@Test
 	public void projectionConverterEnabled() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			// tag::projection-converter-enabled[]
@@ -63,7 +63,7 @@ public class ProjectionConverterIT {
 
 	@Test
 	public void projectionConverterDisabled() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			// tag::projection-converter-disabled[]
@@ -81,7 +81,7 @@ public class ProjectionConverterIT {
 	}
 
 	private void initData() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Order order1 = new Order( 1 );
 			order1.setStatus( OrderStatus.ACKNOWLEDGED );
 			Order order2 = new Order( 2 );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/converter/ProjectionConverterIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/converter/ProjectionConverterIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.search.converter;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -46,7 +46,7 @@ public class ProjectionConverterIT {
 
 	@Test
 	public void projectionConverterEnabled() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			// tag::projection-converter-enabled[]
@@ -63,7 +63,7 @@ public class ProjectionConverterIT {
 
 	@Test
 	public void projectionConverterDisabled() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			// tag::projection-converter-disabled[]
@@ -81,7 +81,7 @@ public class ProjectionConverterIT {
 	}
 
 	private void initData() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Order order1 = new Order( 1 );
 			order1.setStatus( OrderStatus.ACKNOWLEDGED );
 			Order order2 = new Order( 2 );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/paths/FieldPathsIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/paths/FieldPathsIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.search.paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -18,7 +19,6 @@ import org.hibernate.search.engine.search.predicate.SearchPredicate;
 import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -127,14 +127,14 @@ public class FieldPathsIT {
 	// end::withRoot_method[]
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Author isaacAsimov = new Author();
 			isaacAsimov.setId( 1 );
 			isaacAsimov.setFirstName( "Isaac" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/paths/FieldPathsIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/paths/FieldPathsIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.search.paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -127,14 +127,14 @@ public class FieldPathsIT {
 	// end::withRoot_method[]
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Author isaacAsimov = new Author();
 			isaacAsimov.setId( 1 );
 			isaacAsimov.setFirstName( "Isaac" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/ElasticsearchPredicateDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/ElasticsearchPredicateDslIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.search.predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -91,14 +91,14 @@ public class ElasticsearchPredicateDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Author isaacAsimov = new Author();
 			isaacAsimov.setId( ASIMOV_ID );
 			isaacAsimov.setFirstName( "Isaac" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/ElasticsearchPredicateDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/ElasticsearchPredicateDslIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.search.predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -91,14 +91,14 @@ public class ElasticsearchPredicateDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Author isaacAsimov = new Author();
 			isaacAsimov.setId( ASIMOV_ID );
 			isaacAsimov.setFirstName( "Isaac" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/LucenePredicateDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/LucenePredicateDslIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.search.predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -65,14 +65,14 @@ public class LucenePredicateDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Author isaacAsimov = new Author();
 			isaacAsimov.setId( ASIMOV_ID );
 			isaacAsimov.setFirstName( "Isaac" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/LucenePredicateDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/LucenePredicateDslIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.search.predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -65,14 +65,14 @@ public class LucenePredicateDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Author isaacAsimov = new Author();
 			isaacAsimov.setId( ASIMOV_ID );
 			isaacAsimov.setFirstName( "Isaac" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.search.predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -27,7 +28,6 @@ import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.scope.SearchScope;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.util.common.data.RangeBoundInclusion;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -56,7 +56,7 @@ public class PredicateDslIT {
 
 	@Test
 	public void entryPoint() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::entryPoint-lambdas[]
 			SearchSession searchSession = Search.session( entityManager );
 
@@ -70,7 +70,7 @@ public class PredicateDslIT {
 					.containsExactlyInAnyOrder( BOOK1_ID, BOOK3_ID );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::entryPoint-objects[]
 			SearchSession searchSession = Search.session( entityManager );
 
@@ -1031,14 +1031,14 @@ public class PredicateDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Author isaacAsimov = new Author();
 			isaacAsimov.setId( ASIMOV_ID );
 			isaacAsimov.setFirstName( "Isaac" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.search.predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -56,7 +56,7 @@ public class PredicateDslIT {
 
 	@Test
 	public void entryPoint() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// tag::entryPoint-lambdas[]
 			SearchSession searchSession = Search.session( entityManager );
 
@@ -70,7 +70,7 @@ public class PredicateDslIT {
 					.containsExactlyInAnyOrder( BOOK1_ID, BOOK3_ID );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// tag::entryPoint-objects[]
 			SearchSession searchSession = Search.session( entityManager );
 
@@ -1031,14 +1031,14 @@ public class PredicateDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Author isaacAsimov = new Author();
 			isaacAsimov.setId( ASIMOV_ID );
 			isaacAsimov.setFirstName( "Isaac" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/projection/ElasticsearchProjectionDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/projection/ElasticsearchProjectionDslIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.search.projection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.ElasticsearchIndexMetadataTestUtils.defaultPrimaryName;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 import static org.hibernate.search.util.impl.test.JsonHelper.assertJsonEquals;
 
 import java.util.List;
@@ -99,14 +99,14 @@ public class ElasticsearchProjectionDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Author isaacAsimov = new Author();
 			isaacAsimov.setId( ASIMOV_ID );
 			isaacAsimov.setFirstName( "Isaac" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/projection/ElasticsearchProjectionDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/projection/ElasticsearchProjectionDslIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.search.projection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.ElasticsearchIndexMetadataTestUtils.defaultPrimaryName;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 import static org.hibernate.search.util.impl.test.JsonHelper.assertJsonEquals;
 
 import java.util.List;
@@ -19,7 +20,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -99,14 +99,14 @@ public class ElasticsearchProjectionDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Author isaacAsimov = new Author();
 			isaacAsimov.setId( ASIMOV_ID );
 			isaacAsimov.setFirstName( "Isaac" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/projection/LuceneProjectionDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/projection/LuceneProjectionDslIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.search.projection;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -77,14 +77,14 @@ public class LuceneProjectionDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Author isaacAsimov = new Author();
 			isaacAsimov.setId( ASIMOV_ID );
 			isaacAsimov.setFirstName( "Isaac" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/projection/LuceneProjectionDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/projection/LuceneProjectionDslIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.search.projection;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -77,14 +77,14 @@ public class LuceneProjectionDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Author isaacAsimov = new Author();
 			isaacAsimov.setId( ASIMOV_ID );
 			isaacAsimov.setFirstName( "Isaac" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/projection/ProjectionDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/projection/ProjectionDslIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.search.projection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchHitsAssert.assertThatHits;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -34,7 +35,6 @@ import org.hibernate.search.mapper.orm.common.impl.EntityReferenceImpl;
 import org.hibernate.search.mapper.orm.scope.SearchScope;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.TestComparators;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -66,7 +66,7 @@ public class ProjectionDslIT {
 
 	@Test
 	public void entryPoint() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::entryPoint-lambdas[]
 			SearchSession searchSession = Search.session( entityManager );
 
@@ -83,7 +83,7 @@ public class ProjectionDslIT {
 			);
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::entryPoint-objects[]
 			SearchSession searchSession = Search.session( entityManager );
 
@@ -816,14 +816,14 @@ public class ProjectionDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Author isaacAsimov = new Author();
 			isaacAsimov.setId( ASIMOV_ID );
 			isaacAsimov.setFirstName( "Isaac" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/projection/ProjectionDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/projection/ProjectionDslIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.search.projection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchHitsAssert.assertThatHits;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -66,7 +66,7 @@ public class ProjectionDslIT {
 
 	@Test
 	public void entryPoint() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// tag::entryPoint-lambdas[]
 			SearchSession searchSession = Search.session( entityManager );
 
@@ -83,7 +83,7 @@ public class ProjectionDslIT {
 			);
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// tag::entryPoint-objects[]
 			SearchSession searchSession = Search.session( entityManager );
 
@@ -816,14 +816,14 @@ public class ProjectionDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Author isaacAsimov = new Author();
 			isaacAsimov.setId( ASIMOV_ID );
 			isaacAsimov.setFirstName( "Isaac" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/query/ElasticsearchQueryDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/query/ElasticsearchQueryDslIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.search.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import java.util.Map;
@@ -50,7 +50,7 @@ public class ElasticsearchQueryDslIT {
 
 	@Test
 	public void explain() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::explain-elasticsearch[]
 			ElasticsearchSearchQuery<Book> query = searchSession.search( Book.class )
@@ -74,7 +74,7 @@ public class ElasticsearchQueryDslIT {
 
 	@Test
 	public void json() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::elasticsearch-requestTransformer[]
 			List<Book> hits = searchSession.search( Book.class )
@@ -96,7 +96,7 @@ public class ElasticsearchQueryDslIT {
 					.containsExactlyInAnyOrder( BOOK1_ID, BOOK3_ID );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::elasticsearch-responseBody[]
 			ElasticsearchSearchResult<Book> result = searchSession.search( Book.class )
@@ -143,7 +143,7 @@ public class ElasticsearchQueryDslIT {
 	// end::elasticsearch-responseBody-helper[]
 
 	private void initData() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = new Book();
 			book1.setId( BOOK1_ID );
 			book1.setTitle( "I, Robot" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/query/ElasticsearchQueryDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/query/ElasticsearchQueryDslIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.search.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import java.util.Map;
@@ -20,7 +21,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -50,7 +50,7 @@ public class ElasticsearchQueryDslIT {
 
 	@Test
 	public void explain() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::explain-elasticsearch[]
 			ElasticsearchSearchQuery<Book> query = searchSession.search( Book.class )
@@ -74,7 +74,7 @@ public class ElasticsearchQueryDslIT {
 
 	@Test
 	public void json() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::elasticsearch-requestTransformer[]
 			List<Book> hits = searchSession.search( Book.class )
@@ -96,7 +96,7 @@ public class ElasticsearchQueryDslIT {
 					.containsExactlyInAnyOrder( BOOK1_ID, BOOK3_ID );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::elasticsearch-responseBody[]
 			ElasticsearchSearchResult<Book> result = searchSession.search( Book.class )
@@ -143,7 +143,7 @@ public class ElasticsearchQueryDslIT {
 	// end::elasticsearch-responseBody-helper[]
 
 	private void initData() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book1 = new Book();
 			book1.setId( BOOK1_ID );
 			book1.setTitle( "I, Robot" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/query/LuceneQueryDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/query/LuceneQueryDslIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.search.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import javax.persistence.EntityManagerFactory;
 
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -49,7 +49,7 @@ public class LuceneQueryDslIT {
 
 	@Test
 	public void explain() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::explain-lucene[]
 			LuceneSearchQuery<Book> query = searchSession.search( Book.class )
@@ -75,7 +75,7 @@ public class LuceneQueryDslIT {
 
 	@Test
 	public void lowLevel() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::lucene-lowLevel[]
 			LuceneSearchQuery<Book> query = searchSession.search( Book.class )
@@ -107,7 +107,7 @@ public class LuceneQueryDslIT {
 	}
 
 	private void initData() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book1 = new Book();
 			book1.setId( BOOK1_ID );
 			book1.setTitle( "I, Robot" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/query/LuceneQueryDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/query/LuceneQueryDslIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.search.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import javax.persistence.EntityManagerFactory;
 
@@ -49,7 +49,7 @@ public class LuceneQueryDslIT {
 
 	@Test
 	public void explain() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::explain-lucene[]
 			LuceneSearchQuery<Book> query = searchSession.search( Book.class )
@@ -75,7 +75,7 @@ public class LuceneQueryDslIT {
 
 	@Test
 	public void lowLevel() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::lucene-lowLevel[]
 			LuceneSearchQuery<Book> query = searchSession.search( Book.class )
@@ -107,7 +107,7 @@ public class LuceneQueryDslIT {
 	}
 
 	private void initData() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = new Book();
 			book1.setId( BOOK1_ID );
 			book1.setTitle( "I, Robot" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/query/QueryDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/query/QueryDslIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.search.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.ManagedAssert.assertThatManaged;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -34,7 +35,6 @@ import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.search.loading.EntityLoadingCacheLookupStrategy;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.util.common.SearchTimeoutException;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.stat.Statistics;
 
 import org.junit.Before;
@@ -68,7 +68,7 @@ public class QueryDslIT {
 
 	@Test
 	public void entryPoint() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::entryPoint[]
 			// Not shown: get the entity manager and open a transaction
 			SearchSession searchSession = Search.session( entityManager ); // <1>
@@ -92,7 +92,7 @@ public class QueryDslIT {
 
 	@Test
 	public void targetingMultipleEntityTypes() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::targeting-multiple[]
 			SearchResult<Person> result = searchSession.search( Arrays.asList( // <1>
@@ -114,7 +114,7 @@ public class QueryDslIT {
 
 	@Test
 	public void targetingByEntityName() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::targeting-entityName[]
 			SearchResult<Person> result = searchSession.search( // <1>
@@ -139,7 +139,7 @@ public class QueryDslIT {
 
 	@Test
 	public void fetchingBasics() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::fetching-searchResult[]
 			SearchResult<Book> result = searchSession.search( Book.class ) // <1>
@@ -156,7 +156,7 @@ public class QueryDslIT {
 					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID, BOOK3_ID, BOOK4_ID );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::fetching-totalHitCount[]
 			long totalHitCount = searchSession.search( Book.class )
@@ -167,7 +167,7 @@ public class QueryDslIT {
 			assertThat( totalHitCount ).isEqualTo( 4 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::fetching-hits[]
 			List<Book> hits = searchSession.search( Book.class )
@@ -179,7 +179,7 @@ public class QueryDslIT {
 					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID, BOOK3_ID, BOOK4_ID );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::fetching-singleHit[]
 			Optional<Book> hit = searchSession.search( Book.class )
@@ -194,7 +194,7 @@ public class QueryDslIT {
 
 	@Test
 	public void fetchingAllHits() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::fetching-all-searchResult[]
 			SearchResult<Book> result = searchSession.search( Book.class )
@@ -210,7 +210,7 @@ public class QueryDslIT {
 					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::fetching-all-hits[]
 			List<Book> hits = searchSession.search( Book.class )
@@ -225,7 +225,7 @@ public class QueryDslIT {
 
 	@Test
 	public void pagination() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::fetching-pagination-searchResult[]
 			SearchResult<Book> result = searchSession.search( Book.class )
@@ -239,7 +239,7 @@ public class QueryDslIT {
 			assertThat( hits ).isEmpty();
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::fetching-pagination-hits[]
 			List<Book> hits = searchSession.search( Book.class )
@@ -253,7 +253,7 @@ public class QueryDslIT {
 
 	@Test
 	public void scrolling() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			List<Integer> collectedIds = new ArrayList<>();
 			long totalHitCount = 0;
@@ -286,7 +286,7 @@ public class QueryDslIT {
 
 	@Test
 	public void searchQuery() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::searchQuery[]
 			SearchQuery<Book> query = searchSession.search( Book.class ) // <1>
@@ -299,7 +299,7 @@ public class QueryDslIT {
 					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID, BOOK3_ID, BOOK4_ID );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::searchQuery-toORM[]
 			SearchQuery<Book> query = searchSession.search( Book.class ) // <1>
@@ -319,7 +319,7 @@ public class QueryDslIT {
 
 	@Test
 	public void tookAndTimedOut() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::took-timedOut[]
 			SearchQuery<Book> query = searchSession.search( Book.class )
@@ -341,7 +341,7 @@ public class QueryDslIT {
 
 	@Test
 	public void truncateAfter() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::truncateAfter[]
 			SearchResult<Book> result = searchSession.search( Book.class ) // <1>
@@ -362,7 +362,7 @@ public class QueryDslIT {
 
 	@Test
 	public void failAfter() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::failAfter[]
 			try {
@@ -382,7 +382,7 @@ public class QueryDslIT {
 
 	@Test
 	public void cacheLookupStrategy() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Statistics statistics = entityManagerFactory.unwrap( SessionFactory.class ).getStatistics();
 			statistics.setStatisticsEnabled( true );
 			statistics.clear();
@@ -408,7 +408,7 @@ public class QueryDslIT {
 
 	@Test
 	public void fetchSize() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			// tag::fetchSize[]
@@ -427,7 +427,7 @@ public class QueryDslIT {
 
 	@Test
 	public void resultTotal() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::fetching-resultTotal[]
 			SearchResult<Book> result = searchSession.search( Book.class )
@@ -450,7 +450,7 @@ public class QueryDslIT {
 
 	@Test
 	public void resultTotal_totalHitCountThreshold() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::fetching-totalHitCountThreshold[]
 			SearchResult<Book> result = searchSession.search( Book.class )
@@ -471,7 +471,7 @@ public class QueryDslIT {
 	@Test
 	public void graph() {
 		// By default associates are not loaded
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			SearchResult<Manager> result = searchSession.search( Manager.class ) // <1>
@@ -485,7 +485,7 @@ public class QueryDslIT {
 					.allSatisfy( manager -> assertThatManaged( manager.getAssociates() ).isNotInitialized() );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, theEntityManager -> {
+		withinJPATransaction( entityManagerFactory, theEntityManager -> {
 			// tag::graph-byReference[]
 			EntityManager entityManager = /* ... */
 					// end::graph-byReference[]
@@ -508,7 +508,7 @@ public class QueryDslIT {
 					.allSatisfy( manager -> assertThatManaged( manager.getAssociates() ).isInitialized() );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::graph-byName[]
 			SearchResult<Manager> result = Search.session( entityManager ).search( Manager.class ) // <1>
 					.where( f -> f.match()
@@ -525,7 +525,7 @@ public class QueryDslIT {
 	}
 
 	private void initData() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book1 = new Book();
 			book1.setId( BOOK1_ID );
 			book1.setTitle( "I, Robot" );
@@ -548,7 +548,7 @@ public class QueryDslIT {
 			entityManager.persist( book4 );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Manager manager1 = new Manager();
 			manager1.setId( MANAGER1_ID );
 			manager1.setName( "James Green" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/query/QueryDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/query/QueryDslIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.documentation.search.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.ManagedAssert.assertThatManaged;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -68,7 +68,7 @@ public class QueryDslIT {
 
 	@Test
 	public void entryPoint() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// tag::entryPoint[]
 			// Not shown: get the entity manager and open a transaction
 			SearchSession searchSession = Search.session( entityManager ); // <1>
@@ -92,7 +92,7 @@ public class QueryDslIT {
 
 	@Test
 	public void targetingMultipleEntityTypes() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::targeting-multiple[]
 			SearchResult<Person> result = searchSession.search( Arrays.asList( // <1>
@@ -114,7 +114,7 @@ public class QueryDslIT {
 
 	@Test
 	public void targetingByEntityName() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::targeting-entityName[]
 			SearchResult<Person> result = searchSession.search( // <1>
@@ -139,7 +139,7 @@ public class QueryDslIT {
 
 	@Test
 	public void fetchingBasics() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::fetching-searchResult[]
 			SearchResult<Book> result = searchSession.search( Book.class ) // <1>
@@ -156,7 +156,7 @@ public class QueryDslIT {
 					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID, BOOK3_ID, BOOK4_ID );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::fetching-totalHitCount[]
 			long totalHitCount = searchSession.search( Book.class )
@@ -167,7 +167,7 @@ public class QueryDslIT {
 			assertThat( totalHitCount ).isEqualTo( 4 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::fetching-hits[]
 			List<Book> hits = searchSession.search( Book.class )
@@ -179,7 +179,7 @@ public class QueryDslIT {
 					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID, BOOK3_ID, BOOK4_ID );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::fetching-singleHit[]
 			Optional<Book> hit = searchSession.search( Book.class )
@@ -194,7 +194,7 @@ public class QueryDslIT {
 
 	@Test
 	public void fetchingAllHits() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::fetching-all-searchResult[]
 			SearchResult<Book> result = searchSession.search( Book.class )
@@ -210,7 +210,7 @@ public class QueryDslIT {
 					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::fetching-all-hits[]
 			List<Book> hits = searchSession.search( Book.class )
@@ -225,7 +225,7 @@ public class QueryDslIT {
 
 	@Test
 	public void pagination() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::fetching-pagination-searchResult[]
 			SearchResult<Book> result = searchSession.search( Book.class )
@@ -239,7 +239,7 @@ public class QueryDslIT {
 			assertThat( hits ).isEmpty();
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::fetching-pagination-hits[]
 			List<Book> hits = searchSession.search( Book.class )
@@ -253,7 +253,7 @@ public class QueryDslIT {
 
 	@Test
 	public void scrolling() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			List<Integer> collectedIds = new ArrayList<>();
 			long totalHitCount = 0;
@@ -286,7 +286,7 @@ public class QueryDslIT {
 
 	@Test
 	public void searchQuery() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::searchQuery[]
 			SearchQuery<Book> query = searchSession.search( Book.class ) // <1>
@@ -299,7 +299,7 @@ public class QueryDslIT {
 					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID, BOOK3_ID, BOOK4_ID );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::searchQuery-toORM[]
 			SearchQuery<Book> query = searchSession.search( Book.class ) // <1>
@@ -319,7 +319,7 @@ public class QueryDslIT {
 
 	@Test
 	public void tookAndTimedOut() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::took-timedOut[]
 			SearchQuery<Book> query = searchSession.search( Book.class )
@@ -341,7 +341,7 @@ public class QueryDslIT {
 
 	@Test
 	public void truncateAfter() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::truncateAfter[]
 			SearchResult<Book> result = searchSession.search( Book.class ) // <1>
@@ -362,7 +362,7 @@ public class QueryDslIT {
 
 	@Test
 	public void failAfter() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::failAfter[]
 			try {
@@ -382,7 +382,7 @@ public class QueryDslIT {
 
 	@Test
 	public void cacheLookupStrategy() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Statistics statistics = entityManagerFactory.unwrap( SessionFactory.class ).getStatistics();
 			statistics.setStatisticsEnabled( true );
 			statistics.clear();
@@ -408,7 +408,7 @@ public class QueryDslIT {
 
 	@Test
 	public void fetchSize() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			// tag::fetchSize[]
@@ -427,7 +427,7 @@ public class QueryDslIT {
 
 	@Test
 	public void resultTotal() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::fetching-resultTotal[]
 			SearchResult<Book> result = searchSession.search( Book.class )
@@ -450,7 +450,7 @@ public class QueryDslIT {
 
 	@Test
 	public void resultTotal_totalHitCountThreshold() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			// tag::fetching-totalHitCountThreshold[]
 			SearchResult<Book> result = searchSession.search( Book.class )
@@ -471,7 +471,7 @@ public class QueryDslIT {
 	@Test
 	public void graph() {
 		// By default associates are not loaded
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 
 			SearchResult<Manager> result = searchSession.search( Manager.class ) // <1>
@@ -485,7 +485,7 @@ public class QueryDslIT {
 					.allSatisfy( manager -> assertThatManaged( manager.getAssociates() ).isNotInitialized() );
 		} );
 
-		withinJPATransaction( entityManagerFactory, theEntityManager -> {
+		with( entityManagerFactory ).runInTransaction( theEntityManager -> {
 			// tag::graph-byReference[]
 			EntityManager entityManager = /* ... */
 					// end::graph-byReference[]
@@ -508,7 +508,7 @@ public class QueryDslIT {
 					.allSatisfy( manager -> assertThatManaged( manager.getAssociates() ).isInitialized() );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// tag::graph-byName[]
 			SearchResult<Manager> result = Search.session( entityManager ).search( Manager.class ) // <1>
 					.where( f -> f.match()
@@ -525,7 +525,7 @@ public class QueryDslIT {
 	}
 
 	private void initData() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = new Book();
 			book1.setId( BOOK1_ID );
 			book1.setTitle( "I, Robot" );
@@ -548,7 +548,7 @@ public class QueryDslIT {
 			entityManager.persist( book4 );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Manager manager1 = new Manager();
 			manager1.setId( MANAGER1_ID );
 			manager1.setName( "James Green" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/sort/ElasticsearchSortDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/sort/ElasticsearchSortDslIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.search.sort;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -89,14 +89,14 @@ public class ElasticsearchSortDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Author isaacAsimov = new Author();
 			isaacAsimov.setId( ASIMOV_ID );
 			isaacAsimov.setFirstName( "Isaac" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/sort/ElasticsearchSortDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/sort/ElasticsearchSortDslIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.search.sort;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -89,14 +89,14 @@ public class ElasticsearchSortDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Author isaacAsimov = new Author();
 			isaacAsimov.setId( ASIMOV_ID );
 			isaacAsimov.setFirstName( "Isaac" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/sort/LuceneSortDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/sort/LuceneSortDslIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.search.sort;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -84,14 +84,14 @@ public class LuceneSortDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Author isaacAsimov = new Author();
 			isaacAsimov.setId( ASIMOV_ID );
 			isaacAsimov.setFirstName( "Isaac" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/sort/LuceneSortDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/sort/LuceneSortDslIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.search.sort;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -17,7 +18,6 @@ import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -84,14 +84,14 @@ public class LuceneSortDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Author isaacAsimov = new Author();
 			isaacAsimov.setId( ASIMOV_ID );
 			isaacAsimov.setFirstName( "Isaac" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/sort/SortDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/sort/SortDslIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.documentation.search.sort;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.Arrays;
 import java.util.List;
@@ -50,7 +50,7 @@ public class SortDslIT {
 
 	@Test
 	public void entryPoint() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// tag::entryPoint-lambdas[]
 			SearchSession searchSession = Search.session( entityManager );
 
@@ -65,7 +65,7 @@ public class SortDslIT {
 					.containsExactly( BOOK4_ID, BOOK1_ID, BOOK2_ID, BOOK3_ID );
 		} );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			// tag::entryPoint-objects[]
 			SearchSession searchSession = Search.session( entityManager );
 
@@ -343,14 +343,14 @@ public class SortDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Author isaacAsimov = new Author();
 			isaacAsimov.setId( ASIMOV_ID );
 			isaacAsimov.setFirstName( "Isaac" );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/sort/SortDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/sort/SortDslIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.search.sort;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.Arrays;
 import java.util.List;
@@ -21,7 +22,6 @@ import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.scope.SearchScope;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -50,7 +50,7 @@ public class SortDslIT {
 
 	@Test
 	public void entryPoint() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::entryPoint-lambdas[]
 			SearchSession searchSession = Search.session( entityManager );
 
@@ -65,7 +65,7 @@ public class SortDslIT {
 					.containsExactly( BOOK4_ID, BOOK1_ID, BOOK2_ID, BOOK3_ID );
 		} );
 
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::entryPoint-objects[]
 			SearchSession searchSession = Search.session( entityManager );
 
@@ -343,14 +343,14 @@ public class SortDslIT {
 	}
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}
 
 	private void initData() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+		withinJPATransaction( entityManagerFactory, entityManager -> {
 			Author isaacAsimov = new Author();
 			isaacAsimov.setId( ASIMOV_ID );
 			isaacAsimov.setFirstName( "Isaac" );

--- a/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/MassIndexingJobWithCompositeIdIT.java
+++ b/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/MassIndexingJobWithCompositeIdIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.integrationtest.batch.jsr352.massindexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.integrationtest.batch.jsr352.util.JobTestUtil.JOB_TIMEOUT_MS;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.io.Serializable;
 import java.time.LocalDate;
@@ -36,7 +37,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
@@ -79,7 +79,7 @@ public class MassIndexingJobWithCompositeIdIT {
 	public void initData() throws Exception {
 		emf = setupHolder.entityManagerFactory();
 
-		OrmUtils.withinJPATransaction( emf, ( entityManager ) -> {
+		withinJPATransaction( emf, ( entityManager ) -> {
 			for ( LocalDate d = START; d.isBefore( END ); d = d.plusDays( 1 ) ) {
 				entityManager.persist( new EntityWithIdClass( d ) );
 				entityManager.persist( new EntityWithEmbeddedId( d ) );

--- a/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/MassIndexingJobWithCompositeIdIT.java
+++ b/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/MassIndexingJobWithCompositeIdIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.integrationtest.batch.jsr352.massindexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.integrationtest.batch.jsr352.util.JobTestUtil.JOB_TIMEOUT_MS;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.io.Serializable;
 import java.time.LocalDate;
@@ -79,7 +79,7 @@ public class MassIndexingJobWithCompositeIdIT {
 	public void initData() throws Exception {
 		emf = setupHolder.entityManagerFactory();
 
-		withinJPATransaction( emf, ( entityManager ) -> {
+		with( emf ).runInTransaction( entityManager -> {
 			for ( LocalDate d = START; d.isBefore( END ); d = d.plusDays( 1 ) ) {
 				entityManager.persist( new EntityWithIdClass( d ) );
 				entityManager.persist( new EntityWithEmbeddedId( d ) );

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/FilteringOutboxEventFinder.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/FilteringOutboxEventFinder.java
@@ -9,7 +9,7 @@ package org.hibernate.search.integrationtest.mapper.orm.coordination.outboxpolli
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl.OutboxPollingOutboxEventAdditionalJaxbMappingProducer.ENTITY_NAME;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.HashSet;
 import java.util.List;
@@ -81,7 +81,7 @@ public class FilteringOutboxEventFinder {
 
 	public synchronized void showAllEventsUpToNow(SessionFactory sessionFactory) {
 		checkFiltering();
-		withinTransaction( sessionFactory, session -> showOnlyEvents( findOutboxEventIdsNoFilter( session ) ) );
+		with( sessionFactory ).runInTransaction( session -> showOnlyEvents( findOutboxEventIdsNoFilter( session ) ) );
 	}
 
 	public synchronized void showOnlyEvents(List<Long> eventIds) {
@@ -147,7 +147,7 @@ public class FilteringOutboxEventFinder {
 	}
 
 	public void awaitUntilNoMoreVisibleEvents(SessionFactory sessionFactory) {
-		await().untilAsserted( () -> withinTransaction( sessionFactory, session -> {
+		await().untilAsserted( () -> with( sessionFactory ).runInTransaction( session -> {
 			List<OutboxEvent> outboxEntries = findOutboxEventsNotForProcessing( session, 1, Optional.empty() );
 			assertThat( outboxEntries ).isEmpty();
 		} ) );

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingBackendFailureIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingBackendFailureIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.integrationtest.mapper.orm.coordination.outboxpolli
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -56,7 +56,7 @@ public class OutboxPollingAutomaticIndexingBackendFailureIT {
 	@Test
 	public void backendFailure() {
 		setup( 0 );
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 			entity1.setIndexedField( "initialValue" );
@@ -109,7 +109,7 @@ public class OutboxPollingAutomaticIndexingBackendFailureIT {
 	public void backendFailure_retryAfter() {
 		setup( 3 );
 		AtomicLong timeOfTheException = new AtomicLong();
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 			entity1.setIndexedField( "initialValue" );
@@ -164,7 +164,7 @@ public class OutboxPollingAutomaticIndexingBackendFailureIT {
 	@Test
 	public void backendFailure_twoFailuresOfTheSameIndexingWork() {
 		setup( 0 );
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 			entity1.setIndexedField( "initialValue" );
@@ -223,7 +223,7 @@ public class OutboxPollingAutomaticIndexingBackendFailureIT {
 	@Test
 	public void backendFailure_numberOfTrialsExhausted() {
 		setup( 0 );
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 			entity1.setIndexedField( "initialValue" );

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingConcurrencyIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingConcurrencyIT.java
@@ -9,7 +9,6 @@ package org.hibernate.search.integrationtest.mapper.orm.coordination.outboxpolli
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.integrationtest.mapper.orm.coordination.outboxpolling.automaticindexing.OutboxPollingTestUtils.awaitAllAgentsRunningInOneCluster;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -91,7 +90,7 @@ public class OutboxPollingAutomaticIndexingConcurrencyIT {
 		for ( int i = 0; i < ENTITY_COUNT; i += ENTITY_UPDATE_BATCH_SIZE ) {
 			int idStart = i;
 			int idEnd = Math.min( i + ENTITY_UPDATE_BATCH_SIZE, ENTITY_COUNT );
-			withinTransaction( sessionFactory, session -> {
+			with( sessionFactory ).runInTransaction( session -> {
 				for ( int j = idStart; j < idEnd ; j++ ) {
 					IndexedEntity entity = new IndexedEntity( j, "initial" );
 					session.persist( entity );

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingDynamicShardingRebalancingIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingDynamicShardingRebalancingIT.java
@@ -12,7 +12,6 @@ import static org.awaitility.Awaitility.await;
 import static org.hibernate.search.integrationtest.mapper.orm.coordination.outboxpolling.automaticindexing.OutboxPollingTestUtils.awaitAllAgentsRunningInOneCluster;
 import static org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.impl.HibernateOrmMapperOutboxPollingImplSettings.CoordinationRadicals.AGENT_REPOSITORY_PROVIDER;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -106,7 +105,7 @@ public class OutboxPollingAutomaticIndexingDynamicShardingRebalancingIT {
 		int entityCount = 3000;
 		int initialShardCount = 3;
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			for ( int i = 0; i < entityCount; i++ ) {
 				IndexedEntity entity = new IndexedEntity( i, "initial" );
 				session.persist( entity );
@@ -155,7 +154,7 @@ public class OutboxPollingAutomaticIndexingDynamicShardingRebalancingIT {
 		int entityCount = 3000;
 		int initialShardCount = 3;
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			for ( int i = 0; i < entityCount; i++ ) {
 				IndexedEntity entity = new IndexedEntity( i, "initial" );
 				session.persist( entity );
@@ -198,7 +197,7 @@ public class OutboxPollingAutomaticIndexingDynamicShardingRebalancingIT {
 		int entityCount = 3000;
 		int initialShardCount = 3;
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			for ( int i = 0; i < entityCount; i++ ) {
 				IndexedEntity entity = new IndexedEntity( i, "initial" );
 				session.persist( entity );

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingEdgeCasesIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingEdgeCasesIT.java
@@ -159,7 +159,7 @@ public class OutboxPollingAutomaticIndexingEdgeCasesIT {
 		} );
 
 		// Make events visible one by one, so that they are processed in separate batches.
-		List<Long> eventIds = setupHolder.with().applyInTransaction( outboxEventFinder::findOutboxEventIdsNoFilter );
+		List<Long> eventIds = setupHolder.applyInTransaction( outboxEventFinder::findOutboxEventIdsNoFilter );
 		assertThat( eventIds ).hasSize( 2 );
 		for ( Long eventId : eventIds ) {
 			outboxEventFinder.showOnlyEvents( Collections.singletonList( eventId ) );

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingOutOfOrderIdsIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingOutOfOrderIdsIT.java
@@ -87,7 +87,7 @@ public class OutboxPollingAutomaticIndexingOutOfOrderIdsIT {
 			session.remove( entity );
 		} );
 
-		OrmUtils.withinSession( sessionFactory, session -> {
+		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
 			List<OutboxEvent> events = outboxEventFinder.findOutboxEventsNoFilterOrderById( session );
 			assertThat( events ).hasSize( 3 );
 			// Correct order when ordered by id (you'll have to trust me on that)
@@ -106,7 +106,7 @@ public class OutboxPollingAutomaticIndexingOutOfOrderIdsIT {
 			updateOutboxTableRow( session, 4, 3 );
 		} );
 
-		OrmUtils.withinSession( sessionFactory, session -> {
+		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
 			List<OutboxEvent> events = outboxEventFinder.findOutboxEventsNoFilterOrderById( session );
 			assertThat( events ).hasSize( 3 );
 			// Out-of-order when ordered by id (you'll have to trust me on that)
@@ -198,7 +198,7 @@ public class OutboxPollingAutomaticIndexingOutOfOrderIdsIT {
 			session.persist( entity );
 		} );
 
-		OrmUtils.withinSession( sessionFactory, session -> {
+		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
 			List<OutboxEvent> events = outboxEventFinder.findOutboxEventsNoFilterOrderById( session );
 			assertThat( events ).hasSize( 2 );
 			// Correct order when ordered by id (you'll have to trust me on that)
@@ -215,7 +215,7 @@ public class OutboxPollingAutomaticIndexingOutOfOrderIdsIT {
 			updateOutboxTableRow( session, 4, 3 );
 		} );
 
-		OrmUtils.withinSession( sessionFactory, session -> {
+		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
 			List<OutboxEvent> events = outboxEventFinder.findOutboxEventsNoFilterOrderById( session );
 			assertThat( events ).hasSize( 2 );
 			// Out-of-order when ordered by id (you'll have to trust me on that)
@@ -311,7 +311,7 @@ public class OutboxPollingAutomaticIndexingOutOfOrderIdsIT {
 			entity.setText( "third" );
 		} );
 
-		OrmUtils.withinSession( sessionFactory, session -> {
+		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
 			List<OutboxEvent> events = outboxEventFinder.findOutboxEventsNoFilterOrderById( session );
 			assertThat( events ).hasSize( 2 );
 			// Correct order when ordered by id
@@ -331,7 +331,7 @@ public class OutboxPollingAutomaticIndexingOutOfOrderIdsIT {
 			updateOutboxTableRow( session, 4, 3 );
 		} );
 
-		OrmUtils.withinSession( sessionFactory, session -> {
+		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
 			List<OutboxEvent> events = outboxEventFinder.findOutboxEventsNoFilterOrderById( session );
 			assertThat( events ).hasSize( 2 );
 			// Out-of-order when ordered by id

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingRoutingIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingRoutingIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.coordination.outboxpolling.automaticindexing;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,7 +48,7 @@ public class OutboxPollingAutomaticIndexingRoutingIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-4186")
 	public void processingEventsWithOutdatedRoutingKey() {
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			RoutedIndexedEntity entity = new RoutedIndexedEntity( 1, "first", RoutedIndexedEntity.Status.FIRST );
 			session.persist( entity );
 		} );
@@ -62,7 +62,7 @@ public class OutboxPollingAutomaticIndexingRoutingIT {
 		backendMock.verifyExpectationsMet();
 
 		// Update the current routing key (but don't trigger indexing yet: events are being filtered)
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			RoutedIndexedEntity entity = session.find( RoutedIndexedEntity.class, 1 );
 			entity.setStatus( RoutedIndexedEntity.Status.SECOND );
 			entity.setText( "second" );
@@ -70,12 +70,12 @@ public class OutboxPollingAutomaticIndexingRoutingIT {
 
 		// Remember the events at this point
 		List<Long> eventIdsAtSecondStatus = new ArrayList<>();
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			eventIdsAtSecondStatus.addAll( outboxEventFinder.findOutboxEventIdsNoFilter( session ) );
 		} );
 
 		// Update the current routing key again (but don't trigger indexing yet: events are being filtered)
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			RoutedIndexedEntity entity = session.find( RoutedIndexedEntity.class, 1 );
 			entity.setStatus( RoutedIndexedEntity.Status.THIRD );
 			entity.setText( "third" );

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingShardingBaseIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingShardingBaseIT.java
@@ -9,7 +9,6 @@ package org.hibernate.search.integrationtest.mapper.orm.coordination.outboxpolli
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.integrationtest.mapper.orm.coordination.outboxpolling.automaticindexing.OutboxPollingTestUtils.awaitAllAgentsRunningInOneCluster;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -119,7 +118,7 @@ public class OutboxPollingAutomaticIndexingShardingBaseIT {
 	public void uniqueWorkAcrossSessionFactories_insertUpdateDelete_indexed() {
 		SessionFactory sessionFactory = indexingCountHelper.sessionFactory( 0 );
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity = new IndexedEntity( 1, "initial" );
 			session.persist( entity );
 
@@ -128,7 +127,7 @@ public class OutboxPollingAutomaticIndexingShardingBaseIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity = session.getReference( IndexedEntity.class, 1 );
 			entity.setText( "updated" );
 
@@ -137,7 +136,7 @@ public class OutboxPollingAutomaticIndexingShardingBaseIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity = session.getReference( IndexedEntity.class, 1 );
 			session.remove( entity );
 
@@ -153,7 +152,7 @@ public class OutboxPollingAutomaticIndexingShardingBaseIT {
 	public void uniqueWorkAcrossSessionFactories_insertUpdateDelete_contained() {
 		SessionFactory sessionFactory = indexingCountHelper.sessionFactory( 0 );
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedAndContainingEntity containing = new IndexedAndContainingEntity( 1, "initial" );
 			ContainedEntity contained = new ContainedEntity( 2, "initial" );
 			containing.setContained( contained );
@@ -168,7 +167,7 @@ public class OutboxPollingAutomaticIndexingShardingBaseIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			ContainedEntity contained = session.getReference( ContainedEntity.class, 2 );
 			contained.setText( "updated" );
 
@@ -179,7 +178,7 @@ public class OutboxPollingAutomaticIndexingShardingBaseIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedAndContainingEntity containing = session.getReference( IndexedAndContainingEntity.class, 1 );
 			ContainedEntity contained = containing.getContained();
 			containing.setContained( null );
@@ -200,7 +199,7 @@ public class OutboxPollingAutomaticIndexingShardingBaseIT {
 		int entityCount = 1000;
 
 		// A single big insert transaction
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			for ( int i = 0; i < entityCount; i++ ) {
 				IndexedEntity entity = new IndexedEntity( i, "initial" );
 				session.persist( entity );
@@ -224,7 +223,7 @@ public class OutboxPollingAutomaticIndexingShardingBaseIT {
 		for ( int i = 0; i < entityCount; i += batchSize ) {
 			int idStart = i;
 			int idEnd = Math.min( i + batchSize, entityCount );
-			withinTransaction( sessionFactory, session -> {
+			with( sessionFactory ).runInTransaction( session -> {
 				for ( int j = idStart; j < idEnd ; j++ ) {
 					IndexedEntity entity = session.getReference( IndexedEntity.class, j );
 					entity.setText( "updated" );

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingStaticShardingUnevenShardsIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingStaticShardingUnevenShardsIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.coordination.outboxpolling.automaticindexing;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -106,7 +106,7 @@ public class OutboxPollingAutomaticIndexingStaticShardingUnevenShardsIT {
 		int entityCount = 1000;
 
 		// A single big insert transaction
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			for ( int i = 0; i < entityCount; i++ ) {
 				IndexedEntity entity = new IndexedEntity( i, "initial" );
 				session.persist( entity );
@@ -139,7 +139,7 @@ public class OutboxPollingAutomaticIndexingStaticShardingUnevenShardsIT {
 		for ( int i = 0; i < entityCount; i += batchSize ) {
 			int idStart = i;
 			int idEnd = Math.min( i + batchSize, entityCount );
-			withinTransaction( sessionFactory, session -> {
+			with( sessionFactory ).runInTransaction( session -> {
 				for ( int j = idStart; j < idEnd ; j++ ) {
 					IndexedEntity entity = session.getReference( IndexedEntity.class, j );
 					entity.setText( "updated" );

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingCustomEntityMappingIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingCustomEntityMappingIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.integrationtest.mapper.orm.coordination.outboxpolli
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 import static org.junit.Assume.assumeTrue;
 
 import java.util.ArrayList;
@@ -115,7 +115,7 @@ public class OutboxPollingCustomEntityMappingIT {
 		backendMock.verifyExpectationsMet();
 
 		int id = 1;
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity = new IndexedEntity();
 			entity.setId( id );
 			entity.setIndexedField( "value for the field" );
@@ -155,7 +155,7 @@ public class OutboxPollingCustomEntityMappingIT {
 		backendMock.verifyExpectationsMet();
 
 		int id = 1;
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity = new IndexedEntity();
 			entity.setId( id );
 			entity.setIndexedField( "value for the field" );
@@ -218,7 +218,7 @@ public class OutboxPollingCustomEntityMappingIT {
 		backendMock.verifyExpectationsMet();
 
 		int id = 1;
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity = new IndexedEntity();
 			entity.setId( id );
 			entity.setIndexedField( "value for the field" );
@@ -269,7 +269,7 @@ public class OutboxPollingCustomEntityMappingIT {
 				getDialect().canCreateSchema() );
 
 		int id = 1;
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity = new IndexedEntity();
 			entity.setId( id );
 			entity.setIndexedField( "value for the field" );

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/searchmapping/AbortedEventsGenerator.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/searchmapping/AbortedEventsGenerator.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.coordination.outboxpolling.automaticindexing.searchmapping;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -34,10 +34,10 @@ public class AbortedEventsGenerator {
 
 	void generateThreeAbortedEvents() {
 		if ( tenantId == null ) {
-			withinTransaction( sessionFactory, this::generateThreeAbortedEvents );
+			with( sessionFactory ).runInTransaction( this::generateThreeAbortedEvents );
 		}
 		else {
-			withinTransaction( sessionFactory, tenantId, this::generateThreeAbortedEvents );
+			with( sessionFactory, tenantId ).runInTransaction( this::generateThreeAbortedEvents );
 		}
 
 		backendMock.verifyExpectationsMet();

--- a/integrationtest/mapper/orm-envers/src/test/java/org/hibernate/search/integrationtest/mapper/orm/envers/EnversIT.java
+++ b/integrationtest/mapper/orm-envers/src/test/java/org/hibernate/search/integrationtest/mapper/orm/envers/EnversIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.integrationtest.mapper.orm.envers;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.hibernate.search.util.impl.integrationtest.common.stub.backend.StubBackendUtils.reference;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.Arrays;
 import java.util.Optional;
@@ -68,7 +68,7 @@ public class EnversIT {
 	@Test
 	public void test() {
 		// Initial insert
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity indexed = new IndexedEntity();
 			indexed.setId( 1 );
 			indexed.setText( "initial" );
@@ -97,7 +97,7 @@ public class EnversIT {
 		checkSearchLoadedEntityIsLastVersion( "1", "initial", "initial" );
 
 		// Update the indexed entity
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity indexed = session.getReference( IndexedEntity.class, 1 );
 			indexed.setText( "updated" );
 
@@ -117,7 +117,7 @@ public class EnversIT {
 		checkSearchLoadedEntityIsLastVersion( "1", "updated", "initial" );
 
 		// Update the contained entity
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			ContainedEntity contained = session.getReference( ContainedEntity.class, 1 );
 			contained.setText( "updated" );
 
@@ -137,7 +137,7 @@ public class EnversIT {
 		checkSearchLoadedEntityIsLastVersion( "1", "updated", "updated" );
 
 		// Delete the indexed entity
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity indexed = session.getReference( IndexedEntity.class, 1 );
 			session.remove( indexed );
 
@@ -156,7 +156,7 @@ public class EnversIT {
 			int expectedLastRevisionForType,
 			int expectedEntityChangeCountAtLastRevisionOverall,
 			int expectedAuditedObjectCountSoFar) {
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			AuditReader auditReader = AuditReaderFactory.get( session );
 			assertSoftly( assertions -> {
 				assertions.assertThat( findLastRevisionForEntity( auditReader, type ) )
@@ -174,7 +174,7 @@ public class EnversIT {
 
 	private void checkSearchLoadedEntityIsLastVersion(String id,
 			String expectedIndexedEntityText, String expectedContainedEntityText) {
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			backendMock.expectSearchObjects(
 					Arrays.asList( IndexedEntity.NAME ),
 					b -> b.limit( 2 ), // fetchSingleHit() (see below) sets the limit to 2 to check if there really is a single hit

--- a/integrationtest/mapper/orm-envers/src/test/java/org/hibernate/search/integrationtest/mapper/orm/envers/EnversIT.java
+++ b/integrationtest/mapper/orm-envers/src/test/java/org/hibernate/search/integrationtest/mapper/orm/envers/EnversIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.integrationtest.mapper.orm.envers;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.hibernate.search.util.impl.integrationtest.common.stub.backend.StubBackendUtils.reference;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import java.util.Arrays;
 import java.util.Optional;
@@ -28,7 +29,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmb
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.common.rule.StubSearchWorkBehavior;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.annotation.PortedFromSearch5;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
@@ -68,7 +68,7 @@ public class EnversIT {
 	@Test
 	public void test() {
 		// Initial insert
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity indexed = new IndexedEntity();
 			indexed.setId( 1 );
 			indexed.setText( "initial" );
@@ -97,7 +97,7 @@ public class EnversIT {
 		checkSearchLoadedEntityIsLastVersion( "1", "initial", "initial" );
 
 		// Update the indexed entity
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity indexed = session.getReference( IndexedEntity.class, 1 );
 			indexed.setText( "updated" );
 
@@ -117,7 +117,7 @@ public class EnversIT {
 		checkSearchLoadedEntityIsLastVersion( "1", "updated", "initial" );
 
 		// Update the contained entity
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			ContainedEntity contained = session.getReference( ContainedEntity.class, 1 );
 			contained.setText( "updated" );
 
@@ -137,7 +137,7 @@ public class EnversIT {
 		checkSearchLoadedEntityIsLastVersion( "1", "updated", "updated" );
 
 		// Delete the indexed entity
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity indexed = session.getReference( IndexedEntity.class, 1 );
 			session.remove( indexed );
 
@@ -156,7 +156,7 @@ public class EnversIT {
 			int expectedLastRevisionForType,
 			int expectedEntityChangeCountAtLastRevisionOverall,
 			int expectedAuditedObjectCountSoFar) {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			AuditReader auditReader = AuditReaderFactory.get( session );
 			assertSoftly( assertions -> {
 				assertions.assertThat( findLastRevisionForEntity( auditReader, type ) )
@@ -174,7 +174,7 @@ public class EnversIT {
 
 	private void checkSearchLoadedEntityIsLastVersion(String id,
 			String expectedIndexedEntityText, String expectedContainedEntityText) {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			backendMock.expectSearchObjects(
 					Arrays.asList( IndexedEntity.NAME ),
 					b -> b.limit( 2 ), // fetchSingleHit() (see below) sets the limit to 2 to check if there really is a single hit

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/massindexing/MassIndexingManualSchemaManagementIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/massindexing/MassIndexingManualSchemaManagementIT.java
@@ -9,7 +9,7 @@ package org.hibernate.search.integrationtest.mapper.orm.realbackend.massindexing
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.Fail.fail;
 import static org.hibernate.search.integrationtest.mapper.orm.realbackend.util.BookCreatorUtils.prepareBooks;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import javax.persistence.EntityManagerFactory;
 
@@ -64,18 +64,15 @@ public class MassIndexingManualSchemaManagementIT {
 	public void cleanup() {
 		// Necessary to keep the server (ES) or filesystem (Lucene) clean after the tests,
 		// because the schema management strategy is "none"
-		withinJPATransaction(
-				entityManagerFactory,
-				entityManager -> Search.session( entityManager ).schemaManager().dropIfExisting()
+		with( entityManagerFactory ).runInTransaction( entityManager ->
+				Search.session( entityManager ).schemaManager().dropIfExisting()
 		);
 	}
 
 	@Test
 	public void testMassIndexingWithAutomaticDropAndCreate() {
 		// The index doesn't exist initially, since we delete it in "cleanup()" the schema management strategy is "none"
-		withinJPATransaction(
-				entityManagerFactory,
-				entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 					MassIndexer indexer = Search.session( entityManager ).massIndexer()
 							.dropAndCreateSchemaOnStart( true );
 					try {
@@ -91,9 +88,7 @@ public class MassIndexingManualSchemaManagementIT {
 
 	@Test
 	public void testMassIndexingWithManualDropAndCreate() {
-		withinJPATransaction(
-				entityManagerFactory,
-				entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 					// The index doesn't exist initially, since the schema management strategy is "none"
 					Search.session( entityManager ).schemaManager().dropAndCreate();
 

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/massindexing/MassIndexingMonitorIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/massindexing/MassIndexingMonitorIT.java
@@ -9,7 +9,7 @@ package org.hibernate.search.integrationtest.mapper.orm.realbackend.massindexing
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 import static org.hibernate.search.integrationtest.mapper.orm.realbackend.util.BookCreatorUtils.prepareBooks;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import javax.persistence.EntityManagerFactory;
 
@@ -65,9 +65,7 @@ public class MassIndexingMonitorIT {
 
 	@Test
 	public void testMassIndexingMonitor() {
-		withinJPATransaction(
-				entityManagerFactory,
-				entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 					assertThat( BookCreatorUtils.documentsCount( entityManagerFactory ) ).isZero();
 
 					MassIndexer indexer = Search.session( entityManager ).massIndexer()

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/routing/RoutingBridgeConditionalIndexingIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/routing/RoutingBridgeConditionalIndexingIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.realbackend.routing;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -57,7 +57,7 @@ public class RoutingBridgeConditionalIndexingIT {
 	public void testLifecycle() {
 		assertThat( searchAllIds() ).isEmpty();
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = new Book();
 			book1.setId( 1 );
 			book1.setTitle( "I, Robot" );
@@ -67,14 +67,14 @@ public class RoutingBridgeConditionalIndexingIT {
 
 		assertThat( searchAllIds() ).isEmpty();
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = entityManager.getReference( Book.class, 1 );
 			book1.setStatus( Status.PUBLISHED );
 		} );
 
 		assertThat( searchAllIds() ).containsExactly( 1 );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = entityManager.getReference( Book.class, 1 );
 			// Try to fool the routing bridge into not deleting - it shouldn't matter.
 			book1.setStatus( Status.ARCHIVED );
@@ -86,7 +86,7 @@ public class RoutingBridgeConditionalIndexingIT {
 
 	private List<Integer> searchAllIds() {
 		List<Integer> results = new ArrayList<>();
-		withinJPATransaction( entityManagerFactory, entityManager -> Search.session( entityManager )
+		with( entityManagerFactory ).runInTransaction( entityManager -> Search.session( entityManager )
 				.search( Book.class )
 				.select( f -> f.id( Integer.class ) )
 				.where( f -> f.matchAll() )

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/routing/RoutingBridgeRoutingKeyIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/routing/RoutingBridgeRoutingKeyIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.realbackend.routing;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -64,7 +64,7 @@ public class RoutingBridgeRoutingKeyIT {
 		assertThat( searchIdsByRoutingKey( Genre.SCIENCE_FICTION ) ).isEmpty();
 		assertThat( searchIdsByRoutingKey( Genre.CRIME_FICTION ) ).isEmpty();
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = new Book();
 			book1.setId( 1 );
 			book1.setTitle( "I, Robot" );
@@ -75,7 +75,7 @@ public class RoutingBridgeRoutingKeyIT {
 		assertThat( searchIdsByRoutingKey( Genre.SCIENCE_FICTION ) ).containsExactly( 1 );
 		assertThat( searchIdsByRoutingKey( Genre.CRIME_FICTION ) ).isEmpty();
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = entityManager.getReference( Book.class, 1 );
 			book1.setGenre( Genre.CRIME_FICTION );
 		} );
@@ -83,7 +83,7 @@ public class RoutingBridgeRoutingKeyIT {
 		assertThat( searchIdsByRoutingKey( Genre.SCIENCE_FICTION ) ).isEmpty();
 		assertThat( searchIdsByRoutingKey( Genre.CRIME_FICTION ) ).containsExactly( 1 );
 
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			Book book1 = entityManager.getReference( Book.class, 1 );
 			// Try to fool the routing bridge into deleting from the wrong shard - it shouldn't matter.
 			book1.setGenre( Genre.SCIENCE_FICTION );
@@ -97,7 +97,7 @@ public class RoutingBridgeRoutingKeyIT {
 	private List<Integer> searchIdsByRoutingKey(Genre genre) {
 		String routingKey = genre.name();
 		List<Integer> results = new ArrayList<>();
-		withinJPATransaction( entityManagerFactory, entityManager -> Search.session( entityManager )
+		with( entityManagerFactory ).runInTransaction( entityManager -> Search.session( entityManager )
 				.search( Book.class )
 				.select( f -> f.id( Integer.class ) )
 				.where( f -> f.matchAll() )

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/sync/OutOfSyncIndexIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/sync/OutOfSyncIndexIT.java
@@ -9,7 +9,7 @@ package org.hibernate.search.integrationtest.mapper.orm.realbackend.sync;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.integrationtest.mapper.orm.realbackend.util.BookCreatorUtils.prepareBooks;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.countAll;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import javax.persistence.EntityManagerFactory;
 
@@ -58,7 +58,7 @@ public class OutOfSyncIndexIT {
 		assertThat( indexedEntityCount ).isEqualTo( entityCount );
 
 		// Simulate an external delete that Hibernate Search will not be able to detect
-		withinJPATransaction( entityManagerFactory, entityManager ->
+		with( entityManagerFactory ).runInTransaction( entityManager ->
 				entityManager.createQuery( "DELETE FROM book WHERE MOD(id, 2) = 0" )
 						.executeUpdate()
 		);
@@ -71,7 +71,7 @@ public class OutOfSyncIndexIT {
 
 		// Check that running a search query still returns the correct number of hits,
 		// because hits that cannot be loaded are ignored
-		withinJPATransaction( entityManagerFactory, entityManager ->
+		with( entityManagerFactory ).runInTransaction( entityManager ->
 				assertThat(
 						Search.session( entityManager )
 								.search( Book.class )

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/sync/OutOfSyncIndexIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/sync/OutOfSyncIndexIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.integrationtest.mapper.orm.realbackend.sync;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.integrationtest.mapper.orm.realbackend.util.BookCreatorUtils.prepareBooks;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.countAll;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import javax.persistence.EntityManagerFactory;
@@ -19,7 +20,6 @@ import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.automaticindexing.session.AutomaticIndexingSynchronizationStrategyNames;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
@@ -83,7 +83,7 @@ public class OutOfSyncIndexIT {
 	}
 
 	private int entityCount() {
-		return OrmUtils.countAll( entityManagerFactory.createEntityManager(), Book.class ).intValue();
+		return countAll( entityManagerFactory.createEntityManager(), Book.class ).intValue();
 	}
 
 }

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/util/BookCreatorUtils.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/util/BookCreatorUtils.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.integrationtest.mapper.orm.realbackend.util;
 
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.Locale;
 import javax.persistence.EntityManagerFactory;
@@ -19,7 +18,7 @@ public final class BookCreatorUtils {
 	}
 
 	public static void prepareBooks(EntityManagerFactory entityManagerFactory, int numberOfBooks) {
-		withinJPATransaction( entityManagerFactory, entityManager -> {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
 			for ( int i = 0; i < numberOfBooks; i++ ) {
 				Book book = new Book();
 				book.setId( i + 1 );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBasicIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBasicIT.java
@@ -106,7 +106,7 @@ public class AutomaticIndexingBasicIT {
 		assumeTrue( "This test only makes sense if entities are processed in-session",
 				setupHolder.areEntitiesProcessedInSession() );
 
-		setupHolder.with().runNoTransaction( session -> {
+		setupHolder.runNoTransaction( session -> {
 			Transaction trx = session.beginTransaction();
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingEnabledIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingEnabledIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.automaticindexing;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import javax.persistence.Basic;
 import javax.persistence.Entity;
@@ -61,7 +61,7 @@ public class AutomaticIndexingEnabledIT {
 
 		SessionFactory sessionFactory = setup( null, null );
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity( 1, "initialValue" );
 
 			session.persist( entity1 );
@@ -80,7 +80,7 @@ public class AutomaticIndexingEnabledIT {
 
 		SessionFactory sessionFactory = setup( true, null );
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity( 1, "initialValue" );
 
 			session.persist( entity1 );
@@ -99,7 +99,7 @@ public class AutomaticIndexingEnabledIT {
 
 		SessionFactory sessionFactory = setup( false, null );
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity( 1, "initialValue" );
 
 			session.persist( entity1 );
@@ -115,7 +115,7 @@ public class AutomaticIndexingEnabledIT {
 
 		SessionFactory sessionFactory = setup( null, "none" );
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity( 1, "initialValue" );
 
 			session.persist( entity1 );
@@ -131,7 +131,7 @@ public class AutomaticIndexingEnabledIT {
 
 		SessionFactory sessionFactory = setup( null, "session" );
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity( 1, "initialValue" );
 
 			session.persist( entity1 );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/AbstractAutomaticIndexingBridgeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/AbstractAutomaticIndexingBridgeIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.bridge;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 import static org.junit.Assume.assumeTrue;
 
 import java.util.ArrayList;
@@ -52,7 +52,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 	public void directPersistUpdateDelete() {
 		SessionFactory sessionFactory = setupWithTypeBridge();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 			entity1.setDirectField( "initialValue" );
@@ -71,7 +71,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
 			entity1.setDirectField( "updatedValue" );
 
@@ -87,7 +87,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
 
 			session.remove( entity1 );
@@ -102,7 +102,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 	public void indirectAssociationUpdate_typeBridge() {
 		SessionFactory sessionFactory = setupWithTypeBridge();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 
@@ -133,7 +133,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			ContainedEntity containedEntity = new ContainedEntity();
 			containedEntity.setId( 4 );
 			containedEntity.setIncludedInTypeBridge( "initialValue" );
@@ -157,7 +157,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			ContainedEntity containedEntity = new ContainedEntity();
 			containedEntity.setId( 5 );
 			containedEntity.setIncludedInTypeBridge( "updatedValue" );
@@ -182,7 +182,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value that is too deeply nested to matter (it's out of the bridge scope)
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			ContainedEntity containedEntity = new ContainedEntity();
 			containedEntity.setId( 6 );
 			containedEntity.setIncludedInTypeBridge( "outOfScopeValue" );
@@ -198,7 +198,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
 			containingEntity1.getContainedSingle().getContainingAsSingle().clear();
 			containingEntity1.setContainedSingle( null );
@@ -220,7 +220,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 	public void indirectValueUpdate_typeBridge() {
 		SessionFactory sessionFactory = setupWithTypeBridge();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 
@@ -265,7 +265,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating the value
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 4 );
 			containedEntity.setIncludedInTypeBridge( "updatedValue" );
 
@@ -282,7 +282,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value that is not included in the bridge
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 4 );
 			containedEntity.setExcludedFromAll( "updatedExcludedValue" );
 
@@ -291,7 +291,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value that is too deeply nested to matter (it's out of the bridge scope)
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 5 );
 			containedEntity.setIncludedInTypeBridge( "updatedOutOfScopeValue" );
 
@@ -304,7 +304,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 	public void indirectAssociationUpdate_singleValuedPropertyBridge() {
 		SessionFactory sessionFactory = setupWithSingleValuedPropertyBridge();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 
@@ -332,7 +332,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			ContainedEntity containedEntity = new ContainedEntity();
 			containedEntity.setId( 4 );
 			containedEntity.setIncludedInSingleValuedPropertyBridge( "initialValue" );
@@ -353,7 +353,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			ContainedEntity containedEntity = new ContainedEntity();
 			containedEntity.setId( 5 );
 			containedEntity.setIncludedInSingleValuedPropertyBridge( "updatedValue" );
@@ -375,7 +375,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value that is too deeply nested to matter (it's out of the bridge scope)
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			ContainedEntity containedEntity = new ContainedEntity();
 			containedEntity.setId( 6 );
 			containedEntity.setIncludedInSingleValuedPropertyBridge( "outOfScopeValue" );
@@ -391,7 +391,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
 			containingEntity1.getContainedSingle().getContainingAsSingle().clear();
 			containingEntity1.setContainedSingle( null );
@@ -411,7 +411,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 	public void indirectValueUpdate_singleValuedPropertyBridge() {
 		SessionFactory sessionFactory = setupWithSingleValuedPropertyBridge();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 
@@ -453,7 +453,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating the value
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 4 );
 			containedEntity.setIncludedInSingleValuedPropertyBridge( "updatedValue" );
 
@@ -467,7 +467,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value that is not included in the bridge
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 4 );
 			containedEntity.setExcludedFromAll( "updatedExcludedValue" );
 
@@ -476,7 +476,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value that is too deeply nested to matter (it's out of the bridge scope)
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 5 );
 			containedEntity.setIncludedInSingleValuedPropertyBridge( "updatedOutOfScopeValue" );
 
@@ -490,7 +490,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 	public void directAssociationUpdate_multiValuedPropertyBridge() {
 		SessionFactory sessionFactory = setupWithMultiValuedPropertyBridge();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 
@@ -506,7 +506,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
 
 			ContainingEntity containingEntity1 = new ContainingEntity();
@@ -533,7 +533,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a second value
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
 
 			ContainingEntity containingEntity2 = new ContainingEntity();
@@ -560,7 +560,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
 
 			ContainingEntity containingEntity3 = new ContainingEntity();
@@ -591,7 +591,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
 			for ( ContainingEntity containingEntity : entity1.getAssociation2() ) {
 				containingEntity.setAssociation2InverseSide( null );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/AbstractAutomaticIndexingBridgeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/AbstractAutomaticIndexingBridgeIT.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.bridge;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 import static org.junit.Assume.assumeTrue;
 
 import java.util.ArrayList;
@@ -30,7 +31,6 @@ import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.TypeBinder;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Rule;
@@ -52,7 +52,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 	public void directPersistUpdateDelete() {
 		SessionFactory sessionFactory = setupWithTypeBridge();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 			entity1.setDirectField( "initialValue" );
@@ -71,7 +71,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
 			entity1.setDirectField( "updatedValue" );
 
@@ -87,7 +87,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
 
 			session.remove( entity1 );
@@ -102,7 +102,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 	public void indirectAssociationUpdate_typeBridge() {
 		SessionFactory sessionFactory = setupWithTypeBridge();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 
@@ -133,7 +133,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			ContainedEntity containedEntity = new ContainedEntity();
 			containedEntity.setId( 4 );
 			containedEntity.setIncludedInTypeBridge( "initialValue" );
@@ -157,7 +157,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			ContainedEntity containedEntity = new ContainedEntity();
 			containedEntity.setId( 5 );
 			containedEntity.setIncludedInTypeBridge( "updatedValue" );
@@ -182,7 +182,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value that is too deeply nested to matter (it's out of the bridge scope)
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			ContainedEntity containedEntity = new ContainedEntity();
 			containedEntity.setId( 6 );
 			containedEntity.setIncludedInTypeBridge( "outOfScopeValue" );
@@ -198,7 +198,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
 			containingEntity1.getContainedSingle().getContainingAsSingle().clear();
 			containingEntity1.setContainedSingle( null );
@@ -220,7 +220,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 	public void indirectValueUpdate_typeBridge() {
 		SessionFactory sessionFactory = setupWithTypeBridge();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 
@@ -265,7 +265,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating the value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 4 );
 			containedEntity.setIncludedInTypeBridge( "updatedValue" );
 
@@ -282,7 +282,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value that is not included in the bridge
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 4 );
 			containedEntity.setExcludedFromAll( "updatedExcludedValue" );
 
@@ -291,7 +291,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value that is too deeply nested to matter (it's out of the bridge scope)
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 5 );
 			containedEntity.setIncludedInTypeBridge( "updatedOutOfScopeValue" );
 
@@ -304,7 +304,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 	public void indirectAssociationUpdate_singleValuedPropertyBridge() {
 		SessionFactory sessionFactory = setupWithSingleValuedPropertyBridge();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 
@@ -332,7 +332,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			ContainedEntity containedEntity = new ContainedEntity();
 			containedEntity.setId( 4 );
 			containedEntity.setIncludedInSingleValuedPropertyBridge( "initialValue" );
@@ -353,7 +353,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			ContainedEntity containedEntity = new ContainedEntity();
 			containedEntity.setId( 5 );
 			containedEntity.setIncludedInSingleValuedPropertyBridge( "updatedValue" );
@@ -375,7 +375,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value that is too deeply nested to matter (it's out of the bridge scope)
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			ContainedEntity containedEntity = new ContainedEntity();
 			containedEntity.setId( 6 );
 			containedEntity.setIncludedInSingleValuedPropertyBridge( "outOfScopeValue" );
@@ -391,7 +391,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
 			containingEntity1.getContainedSingle().getContainingAsSingle().clear();
 			containingEntity1.setContainedSingle( null );
@@ -411,7 +411,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 	public void indirectValueUpdate_singleValuedPropertyBridge() {
 		SessionFactory sessionFactory = setupWithSingleValuedPropertyBridge();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 
@@ -453,7 +453,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating the value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 4 );
 			containedEntity.setIncludedInSingleValuedPropertyBridge( "updatedValue" );
 
@@ -467,7 +467,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value that is not included in the bridge
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 4 );
 			containedEntity.setExcludedFromAll( "updatedExcludedValue" );
 
@@ -476,7 +476,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value that is too deeply nested to matter (it's out of the bridge scope)
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 5 );
 			containedEntity.setIncludedInSingleValuedPropertyBridge( "updatedOutOfScopeValue" );
 
@@ -490,7 +490,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 	public void directAssociationUpdate_multiValuedPropertyBridge() {
 		SessionFactory sessionFactory = setupWithMultiValuedPropertyBridge();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 
@@ -506,7 +506,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
 
 			ContainingEntity containingEntity1 = new ContainingEntity();
@@ -533,7 +533,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test adding a second value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
 
 			ContainingEntity containingEntity2 = new ContainingEntity();
@@ -560,7 +560,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
 
 			ContainingEntity containingEntity3 = new ContainingEntity();
@@ -591,7 +591,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test removing a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
 			for ( ContainingEntity containingEntity : entity1.getAssociation2() ) {
 				containingEntity.setAssociation2InverseSide( null );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/AutomaticIndexingBridgeExplicitReindexingFunctionalIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/AutomaticIndexingBridgeExplicitReindexingFunctionalIT.java
@@ -7,8 +7,8 @@
 package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.bridge;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.runInTransaction;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -140,7 +140,7 @@ public class AutomaticIndexingBridgeExplicitReindexingFunctionalIT {
 		 * The bridge will not load any entity and will just retrieve data from the database.
 		 */
 		with( sessionFactory ).runNoTransaction( session -> {
-			withinTransaction( session, tx -> {
+			runInTransaction( session, tx -> {
 				ContainedEntity containedEntity = session.getReference( ContainedEntity.class, 10 );
 				containedEntity.setIncludedInTypeBridge( "value2" );
 				backendMock.expectWorks( IndexedEntity.INDEX )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/AutomaticIndexingBridgeExplicitReindexingFunctionalIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/AutomaticIndexingBridgeExplicitReindexingFunctionalIT.java
@@ -85,7 +85,7 @@ public class AutomaticIndexingBridgeExplicitReindexingFunctionalIT {
 	@Test
 	public void test() {
 		// Init
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 			session.persist( entity1 );
@@ -97,7 +97,7 @@ public class AutomaticIndexingBridgeExplicitReindexingFunctionalIT {
 		backendMock.verifyExpectationsMet();
 
 		// Add a contained entity
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = session.getReference( IndexedEntity.class, 1 );
 			ContainedEntity containedEntity = new ContainedEntity();
 			containedEntity.setId( 2 );
@@ -118,7 +118,7 @@ public class AutomaticIndexingBridgeExplicitReindexingFunctionalIT {
 		 * Unfortunately the indexed entity will still be reindexed,
 		 * because Search doesn't know which contained entities are relevant.
 		 */
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = session.getReference( IndexedEntity.class, 1 );
 			for ( int i = 3 ; i < 100 ; ++i ) {
 				ContainedEntity containedEntity = new ContainedEntity();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/AutomaticIndexingBridgeExplicitReindexingFunctionalIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/AutomaticIndexingBridgeExplicitReindexingFunctionalIT.java
@@ -138,7 +138,7 @@ public class AutomaticIndexingBridgeExplicitReindexingFunctionalIT {
 		 * Update one contained entity.
 		 * The bridge will not load any entity and will just retrieve data from the database.
 		 */
-		OrmUtils.withinSession( sessionFactory, session -> {
+		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
 			OrmUtils.withinTransaction( session, tx -> {
 				ContainedEntity containedEntity = session.getReference( ContainedEntity.class, 10 );
 				containedEntity.setIncludedInTypeBridge( "value2" );
@@ -156,7 +156,7 @@ public class AutomaticIndexingBridgeExplicitReindexingFunctionalIT {
 		} );
 
 		// Remove one contained entity.
-		OrmUtils.withinSession( sessionFactory, session -> {
+		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
 			ContainedEntity containedEntity = session.getReference( ContainedEntity.class, 10 );
 			containedEntity.setParent( null );
 			session.remove( containedEntity );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/AutomaticIndexingEmbeddedBridgeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/AutomaticIndexingEmbeddedBridgeIT.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.bridge;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Basic;
@@ -33,7 +35,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.TypeBindin
 import org.hibernate.search.mapper.pojo.model.PojoElementAccessor;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -74,7 +75,7 @@ public class AutomaticIndexingEmbeddedBridgeIT {
 
 	@Test
 	public void indirectValueUpdate_embeddedBridge() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 
@@ -112,7 +113,7 @@ public class AutomaticIndexingEmbeddedBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value used in an included bridge
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 3 );
 			containedEntity.setIncludedInFirstBridge( "updatedValue" );
 
@@ -131,7 +132,7 @@ public class AutomaticIndexingEmbeddedBridgeIT {
 		 * Test updating a value used in an excluded bridge
 		 * (every index field filtered out by the IndexedEmbedded filter)
 		 */
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 4 );
 			containedEntity.setIncludedInSecondBridge( "updatedValue" );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/AutomaticIndexingEmbeddedBridgeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/AutomaticIndexingEmbeddedBridgeIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.bridge;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -75,7 +75,7 @@ public class AutomaticIndexingEmbeddedBridgeIT {
 
 	@Test
 	public void indirectValueUpdate_embeddedBridge() {
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 
@@ -113,7 +113,7 @@ public class AutomaticIndexingEmbeddedBridgeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating a value used in an included bridge
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 3 );
 			containedEntity.setIncludedInFirstBridge( "updatedValue" );
 
@@ -132,7 +132,7 @@ public class AutomaticIndexingEmbeddedBridgeIT {
 		 * Test updating a value used in an excluded bridge
 		 * (every index field filtered out by the IndexedEmbedded filter)
 		 */
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			ContainedEntity containedEntity = session.get( ContainedEntity.class, 4 );
 			containedEntity.setIncludedInSecondBridge( "updatedValue" );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/ContainedInThroughNonContainingIndexedTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/ContainedInThroughNonContainingIndexedTypeIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.bridge;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -63,7 +63,7 @@ public class ContainedInThroughNonContainingIndexedTypeIT {
 
 	@Test
 	public void test() {
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			Containing containing = new Containing();
 			containing.setId( 1 );
 
@@ -88,7 +88,7 @@ public class ContainedInThroughNonContainingIndexedTypeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating the value
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			Contained contained = session.get( Contained.class, 2 );
 			contained.setIndexedInContaining( 42 );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/ContainedInThroughNonContainingIndexedTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/ContainedInThroughNonContainingIndexedTypeIT.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.bridge;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.OneToOne;
@@ -23,7 +25,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyBinding;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
@@ -62,7 +63,7 @@ public class ContainedInThroughNonContainingIndexedTypeIT {
 
 	@Test
 	public void test() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			Containing containing = new Containing();
 			containing.setId( 1 );
 
@@ -87,7 +88,7 @@ public class ContainedInThroughNonContainingIndexedTypeIT {
 		backendMock.verifyExpectationsMet();
 
 		// Test updating the value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			Contained contained = session.get( Contained.class, 2 );
 			contained.setIndexedInContaining( 42 );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/proxy/ContainedInTriggerUnnecessaryCollectionInitializationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/proxy/ContainedInTriggerUnnecessaryCollectionInitializationIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.proxy;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 import static org.junit.Assert.assertFalse;
 
 import java.util.HashSet;
@@ -60,7 +60,7 @@ public class ContainedInTriggerUnnecessaryCollectionInitializationIT {
 
 	@Test
 	public void test() {
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			Group group = new Group();
 			group.setId( 1 );
 			group.setSomeField( "initialValue" );
@@ -90,7 +90,7 @@ public class ContainedInTriggerUnnecessaryCollectionInitializationIT {
 		backendMock.verifyExpectationsMet();
 
 		AtomicReference<Group> groupFromModifyingTransaction = new AtomicReference<>();
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			Group group = session.getReference( Group.class, 1 );
 			groupFromModifyingTransaction.set( group );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/proxy/ContainedInTriggerUnnecessaryCollectionInitializationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/proxy/ContainedInTriggerUnnecessaryCollectionInitializationIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.proxy;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 import static org.junit.Assert.assertFalse;
 
 import java.util.HashSet;
@@ -27,7 +28,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
@@ -60,7 +60,7 @@ public class ContainedInTriggerUnnecessaryCollectionInitializationIT {
 
 	@Test
 	public void test() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			Group group = new Group();
 			group.setId( 1 );
 			group.setSomeField( "initialValue" );
@@ -90,7 +90,7 @@ public class ContainedInTriggerUnnecessaryCollectionInitializationIT {
 		backendMock.verifyExpectationsMet();
 
 		AtomicReference<Group> groupFromModifyingTransaction = new AtomicReference<>();
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			Group group = session.getReference( Group.class, 1 );
 			groupFromModifyingTransaction.set( group );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/session/AutomaticIndexingSynchronizationStrategyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/session/AutomaticIndexingSynchronizationStrategyIT.java
@@ -9,6 +9,7 @@ package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.sessio
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 import static org.hibernate.search.util.impl.test.FutureAssert.assertThatFuture;
 
 import java.lang.invoke.MethodHandles;
@@ -40,7 +41,6 @@ import org.hibernate.search.util.common.impl.Throwables;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.rule.ExpectedLog4jLog;
 
 import org.junit.Rule;
@@ -513,7 +513,7 @@ public class AutomaticIndexingSynchronizationStrategyIT {
 			throws InterruptedException, ExecutionException, TimeoutException {
 		CompletableFuture<?> justBeforeTransactionCommitFuture = new CompletableFuture<>();
 		CompletableFuture<?> transactionThreadFuture = CompletableFuture.runAsync( () -> {
-			OrmUtils.withinTransaction( sessionFactory, session -> {
+			withinTransaction( sessionFactory, session -> {
 				if ( overriddenStrategy != null ) {
 					Search.session( session ).automaticIndexingSynchronizationStrategy( overriddenStrategy );
 				}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/session/AutomaticIndexingSynchronizationStrategyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/session/AutomaticIndexingSynchronizationStrategyIT.java
@@ -9,7 +9,7 @@ package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.sessio
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 import static org.hibernate.search.util.impl.test.FutureAssert.assertThatFuture;
 
 import java.lang.invoke.MethodHandles;
@@ -513,7 +513,7 @@ public class AutomaticIndexingSynchronizationStrategyIT {
 			throws InterruptedException, ExecutionException, TimeoutException {
 		CompletableFuture<?> justBeforeTransactionCommitFuture = new CompletableFuture<>();
 		CompletableFuture<?> transactionThreadFuture = CompletableFuture.runAsync( () -> {
-			withinTransaction( sessionFactory, session -> {
+			with( sessionFactory ).runInTransaction( session -> {
 				if ( overriddenStrategy != null ) {
 					Search.session( session ).automaticIndexingSynchronizationStrategy( overriddenStrategy );
 				}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/session/FlushClearEvictAllIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/session/FlushClearEvictAllIT.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.session;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.ArrayList;
@@ -30,7 +31,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericFie
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
@@ -58,7 +58,7 @@ public class FlushClearEvictAllIT {
 
 	@Test
 	public void test() {
-		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
+		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			Post post = new Post();
 			post.setName( "This is a post" );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/session/FlushClearEvictAllIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/session/FlushClearEvictAllIT.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
+import javax.persistence.EntityManagerFactory;
 import javax.persistence.EntityTransaction;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -23,7 +24,6 @@ import javax.persistence.OneToMany;
 import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
@@ -46,19 +46,19 @@ public class FlushClearEvictAllIT {
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
 
-	private SessionFactory sessionFactory;
+	private EntityManagerFactory entityManagerFactory;
 
 	@Before
 	public void before() {
 		backendMock.expectAnySchema( Post.NAME );
 		backendMock.expectAnySchema( Comment.NAME );
-		sessionFactory = ormSetupHelper.start().setup( Post.class, Comment.class );
+		entityManagerFactory = ormSetupHelper.start().setup( Post.class, Comment.class );
 		backendMock.verifyExpectationsMet();
 	}
 
 	@Test
 	public void test() {
-		OrmUtils.withinEntityManager( sessionFactory, entityManager -> {
+		OrmUtils.with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			Post post = new Post();
 			post.setName( "This is a post" );
 
@@ -79,7 +79,7 @@ public class FlushClearEvictAllIT {
 			}
 
 			entityManager.clear();
-			sessionFactory.getCache().evictAll();
+			entityManagerFactory.getCache().evictAll();
 
 			backendMock.expectWorks( Post.NAME )
 					.executeFollowingWorks()
@@ -107,7 +107,7 @@ public class FlushClearEvictAllIT {
 			}
 
 			entityManager.clear();
-			sessionFactory.getCache().evictAll();
+			entityManagerFactory.getCache().evictAll();
 
 			backendMock.expectWorks( Comment.NAME )
 					.executeFollowingWorks()

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/HibernateOrmIntegrationBooterIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/HibernateOrmIntegrationBooterIT.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.bootstrap;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -42,7 +43,6 @@ import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.BackendMappingHandle;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.StubSchemaManagementWork;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.HibernateOrmMappingHandle;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.SimpleSessionFactoryBuilder;
 
 import org.junit.After;
@@ -133,7 +133,7 @@ public class HibernateOrmIntegrationBooterIT {
 			 */
 			backendMock.verifyExpectationsMet();
 
-			OrmUtils.withinTransaction( sessionFactory, session -> {
+			withinTransaction( sessionFactory, session -> {
 				IndexedEntity entity = new IndexedEntity();
 				entity.id = 1;
 				entity.text = "someText";

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/HibernateOrmIntegrationBooterIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/HibernateOrmIntegrationBooterIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.bootstrap;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -133,7 +133,7 @@ public class HibernateOrmIntegrationBooterIT {
 			 */
 			backendMock.verifyExpectationsMet();
 
-			withinTransaction( sessionFactory, session -> {
+			with( sessionFactory ).runInTransaction( session -> {
 				IndexedEntity entity = new IndexedEntity();
 				entity.id = 1;
 				entity.text = "someText";

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/dynamicmap/DynamicMapBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/dynamicmap/DynamicMapBaseIT.java
@@ -10,7 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.hibernate.search.util.impl.integrationtest.common.stub.backend.StubBackendUtils.reference;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import java.time.LocalDate;
 import java.time.Month;
@@ -88,7 +87,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			Map<String, Object> entity1 = new HashMap<>();
 			entity1.put( "id", 1 );
 			entity1.put( "title", "Hyperion" );
@@ -152,7 +151,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			Map<String, Object> entity1 = new HashMap<>();
 			entity1.put( "id", 1 );
 			entity1.put( "title", "Hyperion" );
@@ -212,7 +211,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			for ( int i = 0; i < 100; i++ ) {
 				Map<String, Object> entity = new HashMap<>();
 				entity.put( "id", i );
@@ -271,7 +270,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			Map<String, Object> entity1 = new HashMap<>();
 			entity1.put( "id", 1 );
 			entity1.put( "title", "Hyperion" );
@@ -344,7 +343,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			Map<String, Object> entity1 = new HashMap<>();
 			entity1.put( "id", 1 );
 			entity1.put( "propertyOfA", "Hyperion" );
@@ -428,7 +427,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			Map<String, Object> book = new HashMap<>();
 			book.put( "id", 1 );
 			book.put( "title", "Hyperion" );
@@ -483,7 +482,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			Map<String, Object> book = new HashMap<>();
 			book.put( "id", 1 );
 			book.put( "title", "Hyperion" );
@@ -539,7 +538,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			Map<String, Object> book = new HashMap<>();
 			book.put( "id", 1 );
 			book.put( "title", "Hyperion" );
@@ -598,7 +597,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			Map<String, Object> book = new HashMap<>();
 			book.put( "id", 1 );
 			book.put( "title", "Hyperion" );
@@ -653,7 +652,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			Map<String, Object> book = new HashMap<>();
 			book.put( "id", 1 );
 			book.put( "title", "Hyperion" );
@@ -716,7 +715,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			Map<String, Object> book = new HashMap<>();
 			book.put( "id", 1 );
 			book.put( "title", "Hyperion" );
@@ -793,7 +792,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			Map<String, Object> book = new HashMap<>();
 			book.put( "id", 1 );
 			book.put( "title", "Hyperion" );
@@ -870,7 +869,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			Map<String, Object> book = new SafeHashCodeDynamicEntity();
 			book.put( "id", 1 );
 			book.put( "title", "Hyperion" );
@@ -949,7 +948,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			Map<String, Object> book = new SafeHashCodeDynamicEntity();
 			book.put( "id", 1 );
 			book.put( "title", "Hyperion" );
@@ -1026,7 +1025,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			Map<String, Object> book = new HashMap<>();
 			book.put( "id", 1 );
 			book.put( "title", "Hyperion" );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/dynamicmap/DynamicMapBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/dynamicmap/DynamicMapBaseIT.java
@@ -9,6 +9,8 @@ package org.hibernate.search.integrationtest.mapper.orm.dynamicmap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.hibernate.search.util.impl.integrationtest.common.stub.backend.StubBackendUtils.reference;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import java.time.LocalDate;
 import java.time.Month;
@@ -38,7 +40,6 @@ import org.hibernate.search.mapper.pojo.model.path.PojoModelPath;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.common.rule.StubSearchWorkBehavior;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Rule;
@@ -87,7 +88,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			Map<String, Object> entity1 = new HashMap<>();
 			entity1.put( "id", 1 );
 			entity1.put( "title", "Hyperion" );
@@ -105,7 +106,7 @@ public class DynamicMapBaseIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
+		with( sessionFactory ).runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Map> query = searchSession.search(
@@ -151,7 +152,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			Map<String, Object> entity1 = new HashMap<>();
 			entity1.put( "id", 1 );
 			entity1.put( "title", "Hyperion" );
@@ -165,7 +166,7 @@ public class DynamicMapBaseIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
+		with( sessionFactory ).runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Object> query = searchSession.search(
@@ -211,7 +212,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			for ( int i = 0; i < 100; i++ ) {
 				Map<String, Object> entity = new HashMap<>();
 				entity.put( "id", i );
@@ -222,7 +223,7 @@ public class DynamicMapBaseIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
+		with( sessionFactory ).runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			SearchScope<Map> scope = searchSession.scope( Map.class, entityTypeName );
@@ -270,7 +271,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			Map<String, Object> entity1 = new HashMap<>();
 			entity1.put( "id", 1 );
 			entity1.put( "title", "Hyperion" );
@@ -284,7 +285,7 @@ public class DynamicMapBaseIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
+		with( sessionFactory ).runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Object> query = searchSession.search(
@@ -343,7 +344,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			Map<String, Object> entity1 = new HashMap<>();
 			entity1.put( "id", 1 );
 			entity1.put( "propertyOfA", "Hyperion" );
@@ -370,7 +371,7 @@ public class DynamicMapBaseIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
+		with( sessionFactory ).runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Map> query = searchSession.search(
@@ -427,7 +428,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			Map<String, Object> book = new HashMap<>();
 			book.put( "id", 1 );
 			book.put( "title", "Hyperion" );
@@ -482,7 +483,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			Map<String, Object> book = new HashMap<>();
 			book.put( "id", 1 );
 			book.put( "title", "Hyperion" );
@@ -538,7 +539,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			Map<String, Object> book = new HashMap<>();
 			book.put( "id", 1 );
 			book.put( "title", "Hyperion" );
@@ -597,7 +598,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			Map<String, Object> book = new HashMap<>();
 			book.put( "id", 1 );
 			book.put( "title", "Hyperion" );
@@ -652,7 +653,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			Map<String, Object> book = new HashMap<>();
 			book.put( "id", 1 );
 			book.put( "title", "Hyperion" );
@@ -715,7 +716,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			Map<String, Object> book = new HashMap<>();
 			book.put( "id", 1 );
 			book.put( "title", "Hyperion" );
@@ -792,7 +793,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			Map<String, Object> book = new HashMap<>();
 			book.put( "id", 1 );
 			book.put( "title", "Hyperion" );
@@ -869,7 +870,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			Map<String, Object> book = new SafeHashCodeDynamicEntity();
 			book.put( "id", 1 );
 			book.put( "title", "Hyperion" );
@@ -948,7 +949,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			Map<String, Object> book = new SafeHashCodeDynamicEntity();
 			book.put( "id", 1 );
 			book.put( "title", "Hyperion" );
@@ -1025,7 +1026,7 @@ public class DynamicMapBaseIT {
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			Map<String, Object> book = new HashMap<>();
 			book.put( "id", 1 );
 			book.put( "title", "Hyperion" );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/dynamicmap/DynamicMapBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/dynamicmap/DynamicMapBaseIT.java
@@ -105,7 +105,7 @@ public class DynamicMapBaseIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinSession( sessionFactory, session -> {
+		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Map> query = searchSession.search(
@@ -165,7 +165,7 @@ public class DynamicMapBaseIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinSession( sessionFactory, session -> {
+		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Object> query = searchSession.search(
@@ -222,7 +222,7 @@ public class DynamicMapBaseIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinSession( sessionFactory, session -> {
+		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			SearchScope<Map> scope = searchSession.scope( Map.class, entityTypeName );
@@ -284,7 +284,7 @@ public class DynamicMapBaseIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinSession( sessionFactory, session -> {
+		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Object> query = searchSession.search(
@@ -370,7 +370,7 @@ public class DynamicMapBaseIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinSession( sessionFactory, session -> {
+		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Map> query = searchSession.search(

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToJpaEntityManagerIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToJpaEntityManagerIT.java
@@ -8,7 +8,6 @@ package org.hibernate.search.integrationtest.mapper.orm.hibernateormapis;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinEntityManager;
 
 import javax.persistence.Entity;
 import javax.persistence.EntityManager;
@@ -60,7 +59,7 @@ public class ToJpaEntityManagerIT {
 
 	@Test
 	public void toJpaEntityManager() {
-		withinEntityManager( setupHolder.entityManagerFactory(), entityManager -> {
+		setupHolder.runNoTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			assertThat( searchSession.toEntityManager() ).isSameAs( entityManager );
 		} );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToJpaQueryIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToJpaQueryIT.java
@@ -10,7 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hibernate.search.util.impl.integrationtest.common.stub.backend.StubBackendUtils.reference;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.ManagedAssert.assertThatManaged;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinEntityManager;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
 
 import java.util.ArrayList;
@@ -140,7 +139,7 @@ public class ToJpaQueryIT {
 
 	@Test
 	public void toJpaQuery() {
-		withinEntityManager( setupHolder.entityManagerFactory(), entityManager -> {
+		setupHolder.runNoTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			TypedQuery<IndexedEntity> query = Search.toJpaQuery( createSimpleQuery( searchSession ) );
 			assertThat( query ).isNotNull();
@@ -149,7 +148,7 @@ public class ToJpaQueryIT {
 
 	@Test
 	public void getResultList() {
-		withinEntityManager( setupHolder.entityManagerFactory(), entityManager -> {
+		setupHolder.runNoTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			TypedQuery<IndexedEntity> query = Search.toJpaQuery( createSimpleQuery( searchSession ) );
 
@@ -174,7 +173,7 @@ public class ToJpaQueryIT {
 
 	@Test
 	public void getSingleResult() {
-		withinEntityManager( setupHolder.entityManagerFactory(), entityManager -> {
+		setupHolder.runNoTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			TypedQuery<IndexedEntity> query = Search.toJpaQuery( createSimpleQuery( searchSession ) );
 
@@ -231,7 +230,7 @@ public class ToJpaQueryIT {
 
 	@Test
 	public void pagination() {
-		withinEntityManager( setupHolder.entityManagerFactory(), entityManager -> {
+		setupHolder.runNoTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			TypedQuery<IndexedEntity> query = Search.toJpaQuery( createSimpleQuery( searchSession ) );
 
@@ -258,7 +257,7 @@ public class ToJpaQueryIT {
 
 	@Test
 	public void timeout_dsl() {
-		withinEntityManager( setupHolder.entityManagerFactory(), entityManager -> {
+		setupHolder.runNoTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			TypedQuery<IndexedEntity> query = Search.toJpaQuery(
 					searchSession.search( IndexedEntity.class )
@@ -284,7 +283,7 @@ public class ToJpaQueryIT {
 
 	@Test
 	public void timeout_jpaHint() {
-		withinEntityManager( setupHolder.entityManagerFactory(), entityManager -> {
+		setupHolder.runNoTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			TypedQuery<IndexedEntity> query = Search.toJpaQuery( createSimpleQuery( searchSession ) );
 
@@ -307,7 +306,7 @@ public class ToJpaQueryIT {
 
 	@Test
 	public void timeout_override() {
-		withinEntityManager( setupHolder.entityManagerFactory(), entityManager -> {
+		setupHolder.runNoTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			TypedQuery<IndexedEntity> query = Search.toJpaQuery(
 					searchSession.search( IndexedEntity.class )
@@ -336,7 +335,7 @@ public class ToJpaQueryIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3628")
 	public void graph_jpaHint_fetch() {
-		withinEntityManager( setupHolder.entityManagerFactory(), entityManager -> {
+		setupHolder.runNoTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			TypedQuery<IndexedEntity> query = Search.toOrmQuery( createSimpleQuery( searchSession ) );
 
@@ -352,7 +351,7 @@ public class ToJpaQueryIT {
 			assertThatManaged( loaded.getContainedLazy() ).isInitialized();
 		} );
 
-		withinEntityManager( setupHolder.entityManagerFactory(), entityManager -> {
+		setupHolder.runNoTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			TypedQuery<IndexedEntity> query = Search.toOrmQuery( createSimpleQuery( searchSession ) );
 
@@ -373,7 +372,7 @@ public class ToJpaQueryIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3628")
 	public void graph_jpaHint_load() {
-		withinEntityManager( setupHolder.entityManagerFactory(), entityManager -> {
+		setupHolder.runNoTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			TypedQuery<IndexedEntity> query = Search.toOrmQuery( createSimpleQuery( searchSession ) );
 
@@ -389,7 +388,7 @@ public class ToJpaQueryIT {
 			assertThatManaged( loaded.getContainedLazy() ).isInitialized();
 		} );
 
-		withinEntityManager( setupHolder.entityManagerFactory(), entityManager -> {
+		setupHolder.runNoTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			TypedQuery<IndexedEntity> query = Search.toOrmQuery( createSimpleQuery( searchSession ) );
 
@@ -409,7 +408,7 @@ public class ToJpaQueryIT {
 
 	@Test
 	public void graph_override_jpaHint() {
-		withinEntityManager( setupHolder.entityManagerFactory(), entityManager -> {
+		setupHolder.runNoTransaction( entityManager -> {
 			SearchSession searchSession = Search.session( entityManager );
 			TypedQuery<IndexedEntity> query = Search.toOrmQuery(
 					searchSession.search( IndexedEntity.class )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToJpaQueryIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToJpaQueryIT.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hibernate.search.util.impl.integrationtest.common.stub.backend.StubBackendUtils.reference;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.ManagedAssert.assertThatManaged;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -78,7 +78,7 @@ public class ToJpaQueryIT {
 
 	@Before
 	public void initData() {
-		withinJPATransaction( setupHolder.entityManagerFactory(), entityManager -> {
+		with( setupHolder.entityManagerFactory() ).runInTransaction( entityManager -> {
 			IndexedEntity indexed1 = new IndexedEntity();
 			indexed1.setId( 1 );
 			indexed1.setText( "this is text (1)" );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToSearchSessionFromSessionProxyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToSearchSessionFromSessionProxyIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.hibernateormapis;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
@@ -31,7 +32,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.common.impl.Futures;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 import org.hibernate.search.util.impl.test.annotation.PortedFromSearch5;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
@@ -105,7 +105,7 @@ public class ToSearchSessionFromSessionProxyIT {
 	public void testThreadBoundSessionWrappingInTransaction() {
 		final Session sessionFromFirstThread = setupHolder.sessionFactory().getCurrentSession();
 		try {
-			OrmUtils.withinTransaction( sessionFromFirstThread, ignored -> {
+			withinTransaction( sessionFromFirstThread, ignored -> {
 				SearchSession searchSessionFromFirstThread = Search.session( sessionFromFirstThread );
 				assertNotNull( searchSessionFromFirstThread );
 				assertThat( searchSessionFromFirstThread.toEntityManager() ).isSameAs( sessionFromFirstThread );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToSearchSessionFromSessionProxyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToSearchSessionFromSessionProxyIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.hibernateormapis;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.runInTransaction;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
@@ -105,7 +105,7 @@ public class ToSearchSessionFromSessionProxyIT {
 	public void testThreadBoundSessionWrappingInTransaction() {
 		final Session sessionFromFirstThread = setupHolder.sessionFactory().getCurrentSession();
 		try {
-			withinTransaction( sessionFromFirstThread, ignored -> {
+			runInTransaction( sessionFromFirstThread, ignored -> {
 				SearchSession searchSessionFromFirstThread = Search.session( sessionFromFirstThread );
 				assertNotNull( searchSessionFromFirstThread );
 				assertThat( searchSessionFromFirstThread.toEntityManager() ).isSameAs( sessionFromFirstThread );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingErrorIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingErrorIT.java
@@ -9,7 +9,7 @@ package org.hibernate.search.integrationtest.mapper.orm.massindexing;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Fail.fail;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -100,7 +100,7 @@ public abstract class AbstractMassIndexingErrorIT {
 		// We need more than 1000 batches in order to reproduce HSEARCH-4236.
 		// That's because of the size of the queue:
 		// see org.hibernate.search.mapper.orm.massindexing.impl.PojoProducerConsumerQueue.DEFAULT_BUFF_LENGTH
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			for ( int i = 4; i < 1500; i++ ) {
 				session.persist( new Book( i, "title " + i, "author " + i ) );
 			}
@@ -501,7 +501,7 @@ public abstract class AbstractMassIndexingErrorIT {
 
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			session.persist( new Book( 1, TITLE_1, AUTHOR_1 ) );
 			session.persist( new Book( 2, TITLE_2, AUTHOR_2 ) );
 			session.persist( new Book( 3, TITLE_3, AUTHOR_3 ) );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingErrorIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingErrorIT.java
@@ -9,6 +9,7 @@ package org.hibernate.search.integrationtest.mapper.orm.massindexing;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Fail.fail;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -35,7 +36,6 @@ import org.hibernate.search.util.impl.integrationtest.common.rule.ThreadSpy;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.StubIndexScaleWork;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.StubSchemaManagementWork;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.SimpleSessionFactoryBuilder;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
@@ -100,7 +100,7 @@ public abstract class AbstractMassIndexingErrorIT {
 		// We need more than 1000 batches in order to reproduce HSEARCH-4236.
 		// That's because of the size of the queue:
 		// see org.hibernate.search.mapper.orm.massindexing.impl.PojoProducerConsumerQueue.DEFAULT_BUFF_LENGTH
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			for ( int i = 4; i < 1500; i++ ) {
 				session.persist( new Book( i, "title " + i, "author " + i ) );
 			}
@@ -501,7 +501,7 @@ public abstract class AbstractMassIndexingErrorIT {
 
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			session.persist( new Book( 1, TITLE_1, AUTHOR_1 ) );
 			session.persist( new Book( 2, TITLE_2, AUTHOR_2 ) );
 			session.persist( new Book( 3, TITLE_3, AUTHOR_3 ) );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingFailureIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingFailureIT.java
@@ -9,6 +9,7 @@ package org.hibernate.search.integrationtest.mapper.orm.massindexing;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Fail.fail;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -27,9 +28,9 @@ import org.hibernate.search.engine.reporting.FailureHandler;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
-import org.hibernate.search.mapper.pojo.massindexing.MassIndexingFailureHandler;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.massindexing.MassIndexingFailureHandler;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.reporting.FailureReportUtils;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
@@ -37,7 +38,6 @@ import org.hibernate.search.util.impl.integrationtest.common.rule.ThreadSpy;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.StubIndexScaleWork;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.StubSchemaManagementWork;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.SimpleSessionFactoryBuilder;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
@@ -113,7 +113,7 @@ public abstract class AbstractMassIndexingFailureIT {
 		// We need more than 1000 batches in order to reproduce HSEARCH-4236.
 		// That's because of the size of the queue:
 		// see org.hibernate.search.mapper.orm.massindexing.impl.PojoProducerConsumerQueue.DEFAULT_BUFF_LENGTH
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			for ( int i = 4; i < 1500; i++ ) {
 				session.persist( new Book( i, "title " + i, "author " + i ) );
 			}
@@ -750,7 +750,7 @@ public abstract class AbstractMassIndexingFailureIT {
 
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			session.persist( new Book( 1, TITLE_1, AUTHOR_1 ) );
 			session.persist( new Book( 2, TITLE_2, AUTHOR_2 ) );
 			session.persist( new Book( 3, TITLE_3, AUTHOR_3 ) );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingFailureIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingFailureIT.java
@@ -9,7 +9,7 @@ package org.hibernate.search.integrationtest.mapper.orm.massindexing;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Fail.fail;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -113,7 +113,7 @@ public abstract class AbstractMassIndexingFailureIT {
 		// We need more than 1000 batches in order to reproduce HSEARCH-4236.
 		// That's because of the size of the queue:
 		// see org.hibernate.search.mapper.orm.massindexing.impl.PojoProducerConsumerQueue.DEFAULT_BUFF_LENGTH
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			for ( int i = 4; i < 1500; i++ ) {
 				session.persist( new Book( i, "title " + i, "author " + i ) );
 			}
@@ -750,7 +750,7 @@ public abstract class AbstractMassIndexingFailureIT {
 
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			session.persist( new Book( 1, TITLE_1, AUTHOR_1 ) );
 			session.persist( new Book( 2, TITLE_2, AUTHOR_2 ) );
 			session.persist( new Book( 3, TITLE_3, AUTHOR_3 ) );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingEmbeddedIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingEmbeddedIdIT.java
@@ -75,7 +75,7 @@ public class MassIndexingEmbeddedIdIT {
 
 	@Test
 	public void defaultMassIndexerStartAndWait() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingEmbeddedIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingEmbeddedIdIT.java
@@ -7,6 +7,8 @@
 package org.hibernate.search.integrationtest.mapper.orm.massindexing;
 
 import static org.assertj.core.api.Fail.fail;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import java.io.Serializable;
 import java.util.UUID;
@@ -31,7 +33,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericFie
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -75,7 +76,7 @@ public class MassIndexingEmbeddedIdIT {
 
 	@Test
 	public void defaultMassIndexerStartAndWait() {
-		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
+		with( sessionFactory ).runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer();
 
@@ -118,7 +119,7 @@ public class MassIndexingEmbeddedIdIT {
 	}
 
 	private void initData() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			book1 = new Book( 1, TITLE_1, AUTHOR_1 );
 			session.persist( book1 );
 			book2 = new Book( 2, TITLE_2, AUTHOR_2 );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingEmbeddedIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingEmbeddedIdIT.java
@@ -8,7 +8,6 @@ package org.hibernate.search.integrationtest.mapper.orm.massindexing;
 
 import static org.assertj.core.api.Fail.fail;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import java.io.Serializable;
 import java.util.UUID;
@@ -119,7 +118,7 @@ public class MassIndexingEmbeddedIdIT {
 	}
 
 	private void initData() {
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			book1 = new Book( 1, TITLE_1, AUTHOR_1 );
 			session.persist( book1 );
 			book2 = new Book( 2, TITLE_2, AUTHOR_2 );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingInterruptionIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingInterruptionIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.massindexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -29,7 +30,6 @@ import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.common.rule.ThreadSpy;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -239,7 +239,7 @@ public class MassIndexingInterruptionIT {
 	}
 
 	private void initData() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			session.persist( new Book( 1, TITLE_1, AUTHOR_1 ) );
 		} );
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingInterruptionIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingInterruptionIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.massindexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -239,7 +239,7 @@ public class MassIndexingInterruptionIT {
 	}
 
 	private void initData() {
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			session.persist( new Book( 1, TITLE_1, AUTHOR_1 ) );
 		} );
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingMonitorIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingMonitorIT.java
@@ -56,7 +56,7 @@ public class MassIndexingMonitorIT {
 	public void simple() {
 		SessionFactory sessionFactory = setup( null );
 
-		OrmUtils.withinSession( sessionFactory, session -> {
+		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingMonitorIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingMonitorIT.java
@@ -8,6 +8,8 @@ package org.hibernate.search.integrationtest.mapper.orm.massindexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import java.util.concurrent.CompletableFuture;
 import javax.persistence.Entity;
@@ -21,14 +23,13 @@ import org.hibernate.search.engine.cfg.EngineSettings;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
-import org.hibernate.search.mapper.pojo.massindexing.MassIndexingMonitor;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.massindexing.MassIndexingMonitor;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.rule.StaticCounters;
 
 import org.junit.Rule;
@@ -56,7 +57,7 @@ public class MassIndexingMonitorIT {
 	public void simple() {
 		SessionFactory sessionFactory = setup( null );
 
-		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
+		with( sessionFactory ).runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer();
 
@@ -121,7 +122,7 @@ public class MassIndexingMonitorIT {
 
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			session.persist( new Book( 1, TITLE_1, AUTHOR_1 ) );
 			session.persist( new Book( 2, TITLE_2, AUTHOR_2 ) );
 			session.persist( new Book( 3, TITLE_3, AUTHOR_3 ) );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingMonitorIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingMonitorIT.java
@@ -9,7 +9,6 @@ package org.hibernate.search.integrationtest.mapper.orm.massindexing;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import java.util.concurrent.CompletableFuture;
 import javax.persistence.Entity;
@@ -122,7 +121,7 @@ public class MassIndexingMonitorIT {
 
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			session.persist( new Book( 1, TITLE_1, AUTHOR_1 ) );
 			session.persist( new Book( 2, TITLE_2, AUTHOR_2 ) );
 			session.persist( new Book( 3, TITLE_3, AUTHOR_3 ) );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingNonEntityIdDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingNonEntityIdDocumentIdIT.java
@@ -8,7 +8,6 @@ package org.hibernate.search.integrationtest.mapper.orm.massindexing;
 
 import static org.assertj.core.api.Fail.fail;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -110,7 +109,7 @@ public class MassIndexingNonEntityIdDocumentIdIT {
 	}
 
 	private void initData() {
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			session.persist( new Book( 1, 41, TITLE_1, AUTHOR_1 ) );
 			session.persist( new Book( 2, 42, TITLE_2, AUTHOR_2 ) );
 			session.persist( new Book( 3, 43, TITLE_3, AUTHOR_3 ) );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingNonEntityIdDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingNonEntityIdDocumentIdIT.java
@@ -7,6 +7,8 @@
 package org.hibernate.search.integrationtest.mapper.orm.massindexing;
 
 import static org.assertj.core.api.Fail.fail;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -24,7 +26,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericFie
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
@@ -67,7 +68,7 @@ public class MassIndexingNonEntityIdDocumentIdIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3203")
 	public void defaultMassIndexerStartAndWait() {
-		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
+		with( sessionFactory ).runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer();
 
@@ -109,7 +110,7 @@ public class MassIndexingNonEntityIdDocumentIdIT {
 	}
 
 	private void initData() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			session.persist( new Book( 1, 41, TITLE_1, AUTHOR_1 ) );
 			session.persist( new Book( 2, 42, TITLE_2, AUTHOR_2 ) );
 			session.persist( new Book( 3, 43, TITLE_3, AUTHOR_3 ) );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingNonEntityIdDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingNonEntityIdDocumentIdIT.java
@@ -67,7 +67,7 @@ public class MassIndexingNonEntityIdDocumentIdIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3203")
 	public void defaultMassIndexerStartAndWait() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingPrimitiveIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingPrimitiveIdIT.java
@@ -8,7 +8,6 @@ package org.hibernate.search.integrationtest.mapper.orm.massindexing;
 
 import static org.assertj.core.api.Fail.fail;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -90,7 +89,7 @@ public class MassIndexingPrimitiveIdIT {
 	}
 
 	private void initData() {
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			session.persist( new EntityWithPrimitiveId( 1 ) );
 			session.persist( new EntityWithPrimitiveId( 2 ) );
 			session.persist( new EntityWithPrimitiveId( 3 ) );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingPrimitiveIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingPrimitiveIdIT.java
@@ -55,7 +55,7 @@ public class MassIndexingPrimitiveIdIT {
 
 	@Test
 	public void entityWithPrimitiveId() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingPrimitiveIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingPrimitiveIdIT.java
@@ -7,6 +7,8 @@
 package org.hibernate.search.integrationtest.mapper.orm.massindexing;
 
 import static org.assertj.core.api.Fail.fail;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -22,7 +24,6 @@ import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
@@ -55,7 +56,7 @@ public class MassIndexingPrimitiveIdIT {
 
 	@Test
 	public void entityWithPrimitiveId() {
-		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
+		with( sessionFactory ).runNoTransaction( session -> {
 			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer();
 
@@ -89,7 +90,7 @@ public class MassIndexingPrimitiveIdIT {
 	}
 
 	private void initData() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			session.persist( new EntityWithPrimitiveId( 1 ) );
 			session.persist( new EntityWithPrimitiveId( 2 ) );
 			session.persist( new EntityWithPrimitiveId( 3 ) );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/AnnotationMappingAccessTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/AnnotationMappingAccessTypeIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 import static org.junit.Assert.fail;
 
 import java.io.Serializable;
@@ -87,7 +87,7 @@ public class AnnotationMappingAccessTypeIT {
 
 	@Test
 	public void index() {
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.id = 1;
 			entity1.fieldWithNonDefaultFieldAccess = "nonDefaultFieldAccess";

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/AnnotationMappingAccessTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/AnnotationMappingAccessTypeIT.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 import static org.junit.Assert.fail;
 
 import java.io.Serializable;
@@ -29,7 +30,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -87,7 +87,7 @@ public class AnnotationMappingAccessTypeIT {
 
 	@Test
 	public void index() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.id = 1;
 			entity1.fieldWithNonDefaultFieldAccess = "nonDefaultFieldAccess";

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BackRefPropertyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BackRefPropertyIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,7 +29,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyValue;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Rule;
@@ -68,7 +68,7 @@ public class BackRefPropertyIT {
 
 		// If we get here the bug was solved, but let's at least check that indexing works
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity containing1 = new IndexedEntity();
 			containing1.setId( 0 );
 			IndexedEntity containing2 = new IndexedEntity();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BackRefPropertyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BackRefPropertyIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -68,7 +68,7 @@ public class BackRefPropertyIT {
 
 		// If we get here the bug was solved, but let's at least check that indexing works
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity containing1 = new IndexedEntity();
 			containing1.setId( 0 );
 			IndexedEntity containing2 = new IndexedEntity();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BindingUsingPropertyMarkerAccessIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BindingUsingPropertyMarkerAccessIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -89,7 +89,7 @@ public class BindingUsingPropertyMarkerAccessIT<TIndexed> {
 	 */
 	@Test
 	public void indexing() {
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			TIndexed entity1 = modelPrimitives.create( 1, 42.0, 42.0 );
 
 			session.persist( entity1 );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BindingUsingPropertyMarkerAccessIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BindingUsingPropertyMarkerAccessIT.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
@@ -20,7 +22,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
@@ -88,7 +89,7 @@ public class BindingUsingPropertyMarkerAccessIT<TIndexed> {
 	 */
 	@Test
 	public void indexing() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			TIndexed entity1 = modelPrimitives.create( 1, 42.0, 42.0 );
 
 			session.persist( entity1 );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.ManagedAssert.assertThatManaged;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -37,7 +38,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDe
 import org.hibernate.search.util.common.impl.CollectionHelper;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
@@ -100,7 +100,7 @@ public class BytecodeEnhancementIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3581")
 	public void test() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			// This cast is necessary to work around https://hibernate.atlassian.net/browse/HHH-14006
 			( (IndexedEntitySuperClass) entity1 ).id = 1;
@@ -165,7 +165,7 @@ public class BytecodeEnhancementIT {
 
 			AtomicReference<IndexedEntity> entityFromTransaction = new AtomicReference<>();
 
-			OrmUtils.withinTransaction( sessionFactory, session -> {
+			withinTransaction( sessionFactory, session -> {
 				IndexedEntity entity = session.getReference( IndexedEntity.class, 1 );
 				entityFromTransaction.set( entity );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.ManagedAssert.assertThatManaged;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -100,7 +100,7 @@ public class BytecodeEnhancementIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3581")
 	public void test() {
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			// This cast is necessary to work around https://hibernate.atlassian.net/browse/HHH-14006
 			( (IndexedEntitySuperClass) entity1 ).id = 1;
@@ -165,7 +165,7 @@ public class BytecodeEnhancementIT {
 
 			AtomicReference<IndexedEntity> entityFromTransaction = new AtomicReference<>();
 
-			withinTransaction( sessionFactory, session -> {
+			with( sessionFactory ).runInTransaction( session -> {
 				IndexedEntity entity = session.getReference( IndexedEntity.class, 1 );
 				entityFromTransaction.set( entity );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/GenericPropertyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/GenericPropertyIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -62,7 +62,7 @@ public class GenericPropertyIT {
 
 	@Test
 	public void index() {
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 			GenericEntity<String> genericEntity = new StringGenericEntity();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/GenericPropertyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/GenericPropertyIT.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Basic;
@@ -20,7 +22,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -61,7 +62,7 @@ public class GenericPropertyIT {
 
 	@Test
 	public void index() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 			GenericEntity<String> genericEntity = new StringGenericEntity();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/IdClassIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/IdClassIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -62,7 +62,7 @@ public class IdClassIT {
 				.setup( NonIdClassIndexed.class, IdClassNonIndexed.class );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			NonIdClassIndexed entity = new NonIdClassIndexed();
 			entity.setId( 1 );
 
@@ -85,7 +85,7 @@ public class IdClassIT {
 				.setup( IdClassIndexedWithDocumentId.class );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IdClassIndexedWithDocumentId entity = new IdClassIndexedWithDocumentId();
 			entity.setId1( 10 );
 			entity.setId2( 7 );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/IdClassIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/IdClassIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -20,7 +21,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Rule;
@@ -62,7 +62,7 @@ public class IdClassIT {
 				.setup( NonIdClassIndexed.class, IdClassNonIndexed.class );
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			NonIdClassIndexed entity = new NonIdClassIndexed();
 			entity.setId( 1 );
 
@@ -85,7 +85,7 @@ public class IdClassIT {
 				.setup( IdClassIndexedWithDocumentId.class );
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IdClassIndexedWithDocumentId entity = new IdClassIndexedWithDocumentId();
 			entity.setId1( 10 );
 			entity.setId2( 7 );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/IdDerivedFromAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/IdDerivedFromAssociationIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.io.Serializable;
 import javax.persistence.Entity;
@@ -66,7 +66,7 @@ public class IdDerivedFromAssociationIT {
 				.setup( IndexedBaseForNonIndexedDerived.class, NonIndexedDerived.class );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedBaseForNonIndexedDerived base = new IndexedBaseForNonIndexedDerived();
 			session.persist( base );
 
@@ -88,7 +88,7 @@ public class IdDerivedFromAssociationIT {
 				.setup( NonIndexedBaseForIndexedDerivedWithDocumentId.class, IndexedDerivedWithDocumentId.class );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			NonIndexedBaseForIndexedDerivedWithDocumentId base = new NonIndexedBaseForIndexedDerivedWithDocumentId();
 			session.persist( base );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/JpaIdAsDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/JpaIdAsDocumentIdIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,7 +50,7 @@ public class JpaIdAsDocumentIdIT {
 				.setup( IndexedEntity.class, ContainedEntity.class );
 		backendMock.verifyExpectationsMet();
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 0 );
 			ContainedEntity contained1 = new ContainedEntity();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/JpaIdAsDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/JpaIdAsDocumentIdIT.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Entity;
@@ -21,7 +23,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -49,7 +50,7 @@ public class JpaIdAsDocumentIdIT {
 				.setup( IndexedEntity.class, ContainedEntity.class );
 		backendMock.verifyExpectationsMet();
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 0 );
 			ContainedEntity contained1 = new ContainedEntity();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/MappedSuperclassIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/MappedSuperclassIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -58,7 +58,7 @@ public class MappedSuperclassIT {
 
 	@Test
 	public void index() {
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity indexedPojo = new IndexedEntity( 1, "Using some text here" );
 			session.persist( indexedPojo );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/MappedSuperclassIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/MappedSuperclassIT.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
@@ -18,7 +20,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.Programm
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
@@ -57,7 +58,7 @@ public class MappedSuperclassIT {
 
 	@Test
 	public void index() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity indexedPojo = new IndexedEntity( 1, "Using some text here" );
 			session.persist( indexedPojo );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/ProgrammaticMappingAccessTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/ProgrammaticMappingAccessTypeIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 import static org.junit.Assert.fail;
 
 import java.io.Serializable;
@@ -90,7 +90,7 @@ public class ProgrammaticMappingAccessTypeIT {
 
 	@Test
 	public void index() {
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.id = 1;
 			entity1.fieldWithNonDefaultFieldAccess = "nonDefaultFieldAccess";

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/ProgrammaticMappingAccessTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/ProgrammaticMappingAccessTypeIT.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 import static org.junit.Assert.fail;
 
 import java.io.Serializable;
@@ -31,7 +32,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.Programm
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -90,7 +90,7 @@ public class ProgrammaticMappingAccessTypeIT {
 
 	@Test
 	public void index() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.id = 1;
 			entity1.fieldWithNonDefaultFieldAccess = "nonDefaultFieldAccess";

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/PropertyInheritanceIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/PropertyInheritanceIT.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Entity;
@@ -19,7 +21,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -58,7 +59,7 @@ public class PropertyInheritanceIT {
 
 	@Test
 	public void index() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 			entity1.setParentDeclaredProperty( "parent-declared-1" );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/PropertyInheritanceIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/PropertyInheritanceIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -59,7 +59,7 @@ public class PropertyInheritanceIT {
 
 	@Test
 	public void index() {
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.setId( 1 );
 			entity1.setParentDeclaredProperty( "parent-declared-1" );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/ProxyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/ProxyIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import javax.persistence.Basic;
 import javax.persistence.Entity;
@@ -60,7 +60,7 @@ public class ProxyIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-383")
 	public void proxyAccess() {
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			EntityWithPropertyAccessTypeForId entity1 = new EntityWithPropertyAccessTypeForId();
 			entity1.id = 1;
 			entity1.text = "initialValue";
@@ -73,7 +73,7 @@ public class ProxyIT {
 					);
 		} );
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			ParentEntity proxy = session.getReference( ParentEntity.class, 1 );
 
 			// 'proxy' is a Hibernate proxy and accessing its fields will not work, even after the proxy is initialized

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/ProxyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/ProxyIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import javax.persistence.Basic;
 import javax.persistence.Entity;
@@ -20,7 +21,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericFie
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
@@ -60,7 +60,7 @@ public class ProxyIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-383")
 	public void proxyAccess() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			EntityWithPropertyAccessTypeForId entity1 = new EntityWithPropertyAccessTypeForId();
 			entity1.id = 1;
 			entity1.text = "initialValue";
@@ -73,7 +73,7 @@ public class ProxyIT {
 					);
 		} );
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			ParentEntity proxy = session.getReference( ParentEntity.class, 1 );
 
 			// 'proxy' is a Hibernate proxy and accessing its fields will not work, even after the proxy is initialized

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/SyntheticPropertyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/SyntheticPropertyIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -25,7 +26,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Rule;
@@ -62,7 +62,7 @@ public class SyntheticPropertyIT {
 
 		// If we get here the bug was solved, but let's at least check that indexing works
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			IndexedEntity containing1 = new IndexedEntity();
 			containing1.setId( 0 );
 			IndexedEntity containing2 = new IndexedEntity();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/SyntheticPropertyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/SyntheticPropertyIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -62,7 +62,7 @@ public class SyntheticPropertyIT {
 
 		// If we get here the bug was solved, but let's at least check that indexing works
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity containing1 = new IndexedEntity();
 			containing1.setId( 0 );
 			IndexedEntity containing2 = new IndexedEntity();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/TransientPropertyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/TransientPropertyIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import javax.persistence.Basic;
 import javax.persistence.Entity;
@@ -66,7 +66,7 @@ public class TransientPropertyIT {
 
 		SessionFactory sessionFactory = ormSetupHelper.start().setup( EntityWithDerivedFrom.class );
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			EntityWithDerivedFrom entity1 = new EntityWithDerivedFrom();
 			entity1.setId( 1 );
 			entity1.setA( 2 );
@@ -84,7 +84,7 @@ public class TransientPropertyIT {
 
 		// A is used to derive the transient property, so it should trigger reindexing.
 		// More related tests in the AutomaticIndexing*IT tests.
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			EntityWithDerivedFrom entity1 = session.getReference( EntityWithDerivedFrom.class, 1 );
 			entity1.setA( 4 );
 
@@ -98,7 +98,7 @@ public class TransientPropertyIT {
 		backendMock.verifyExpectationsMet();
 
 		// C is not used to derive the transient property, so it should not trigger reindexing.
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			EntityWithDerivedFrom entity1 = session.getReference( EntityWithDerivedFrom.class, 1 );
 			entity1.setC( 42 );
 
@@ -115,7 +115,7 @@ public class TransientPropertyIT {
 
 		SessionFactory sessionFactory = ormSetupHelper.start().setup( EntityWithDerivedFromAndBridge.class );
 
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			EntityWithDerivedFromAndBridge entity1 = new EntityWithDerivedFromAndBridge();
 			entity1.setId( 1 );
 			entity1.setA( 2 );
@@ -133,7 +133,7 @@ public class TransientPropertyIT {
 
 		// A is used to derive the transient property, so it should trigger reindexing.
 		// More related tests in the AutomaticIndexing*IT tests.
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			EntityWithDerivedFromAndBridge entity1 = session.getReference( EntityWithDerivedFromAndBridge.class, 1 );
 			entity1.setA( 4 );
 
@@ -147,7 +147,7 @@ public class TransientPropertyIT {
 		backendMock.verifyExpectationsMet();
 
 		// C is not used to derive the transient property, so it should not trigger reindexing.
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			EntityWithDerivedFromAndBridge entity1 = session.getReference( EntityWithDerivedFromAndBridge.class, 1 );
 			entity1.setC( 42 );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/TransientPropertyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/TransientPropertyIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import javax.persistence.Basic;
 import javax.persistence.Entity;
@@ -30,7 +31,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyVa
 import org.hibernate.search.util.impl.integrationtest.common.reporting.FailureReportUtils;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -66,7 +66,7 @@ public class TransientPropertyIT {
 
 		SessionFactory sessionFactory = ormSetupHelper.start().setup( EntityWithDerivedFrom.class );
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			EntityWithDerivedFrom entity1 = new EntityWithDerivedFrom();
 			entity1.setId( 1 );
 			entity1.setA( 2 );
@@ -84,7 +84,7 @@ public class TransientPropertyIT {
 
 		// A is used to derive the transient property, so it should trigger reindexing.
 		// More related tests in the AutomaticIndexing*IT tests.
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			EntityWithDerivedFrom entity1 = session.getReference( EntityWithDerivedFrom.class, 1 );
 			entity1.setA( 4 );
 
@@ -98,7 +98,7 @@ public class TransientPropertyIT {
 		backendMock.verifyExpectationsMet();
 
 		// C is not used to derive the transient property, so it should not trigger reindexing.
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			EntityWithDerivedFrom entity1 = session.getReference( EntityWithDerivedFrom.class, 1 );
 			entity1.setC( 42 );
 
@@ -115,7 +115,7 @@ public class TransientPropertyIT {
 
 		SessionFactory sessionFactory = ormSetupHelper.start().setup( EntityWithDerivedFromAndBridge.class );
 
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			EntityWithDerivedFromAndBridge entity1 = new EntityWithDerivedFromAndBridge();
 			entity1.setId( 1 );
 			entity1.setA( 2 );
@@ -133,7 +133,7 @@ public class TransientPropertyIT {
 
 		// A is used to derive the transient property, so it should trigger reindexing.
 		// More related tests in the AutomaticIndexing*IT tests.
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			EntityWithDerivedFromAndBridge entity1 = session.getReference( EntityWithDerivedFromAndBridge.class, 1 );
 			entity1.setA( 4 );
 
@@ -147,7 +147,7 @@ public class TransientPropertyIT {
 		backendMock.verifyExpectationsMet();
 
 		// C is not used to derive the transient property, so it should not trigger reindexing.
-		OrmUtils.withinTransaction( sessionFactory, session -> {
+		withinTransaction( sessionFactory, session -> {
 			EntityWithDerivedFromAndBridge entity1 = session.getReference( EntityWithDerivedFromAndBridge.class, 1 );
 			entity1.setC( 42 );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/scope/ScopeExtensionIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/scope/ScopeExtensionIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.scope;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -19,7 +20,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.impl.StubIndexScope;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -44,7 +44,7 @@ public class ScopeExtensionIT {
 
 	@Test
 	public void test() {
-		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
+		with( sessionFactory ).runNoTransaction( session -> {
 			IndexScope indexScope = Search.session( session ).scope( Author.class )
 					.extension( original -> original );
 			assertThat( indexScope ).isInstanceOf( StubIndexScope.class );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/scope/ScopeExtensionIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/scope/ScopeExtensionIT.java
@@ -44,7 +44,7 @@ public class ScopeExtensionIT {
 
 	@Test
 	public void test() {
-		OrmUtils.withinSession( sessionFactory, session -> {
+		OrmUtils.with( sessionFactory ).runNoTransaction( session -> {
 			IndexScope indexScope = Search.session( session ).scope( Author.class )
 					.extension( original -> original );
 			assertThat( indexScope ).isInstanceOf( StubIndexScope.class );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/AbstractSearchQueryEntityLoadingSingleTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/AbstractSearchQueryEntityLoadingSingleTypeIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.search.loading;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.Collections;
 import java.util.List;
@@ -42,7 +42,7 @@ public abstract class AbstractSearchQueryEntityLoadingSingleTypeIT<T> extends Ab
 
 	protected final void persistThatManyEntities(int entityCount) {
 		// We don't care about what is indexed exactly, so use the lenient mode
-		backendMock().inLenientMode( () -> withinTransaction( sessionFactory(), session -> {
+		backendMock().inLenientMode( () -> with( sessionFactory() ).runInTransaction( session -> {
 			for ( int i = 0; i < entityCount; i++ ) {
 				session.persist( model.newIndexed( i, mapping ) );
 			}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityChangingScrollingIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityChangingScrollingIT.java
@@ -9,6 +9,7 @@ package org.hibernate.search.integrationtest.mapper.orm.search.loading;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchHitsAssert.assertThatHits;
 import static org.hibernate.search.util.impl.integrationtest.common.stub.backend.StubBackendUtils.reference;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,7 +32,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.common.rule.StubNextScrollWorkBehavior;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -57,7 +57,7 @@ public class SearchQueryEntityChangingScrollingIT {
 
 	@Test
 	public void test() {
-		backendMock.inLenientMode( () -> OrmUtils.withinTransaction( sessionFactory, session -> {
+		backendMock.inLenientMode( () -> withinTransaction( sessionFactory, session -> {
 			for ( int i = 0; i < 12; i++ ) {
 				session.persist( new SimpleEntity( i ) );
 			}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityChangingScrollingIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityChangingScrollingIT.java
@@ -9,7 +9,7 @@ package org.hibernate.search.integrationtest.mapper.orm.search.loading;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchHitsAssert.assertThatHits;
 import static org.hibernate.search.util.impl.integrationtest.common.stub.backend.StubBackendUtils.reference;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -57,7 +57,7 @@ public class SearchQueryEntityChangingScrollingIT {
 
 	@Test
 	public void test() {
-		backendMock.inLenientMode( () -> withinTransaction( sessionFactory, session -> {
+		backendMock.inLenientMode( () -> with( sessionFactory ).runInTransaction( session -> {
 			for ( int i = 0; i < 12; i++ ) {
 				session.persist( new SimpleEntity( i ) );
 			}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingGraphIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingGraphIT.java
@@ -9,7 +9,6 @@ package org.hibernate.search.integrationtest.mapper.orm.search.loading;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.ManagedAssert.assertThatManaged;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -90,7 +89,7 @@ public class SearchQueryEntityLoadingGraphIT<T> extends AbstractSearchQueryEntit
 	@Before
 	public void initData() {
 		// We don't care about what is indexed exactly, so use the lenient mode
-		backendMock.inLenientMode( () -> withinTransaction( sessionFactory(), session -> {
+		backendMock.inLenientMode( () -> with( sessionFactory() ).runInTransaction( session -> {
 			session.persist( model.newIndexedWithContained( 0, mapping ) );
 			session.persist( model.newIndexedWithContained( 1, mapping ) );
 			session.persist( model.newIndexedWithContained( 2, mapping ) );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingGraphIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingGraphIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.integrationtest.mapper.orm.search.loading;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.ManagedAssert.assertThatManaged;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import java.util.ArrayList;
@@ -22,7 +23,6 @@ import org.hibernate.search.integrationtest.mapper.orm.search.loading.model.sing
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.ReusableOrmSetupHolder;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
@@ -159,7 +159,7 @@ public class SearchQueryEntityLoadingGraphIT<T> extends AbstractSearchQueryEntit
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3628")
 	public void graphName_null() {
-		assertThatThrownBy( () -> OrmUtils.with( sessionFactory() ).runNoTransaction( session ->
+		assertThatThrownBy( () -> with( sessionFactory() ).runNoTransaction( session ->
 				Search.session( session ).search( model.getIndexedClass() )
 						.where( f -> f.matchAll() )
 						.loading( o -> o.graph( (String) null, GraphSemantic.FETCH ) )
@@ -172,7 +172,7 @@ public class SearchQueryEntityLoadingGraphIT<T> extends AbstractSearchQueryEntit
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3628")
 	public void graphName_invalid() {
-		assertThatThrownBy( () -> OrmUtils.with( sessionFactory() ).runNoTransaction( session ->
+		assertThatThrownBy( () -> with( sessionFactory() ).runNoTransaction( session ->
 				Search.session( session ).search( model.getIndexedClass() )
 						.where( f -> f.matchAll() )
 						.loading( o -> o.graph( "invalidGraphName", GraphSemantic.FETCH ) )
@@ -185,7 +185,7 @@ public class SearchQueryEntityLoadingGraphIT<T> extends AbstractSearchQueryEntit
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3628")
 	public void graphName_graphSemantic_null() {
-		assertThatThrownBy( () -> OrmUtils.with( sessionFactory() ).runNoTransaction( session ->
+		assertThatThrownBy( () -> with( sessionFactory() ).runNoTransaction( session ->
 				Search.session( session ).search( model.getIndexedClass() )
 						.where( f -> f.matchAll() )
 						.loading( o -> o.graph( model.getEagerGraphName(), null ) )
@@ -198,7 +198,7 @@ public class SearchQueryEntityLoadingGraphIT<T> extends AbstractSearchQueryEntit
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3628")
 	public void graph_null() {
-		assertThatThrownBy( () -> OrmUtils.with( sessionFactory() ).runNoTransaction( session ->
+		assertThatThrownBy( () -> with( sessionFactory() ).runNoTransaction( session ->
 				Search.session( session ).search( model.getIndexedClass() )
 						.where( f -> f.matchAll() )
 						.loading( o -> o.graph( (RootGraph<?>) null, GraphSemantic.FETCH ) )
@@ -211,7 +211,7 @@ public class SearchQueryEntityLoadingGraphIT<T> extends AbstractSearchQueryEntit
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3628")
 	public void graph_graphSemantic_null() {
-		assertThatThrownBy( () -> OrmUtils.with( sessionFactory() ).runNoTransaction( session ->
+		assertThatThrownBy( () -> with( sessionFactory() ).runNoTransaction( session ->
 				Search.session( session ).search( model.getIndexedClass() )
 						.where( f -> f.matchAll() )
 						.loading( o -> o.graph( session.getEntityGraph( model.getEagerGraphName() ), null ) )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingGraphIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingGraphIT.java
@@ -159,12 +159,12 @@ public class SearchQueryEntityLoadingGraphIT<T> extends AbstractSearchQueryEntit
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3628")
 	public void graphName_null() {
-		assertThatThrownBy( () -> OrmUtils.withinSession( sessionFactory(), session -> {
-			Search.session( session ).search( model.getIndexedClass() )
-					.where( f -> f.matchAll() )
-					.loading( o -> o.graph( (String) null, GraphSemantic.FETCH ) )
-					.toQuery();
-		} ) )
+		assertThatThrownBy( () -> OrmUtils.with( sessionFactory() ).runNoTransaction( session ->
+				Search.session( session ).search( model.getIndexedClass() )
+						.where( f -> f.matchAll() )
+						.loading( o -> o.graph( (String) null, GraphSemantic.FETCH ) )
+						.toQuery()
+		) )
 				.isInstanceOf( IllegalArgumentException.class )
 				.hasMessageContaining( "'graphName' must not be null" );
 	}
@@ -172,12 +172,12 @@ public class SearchQueryEntityLoadingGraphIT<T> extends AbstractSearchQueryEntit
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3628")
 	public void graphName_invalid() {
-		assertThatThrownBy( () -> OrmUtils.withinSession( sessionFactory(), session -> {
-			Search.session( session ).search( model.getIndexedClass() )
-					.where( f -> f.matchAll() )
-					.loading( o -> o.graph( "invalidGraphName", GraphSemantic.FETCH ) )
-					.toQuery();
-		} ) )
+		assertThatThrownBy( () -> OrmUtils.with( sessionFactory() ).runNoTransaction( session ->
+				Search.session( session ).search( model.getIndexedClass() )
+						.where( f -> f.matchAll() )
+						.loading( o -> o.graph( "invalidGraphName", GraphSemantic.FETCH ) )
+						.toQuery()
+		) )
 				.isInstanceOf( IllegalArgumentException.class )
 				.hasMessageContainingAll( "Could not locate EntityGraph with given name", "invalidGraphName" );
 	}
@@ -185,12 +185,12 @@ public class SearchQueryEntityLoadingGraphIT<T> extends AbstractSearchQueryEntit
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3628")
 	public void graphName_graphSemantic_null() {
-		assertThatThrownBy( () -> OrmUtils.withinSession( sessionFactory(), session -> {
-			Search.session( session ).search( model.getIndexedClass() )
-					.where( f -> f.matchAll() )
-					.loading( o -> o.graph( model.getEagerGraphName(), null ) )
-					.toQuery();
-		} ) )
+		assertThatThrownBy( () -> OrmUtils.with( sessionFactory() ).runNoTransaction( session ->
+				Search.session( session ).search( model.getIndexedClass() )
+						.where( f -> f.matchAll() )
+						.loading( o -> o.graph( model.getEagerGraphName(), null ) )
+						.toQuery()
+		) )
 				.isInstanceOf( IllegalArgumentException.class )
 				.hasMessageContaining( "'semantic' must not be null" );
 	}
@@ -198,12 +198,12 @@ public class SearchQueryEntityLoadingGraphIT<T> extends AbstractSearchQueryEntit
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3628")
 	public void graph_null() {
-		assertThatThrownBy( () -> OrmUtils.withinSession( sessionFactory(), session -> {
-			Search.session( session ).search( model.getIndexedClass() )
-					.where( f -> f.matchAll() )
-					.loading( o -> o.graph( (RootGraph<?>) null, GraphSemantic.FETCH ) )
-					.toQuery();
-		} ) )
+		assertThatThrownBy( () -> OrmUtils.with( sessionFactory() ).runNoTransaction( session ->
+				Search.session( session ).search( model.getIndexedClass() )
+						.where( f -> f.matchAll() )
+						.loading( o -> o.graph( (RootGraph<?>) null, GraphSemantic.FETCH ) )
+						.toQuery()
+		) )
 				.isInstanceOf( IllegalArgumentException.class )
 				.hasMessageContaining( "'graph' must not be null" );
 	}
@@ -211,12 +211,12 @@ public class SearchQueryEntityLoadingGraphIT<T> extends AbstractSearchQueryEntit
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3628")
 	public void graph_graphSemantic_null() {
-		assertThatThrownBy( () -> OrmUtils.withinSession( sessionFactory(), session -> {
-			Search.session( session ).search( model.getIndexedClass() )
-					.where( f -> f.matchAll() )
-					.loading( o -> o.graph( session.getEntityGraph( model.getEagerGraphName() ), null ) )
-					.toQuery();
-		} ) )
+		assertThatThrownBy( () -> OrmUtils.with( sessionFactory() ).runNoTransaction( session ->
+				Search.session( session ).search( model.getIndexedClass() )
+						.where( f -> f.matchAll() )
+						.loading( o -> o.graph( session.getEntityGraph( model.getEagerGraphName() ), null ) )
+						.toQuery()
+		) )
 				.isInstanceOf( IllegalArgumentException.class )
 				.hasMessageContaining( "'semantic' must not be null" );
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingNonUniqueDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingNonUniqueDocumentIdIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.search.loading;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -20,7 +21,6 @@ import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.common.rule.StubSearchWorkBehavior;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.StubBackendUtils;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -45,7 +45,7 @@ public class SearchQueryEntityLoadingNonUniqueDocumentIdIT {
 
 	@Test
 	public void nonUniqueDocumentId() {
-		backendMock.inLenientMode( () -> OrmUtils.withinTransaction( sessionFactory, session -> {
+		backendMock.inLenientMode( () -> withinTransaction( sessionFactory, session -> {
 			for ( long i = 0; i < 2; i++ ) {
 				IndexedEntity entity = new IndexedEntity();
 				entity.setId( i );
@@ -54,7 +54,7 @@ public class SearchQueryEntityLoadingNonUniqueDocumentIdIT {
 			}
 		} ) );
 
-		assertThatThrownBy( () -> OrmUtils.withinTransaction( sessionFactory, session -> {
+		assertThatThrownBy( () -> withinTransaction( sessionFactory, session -> {
 			backendMock.expectSearchObjects( IndexedEntity.NAME,
 					StubSearchWorkBehavior.of( 1, StubBackendUtils.reference( IndexedEntity.NAME, "0" ) ) );
 			Search.session( session ).search( IndexedEntity.class )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingNonUniqueDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingNonUniqueDocumentIdIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.search.loading;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -45,7 +45,7 @@ public class SearchQueryEntityLoadingNonUniqueDocumentIdIT {
 
 	@Test
 	public void nonUniqueDocumentId() {
-		backendMock.inLenientMode( () -> withinTransaction( sessionFactory, session -> {
+		backendMock.inLenientMode( () -> with( sessionFactory ).runInTransaction( session -> {
 			for ( long i = 0; i < 2; i++ ) {
 				IndexedEntity entity = new IndexedEntity();
 				entity.setId( i );
@@ -54,7 +54,7 @@ public class SearchQueryEntityLoadingNonUniqueDocumentIdIT {
 			}
 		} ) );
 
-		assertThatThrownBy( () -> withinTransaction( sessionFactory, session -> {
+		assertThatThrownBy( () -> with( sessionFactory ).runInTransaction( session -> {
 			backendMock.expectSearchObjects( IndexedEntity.NAME,
 					StubSearchWorkBehavior.of( 1, StubBackendUtils.reference( IndexedEntity.NAME, "0" ) ) );
 			Search.session( session ).search( IndexedEntity.class )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/spi/DifferentSessionFactoriesIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/spi/DifferentSessionFactoriesIT.java
@@ -57,9 +57,9 @@ public class DifferentSessionFactoriesIT {
 						.getServiceRegistry().getService( HibernateSearchContextProviderService.class );
 
 		// try to use an entityManager owned by the original session factory instead
-		assertThatThrownBy( () -> OrmUtils.withinSession( sessionFactory, session -> {
-			HibernateOrmSearchSession.get( contextProvider.get(), (SessionImplementor) session );
-		} ) )
+		assertThatThrownBy( () -> OrmUtils.with( sessionFactory ).runNoTransaction( session ->
+				HibernateOrmSearchSession.get( contextProvider.get(), (SessionImplementor) session )
+		) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContaining(
 						"Unable to create a SearchSession for sessions created using a different session factory."

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/spi/DifferentSessionFactoriesIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/spi/DifferentSessionFactoriesIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.spi;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import javax.persistence.Entity;
 import javax.persistence.EntityManager;
@@ -21,7 +22,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -57,7 +57,7 @@ public class DifferentSessionFactoriesIT {
 						.getServiceRegistry().getService( HibernateSearchContextProviderService.class );
 
 		// try to use an entityManager owned by the original session factory instead
-		assertThatThrownBy( () -> OrmUtils.with( sessionFactory ).runNoTransaction( session ->
+		assertThatThrownBy( () -> with( sessionFactory ).runNoTransaction( session ->
 				HibernateOrmSearchSession.get( contextProvider.get(), (SessionImplementor) session )
 		) )
 				.isInstanceOf( SearchException.class )

--- a/integrationtest/mapper/orm/src/test/java17/org/hibernate/search/integrationtest/mapper/orm/model/IndexedEmbeddedRecordIT.java
+++ b/integrationtest/mapper/orm/src/test/java17/org/hibernate/search/integrationtest/mapper/orm/model/IndexedEmbeddedRecordIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.model;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.List;
 import javax.persistence.ElementCollection;
@@ -63,7 +63,7 @@ public class IndexedEmbeddedRecordIT {
 
 	@Test
 	public void index() {
-		withinTransaction( sessionFactory, session -> {
+		with( sessionFactory ).runInTransaction( session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.id = 1;
 			MyRecord myRecord = new MyRecord( "someText", 42, List.of( "someText2", "someText3" ) );

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/backend/SyncBackendLongWorkListStressTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/backend/SyncBackendLongWorkListStressTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.test.backend;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.countAll;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Map;
@@ -19,7 +20,6 @@ import org.hibernate.search.mapper.orm.automaticindexing.session.AutomaticIndexi
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.mapper.orm.schema.management.SchemaManagementStrategyName;
 import org.hibernate.search.test.SearchTestBase;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Test;
 
@@ -44,7 +44,7 @@ public class SyncBackendLongWorkListStressTest extends SearchTestBase {
 
 		Transaction tx = s.beginTransaction();
 		// count of entities in database needs to be checked before SF is closed (HSQLDB will forget the entities)
-		Number count = OrmUtils.countAll( s, Clock.class );
+		Number count = countAll( s, Clock.class );
 		assertEquals( NUM_SAVED_ENTITIES, count.intValue() );
 		tx.commit();
 		s.close();

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/batchindexing/CollectionInitializeTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/batchindexing/CollectionInitializeTest.java
@@ -7,6 +7,7 @@
 
 package org.hibernate.search.test.batchindexing;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.listAll;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
@@ -15,7 +16,6 @@ import org.hibernate.Transaction;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.test.SearchTestBase;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Test;
 
@@ -31,7 +31,7 @@ public class CollectionInitializeTest extends SearchTestBase {
 		FullTextSession fullTextSession = Search.getFullTextSession( openSession() );
 		initializeData( fullTextSession );
 		try {
-			List list = OrmUtils.listAll( fullTextSession, LegacyCarPlant.class );
+			List list = listAll( fullTextSession, LegacyCarPlant.class );
 			assertEquals( 1, list.size() );
 			fullTextSession.createIndexer( LegacyCarPlant.class ).startAndWait();
 			int resultSize = fullTextSession.createFullTextQuery( new MatchAllDocsQuery(), LegacyCarPlant.class ).getResultSize();

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/batchindexing/DatabaseMultitenancyTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/batchindexing/DatabaseMultitenancyTest.java
@@ -7,12 +7,12 @@
 package org.hibernate.search.test.batchindexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.listAll;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.lucene.search.Query;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.search.FullTextSession;
@@ -20,12 +20,13 @@ import org.hibernate.search.Search;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.util.common.impl.CollectionHelper;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.hibernate.testing.RequiresDialect;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import org.apache.lucene.search.Query;
 
 /**
  * This is a test class to check that search can be used with ORM in multi-tenancy.
@@ -234,7 +235,7 @@ public class DatabaseMultitenancyTest extends SearchTestBase {
 
 	private void deleteClocks(Session session) {
 		session.beginTransaction();
-		List<Clock> clocks = OrmUtils.listAll( session, Clock.class );
+		List<Clock> clocks = listAll( session, Clock.class );
 		for ( Clock clock : clocks ) {
 			session.delete( clock );
 		}

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/batchindexing/IndexingGeneratedCorpusTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/batchindexing/IndexingGeneratedCorpusTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.test.batchindexing;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.countAll;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -26,7 +27,6 @@ import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
 import org.hibernate.search.engine.cfg.BackendSettings;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
 import org.hibernate.search.testsupport.textbuilder.SentenceInventor;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
@@ -232,7 +232,7 @@ public class IndexingGeneratedCorpusTest {
 		try {
 			Transaction tx = session.beginTransaction();
 			try {
-				Number countAsNumber = OrmUtils.countAll( session, type );
+				Number countAsNumber = countAll( session, type );
 				return countAsNumber.longValue();
 			}
 			finally {

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/nested/containedIn/LazyM2OContainedInTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/nested/containedIn/LazyM2OContainedInTest.java
@@ -7,23 +7,24 @@
 
 package org.hibernate.search.test.embedded.nested.containedIn;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.listAll;
+import static org.junit.Assert.assertEquals;
+
 import java.util.Map;
 
-import org.apache.lucene.document.LongPoint;
-import org.apache.lucene.index.Term;
-import org.apache.lucene.search.TermQuery;
 import org.hibernate.Transaction;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.TestForIssue;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.hibernate.testing.cache.CachingRegionFactory;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.TermQuery;
 
 /**
  * @author Emmanuel Bernard
@@ -69,10 +70,10 @@ public class LazyM2OContainedInTest extends SearchTestBase {
 		tx.commit();
 
 		tx = fts.beginTransaction();
-		for ( Entity2ForDoc0 e : OrmUtils.listAll( fts, Entity2ForDoc0.class ) ) {
+		for ( Entity2ForDoc0 e : listAll( fts, Entity2ForDoc0.class ) ) {
 			fts.delete( e );
 		}
-		for ( Entity1ForDoc0 e : OrmUtils.listAll( fts, Entity1ForDoc0.class ) ) {
+		for ( Entity1ForDoc0 e : listAll( fts, Entity1ForDoc0.class ) ) {
 			fts.delete( e );
 		}
 		tx.commit();
@@ -134,10 +135,10 @@ public class LazyM2OContainedInTest extends SearchTestBase {
 				fts.createFullTextQuery( new TermQuery( new Term( "entity1.uid", String.valueOf( otherId ) ) ), Entity2ForUnindexed.class ).getResultSize() );
 
 		tx = fts.beginTransaction();
-		for ( Entity2ForUnindexed e : OrmUtils.listAll( fts, Entity2ForUnindexed.class ) ) {
+		for ( Entity2ForUnindexed e : listAll( fts, Entity2ForUnindexed.class ) ) {
 			fts.delete( e );
 		}
-		for ( Entity1ForUnindexed e : OrmUtils.listAll( fts, Entity1ForUnindexed.class ) ) {
+		for ( Entity1ForUnindexed e : listAll( fts, Entity1ForUnindexed.class ) ) {
 			fts.delete( e );
 		}
 		tx.commit();

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/PathEmbeddedDepthTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/PathEmbeddedDepthTest.java
@@ -7,6 +7,7 @@
 
 package org.hibernate.search.test.embedded.path;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.listAll;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -19,7 +20,6 @@ import org.hibernate.search.Search;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.After;
 import org.junit.Before;
@@ -155,7 +155,7 @@ public class PathEmbeddedDepthTest extends SearchTestBase {
 	private void deleteAll(Session s, Class<?>... classes) {
 		Transaction tx = s.beginTransaction();
 		for ( Class<?> each : classes ) {
-			List<?> list = OrmUtils.listAll( s, each );
+			List<?> list = listAll( s, each );
 			for ( Object object : list ) {
 				s.delete( object );
 			}

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/defaultdepth/DefaultDepthPathCaseEmbeddedTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/defaultdepth/DefaultDepthPathCaseEmbeddedTest.java
@@ -7,6 +7,7 @@
 
 package org.hibernate.search.test.embedded.path.defaultdepth;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.listAll;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -19,7 +20,6 @@ import org.hibernate.search.Search;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.After;
 import org.junit.Before;
@@ -99,7 +99,7 @@ public class DefaultDepthPathCaseEmbeddedTest extends SearchTestBase {
 	private void deleteAll(Session s, Class<?>... classes) {
 		Transaction tx = s.beginTransaction();
 		for ( Class<?> each : classes ) {
-			List<?> list = OrmUtils.listAll( s, each );
+			List<?> list = listAll( s, each );
 			for ( Object object : list ) {
 				s.delete( object );
 			}

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/depth/PathRespectDepthCaseEmbeddedTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/depth/PathRespectDepthCaseEmbeddedTest.java
@@ -7,6 +7,7 @@
 
 package org.hibernate.search.test.embedded.path.depth;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.listAll;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -19,7 +20,6 @@ import org.hibernate.search.Search;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.After;
 import org.junit.Before;
@@ -108,7 +108,7 @@ public class PathRespectDepthCaseEmbeddedTest extends SearchTestBase {
 	private void deleteAll(Session s, Class<?>... classes) {
 		Transaction tx = s.beginTransaction();
 		for ( Class<?> each : classes ) {
-			List<?> list = OrmUtils.listAll( s, each );
+			List<?> list = listAll( s, each );
 			for ( Object object : list ) {
 				s.delete( object );
 			}

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/multiple/MultiplePathCaseEmbeddedTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/multiple/MultiplePathCaseEmbeddedTest.java
@@ -7,6 +7,7 @@
 
 package org.hibernate.search.test.embedded.path.multiple;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.listAll;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -19,7 +20,6 @@ import org.hibernate.search.Search;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.After;
 import org.junit.Before;
@@ -129,7 +129,7 @@ public class MultiplePathCaseEmbeddedTest extends SearchTestBase {
 	private void deleteAll(Session s, Class<?>... classes) {
 		Transaction tx = s.beginTransaction();
 		for ( Class<?> each : classes ) {
-			List<?> list = OrmUtils.listAll( s, each );
+			List<?> list = listAll( s, each );
 			for ( Object object : list ) {
 				s.delete( object );
 			}

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/prefixed/PrefixedEmbeddedCaseInPathTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/prefixed/PrefixedEmbeddedCaseInPathTest.java
@@ -7,6 +7,7 @@
 
 package org.hibernate.search.test.embedded.path.prefixed;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.listAll;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -19,7 +20,6 @@ import org.hibernate.search.Search;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.After;
 import org.junit.Before;
@@ -109,7 +109,7 @@ public class PrefixedEmbeddedCaseInPathTest extends SearchTestBase {
 	private void deleteAll(Session s, Class<?>... classes) {
 		Transaction tx = s.beginTransaction();
 		for ( Class<?> each : classes ) {
-			List<?> list = OrmUtils.listAll( s, each );
+			List<?> list = listAll( s, each );
 			for ( Object object : list ) {
 				s.delete( object );
 			}

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/renamed/RenamedFieldPathCaseEmbeddedTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/renamed/RenamedFieldPathCaseEmbeddedTest.java
@@ -7,6 +7,7 @@
 
 package org.hibernate.search.test.embedded.path.renamed;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.listAll;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -19,7 +20,6 @@ import org.hibernate.search.Search;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.After;
 import org.junit.Before;
@@ -109,7 +109,7 @@ public class RenamedFieldPathCaseEmbeddedTest extends SearchTestBase {
 	private void deleteAll(Session s, Class<?>... classes) {
 		Transaction tx = s.beginTransaction();
 		for ( Class<?> each : classes ) {
-			List<?> list = OrmUtils.listAll( s, each );
+			List<?> list = listAll( s, each );
 			for ( Object object : list ) {
 				s.delete( object );
 			}

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/simple/SimplePathCaseEmbeddedTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/simple/SimplePathCaseEmbeddedTest.java
@@ -7,6 +7,7 @@
 
 package org.hibernate.search.test.embedded.path.simple;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.listAll;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -19,7 +20,6 @@ import org.hibernate.search.Search;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.After;
 import org.junit.Before;
@@ -99,7 +99,7 @@ public class SimplePathCaseEmbeddedTest extends SearchTestBase {
 	private void deleteAll(Session s, Class<?>... classes) {
 		Transaction tx = s.beginTransaction();
 		for ( Class<?> each : classes ) {
-			List<?> list = OrmUtils.listAll( s, each );
+			List<?> list = listAll( s, each );
 			for ( Object object : list ) {
 				s.delete( object );
 			}

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/engine/LazyCollectionsUpdatingTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/engine/LazyCollectionsUpdatingTest.java
@@ -6,23 +6,24 @@
  */
 package org.hibernate.search.test.engine;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.listAll;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.util.List;
 import java.util.Map;
 
-import org.apache.lucene.index.Term;
-import org.apache.lucene.search.TermQuery;
 import org.hibernate.Transaction;
 import org.hibernate.search.FullTextQuery;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.test.SearchTestBase;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.TermQuery;
 
 /**
  * TestCase for HSEARCH-178 (Search hitting HHH-2763)
@@ -39,7 +40,7 @@ public class LazyCollectionsUpdatingTest extends SearchTestBase {
 		FullTextSession fullTextSession = Search.getFullTextSession( openSession() );
 		try {
 			Transaction tx = fullTextSession.beginTransaction();
-			List list = OrmUtils.listAll( fullTextSession, BusStop.class );
+			List list = listAll( fullTextSession, BusStop.class );
 			assertNotNull( list );
 			assertEquals( 4, list.size() );
 			BusStop busStop = (BusStop) list.get( 1 );
@@ -57,7 +58,7 @@ public class LazyCollectionsUpdatingTest extends SearchTestBase {
 		assertFindsByRoadName( "buonarroti" );
 		FullTextSession fullTextSession = Search.getFullTextSession( openSession() );
 		try {
-			List list = OrmUtils.listAll( fullTextSession, BusStop.class );
+			List list = listAll( fullTextSession, BusStop.class );
 			assertNotNull( list );
 			assertEquals( 4, list.size() );
 			BusStop busStop = (BusStop) list.get( 1 );

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/engine/RollbackTransactionTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/engine/RollbackTransactionTest.java
@@ -6,17 +6,18 @@
  */
 package org.hibernate.search.test.engine;
 
-import org.apache.lucene.search.MatchAllDocsQuery;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.listAll;
+import static org.junit.Assert.assertEquals;
+
 import org.hibernate.Transaction;
 import org.hibernate.search.FullTextQuery;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.test.SearchTestBase;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import org.apache.lucene.search.MatchAllDocsQuery;
 
 /**
  * Verify index changes queued during a transaction are canceled
@@ -75,7 +76,7 @@ public class RollbackTransactionTest extends SearchTestBase {
 	public int countBusLineByDatabaseCount() {
 		FullTextSession fullTextSession = Search.getFullTextSession( openSession() );
 		Transaction tx = fullTextSession.beginTransaction();
-		int count = OrmUtils.listAll( fullTextSession, BusLine.class ).size();
+		int count = listAll( fullTextSession, BusLine.class ).size();
 		tx.commit();
 		fullTextSession.close();
 		return count;

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/query/QueryLoaderTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/query/QueryLoaderTest.java
@@ -6,24 +6,23 @@
  */
 package org.hibernate.search.test.query;
 
-import java.util.List;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.listAll;
+import static org.junit.Assert.assertEquals;
 
-import org.apache.lucene.queryparser.classic.QueryParser;
-import org.apache.lucene.search.Query;
+import java.util.List;
 
 import org.hibernate.Session;
 import org.hibernate.Transaction;
-
 import org.hibernate.search.FullTextQuery;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.TestConstants;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.Query;
 
 /**
  * @author Emmanuel Bernard
@@ -92,7 +91,7 @@ public class QueryLoaderTest extends SearchTestBase {
 		music.getAuthors().clear();
 		music2.getAuthors().clear();
 
-		for ( Object o : OrmUtils.listAll( s, Object.class ) ) {
+		for ( Object o : listAll( s, Object.class ) ) {
 			s.delete( o );
 		}
 

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/query/initandlookup/SecondLCAndPCLookupTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/query/initandlookup/SecondLCAndPCLookupTest.java
@@ -7,12 +7,11 @@
 package org.hibernate.search.test.query.initandlookup;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.listAll;
 
 import java.util.List;
 import java.util.Map;
 
-import org.apache.lucene.search.MatchAllDocsQuery;
-import org.apache.lucene.search.Query;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.cfg.Environment;
@@ -23,12 +22,15 @@ import org.hibernate.search.query.DatabaseRetrievalMethod;
 import org.hibernate.search.query.ObjectLookupMethod;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.test.SearchTestBase;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.StaticIndexingSwitch;
 import org.hibernate.stat.Statistics;
+
 import org.hibernate.testing.cache.CachingRegionFactory;
 import org.junit.Rule;
 import org.junit.Test;
+
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
 
 /**
  * Test second level cache and persistence context lookup methods
@@ -187,7 +189,7 @@ public class SecondLCAndPCLookupTest extends SearchTestBase {
 
 		indexingSwitch.enable( false ); // disable processing of index updates
 		Transaction tx = session.beginTransaction();
-		List list = OrmUtils.listAll( session, Kernel.class );
+		List list = listAll( session, Kernel.class );
 		assertThat( list ).hasSize( 2 );
 		session.delete( list.get( 0 ) );
 		tx.commit();

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/query/initandlookup/StrictSecondLCAndPCLookupTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/query/initandlookup/StrictSecondLCAndPCLookupTest.java
@@ -6,10 +6,12 @@
  */
 package org.hibernate.search.test.query.initandlookup;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.listAll;
+
 import java.util.List;
 import java.util.Map;
 
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.cfg.Environment;
@@ -19,14 +21,14 @@ import org.hibernate.search.Search;
 import org.hibernate.search.query.DatabaseRetrievalMethod;
 import org.hibernate.search.query.ObjectLookupMethod;
 import org.hibernate.search.test.SearchTestBase;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.StaticIndexingSwitch;
 import org.hibernate.stat.Statistics;
+
 import org.hibernate.testing.cache.CachingRegionFactory;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.apache.lucene.search.MatchAllDocsQuery;
 
 /**
  * Test second level cache and persistence context lookup methods
@@ -48,7 +50,7 @@ public class StrictSecondLCAndPCLookupTest extends SearchTestBase {
 
 		indexingSwitch.enable( false ); // disable processing of index updates
 		Transaction tx = session.beginTransaction();
-		List list = OrmUtils.listAll( session, StrictKernel.class );
+		List list = listAll( session, StrictKernel.class );
 		assertThat( list ).hasSize( 2 );
 		session.delete( list.get( 0 ) );
 		tx.commit();

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/session/MassIndexTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/session/MassIndexTest.java
@@ -6,16 +6,15 @@
  */
 package org.hibernate.search.test.session;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.listAll;
+import static org.junit.Assert.assertEquals;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.lucene.index.Term;
-import org.apache.lucene.queryparser.classic.QueryParser;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermQuery;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.jdbc.Work;
@@ -23,11 +22,13 @@ import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.TestConstants;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 
 /**
  * @author Emmanuel Bernard
@@ -87,7 +88,7 @@ public class MassIndexTest extends SearchTestBase {
 		parser = new QueryParser( "noDefaultField", TestConstants.stopAnalyzer );
 		result = s.createFullTextQuery( parser.parse( "body:write" ) ).list();
 		assertEquals( 0, result.size() );
-		result = OrmUtils.listAll( s, Email.class );
+		result = listAll( s, Email.class );
 		for ( int i = 0; i < loop / 2; i++ ) {
 			s.index( result.get( i ) );
 		}

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/session/MassIndexUsingManualFlushTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/session/MassIndexUsingManualFlushTest.java
@@ -6,12 +6,14 @@
  */
 package org.hibernate.search.test.session;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.queryAll;
+import static org.junit.Assert.assertEquals;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 
-import org.apache.lucene.queryparser.classic.QueryParser;
 import org.hibernate.ScrollMode;
 import org.hibernate.ScrollableResults;
 import org.hibernate.Transaction;
@@ -20,11 +22,10 @@ import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.TestConstants;
-import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import org.apache.lucene.queryparser.classic.QueryParser;
 
 /**
  * @author Emmanuel Bernard
@@ -55,7 +56,7 @@ public class MassIndexUsingManualFlushTest extends SearchTestBase {
 		//check non created object does get found!!1
 		s = Search.getFullTextSession( openSession() );
 		tx = s.beginTransaction();
-		ScrollableResults results = OrmUtils.queryAll( s, Email.class ).scroll( ScrollMode.FORWARD_ONLY );
+		ScrollableResults results = queryAll( s, Email.class ).scroll( ScrollMode.FORWARD_ONLY );
 		int index = 0;
 		while ( results.next() ) {
 			index++;

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/JPAPersistenceRunner.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/JPAPersistenceRunner.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.util.impl.integrationtest.mapper.orm;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.EntityTransaction;
@@ -37,7 +39,7 @@ class JPAPersistenceRunner implements PersistenceRunner<EntityManager, EntityTra
 	@Override
 	public <R, E extends Throwable> R applyInTransaction(ThrowingBiFunction<? super EntityManager, ? super EntityTransaction, R, E> action) throws E {
 		return applyNoTransaction( entityManager ->
-				OrmUtils.withinJPATransaction( entityManager, tx -> action.apply( entityManager, tx ) )
+				withinJPATransaction( entityManager, tx -> action.apply( entityManager, tx ) )
 		);
 	}
 }

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/JPAPersistenceRunner.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/JPAPersistenceRunner.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.util.impl.integrationtest.mapper.orm;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinJPATransaction;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.applyInJPATransaction;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -39,7 +39,7 @@ class JPAPersistenceRunner implements PersistenceRunner<EntityManager, EntityTra
 	@Override
 	public <R, E extends Throwable> R applyInTransaction(ThrowingBiFunction<? super EntityManager, ? super EntityTransaction, R, E> action) throws E {
 		return applyNoTransaction( entityManager ->
-				withinJPATransaction( entityManager, tx -> action.apply( entityManager, tx ) )
+				applyInJPATransaction( entityManager, tx -> action.apply( entityManager, tx ) )
 		);
 	}
 }

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/NativePersistenceRunner.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/NativePersistenceRunner.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.util.impl.integrationtest.mapper.orm;
 
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
@@ -38,7 +40,7 @@ class NativePersistenceRunner implements PersistenceRunner<Session, Transaction>
 	@Override
 	public <R, E extends Throwable> R applyInTransaction(ThrowingBiFunction<? super Session, ? super Transaction, R, E> action) throws E {
 		return applyNoTransaction( session ->
-				OrmUtils.withinTransaction( session, tx -> {
+				withinTransaction( session, tx -> {
 					return action.apply( session, tx );
 				} )
 		);

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/NativePersistenceRunner.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/NativePersistenceRunner.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.search.util.impl.integrationtest.mapper.orm;
 
-import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
-
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
@@ -40,9 +38,11 @@ class NativePersistenceRunner implements PersistenceRunner<Session, Transaction>
 	@Override
 	public <R, E extends Throwable> R applyInTransaction(ThrowingBiFunction<? super Session, ? super Transaction, R, E> action) throws E {
 		return applyNoTransaction( session ->
-				withinTransaction( session, tx -> {
+				//CHECKSTYLE:OFF: RegexpSinglelineJava - cannot use static import as that would clash with method of this class
+				OrmUtils.applyInTransaction( session, tx -> {
 					return action.apply( session, tx );
 				} )
+				//CHECKSTYLE:ON
 		);
 	}
 }

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmUtils.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmUtils.java
@@ -35,10 +35,6 @@ public final class OrmUtils {
 		return new NativePersistenceRunner( sessionFactory, tenantId );
 	}
 
-	public static void withinSession(SessionFactory sessionFactory, Consumer<? super Session> action) {
-		with( sessionFactory ).runNoTransaction( action );
-	}
-
 	public static void withinTransaction(SessionFactory sessionFactory, Consumer<Session> action) {
 		with( sessionFactory ).runInTransaction( action );
 	}

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmUtils.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmUtils.java
@@ -43,10 +43,6 @@ public final class OrmUtils {
 		with( sessionFactory, tenantId ).runInTransaction( action );
 	}
 
-	public static <E extends Throwable> void withinJPATransaction(EntityManagerFactory entityManagerFactory, ThrowingConsumer<EntityManager, E> action) throws E {
-		with( entityManagerFactory ).runInTransaction( action );
-	}
-
 	public static <E extends Throwable> void withinTransaction(Session session, ThrowingConsumer<Transaction, E> action) throws E {
 		withinTransaction( session, tx -> {
 			action.accept( tx );

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmUtils.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmUtils.java
@@ -35,14 +35,14 @@ public final class OrmUtils {
 		return new NativePersistenceRunner( sessionFactory, tenantId );
 	}
 
-	public static <E extends Throwable> void withinTransaction(Session session, ThrowingConsumer<Transaction, E> action) throws E {
-		withinTransaction( session, tx -> {
+	public static <E extends Throwable> void runInTransaction(Session session, ThrowingConsumer<Transaction, E> action) throws E {
+		applyInTransaction( session, tx -> {
 			action.accept( tx );
 			return null;
 		} );
 	}
 
-	public static <R, E extends Throwable> R withinTransaction(Session session, ThrowingFunction<Transaction, R, E> action) throws E {
+	public static <R, E extends Throwable> R applyInTransaction(Session session, ThrowingFunction<Transaction, R, E> action) throws E {
 		Transaction tx = null;
 		try {
 			tx = session.beginTransaction();
@@ -77,7 +77,7 @@ public final class OrmUtils {
 		}
 	}
 
-	public static <R, E extends Throwable> R withinJPATransaction(EntityManager entityManager, ThrowingFunction<EntityTransaction, R, E> action) throws E {
+	public static <R, E extends Throwable> R applyInJPATransaction(EntityManager entityManager, ThrowingFunction<EntityTransaction, R, E> action) throws E {
 		EntityTransaction tx = null;
 		try {
 			tx = entityManager.getTransaction();

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmUtils.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmUtils.java
@@ -39,10 +39,6 @@ public final class OrmUtils {
 		with( sessionFactory ).runNoTransaction( action );
 	}
 
-	public static void withinEntityManager(EntityManagerFactory entityManagerFactory, Consumer<EntityManager> action) {
-		with( entityManagerFactory ).runNoTransaction( action );
-	}
-
 	public static void withinTransaction(SessionFactory sessionFactory, Consumer<Session> action) {
 		with( sessionFactory ).runInTransaction( action );
 	}

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmUtils.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmUtils.java
@@ -7,8 +7,6 @@
 package org.hibernate.search.util.impl.integrationtest.mapper.orm;
 
 import java.util.List;
-import java.util.function.Consumer;
-import java.util.function.Function;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.EntityTransaction;
@@ -17,6 +15,8 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.hibernate.query.Query;
+import org.hibernate.search.util.impl.test.function.ThrowingConsumer;
+import org.hibernate.search.util.impl.test.function.ThrowingFunction;
 
 public final class OrmUtils {
 
@@ -35,26 +35,26 @@ public final class OrmUtils {
 		return new NativePersistenceRunner( sessionFactory, tenantId );
 	}
 
-	public static void withinTransaction(SessionFactory sessionFactory, Consumer<Session> action) {
+	public static <E extends Throwable> void withinTransaction(SessionFactory sessionFactory, ThrowingConsumer<Session, E> action) throws E {
 		with( sessionFactory ).runInTransaction( action );
 	}
 
-	public static void withinTransaction(SessionFactory sessionFactory, String tenantId, Consumer<Session> action) {
+	public static <E extends Throwable> void withinTransaction(SessionFactory sessionFactory, String tenantId, ThrowingConsumer<Session, E> action) throws E {
 		with( sessionFactory, tenantId ).runInTransaction( action );
 	}
 
-	public static void withinJPATransaction(EntityManagerFactory entityManagerFactory, Consumer<EntityManager> action) {
+	public static <E extends Throwable> void withinJPATransaction(EntityManagerFactory entityManagerFactory, ThrowingConsumer<EntityManager, E> action) throws E {
 		with( entityManagerFactory ).runInTransaction( action );
 	}
 
-	public static void withinTransaction(Session session, Consumer<Transaction> action) {
+	public static <E extends Throwable> void withinTransaction(Session session, ThrowingConsumer<Transaction, E> action) throws E {
 		withinTransaction( session, tx -> {
 			action.accept( tx );
 			return null;
 		} );
 	}
 
-	public static <R> R withinTransaction(Session session, Function<Transaction, R> action) {
+	public static <R, E extends Throwable> R withinTransaction(Session session, ThrowingFunction<Transaction, R, E> action) throws E {
 		Transaction tx = null;
 		try {
 			tx = session.beginTransaction();
@@ -89,7 +89,7 @@ public final class OrmUtils {
 		}
 	}
 
-	public static <R> R withinJPATransaction(EntityManager entityManager, Function<EntityTransaction, R> action) {
+	public static <R, E extends Throwable> R withinJPATransaction(EntityManager entityManager, ThrowingFunction<EntityTransaction, R, E> action) throws E {
 		EntityTransaction tx = null;
 		try {
 			tx = entityManager.getTransaction();

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmUtils.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmUtils.java
@@ -35,14 +35,6 @@ public final class OrmUtils {
 		return new NativePersistenceRunner( sessionFactory, tenantId );
 	}
 
-	public static <E extends Throwable> void withinTransaction(SessionFactory sessionFactory, ThrowingConsumer<Session, E> action) throws E {
-		with( sessionFactory ).runInTransaction( action );
-	}
-
-	public static <E extends Throwable> void withinTransaction(SessionFactory sessionFactory, String tenantId, ThrowingConsumer<Session, E> action) throws E {
-		with( sessionFactory, tenantId ).runInTransaction( action );
-	}
-
 	public static <E extends Throwable> void withinTransaction(Session session, ThrowingConsumer<Transaction, E> action) throws E {
 		withinTransaction( session, tx -> {
 			action.accept( tx );

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/PersistenceRunner.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/PersistenceRunner.java
@@ -6,12 +6,13 @@
  */
 package org.hibernate.search.util.impl.integrationtest.mapper.orm;
 
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
-import java.util.function.Function;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityTransaction;
+
+import org.hibernate.search.util.impl.test.function.ThrowingBiConsumer;
+import org.hibernate.search.util.impl.test.function.ThrowingBiFunction;
+import org.hibernate.search.util.impl.test.function.ThrowingConsumer;
+import org.hibernate.search.util.impl.test.function.ThrowingFunction;
 
 /**
  * An easy way to run code in the context of an {@link EntityManager}/{@link org.hibernate.Session}
@@ -22,29 +23,29 @@ import javax.persistence.EntityTransaction;
  */
 public interface PersistenceRunner<C, T> {
 
-	<R> R applyNoTransaction(Function<? super C, R> action);
+	<R, E extends Throwable> R applyNoTransaction(ThrowingFunction<? super C, R, E> action) throws E;
 
-	default void runNoTransaction(Consumer<? super C> action) {
+	default <E extends Throwable> void runNoTransaction(ThrowingConsumer<? super C, E> action) throws E {
 		applyNoTransaction( c -> {
 			action.accept( c );
 			return null;
 		} );
 	}
 
-	default <R> R applyInTransaction(Function<? super C, R> action) {
+	default <R, E extends Throwable> R applyInTransaction(ThrowingFunction<? super C, R, E> action) throws E {
 		return applyInTransaction( (c, t) -> action.apply( c ) );
 	}
 
-	<R> R applyInTransaction(BiFunction<? super C, ? super T, R> action);
+	<R, E extends Throwable> R applyInTransaction(ThrowingBiFunction<? super C, ? super T, R, E> action) throws E;
 
-	default void runInTransaction(Consumer<? super C> action) {
+	default <E extends Throwable> void runInTransaction(ThrowingConsumer<? super C, E> action) throws E {
 		applyInTransaction( c -> {
 			action.accept( c );
 			return null;
 		} );
 	}
 
-	default void runInTransaction(BiConsumer<? super C, T> action) {
+	default <E extends Throwable> void runInTransaction(ThrowingBiConsumer<? super C, T, E> action) throws E {
 		applyInTransaction( (c, t) -> {
 			action.accept( c, t );
 			return null;

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/ReusableOrmSetupHolder.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/ReusableOrmSetupHolder.java
@@ -21,7 +21,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.criteria.CriteriaBuilder;
@@ -98,7 +100,7 @@ import org.jboss.logging.Logger;
  * 	}
  * }</pre>
  */
-public class ReusableOrmSetupHolder implements TestRule {
+public class ReusableOrmSetupHolder implements TestRule, PersistenceRunner<Session, Transaction> {
 	private static final Logger log = Logger.getLogger( ReusableOrmSetupHolder.class.getName() );
 
 	/**
@@ -226,12 +228,22 @@ public class ReusableOrmSetupHolder implements TestRule {
 		return sessionFactory;
 	}
 
-	public PersistenceRunner<Session, Transaction> with() {
+	private PersistenceRunner<Session, Transaction> with() {
 		return OrmUtils.with( sessionFactory() );
 	}
 
 	public PersistenceRunner<Session, Transaction> with(String tenantId) {
 		return OrmUtils.with( sessionFactory(), tenantId );
+	}
+
+	@Override
+	public <R> R applyNoTransaction(Function<? super Session, R> action) {
+		return with().applyNoTransaction( action );
+	}
+
+	@Override
+	public <R> R applyInTransaction(BiFunction<? super Session, ? super Transaction, R> action) {
+		return with().applyInTransaction( action );
 	}
 
 	public void runInTransaction(Consumer<? super Session> action) {

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/ReusableOrmSetupHolder.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/ReusableOrmSetupHolder.java
@@ -230,11 +230,15 @@ public class ReusableOrmSetupHolder implements TestRule, PersistenceRunner<Sessi
 	}
 
 	private PersistenceRunner<Session, Transaction> with() {
+		//CHECKSTYLE:OFF: RegexpSinglelineJava - cannot use static import as that would clash with method of this class
 		return OrmUtils.with( sessionFactory() );
+		////CHECKSTYLE:ON
 	}
 
 	public PersistenceRunner<Session, Transaction> with(String tenantId) {
+		//CHECKSTYLE:OFF: RegexpSinglelineJava - cannot use static import as that would clash with method of this class
 		return OrmUtils.with( sessionFactory(), tenantId );
+		//CHECKSTYLE:ON
 	}
 
 	@Override
@@ -432,7 +436,9 @@ public class ReusableOrmSetupHolder implements TestRule, PersistenceRunner<Sessi
 			if ( mapping != null ) {
 				mapping.listenerEnabled( false );
 			}
+			//CHECKSTYLE:OFF: RegexpSinglelineJava - cannot use static import as that would clash with method of this class
 			OrmUtils.with( sessionFactory, tenantId ).runInTransaction( preClear );
+			//CHECKSTYLE:ON
 			if ( mapping != null ) {
 				mapping.listenerEnabled( true );
 			}
@@ -486,7 +492,9 @@ public class ReusableOrmSetupHolder implements TestRule, PersistenceRunner<Sessi
 				mapping.listenerEnabled( false );
 			}
 			try {
+				//CHECKSTYLE:OFF: RegexpSinglelineJava - cannot use static import as that would clash with method of this class
 				OrmUtils.with( sessionFactory, tenantId ).runInTransaction( s -> {
+					//CHECKSTYLE:ON
 					Query<?> query = selectAllOfSpecificType( entityType, s );
 					try {
 						query.list().forEach( s::remove );
@@ -504,7 +512,9 @@ public class ReusableOrmSetupHolder implements TestRule, PersistenceRunner<Sessi
 			}
 		}
 		else {
+			//CHECKSTYLE:OFF: RegexpSinglelineJava - cannot use static import as that would clash with method of this class
 			OrmUtils.with( sessionFactory, tenantId ).runInTransaction( s -> {
+				//CHECKSTYLE:ON
 				Query<?> query = deleteAllOfSpecificType( entityType, s );
 				try {
 					query.executeUpdate();

--- a/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/function/ThrowingBiConsumer.java
+++ b/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/function/ThrowingBiConsumer.java
@@ -1,0 +1,12 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.test.function;
+
+@FunctionalInterface
+public interface ThrowingBiConsumer<T, U, E extends Throwable> {
+	void accept(T t, U u) throws E;
+}

--- a/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/function/ThrowingBiFunction.java
+++ b/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/function/ThrowingBiFunction.java
@@ -1,0 +1,12 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.test.function;
+
+@FunctionalInterface
+public interface ThrowingBiFunction<T, U, R, E extends Throwable> {
+	R apply(T t, U u) throws E;
+}

--- a/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/function/ThrowingConsumer.java
+++ b/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/function/ThrowingConsumer.java
@@ -1,0 +1,12 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.test.function;
+
+@FunctionalInterface
+public interface ThrowingConsumer<T, E extends Throwable> {
+	void accept(T t) throws E;
+}

--- a/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/function/ThrowingFunction.java
+++ b/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/function/ThrowingFunction.java
@@ -1,0 +1,12 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.test.function;
+
+@FunctionalInterface
+public interface ThrowingFunction<T, R, E extends Throwable> {
+	R apply(T t) throws E;
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4586

I was also wondering if those `withinTransaction()` methods that are delegating to `with().run...()` methods should go away as well ?