### PR TITLE
HSEARCH-4484 + HSEARCH-4608 + HSEARCH-4609 + HSEARCH-4610 Upgrade dependencies

### DIFF
--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -646,7 +646,7 @@
                 <db.dialect>org.hibernate.dialect.H2Dialect</db.dialect>
                 <jdbc.driver.groupId>com.h2database</jdbc.driver.groupId>
                 <jdbc.driver.artifactId>h2</jdbc.driver.artifactId>
-                <jdbc.driver.version>${version.com.h2database}</jdbc.driver.version>
+                <jdbc.driver.version>2.1.214</jdbc.driver.version>
                 <jdbc.driver>org.h2.Driver</jdbc.driver>
                 <jdbc.url>jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1</jdbc.url>
                 <jdbc.user>sa</jdbc.user>

--- a/pom.xml
+++ b/pom.xml
@@ -328,7 +328,7 @@
         <version.org.awaitily>4.2.0</version.org.awaitily>
         <version.org.skyscreamer.jsonassert>1.5.0</version.org.skyscreamer.jsonassert>
         <version.io.takari.junit>1.2.7</version.io.takari.junit>
-        <version.com.h2database>2.1.212</version.com.h2database>
+        <version.com.h2database>2.1.214</version.com.h2database>
         <version.com.github.tomakehurst.wiremock>2.27.2</version.com.github.tomakehurst.wiremock>
         <version.org.apache.commons.lang3>3.12.0</version.org.apache.commons.lang3>
         <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>

--- a/pom.xml
+++ b/pom.xml
@@ -475,7 +475,7 @@
                 is outdated and leads to compilation errors.
          -->
         <version.org.codehaus.plexus.plexus-compiler.compiler-eclipse>2.12.0</version.org.codehaus.plexus.plexus-compiler.compiler-eclipse>
-        <version.org.eclipse.jdt.ecj>3.29.0</version.org.eclipse.jdt.ecj>
+        <version.org.eclipse.jdt.ecj>3.30.0</version.org.eclipse.jdt.ecj>
 
         <!--
             The absolute path to the root project directory.

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.2+ -->
-        <version.org.elasticsearch.client>8.2.2</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>8.2.3</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-8.3) becomes the default. -->

--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
         <!-- >>> JSR 352: JBatch runtime -->
         <version.com.ibm.jbatch>1.0</version.com.ibm.jbatch>
         <version.com.ibm.jbatch.jakarta>2.1.1</version.com.ibm.jbatch.jakarta>
-        <version.org.apache.derby>10.13.1.1</version.org.apache.derby>
+        <version.org.apache.derby>10.16.1.1</version.org.apache.derby>
 
         <!-- >>> JSR 352: JBeret SE dependencies -->
         <version.org.jboss.marshalling>2.0.12.Final</version.org.jboss.marshalling>

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <!-- Nothing beyond common dependencies -->
 
         <!-- >>> Lucene -->
-        <version.org.apache.lucene>8.11.1</version.org.apache.lucene>
+        <version.org.apache.lucene>8.11.2</version.org.apache.lucene>
         <javadoc.org.apache.lucene.tag>${parsed-version.org.apache.lucene.majorVersion}_${parsed-version.org.apache.lucene.minorVersion}_${parsed-version.org.apache.lucene.incrementalVersion}</javadoc.org.apache.lucene.tag>
         <javadoc.org.apache.lucene.core.url>https://lucene.apache.org/core/${javadoc.org.apache.lucene.tag}/core/</javadoc.org.apache.lucene.core.url>
         <javadoc.org.apache.lucene.analyzers-common.url>https://lucene.apache.org/core/${javadoc.org.apache.lucene.tag}/analyzers-common/</javadoc.org.apache.lucene.analyzers-common.url>

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
         <version.org.elasticsearch.compatible.not-regularly-tested.text>7.0 or 8.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest micro of each Elasticsearch branch -->
-        <version.org.elasticsearch.latest-8.2>8.2.2</version.org.elasticsearch.latest-8.2>
+        <version.org.elasticsearch.latest-8.2>8.2.3</version.org.elasticsearch.latest-8.2>
         <version.org.elasticsearch.latest-8.1>8.1.3</version.org.elasticsearch.latest-8.1>
         <version.org.elasticsearch.latest-8.0>8.0.1</version.org.elasticsearch.latest-8.0>
         <version.org.elasticsearch.latest-7.17>7.17.0</version.org.elasticsearch.latest-7.17>

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
         <version.javax.enterprise>2.0</version.javax.enterprise>
         <version.jakarta.enterprise>3.0.1</version.jakarta.enterprise>
         <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>1.0.2.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>
-        <version.jakarta.annotation-api>2.1.0</version.jakarta.annotation-api>
+        <version.jakarta.annotation-api>2.1.1</version.jakarta.annotation-api>
         <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>1.1.1.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>
         <version.jakarta.transaction-api>2.0.1</version.jakarta.transaction-api>
         <!-- We need dependency management on these ones to avoid dependency divergence created by our own dependencies

--- a/util/internal/integrationtest/jbatch-runtime/src/main/resources/META-INF/services/batch-config.properties
+++ b/util/internal/integrationtest/jbatch-runtime/src/main/resources/META-INF/services/batch-config.properties
@@ -4,3 +4,8 @@
 # However, we still customize the database location
 # (the default uses a "RUNTIMEDB" directory in the current working directory)
 JDBC_URL=jdbc:derby:memory:jbatch;create=true
+
+# ... and we need to update the name of the Derby JDBC driver class,
+# which for some reason JBatch is specifying explicitly instead of relying
+# on JDBC driver autoloading based on JDBC URL schemes... ("jdbc:derby:")
+JDBC_DRIVER=org.apache.derby.iapi.jdbc.AutoloadedDriver


### PR DESCRIPTION
* [HSEARCH-4610](https://hibernate.atlassian.net/browse/HSEARCH-4610): Upgrade to Elasticsearch client 8.2.3 and test against Elasticsearch 8.2.3
* [HSEARCH-4609](https://hibernate.atlassian.net/browse/HSEARCH-4609): Upgrade to Lucene 8.11.2
* [HSEARCH-4608](https://hibernate.atlassian.net/browse/HSEARCH-4608): Upgrade to the latest version of Jakarta dependencies in -orm6/-jakarta artifacts
* [HSEARCH-4484](https://hibernate.atlassian.net/browse/HSEARCH-4484): Upgrade build dependencies to the latest version

