### PR TITLE
Backport HSEARCH-4596 to branch 6.1 - Upgrade to Hibernate ORM 6.0.2.Final for -orm6 artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
         <version.javax.persistence>2.2</version.javax.persistence>
 
         <!-- >>> ORM 6 / Jakarta Persistence -->
-        <version.org.hibernate.orm>6.0.1.Final</version.org.hibernate.orm>
+        <version.org.hibernate.orm>6.0.2.Final</version.org.hibernate.orm>
         <javadoc.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/javadocs/</javadoc.org.hibernate.orm.url>
         <documentation.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/userguide/html_single/Hibernate_User_Guide.html</documentation.org.hibernate.orm.url>
         <version.org.hibernate.commons.annotations.orm6>6.0.1.Final</version.org.hibernate.commons.annotations.orm6>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4596

Backport of #3074 to branch 6.1.