### PR TITLE
HSEARCH-4548 Switch to LocalStack to test AWS OpenSearch/Elasticsearch Service

### DIFF
--- a/backend/elasticsearch-aws/src/main/java/org/hibernate/search/backend/elasticsearch/aws/impl/AwsSigningRequestInterceptor.java
+++ b/backend/elasticsearch-aws/src/main/java/org/hibernate/search/backend/elasticsearch/aws/impl/AwsSigningRequestInterceptor.java
@@ -107,6 +107,7 @@ class AwsSigningRequestInterceptor implements HttpRequestInterceptor {
 		HttpCoreContext coreContext = HttpCoreContext.adapt( context );
 		HttpHost targetHost = coreContext.getTargetHost();
 		awsRequestBuilder.host( targetHost.getHostName() );
+		awsRequestBuilder.port( targetHost.getPort() );
 		awsRequestBuilder.protocol( targetHost.getSchemeName() );
 
 		RequestLine requestLine = request.getRequestLine();


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4548

I thought I'd take a look at this one. You won't find much in the committed changes yet as I was just trying to figure out how it can all work. While doing so I've stumbled on the issue that Localstack creates service URLs with ports:
```
"Endpoint": "hsearch-cluster.us-east-1.opensearch.localhost.localstack.cloud:4566"
```
and the `AwsSigningRequestInterceptor` was ignoring the port part. Hence when the `test.elasticsearch.connection.aws.signing.enabled` was enabled the tests were just failing with `500` status code as they weren't able to connect anywhere (aws re-written request was missing port).

Another potential issue is that IAM is a part of ***Pro*** Localstack (https://docs.localstack.cloud/aws/iam/).

I won't go into much detail on some of the steps, but here's how I've approached it:

1. Install awslocal. the guide is here - https://docs.localstack.cloud/integrations/aws-cli/#localstack-aws-cli-awslocal
2. Put together the docker-compose file which is slightly modified from the one given for opensearch on localstack:
```yml
version: "3.9"

services:
  opensearch:
    container_name: opensearch
    image: opensearchproject/opensearch:1.1.0
    network_mode: bridge
    environment:
      - node.name=opensearch
      - cluster.name=opensearch-docker-cluster
      - discovery.type=single-node
      - bootstrap.memory_lock=true
      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
      - "DISABLE_SECURITY_PLUGIN=true"
    ports:
      - "9200:9200"
    ulimits:
      memlock:
        soft: -1
        hard: -1
    volumes:
      - data01:/usr/share/opensearch/data

  localstack:
    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
    image: localstack/localstack
    network_mode: bridge
    ports:
      - "127.0.0.1:4510-4559:4510-4559"  # external service port range
      - "127.0.0.1:4566:4566"            # LocalStack Edge Proxy
    depends_on:
      - opensearch
    environment:
      # - ENFORCE_IAM=1 # Testign the IAM until realized that it won't work becuase of it being Pro version only 
      - OPENSEARCH_CUSTOM_BACKEND=http://opensearch:9200
      - SERVICES=${SERVICES-}
      - DEBUG=${DEBUG-}
      - DATA_DIR=${DATA_DIR-}
      - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR-}
      - LOCALSTACK_HOSTNAME=localhost.localstack.cloud
      # - OPENSEARCH_ENDPOINT_STRATEGY=port  # used different strategies while testing as there were some issues with certificate validation
      # Ended up still using the default as other options do not play nicely with HSEARCH.
      - HOST_TMP_FOLDER=${TMPDIR:-/tmp/}localstack
      - DOCKER_HOST=unix:///var/run/docker.sock
    volumes:
      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
      - "/var/run/docker.sock:/var/run/docker.sock"
    links:
      - opensearch

volumes:
  data01:
    driver: local
```
3. With that in place:
```bash
# start the localstack docker:
docker-compose up -d

# create `hsearch` user to be used for integration tests
awslocal iam create-user --user-name search

# create `AccessKeyId` and `SecretAccessKey` to be passed to HSEARCH
awslocal iam create-access-key --user-name search

# create an opensearch domain.
# I have also tried to pass in `--access-policies` but that had no effect so it's omitted here:
awslocal opensearch create-domain --domain-name hsearch-cluster
# create
```
4. try to run the integration tests against the localstack:
```bash
mvn clean install -Dsurefire.environment=opensearch-aws-1_1-credentials-static \
    --fail-at-end -pl org.hibernate.search:hibernate-search-integrationtest-backend-elasticsearch,org.hibernate.search:hibernate-search-integrationtest-showcase-library \
   -Popensearch-1.0 \
   -Dtest.elasticsearch.connection.version=1.1 \
   -Dtest.elasticsearch.connection.uris=http://hsearch-cluster.us-east-1.opensearch.localhost.localstack.cloud:4566 \
   -Dtest.elasticsearch.connection.aws.signing.enabled=true -Dtest.elasticsearch.connection.aws.region=us-east-1 \
   -Dtest.elasticsearch.connection.aws.credentials.type=static \
   -Dtest.elasticsearch.connection.aws.credentials.access_key_id=whatever_the_generated_key_was \
   -Dtest.elasticsearch.connection.aws.credentials.secret_access_key=whatever_the_generated_key_was
```

There were ~50 failures with things like:
```
HSEARCH400007: Elasticsearch request failed: HSEARCH400090: Elasticsearch response indicates a failure.
Request: POST /_bulk with parameters {}
Response: 400 '' from 'http://hsearch-cluster.us-east-1.opensearch.localhost.localstack.cloud:4566' with body 
{
  "error": {
    "root_cause": [
      {
        "type": "number_format_exception",
        "reason": "For input string: \"{\"index\":{\"_index\":\"indexname-write\",\"_id\":\"3\"}}\" under radix 16"
      }
    ],
    "type": "number_format_exception",
    "reason": "For input string: \"{\"index\":{\"_index\":\"indexname-write\",\"_id\":\"3\"}}\" under radix 16"
  },
  "status": 400
}
```

I wasn't sure how exactly the credentials are retrieved on CI builds right now, meaning which particular AWS `CredentialsProvider` is triggered, so I've limited my experiments only to `static` credentials. 

With that said I suppose we can put something like this on CI, but we'd probably still need to rely on AWS to be 100% that integration works. Maybe at least with one version of ES and Opensearch ? Also because of the "missing" IAM and the way locakstack works (starting containers) I was wondering if it would bring much benefit compared to simply running the tests against the containerized services themselves?
