### PR TITLE
HSEARCH-4484 + HSEARCH-4598 + HSEARCH-4599 Upgrade dependencies

### DIFF
--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/ElasticsearchIndexIndexingPlanExecutionTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/ElasticsearchIndexIndexingPlanExecutionTest.java
@@ -50,7 +50,7 @@ public class ElasticsearchIndexIndexingPlanExecutionTest {
 	@Mock
 	private ElasticsearchSerialWorkOrchestrator orchestratorMock;
 
-	@Mock(lenient = true)
+	@Mock(strictness = Strictness.LENIENT)
 	private EntityReferenceFactory<StubEntityReference> entityReferenceFactoryMock;
 
 	private final List<SingleDocumentIndexingWork> workMocks = new ArrayList<>();
@@ -291,7 +291,7 @@ public class ElasticsearchIndexIndexingPlanExecutionTest {
 		int id = workMocks.size();
 		String workName = workInfo( id );
 		SingleDocumentIndexingWork workMock = mock( SingleDocumentIndexingWork.class,
-				withSettings().name( workName ).lenient() );
+				withSettings().name( workName ).strictness( Strictness.LENIENT ) );
 		when( workMock.getEntityTypeName() ).thenReturn( TYPE_NAME );
 		when( workMock.getEntityIdentifier() ).thenReturn( id );
 		workMocks.add( workMock );

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/work/impl/BulkWorkTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/work/impl/BulkWorkTest.java
@@ -48,7 +48,7 @@ public class BulkWorkTest {
 
 	@Mock
 	private ElasticsearchClient clientMock;
-	@Mock(lenient = true)
+	@Mock(strictness = Strictness.LENIENT)
 	private ElasticsearchWorkExecutionContext contextMock;
 
 	@Before

--- a/backend/lucene/src/test/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneBatchedWorkProcessorTest.java
+++ b/backend/lucene/src/test/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneBatchedWorkProcessorTest.java
@@ -222,7 +222,8 @@ public class LuceneBatchedWorkProcessorTest {
 	private <T> IndexingWork<T> workMock() {
 		int id = nextWorkId++;
 		String workName = workInfo( id );
-		IndexingWork<T> workMock = mock( IndexingWork.class, withSettings().name( workName ).lenient() );
+		IndexingWork<T> workMock = mock( IndexingWork.class,
+				withSettings().name( workName ).strictness( Strictness.LENIENT ) );
 		when( workMock.getInfo() ).thenReturn( workInfo( id ) );
 		return workMock;
 	}

--- a/backend/lucene/src/test/java/org/hibernate/search/backend/lucene/work/execution/impl/LuceneIndexIndexingPlanExecutionTest.java
+++ b/backend/lucene/src/test/java/org/hibernate/search/backend/lucene/work/execution/impl/LuceneIndexIndexingPlanExecutionTest.java
@@ -71,7 +71,7 @@ public class LuceneIndexIndexingPlanExecutionTest {
 	@Mock
 	private LuceneSerialWorkOrchestrator orchestratorMock;
 
-	@Mock(lenient = true)
+	@Mock(strictness = Strictness.LENIENT)
 	private EntityReferenceFactory<StubEntityReference> entityReferenceFactoryMock;
 
 	private final List<SingleDocumentIndexingWork> workMocks = new ArrayList<>();
@@ -594,7 +594,7 @@ public class LuceneIndexIndexingPlanExecutionTest {
 		int id = workMocks.size();
 		String workName = workInfo( id );
 		SingleDocumentIndexingWork workMock = mock( SingleDocumentIndexingWork.class,
-				withSettings().name( workName ).lenient() );
+				withSettings().name( workName ).strictness( Strictness.LENIENT ) );
 		when( workMock.getInfo() ).thenReturn( workName );
 		when( workMock.getEntityTypeName() ).thenReturn( TYPE_NAME );
 		when( workMock.getEntityIdentifier() ).thenReturn( id );

--- a/engine/src/test/java/org/hibernate/search/engine/cfg/spi/ConfigurationPropertyBeanReferenceTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/cfg/spi/ConfigurationPropertyBeanReferenceTest.java
@@ -44,7 +44,7 @@ public class ConfigurationPropertyBeanReferenceTest {
 
 	@Mock
 	private ConfigurationPropertySource sourceMock;
-	@Mock(lenient = true, answer = Answers.CALLS_REAL_METHODS)
+	@Mock(strictness = Strictness.LENIENT, answer = Answers.CALLS_REAL_METHODS)
 	private BeanResolver beanResolverMock;
 
 	@Test

--- a/engine/src/test/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolderTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolderTest.java
@@ -62,7 +62,7 @@ public class IndexManagerBuildingStateHolderTest {
 	@Mock(answer = Answers.CALLS_REAL_METHODS)
 	private ConfigurationPropertySource configurationSourceMock;
 
-	@Mock(lenient = true, answer = Answers.CALLS_REAL_METHODS)
+	@Mock(strictness = Strictness.LENIENT, answer = Answers.CALLS_REAL_METHODS)
 	private BeanResolver beanResolverMock;
 
 	@Mock

--- a/engine/src/test/java/org/hibernate/search/engine/mapper/mapping/building/impl/ConfiguredIndexSchemaManagerNestingContextTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/mapper/mapping/building/impl/ConfiguredIndexSchemaManagerNestingContextTest.java
@@ -49,16 +49,16 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 	@Rule
 	public final MockitoRule mockito = MockitoJUnit.rule().strictness( Strictness.STRICT_STUBS );
 
-	@Mock(lenient = true)
+	@Mock(strictness = Strictness.LENIENT)
 	private MappableTypeModel typeModel1Mock;
 
-	@Mock(lenient = true)
+	@Mock(strictness = Strictness.LENIENT)
 	private MappableTypeModel typeModel2Mock;
 
-	@Mock(lenient = true)
+	@Mock(strictness = Strictness.LENIENT)
 	private MappableTypeModel typeModel3Mock;
 
-	@Mock(lenient = true)
+	@Mock(strictness = Strictness.LENIENT)
 	private MappableTypeModel typeModel4Mock;
 
 	@Mock

--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
          -->
         <version.com.fasterxml.jackson.databind>2.13.3</version.com.fasterxml.jackson.databind>
         <!-- Reactive-streams: used by the AWS SDK -->
-        <version.org.reactivestreams.reactive-streams>1.0.3</version.org.reactivestreams.reactive-streams>
+        <version.org.reactivestreams.reactive-streams>1.0.4</version.org.reactivestreams.reactive-streams>
         <!-- slf4j: used by the AWS SDK -->
         <version.org.slf4j>1.7.36</version.org.slf4j>
 

--- a/pom.xml
+++ b/pom.xml
@@ -399,7 +399,7 @@
         <version.scripting.plugin>3.0.0</version.scripting.plugin>
         <version.gpg.plugin>3.0.1</version.gpg.plugin>
         <version.org.codehaus.groovy-jsr223>3.0.10</version.org.codehaus.groovy-jsr223>
-        <version.com.puppycrawl.tools.checkstyle>10.2</version.com.puppycrawl.tools.checkstyle>
+        <version.com.puppycrawl.tools.checkstyle>10.3</version.com.puppycrawl.tools.checkstyle>
 
         <!-- Asciidoctor -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
         <version.org.elasticsearch.compatible.not-regularly-tested.text>7.0 or 8.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest micro of each Elasticsearch branch -->
-        <version.org.elasticsearch.latest-8.2>8.2.1</version.org.elasticsearch.latest-8.2>
+        <version.org.elasticsearch.latest-8.2>8.2.2</version.org.elasticsearch.latest-8.2>
         <version.org.elasticsearch.latest-8.1>8.1.3</version.org.elasticsearch.latest-8.1>
         <version.org.elasticsearch.latest-8.0>8.0.1</version.org.elasticsearch.latest-8.0>
         <version.org.elasticsearch.latest-7.17>7.17.0</version.org.elasticsearch.latest-7.17>

--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
         <version.org.osgi.core>6.0.0</version.org.osgi.core>
 
         <version.org.hamcrest>2.2</version.org.hamcrest>
-        <version.org.mockito>4.5.1</version.org.mockito>
+        <version.org.mockito>4.6.0</version.org.mockito>
         <version.org.assertj.assertj-core>3.22.0</version.org.assertj.assertj-core>
         <version.org.awaitily>4.2.0</version.org.awaitily>
         <version.org.skyscreamer.jsonassert>1.5.0</version.org.skyscreamer.jsonassert>

--- a/pom.xml
+++ b/pom.xml
@@ -393,7 +393,7 @@
         <version.jacoco.plugin>0.8.8</version.jacoco.plugin>
         <version.coveralls.plugin>4.3.0</version.coveralls.plugin>
         <version.com.buschmais.jqassistant.plugin>1.11.1</version.com.buschmais.jqassistant.plugin>
-        <version.docker.maven.plugin>0.39.1</version.docker.maven.plugin>
+        <version.docker.maven.plugin>0.40.0</version.docker.maven.plugin>
         <version.moditect.plugin>1.0.0.RC2</version.moditect.plugin>
         <version.sonar.plugin>3.9.1.2184</version.sonar.plugin>
         <version.scripting.plugin>3.0.0</version.scripting.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.2+ -->
-        <version.org.elasticsearch.client>8.2.1</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>8.2.2</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-8.3) becomes the default. -->


### PR DESCRIPTION
* [HSEARCH-4599](https://hibernate.atlassian.net/browse/HSEARCH-4599): Upgrade to Elasticsearch client 8.2.2 and test against Elasticsearch 8.2.2
* [HSEARCH-4598](https://hibernate.atlassian.net/browse/HSEARCH-4598): Upgrade to Reactive Streams 1.0.4
* [HSEARCH-4484](https://hibernate.atlassian.net/browse/HSEARCH-4484): Upgrade build dependencies to the latest version



Follows up on https://github.com/hibernate/hibernate-search/pull/2895, https://github.com/hibernate/hibernate-search/pull/2902, https://github.com/hibernate/hibernate-search/pull/2904, #2913, #2931, #2941, #2954, #2293 #2983, #3021, #3028, #3041, #3052, #3066