### PR TITLE
HSEARCH-4594 Allow multi-valued bean references for configurers defined in configuration properties

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchIndexSettings.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchIndexSettings.java
@@ -24,12 +24,12 @@ public final class ElasticsearchIndexSettings {
 	/**
 	 * The analysis configurer applied to this index.
 	 * <p>
-	 * Expects a reference to a bean of type {@link ElasticsearchAnalysisConfigurer}.
+	 * Expects a single-valued or multi-valued reference to beans of type {@link ElasticsearchAnalysisConfigurer}.
 	 * <p>
 	 * Defaults to no value.
 	 *
 	 * @see org.hibernate.search.engine.cfg The core documentation of configuration properties,
-	 * which includes a description of the "bean reference" properties and accepted values.
+	 * which includes a description of the "multi-valued bean reference" properties and accepted values.
 	 */
 	public static final String ANALYSIS_CONFIGURER = "analysis.configurer";
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/cfg/LuceneBackendSettings.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/cfg/LuceneBackendSettings.java
@@ -57,24 +57,24 @@ public final class LuceneBackendSettings {
 	/**
 	 * The analysis configurer to use.
 	 * <p>
-	 * Expects a reference to a bean of type {@link LuceneAnalysisConfigurer}.
+	 * Expects a single-valued or multi-valued reference to beans of type {@link LuceneAnalysisConfigurer}.
 	 * <p>
 	 * Defaults to no value.
 	 *
 	 * @see org.hibernate.search.engine.cfg The core documentation of configuration properties,
-	 * which includes a description of the "bean reference" properties and accepted values.
+	 * which includes a description of the "multi-valued bean reference" properties and accepted values.
 	 */
 	public static final String ANALYSIS_CONFIGURER = "analysis.configurer";
 
 	/**
 	 * The query caching configurer to use.
 	 * <p>
-	 * Expects a reference to a bean of type {@link QueryCachingConfigurer}.
+	 * Expects a single-valued or multi-valued reference to beans of type {@link QueryCachingConfigurer}.
 	 * <p>
 	 * Defaults to no value.
 	 *
 	 * @see org.hibernate.search.engine.cfg The core documentation of configuration properties,
-	 * which includes a description of the "bean reference" properties and accepted values.
+	 * which includes a description of the "multi-valued bean reference" properties and accepted values.
 	 */
 	public static final String QUERY_CACHING_CONFIGURER = "query.caching.configurer";
 

--- a/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
+++ b/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
@@ -978,6 +978,8 @@ To configure analysis in an Elasticsearch backend, you will need to:
 to a <<configuration-bean-reference-parsing,bean reference>> pointing to the implementation,
 for example `class:com.mycompany.MyAnalysisConfigurer`.
 
+TIP: You can pass multiple bean references separated by commas. See <<configuration-property-types>>.
+
 Hibernate Search will call the `configure` method of this implementation on startup,
 and the configurer will be able to take advantage of a DSL to define
 <<backend-elasticsearch-analysis-analyzers,analyzers and normalizers>>.

--- a/documentation/src/main/asciidoc/reference/backend-lucene.asciidoc
+++ b/documentation/src/main/asciidoc/reference/backend-lucene.asciidoc
@@ -579,6 +579,8 @@ To configure analysis in a Lucene backend, you will need to:
 to a <<configuration-bean-reference-parsing,bean reference>> pointing to the implementation,
 for example `class:com.mycompany.MyAnalysisConfigurer`.
 
+TIP: You can pass multiple bean references separated by commas. See <<configuration-property-types>>.
+
 Hibernate Search will call the `configure` method of this implementation on startup,
 and the configurer will be able to take advantage of a DSL to define
 <<backend-lucene-analysis-analyzers,analyzers and normalizers>> or even (for more advanced use) the <<backend-lucene-analysis-similarity,similarity>>.
@@ -1173,6 +1175,8 @@ To configure caching in a Lucene backend, you will need to:
 `hibernate.search.backend.query.caching.configurer`
 to a <<configuration-bean-reference-parsing,bean reference>> pointing to the implementation,
 for example `class:com.mycompany.MyQueryCachingConfigurer`.
+
+TIP: You can pass multiple bean references separated by commas. See <<configuration-property-types>>.
 
 Hibernate Search will call the `configure` method of this implementation on startup,
 and the configurer will be able to take advantage of a DSL to define

--- a/documentation/src/main/asciidoc/reference/configuration.asciidoc
+++ b/documentation/src/main/asciidoc/reference/configuration.asciidoc
@@ -118,10 +118,14 @@ Here are the definitions of all property types.
 or a reference by type as a `java.lang.Class`
 (see <<configuration-bean-reference>>)
 |See <<configuration-bean-reference-parsing>>
-|Multivalued bean reference of type T
-|A `java.util.Collection` containing bean references (see above)
-|Comma-separated string containing bean references (see above)
 |===============
+
+When a configuration property of any type above is documented as multivalued,
+that property accepts either:
+
+* A `java.util.Collection` containing any Java object that would be accepted for a single-valued property of the same type (see above);
+* or a comma-separated string containing strings that would be accepted for a single-valued property of the same type (see above);
+* or a single Java object that would be accepted for a single-valued property of the same type (see above).
 
 [[configuration-builder]]
 === Configuration Builders

--- a/documentation/src/main/asciidoc/reference/mapper-orm-mapping-programmatic.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapper-orm-mapping-programmatic.asciidoc
@@ -22,6 +22,8 @@ Implementing a programmatic mapping requires two steps:
 to a <<configuration-bean-reference-parsing,bean reference>> pointing to the implementation,
 for example `class:com.mycompany.MyMappingConfigurer`.
 
+TIP: You can pass multiple bean references separated by commas. See <<configuration-property-types>>.
+
 Hibernate Search will call the `configure` method of this implementation on startup,
 and the configurer will be able to take advantage of a DSL to define
 the programmatic mapping.

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/package-info.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/package-info.java
@@ -35,12 +35,13 @@
  *
  * <h2 id="bean-reference-multi">Multi-valued bean reference</h2>
  *
- * A multi-valued reference to a bean of type {@code T} can be passed as either:
+ * A multivalued reference to a bean of type {@code T} can be passed as either:
  * <ul>
  * <li>A {@link java.util.Collection Collection} containing any
  * <a href="bean-reference">value that is accepted as a bean reference</a></li>
  * <li>or a comma-separated {@link java.lang.String String} containing any
  * <a href="bean-reference">String value that is accepted as a bean reference</a></li>
+ * <li>or any value accepted for a <a href="#bean-reference">single-valued bean reference</a></li>
  * </ul>
  */
 package org.hibernate.search.engine.cfg;

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/spi/ConvertUtils.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/spi/ConvertUtils.java
@@ -10,6 +10,7 @@ import java.lang.invoke.MethodHandles;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -306,7 +307,19 @@ public final class ConvertUtils {
 					.collect( Collectors.toList() );
 		}
 		else {
-			throw log.invalidMultiPropertyValue();
+			T singleElement;
+			try {
+				singleElement = elementConverter.apply( value );
+			}
+			catch (RuntimeException e) {
+				throw log.invalidMultiPropertyValue( e.getMessage(), e );
+			}
+			if ( singleElement == null ) {
+				return Collections.emptyList();
+			}
+			else {
+				return Collections.singletonList( singleElement );
+			}
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
@@ -98,8 +98,9 @@ public interface Log extends BasicLogger {
 	SearchException invalidLongPropertyValue(String nestedErrorMessage, @Cause Exception cause);
 
 	@Message(id = ID_OFFSET + 6,
-			value = "Invalid multi value: expected either a Collection or a String.")
-	SearchException invalidMultiPropertyValue();
+			value = "Invalid multi value: expected either a single value of the correct type, a Collection, or a String,"
+					+ " and interpreting as a single value failed with the following exception. %1$s")
+	SearchException invalidMultiPropertyValue(String nestedErrorMessage, @Cause Exception cause);
 
 	@Message(id = ID_OFFSET + 14,
 			value = "Invalid index field name '%1$s': field names cannot be null or empty.")

--- a/engine/src/test/java/org/hibernate/search/engine/cfg/spi/ConfigurationPropertyInvalidSimpleValuesTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/cfg/spi/ConfigurationPropertyInvalidSimpleValuesTest.java
@@ -258,11 +258,12 @@ public class ConfigurationPropertyInvalidSimpleValuesTest<T> {
 		when( sourceMock.get( key ) ).thenReturn( (Optional) Optional.of( invalidTypeValue ) );
 		when( sourceMock.resolve( key ) ).thenReturn( Optional.of( resolvedKey ) );
 		assertThatThrownBy( () -> property.get( sourceMock ) )
-				.hasMessageContaining(
+				.hasMessageContainingAll(
 						"Invalid value for configuration property '" + resolvedKey
-								+ "': '" + invalidTypeValue + "'."
-				)
-				.hasMessageContaining( "Invalid multi value: expected either a Collection or a String" )
+								+ "': '" + invalidTypeValue + "'.",
+						"Invalid multi value: expected either a single value of the correct type, a Collection, or a String",
+						"interpreting as a single value failed with the following exception",
+						expectedInvalidValueTypeMessagePrefix )
 				.hasCauseInstanceOf( SearchException.class );
 		verifyNoOtherSourceInteractionsAndReset();
 	}

--- a/engine/src/test/java/org/hibernate/search/engine/cfg/spi/ConfigurationPropertyValidSimpleValuesTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/cfg/spi/ConfigurationPropertyValidSimpleValuesTest.java
@@ -192,7 +192,14 @@ public class ConfigurationPropertyValidSimpleValuesTest<T> {
 		assertThat( result ).isNotEmpty();
 		assertThat( result.get() ).containsExactly( expectedValue, expectedValue );
 
-		// Typed value - one
+		// Typed value - one (not wrapped in a collection)
+		when( sourceMock.get( key ) ).thenReturn( (Optional) Optional.of( expectedValue ) );
+		result = property.get( sourceMock );
+		verifyNoOtherSourceInteractionsAndReset();
+		assertThat( result ).isNotEmpty();
+		assertThat( result.get() ).containsExactly( expectedValue );
+
+		// Typed value - one (wrapped in a collection)
 		when( sourceMock.get( key ) ).thenReturn( (Optional) Optional.of( createCollection( expectedValue ) ) );
 		result = property.get( sourceMock );
 		verifyNoOtherSourceInteractionsAndReset();

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/analysis/LuceneAnalysisConfigurerIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/analysis/LuceneAnalysisConfigurerIT.java
@@ -201,6 +201,31 @@ public class LuceneAnalysisConfigurerIT {
 		}
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4594")
+	public void multipleConfigurers() {
+		LuceneBackend backend = setup( MultipleConfigurers1.class.getName() + "," + MultipleConfigurers2.class.getName() );
+
+		assertThat( backend.analyzer( "analyzer1" ) ).isPresent();
+		assertThat( backend.analyzer( "analyzer2" ) ).isPresent();
+	}
+
+	public static class MultipleConfigurers1 implements LuceneAnalysisConfigurer {
+		@Override
+		public void configure(LuceneAnalysisConfigurationContext context) {
+			context.analyzer( "analyzer1" ).custom()
+					.tokenizer( "whitespace" );
+		}
+	}
+
+	public static class MultipleConfigurers2 implements LuceneAnalysisConfigurer {
+		@Override
+		public void configure(LuceneAnalysisConfigurationContext context) {
+			context.analyzer( "analyzer2" ).custom()
+					.tokenizer( "whitespace" );
+		}
+	}
+
 	private LuceneBackend setup(String analysisConfigurer) {
 		return setupHelper.start()
 				.expectCustomBeans()

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/mapping/definition/HibernateOrmSearchMappingConfigurerIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/mapping/definition/HibernateOrmSearchMappingConfigurerIT.java
@@ -1,0 +1,139 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.orm.mapping.definition;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
+import org.hibernate.search.mapper.orm.mapping.HibernateOrmMappingConfigurationContext;
+import org.hibernate.search.mapper.orm.mapping.HibernateOrmSearchMappingConfigurer;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+public class HibernateOrmSearchMappingConfigurerIT {
+
+	@Rule
+	public BackendMock backendMock = new BackendMock();
+
+	@Rule
+	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+
+	@Test
+	public void none() {
+		backendMock.expectSchema( IndexedEntity.INDEX, b -> b
+				.field( "annotationMapped", String.class )
+		);
+
+		ormSetupHelper.start()
+				.setup( IndexedEntity.class );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void single() {
+		backendMock.expectSchema( IndexedEntity.INDEX, b -> b
+				.field( "annotationMapped", String.class )
+				.field( "nonAnnotationMapped1", String.class )
+		);
+
+		ormSetupHelper.start()
+				.withProperty( HibernateOrmMapperSettings.MAPPING_CONFIGURER,
+						MappingConfigurer1.class.getName() )
+				.setup( IndexedEntity.class );
+		backendMock.verifyExpectationsMet();
+	}
+
+	public static class MappingConfigurer1 implements HibernateOrmSearchMappingConfigurer {
+		@Override
+		public void configure(HibernateOrmMappingConfigurationContext context) {
+			context.programmaticMapping().type( IndexedEntity.class )
+					.property( "nonAnnotationMapped1" )
+					.keywordField();
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4594")
+	public void multiple() {
+		backendMock.expectSchema( IndexedEntity.INDEX, b -> b
+				.field( "annotationMapped", String.class )
+				.field( "nonAnnotationMapped1", String.class )
+				.field( "nonAnnotationMapped2", String.class )
+		);
+
+		ormSetupHelper.start()
+				.withProperty( HibernateOrmMapperSettings.MAPPING_CONFIGURER,
+						MappingConfigurer1.class.getName() + "," + MappingConfigurer2.class.getName() )
+				.setup( IndexedEntity.class );
+		backendMock.verifyExpectationsMet();
+	}
+
+	public static class MappingConfigurer2 implements HibernateOrmSearchMappingConfigurer {
+		@Override
+		public void configure(HibernateOrmMappingConfigurationContext context) {
+			context.programmaticMapping().type( IndexedEntity.class )
+					.property( "nonAnnotationMapped2" )
+					.keywordField();
+		}
+	}
+
+	@Entity(name = "indexed")
+	@Indexed(index = IndexedEntity.INDEX)
+	public static final class IndexedEntity {
+		public static final String INDEX = "IndexedEntity";
+
+		@Id
+		private Integer id;
+
+		@KeywordField
+		private String annotationMapped;
+
+		private String nonAnnotationMapped1;
+
+		private String nonAnnotationMapped2;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getAnnotationMapped() {
+			return annotationMapped;
+		}
+
+		public void setAnnotationMapped(String annotationMapped) {
+			this.annotationMapped = annotationMapped;
+		}
+
+		public String getNonAnnotationMapped1() {
+			return nonAnnotationMapped1;
+		}
+
+		public void setNonAnnotationMapped1(String nonAnnotationMapped1) {
+			this.nonAnnotationMapped1 = nonAnnotationMapped1;
+		}
+
+		public String getNonAnnotationMapped2() {
+			return nonAnnotationMapped2;
+		}
+
+		public void setNonAnnotationMapped2(String nonAnnotationMapped2) {
+			this.nonAnnotationMapped2 = nonAnnotationMapped2;
+		}
+	}
+
+}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/cfg/HibernateOrmMapperSettings.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/cfg/HibernateOrmMapperSettings.java
@@ -119,7 +119,7 @@ public final class HibernateOrmMapperSettings {
 	 * Expects a Boolean value such as {@code true} or {@code false},
 	 * or a string that can be parsed to such Boolean value.
 	 * <p>
-	 * Defaults to {@code Defaults#ENABLE_ANNOTATION_MAPPING}.
+	 * Defaults to {@link Defaults#MAPPING_PROCESS_ANNOTATIONS}.
 	 */
 	public static final String MAPPING_PROCESS_ANNOTATIONS = PREFIX + Radicals.MAPPING_PROCESS_ANNOTATIONS;
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/cfg/HibernateOrmMapperSettings.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/cfg/HibernateOrmMapperSettings.java
@@ -126,12 +126,12 @@ public final class HibernateOrmMapperSettings {
 	/**
 	 * The mapping configurer to use.
 	 * <p>
-	 * Expects a reference to a bean of type {@link HibernateOrmSearchMappingConfigurer}.
+	 * Expects a single-valued or multi-valued reference to beans of type {@link HibernateOrmSearchMappingConfigurer}.
 	 * <p>
 	 * Defaults to no value.
 	 *
 	 * @see org.hibernate.search.engine.cfg The core documentation of configuration properties,
-	 * which includes a description of the "bean reference" properties and accepted values.
+	 * which includes a description of the "multi-valued bean reference" properties and accepted values.
 	 */
 	public static final String MAPPING_CONFIGURER = PREFIX + Radicals.MAPPING_CONFIGURER;
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMappingInitiator.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMappingInitiator.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.mapper.orm.mapping.impl;
 
+import java.util.List;
+
 import org.hibernate.MultiTenancyStrategy;
 import org.hibernate.annotations.common.reflection.ReflectionManager;
 import org.hibernate.boot.Metadata;
@@ -47,9 +49,10 @@ public class HibernateOrmMappingInitiator extends AbstractPojoMappingInitiator<H
 					.withDefault( HibernateOrmMapperSettings.Defaults.MAPPING_PROCESS_ANNOTATIONS )
 					.build();
 
-	private static final OptionalConfigurationProperty<BeanReference<? extends HibernateOrmSearchMappingConfigurer>> MAPPING_CONFIGURER =
+	private static final OptionalConfigurationProperty<List<BeanReference<? extends HibernateOrmSearchMappingConfigurer>>> MAPPING_CONFIGURER =
 			ConfigurationProperty.forKey( HibernateOrmMapperSettings.Radicals.MAPPING_CONFIGURER )
 					.asBeanReference( HibernateOrmSearchMappingConfigurer.class )
+					.multivalued()
 					.build();
 
 	public static HibernateOrmMappingInitiator create(Metadata metadata, ReflectionManager reflectionManager,
@@ -142,8 +145,10 @@ public class HibernateOrmMappingInitiator extends AbstractPojoMappingInitiator<H
 		// Apply the user-provided mapping configurer if necessary
 		MAPPING_CONFIGURER.getAndMap( propertySource, beanResolver::resolve )
 				.ifPresent( holder -> {
-					try ( BeanHolder<? extends HibernateOrmSearchMappingConfigurer> configurerHolder = holder ) {
-						configurerHolder.get().configure( this );
+					try ( BeanHolder<List<HibernateOrmSearchMappingConfigurer>> configurerHolder = holder ) {
+						for ( HibernateOrmSearchMappingConfigurer configurer : configurerHolder.get() ) {
+							configurer.configure( this );
+						}
 					}
 				} );
 

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/SimpleSessionFactoryBuilder.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/SimpleSessionFactoryBuilder.java
@@ -38,7 +38,7 @@ public final class SimpleSessionFactoryBuilder {
 	@SuppressForbiddenApis(reason = "Strangely, this API involves the internal TcclLookupPrecedence class,"
 			+ " and there's nothing we can do about it")
 	public SimpleSessionFactoryBuilder setTcclLookupPrecedenceBefore() {
-		return onBootstraServiceRegistryBuilder( builder -> builder.applyTcclLookupPrecedence( TcclLookupPrecedence.BEFORE ) );
+		return onBootstrapServiceRegistryBuilder( builder -> builder.applyTcclLookupPrecedence( TcclLookupPrecedence.BEFORE ) );
 	}
 
 	public SimpleSessionFactoryBuilder setProperty(String key, Object value) {
@@ -72,7 +72,7 @@ public final class SimpleSessionFactoryBuilder {
 		return onMetadataSources( sources -> paths.forEach( sources::addResource ) );
 	}
 
-	public SimpleSessionFactoryBuilder onBootstraServiceRegistryBuilder(Consumer<BootstrapServiceRegistryBuilder> contributor) {
+	public SimpleSessionFactoryBuilder onBootstrapServiceRegistryBuilder(Consumer<BootstrapServiceRegistryBuilder> contributor) {
 		bootstrapServiceRegistryBuilderContributors.add( contributor );
 		return this;
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4594
