### PR TITLE
Backport HSEARCH-4600 to branch 6.1 - Fix flaky assertion in OutboxPollingAutomaticIndexingEventSendingIT

### DIFF
--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingEventSendingIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingEventSendingIT.java
@@ -309,11 +309,11 @@ public class OutboxPollingAutomaticIndexingEventSendingIT {
 			entity.setText( "updated" );
 		} );
 
-		outboxEventFinder.showAllEventsUpToNow( setupHolder.sessionFactory() );
 		backendMock.expectWorks( IndexedAndContainedEntity.NAME )
 				.addOrUpdate( "2", b -> b
 						.field( "text", "updated" )
 						.field( "nonIndexedEmbeddedText", "initial" ) );
+		outboxEventFinder.showAllEventsUpToNow( setupHolder.sessionFactory() );
 		backendMock.verifyExpectationsMet();
 		// Processing the update event should yield more events for containing entities
 		backendMock.indexingWorkExpectations().awaitIndexingAssertions( () -> {
@@ -406,11 +406,11 @@ public class OutboxPollingAutomaticIndexingEventSendingIT {
 			entity.setNonIndexedEmbeddedText( "updated" );
 		} );
 
-		outboxEventFinder.showAllEventsUpToNow( setupHolder.sessionFactory() );
 		backendMock.expectWorks( IndexedAndContainedEntity.NAME )
 				.addOrUpdate( "2", b -> b
 						.field( "text", "initial" )
 						.field( "nonIndexedEmbeddedText", "updated" ) );
+		outboxEventFinder.showAllEventsUpToNow( setupHolder.sessionFactory() );
 		backendMock.verifyExpectationsMet();
 		// Processing this update event shouldn't yield more events,
 		// because the changed field is not indexed-embedded.


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4600

Backport of #3084 to branch 6.1.