### PR TITLE
HSEARCH-4597 Fix unfinished sentences in the documentation

### DIFF
--- a/documentation/src/main/asciidoc/reference/mapper-orm-bridge-index-field-dsl.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapper-orm-bridge-index-field-dsl.asciidoc
@@ -190,7 +190,7 @@ but omits the field names.
 A field template is always declared in a binder: either in a <<mapper-orm-bridge-typebridge,type binder>>
 or in a <<mapper-orm-bridge-propertybridge,property binder>>.
 As for static fields, the entry point to declaring a template is the `IndexNode`
-passed to the binder's `bind(...)` method
+passed to the binder's `bind(...)` method.
 A call to the `fieldTemplate` method on the schema element will declare a field template.
 
 Assuming a field template was declared during binding,

--- a/documentation/src/main/asciidoc/reference/search-dsl-predicate.asciidoc
+++ b/documentation/src/main/asciidoc/reference/search-dsl-predicate.asciidoc
@@ -1530,7 +1530,7 @@ or it doesn't match and it won't benefit from the score of this predicate.
 
 Predicates with a variable score have a more subtle impact on the score.
 For example the <<search-dsl-predicate-match,`match` predicate>>, on a text field,
-will yield a higher score for documents
+will yield a higher score for documents that contain the term to match multiple times.
 
 When this "variable score" behavior is not desired,
 you can suppress it by calling `.constantScore()`.


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4597

Apparently there was only the one, and a missing period.

I used this regexp to look for more:

```
^(?!\s*[*/\[=:.@]|.*\||hibernate.search|spring.jpa).*[a-z]\n(?!\s*[a-z0-1\*"(<`>]|\.\.\.|--|\d\.|Hibernate|Unicode)
```