### PR TITLE
Backport HSEARCH-4565 + HSEARCH-4611 to branch 6.1 - Cyclic dependency detection for IndexingDependency(derivedFrom = ...) does not detect "buried" cycles

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
@@ -187,7 +187,10 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET + 44, value = "Invalid type '%1$s': missing constructor. The type must expose a public constructor with a single parameter of type Map.")
 	SearchException noPublicMapArgConstructor(@FormatWith(ClassFormatter.class) Class<?> classToLoad);
 
-	@Message(id = ID_OFFSET + 46, value = "Infinite @IndexedEmbedded recursion involving path '%1$s' on type '%2$s'.")
+	@Message(id = ID_OFFSET + 46, value = "Cyclic @IndexedEmbedded recursion starting from type '%2$s'."
+			+ " Path starting from that type and ending with a cycle: '%1$s'."
+			+ " A type cannot declare an unrestricted @IndexedEmbedded to itself, even indirectly."
+			+ " To break the cycle, you should consider adding filters to your @IndexedEmbedded: includePaths, includeDepth, ...")
 	SearchException indexedEmbeddedCyclicRecursion(String cyclicRecursionPath,
 			@FormatWith(MappableTypeModelFormatter.class) MappableTypeModel parentTypeModel);
 

--- a/engine/src/main/java/org/hibernate/search/engine/reporting/spi/RootFailureCollector.java
+++ b/engine/src/main/java/org/hibernate/search/engine/reporting/spi/RootFailureCollector.java
@@ -219,11 +219,7 @@ public final class RootFailureCollector implements FailureCollector {
 		synchronized void appendFailuresTo(ToStringTreeBuilder builder) {
 			builder.startObject( context.render() );
 			if ( !failureMessages.isEmpty() ) {
-				builder.startList( EngineEventContextMessages.INSTANCE.failureReportFailures() );
-				for ( String failureMessage : failureMessages ) {
-					builder.value( failureMessage );
-				}
-				builder.endList();
+				builder.attribute( EngineEventContextMessages.INSTANCE.failureReportFailures(), failureMessages );
 			}
 			appendChildrenFailuresTo( builder );
 			builder.endObject();

--- a/engine/src/test/java/org/hibernate/search/engine/mapper/mapping/building/impl/ConfiguredIndexSchemaManagerNestingContextTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/mapper/mapping/building/impl/ConfiguredIndexSchemaManagerNestingContextTest.java
@@ -139,10 +139,8 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 				);
 		} )
 				.isInstanceOf( SearchException.class )
-				.hasMessageContainingAll(
-						"Infinite @IndexedEmbedded recursion",
-						"path 'level1.prefix1_level1.prefix1_'",
-						"type '" + typeModel1Mock.toString() + "'"
+				.hasMessageContainingAll( "Cyclic @IndexedEmbedded recursion starting from type '" + typeModel1Mock.toString() + "'",
+						"Path starting from that type and ending with a cycle: 'level1.prefix1_level1.prefix1_'"
 				);
 		verifyNoOtherInteractionsAndReset();
 	}
@@ -172,10 +170,8 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 			);
 		} )
 				.isInstanceOf( SearchException.class )
-				.hasMessageContainingAll(
-						"Infinite @IndexedEmbedded recursion",
-						"path 'level1.prefix1_level2.prefix2_level1.prefix1_'",
-						"type '" + typeModel1Mock.toString() + "'"
+				.hasMessageContainingAll( "Cyclic @IndexedEmbedded recursion starting from type '" + typeModel1Mock.toString() + "'",
+						"Path starting from that type and ending with a cycle: 'level1.prefix1_level2.prefix2_level1.prefix1_'"
 				);
 		verifyNoOtherInteractionsAndReset();
 	}

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/DependencyIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/DependencyIT.java
@@ -683,9 +683,12 @@ public class DependencyIT {
 				.satisfies( FailureReportUtils.hasFailureReport()
 						.typeContext( DerivedFromCycle.A.class.getName() )
 						.pathContext( ".derivedA<no value extractors>" )
-						.failure( "Unable to resolve dependencies of a derived property:"
-								+ " there is a cyclic dependency involving path '.derivedA<no value extractors>'"
-								+ " on type '" + DerivedFromCycle.A.class.getName() + "'",
+						.multilineFailure( "Unable to resolve dependencies of a derived property:"
+										+ " there is a cyclic dependency starting from type '" + DerivedFromCycle.A.class.getName() + "'",
+								"Derivation chain starting from that type and ending with a cycle:\n"
+										+ "- " + DerivedFromCycle.A.class.getName() + "#.b<default value extractors>.derivedB<default value extractors>\n"
+										+ "- " + DerivedFromCycle.B.class.getName() + "#.c<default value extractors>.derivedC<default value extractors>\n"
+										+ "- " + DerivedFromCycle.C.class.getName() + "#.a<default value extractors>.derivedA<default value extractors>\n",
 								"A derived property cannot be marked as derived from itself",
 								"you should consider disabling automatic reindexing"
 						) );
@@ -753,9 +756,12 @@ public class DependencyIT {
 				.satisfies( FailureReportUtils.hasFailureReport()
 						.typeContext( DerivedFromCycle.Zero.class.getName() )
 						.pathContext( ".derivedZero<no value extractors>" )
-						.failure( "Unable to resolve dependencies of a derived property:"
-										+ " there is a cyclic dependency involving path '.derivedA<no value extractors>'"
-										+ " on type '" + DerivedFromCycle.A.class.getName() + "'",
+						.multilineFailure( "Unable to resolve dependencies of a derived property:"
+										+ " there is a cyclic dependency starting from type '" + DerivedFromCycle.A.class.getName() + "'",
+								"Derivation chain starting from that type and ending with a cycle:\n"
+										+ "- " + DerivedFromCycle.A.class.getName() + "#.b<default value extractors>.derivedB<default value extractors>\n"
+										+ "- " + DerivedFromCycle.B.class.getName() + "#.c<default value extractors>.derivedC<default value extractors>\n"
+										+ "- " + DerivedFromCycle.C.class.getName() + "#.a<default value extractors>.derivedA<default value extractors>\n",
 								"A derived property cannot be marked as derived from itself",
 								"you should consider disabling automatic reindexing"
 						)

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/IndexedEmbeddedBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/IndexedEmbeddedBaseIT.java
@@ -1572,8 +1572,10 @@ public class IndexedEmbeddedBaseIT {
 				.satisfies( FailureReportUtils.hasFailureReport()
 						.typeContext( Model.EntityA.class.getName() )
 						.pathContext( ".b<no value extractors>.a<no value extractors>.b" )
-						.failure( "Infinite @IndexedEmbedded recursion involving path 'b.a.b.' on type '"
-								+ Model.EntityA.class.getName() + "'" )
+						.failure( "Cyclic @IndexedEmbedded recursion starting from type '" + Model.EntityA.class.getName() + "'",
+								"Path starting from that type and ending with a cycle: 'b.a.b.'",
+								"A type cannot declare an unrestricted @IndexedEmbedded to itself, even indirectly",
+								"To break the cycle, you should consider adding filters to your @IndexedEmbedded: includePaths, includeDepth, ..." )
 				);
 	}
 
@@ -1606,8 +1608,10 @@ public class IndexedEmbeddedBaseIT {
 				.satisfies( FailureReportUtils.hasFailureReport()
 						.typeContext( Model.EntityA.class.getName() )
 						.pathContext( ".b<no value extractors>.c<no value extractors>.b<no value extractors>.c" )
-						.failure( "Infinite @IndexedEmbedded recursion involving path 'c.b.c.' on type '"
-								+ Model.EntityB.class.getName() + "'" )
+						.failure( "Cyclic @IndexedEmbedded recursion starting from type '" + Model.EntityB.class.getName() + "'",
+								"Path starting from that type and ending with a cycle: 'c.b.c.'",
+								"A type cannot declare an unrestricted @IndexedEmbedded to itself, even indirectly",
+								"To break the cycle, you should consider adding filters to your @IndexedEmbedded: includePaths, includeDepth, ..." )
 				);
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/AbstractPojoIndexingDependencyCollectorDirectValueNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/AbstractPojoIndexingDependencyCollectorDirectValueNode.java
@@ -25,6 +25,7 @@ import org.hibernate.search.mapper.pojo.model.path.impl.BoundPojoModelPathValueN
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeModel;
 import org.hibernate.search.mapper.pojo.model.spi.PojoTypeModel;
 import org.hibernate.search.util.common.AssertionFailure;
+import org.hibernate.search.util.common.data.impl.LinkedNode;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 /**
@@ -93,7 +94,7 @@ public abstract class AbstractPojoIndexingDependencyCollectorDirectValueNode<P, 
 	public abstract void collectDependency();
 
 	abstract void doCollectDependency(
-			PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?> initialNodeCollectingDependency);
+			LinkedNode<PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?>> derivedDependencyPath);
 
 	@Override
 	final PojoIndexingDependencyCollectorTypeNode<?> lastEntityNode() {

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/AbstractPojoIndexingDependencyCollectorDirectValueNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/AbstractPojoIndexingDependencyCollectorDirectValueNode.java
@@ -93,8 +93,7 @@ public abstract class AbstractPojoIndexingDependencyCollectorDirectValueNode<P, 
 
 	public abstract void collectDependency();
 
-	abstract void doCollectDependency(
-			LinkedNode<PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?>> derivedDependencyPath);
+	abstract void doCollectDependency(LinkedNode<DerivedDependencyWalkingInfo> derivedDependencyPath);
 
 	@Override
 	final PojoIndexingDependencyCollectorTypeNode<?> lastEntityNode() {

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/DerivedDependencyWalkingInfo.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/DerivedDependencyWalkingInfo.java
@@ -1,0 +1,28 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.automaticindexing.building.impl;
+
+import org.hibernate.search.mapper.pojo.model.path.PojoModelPath;
+import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeModel;
+
+public final class DerivedDependencyWalkingInfo {
+	public final PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?> node;
+	public final PojoRawTypeModel<?> definingTypeModel;
+	public final PojoModelPath derivedFromPath;
+
+	public DerivedDependencyWalkingInfo(PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?> node,
+			PojoModelPath derivedFromPath) {
+		this.node = node;
+		this.definingTypeModel = node.parentNode.parentNode().typeModel().rawType();
+		this.derivedFromPath = derivedFromPath;
+	}
+
+	@Override
+	public String toString() {
+		return definingTypeModel.name() + "#" + derivedFromPath.toPathString();
+	}
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/PojoIndexingDependencyCollectorMonomorphicDirectValueNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/PojoIndexingDependencyCollectorMonomorphicDirectValueNode.java
@@ -7,13 +7,13 @@
 package org.hibernate.search.mapper.pojo.automaticindexing.building.impl;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Optional;
 
 import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
 import org.hibernate.search.mapper.pojo.logging.impl.Log;
 import org.hibernate.search.mapper.pojo.model.path.PojoModelPathValueNode;
 import org.hibernate.search.mapper.pojo.model.path.binding.impl.PojoModelPathBinder;
 import org.hibernate.search.mapper.pojo.model.path.impl.BoundPojoModelPathValueNode;
-import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeModel;
 import org.hibernate.search.util.common.data.impl.LinkedNode;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
@@ -35,33 +35,21 @@ public class PojoIndexingDependencyCollectorMonomorphicDirectValueNode<P, V>
 
 	static <P, V> PojoIndexingDependencyCollectorMonomorphicDirectValueNode<P, V> create(
 			PojoIndexingDependencyCollectorPropertyNode<?, P> parentNode,
-			BoundPojoModelPathValueNode<?, P, V> modelPathFromLastTypeNode,
 			BoundPojoModelPathValueNode<?, P, V> modelPathFromLastEntityNode,
 			PojoImplicitReindexingResolverBuildingHelper buildingHelper) {
 		return new PojoIndexingDependencyCollectorMonomorphicDirectValueNode<>( parentNode,
-				modelPathFromLastTypeNode, modelPathFromLastEntityNode,
-				Metadata.create( buildingHelper, parentNode, modelPathFromLastTypeNode.getExtractorPath() ),
+				modelPathFromLastEntityNode,
+				Metadata.create( buildingHelper, parentNode, modelPathFromLastEntityNode.getExtractorPath() ),
 				buildingHelper
 		);
 	}
 
-	/**
-	 * The path to this node from the last type node, i.e. from the node
-	 * representing the type holding the property from which this value is extracted.
-	 */
-	private final BoundPojoModelPathValueNode<?, P, V> modelPathFromLastTypeNode;
-	private final PojoModelPathValueNode unboundModelPathFromLastTypeNode;
-
 	PojoIndexingDependencyCollectorMonomorphicDirectValueNode(
 			PojoIndexingDependencyCollectorPropertyNode<?, P> parentNode,
-			BoundPojoModelPathValueNode<?, P, V> modelPathFromLastTypeNode,
 			BoundPojoModelPathValueNode<?, P, V> modelPathFromLastEntityNode,
 			Metadata metadata,
 			PojoImplicitReindexingResolverBuildingHelper buildingHelper) {
 		super( parentNode, modelPathFromLastEntityNode, metadata, buildingHelper );
-		this.modelPathFromLastTypeNode = modelPathFromLastTypeNode;
-		// The path is used for comparisons (equals), so we need it unbound
-		this.unboundModelPathFromLastTypeNode = modelPathFromLastTypeNode.toUnboundPath();
 	}
 
 	@Override
@@ -92,50 +80,18 @@ public class PojoIndexingDependencyCollectorMonomorphicDirectValueNode<P, V>
 	}
 
 	@Override
-	void doCollectDependency(
-			LinkedNode<PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?>> derivedDependencyPath) {
+	void doCollectDependency(LinkedNode<DerivedDependencyWalkingInfo> derivedDependencyPath) {
 		ReindexOnUpdate composedReindexOnUpdate = derivedDependencyPath == null ? metadata.reindexOnUpdate
-				: derivedDependencyPath.last.value.composeReindexOnUpdate( lastEntityNode(), metadata.reindexOnUpdate );
+				: derivedDependencyPath.last.value.node.composeReindexOnUpdate( lastEntityNode(), metadata.reindexOnUpdate );
 		if ( ReindexOnUpdate.NO.equals( composedReindexOnUpdate ) ) {
 			// Updates are ignored
 			return;
-		}
-
-		if ( derivedDependencyPath != null ) {
-			for ( PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?> derivedPathNode : derivedDependencyPath ) {
-				PojoRawTypeModel<?> initialType = derivedPathNode.modelPathFromLastTypeNode
-						.getRootType().rawType();
-				PojoModelPathValueNode initialValuePath = derivedPathNode.unboundModelPathFromLastTypeNode;
-				PojoRawTypeModel<?> latestType = modelPathFromLastTypeNode.getRootType().rawType();
-				PojoModelPathValueNode latestValuePath = unboundModelPathFromLastTypeNode;
-				if ( initialType.equals( latestType ) && initialValuePath.equals( latestValuePath ) ) {
-					/*
-					 * We found a cycle in the derived dependency path.
-					 * This can happen for example if:
-					 * - property "foo" on type A is marked as derived from itself
-					 * - property "foo" on type A is marked as derived from property "bar" on type B,
-					 *   which is marked as derived from property "foo" on type "A".
-					 * - property "foo" on type A is marked as derived from property "bar" on type B,
-					 *   which is marked as derived from property "foobar" on type "C".
-					 *   which is marked as derived from property "bar" on type "B".
-					 * Even if such a dependency might work in practice at runtime,
-					 * for example because the link A => B never leads to a B that refers to the same A,
-					 * even indirectly,
-					 * we cannot support it here because we need to model dependencies as a static tree,
-					 * which in such case would have an infinite depth.
-					 */
-					throw log.infiniteRecursionForDerivedFrom( latestType, latestValuePath );
-				}
-			}
 		}
 
 		if ( metadata.derivedFrom.isEmpty() ) {
 			parentNode.parentNode().collectDependency( this.modelPathFromLastEntityNode );
 		}
 		else {
-			LinkedNode<PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?>> updatedDerivedDependencyPath =
-					derivedDependencyPath == null ? LinkedNode.of( this )
-							: derivedDependencyPath.withHead( this );
 			/*
 			 * The value represented by this node is derived from other, base values.
 			 * If we rely on the value represented by this node when indexing,
@@ -149,11 +105,44 @@ public class PojoIndexingDependencyCollectorMonomorphicDirectValueNode<P, V>
 			 */
 			PojoIndexingDependencyCollectorTypeNode<?> lastTypeNode = parentNode.parentNode();
 			for ( PojoModelPathValueNode path : metadata.derivedFrom ) {
+				DerivedDependencyWalkingInfo newDerivedDependencyInfo = new DerivedDependencyWalkingInfo( this, path );
+				if ( derivedDependencyPath != null ) {
+					checkForDerivedDependencyCycle( derivedDependencyPath, newDerivedDependencyInfo );
+				}
+				LinkedNode<DerivedDependencyWalkingInfo> updatedDerivedDependencyPath =
+						derivedDependencyPath == null ? LinkedNode.of( newDerivedDependencyInfo )
+								: derivedDependencyPath.withHead( newDerivedDependencyInfo );
 				PojoModelPathBinder.bind(
 						lastTypeNode, path,
 						PojoIndexingDependencyCollectorNode.walker( updatedDerivedDependencyPath )
 				);
 			}
+		}
+	}
+
+	private void checkForDerivedDependencyCycle(LinkedNode<DerivedDependencyWalkingInfo> derivedDependencyPath,
+			DerivedDependencyWalkingInfo newDerivedDependencyInfo) {
+		Optional<LinkedNode<DerivedDependencyWalkingInfo>> cycle = derivedDependencyPath.findAndReverse(
+				other -> newDerivedDependencyInfo.definingTypeModel.equals( other.definingTypeModel )
+						&& newDerivedDependencyInfo.derivedFromPath.equals( other.derivedFromPath ) );
+		if ( cycle.isPresent() ) {
+			/*
+			 * We found a cycle in the derived dependency path.
+			 * This can happen for example if:
+			 * - property "foo" on type A is marked as derived from itself
+			 * - property "foo" on type A is marked as derived from property "bar" on type B,
+			 *   which is marked as derived from property "foo" on type "A".
+			 * - property "foo" on type A is marked as derived from property "bar" on type B,
+			 *   which is marked as derived from property "foobar" on type "C".
+			 *   which is marked as derived from property "bar" on type "B".
+			 * Even if such a dependency might work in practice at runtime,
+			 * for example because the link A => B never leads to a B that refers to the same A,
+			 * even indirectly,
+			 * we cannot support it here because we need to model dependencies as a static tree,
+			 * which in such case would have an infinite depth.
+			 */
+			throw log.infiniteRecursionForDerivedFrom( newDerivedDependencyInfo.definingTypeModel,
+					cycle.get() );
 		}
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/PojoIndexingDependencyCollectorNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/PojoIndexingDependencyCollectorNode.java
@@ -17,8 +17,7 @@ public abstract class PojoIndexingDependencyCollectorNode {
 		return new Walker( null );
 	}
 
-	static Walker walker(
-			LinkedNode<PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?>> derivedDependencyPath) {
+	static Walker walker(LinkedNode<DerivedDependencyWalkingInfo> derivedDependencyPath) {
 		return new Walker( derivedDependencyPath );
 	}
 
@@ -65,9 +64,9 @@ public abstract class PojoIndexingDependencyCollectorNode {
 			PojoIndexingDependencyCollectorPropertyNode<?, ?>,
 			AbstractPojoIndexingDependencyCollectorDirectValueNode<?, ?>
 			> {
-		private final LinkedNode<PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?>> derivedDependencyPath;
+		private final LinkedNode<DerivedDependencyWalkingInfo> derivedDependencyPath;
 
-		Walker(LinkedNode<PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?>> derivedDependencyPath) {
+		Walker(LinkedNode<DerivedDependencyWalkingInfo> derivedDependencyPath) {
 			this.derivedDependencyPath = derivedDependencyPath;
 		}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/PojoIndexingDependencyCollectorNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/PojoIndexingDependencyCollectorNode.java
@@ -9,6 +9,7 @@ package org.hibernate.search.mapper.pojo.automaticindexing.building.impl;
 import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
 import org.hibernate.search.mapper.pojo.extractor.mapping.programmatic.ContainerExtractorPath;
 import org.hibernate.search.mapper.pojo.model.path.binding.impl.PojoModelPathWalker;
+import org.hibernate.search.util.common.data.impl.LinkedNode;
 
 public abstract class PojoIndexingDependencyCollectorNode {
 
@@ -16,8 +17,9 @@ public abstract class PojoIndexingDependencyCollectorNode {
 		return new Walker( null );
 	}
 
-	static Walker walker(PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?> initialNodeCollectingDependency) {
-		return new Walker( initialNodeCollectingDependency );
+	static Walker walker(
+			LinkedNode<PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?>> derivedDependencyPath) {
+		return new Walker( derivedDependencyPath );
 	}
 
 	final PojoImplicitReindexingResolverBuildingHelper buildingHelper;
@@ -63,10 +65,10 @@ public abstract class PojoIndexingDependencyCollectorNode {
 			PojoIndexingDependencyCollectorPropertyNode<?, ?>,
 			AbstractPojoIndexingDependencyCollectorDirectValueNode<?, ?>
 			> {
-		private final PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?> initialNodeCollectingDependency;
+		private final LinkedNode<PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?>> derivedDependencyPath;
 
-		Walker(PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?> initialNodeCollectingDependency) {
-			this.initialNodeCollectingDependency = initialNodeCollectingDependency;
+		Walker(LinkedNode<PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?>> derivedDependencyPath) {
+			this.derivedDependencyPath = derivedDependencyPath;
 		}
 
 		@Override
@@ -80,7 +82,7 @@ public abstract class PojoIndexingDependencyCollectorNode {
 				PojoIndexingDependencyCollectorPropertyNode<?, ?> propertyNode,
 				ContainerExtractorPath extractorPath) {
 			AbstractPojoIndexingDependencyCollectorDirectValueNode<?, ?> node = propertyNode.value( extractorPath );
-			node.doCollectDependency( initialNodeCollectingDependency );
+			node.doCollectDependency( derivedDependencyPath );
 			return node;
 		}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/PojoIndexingDependencyCollectorPolymorphicDirectValueNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/PojoIndexingDependencyCollectorPolymorphicDirectValueNode.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.hibernate.search.mapper.pojo.extractor.impl.BoundContainerExtractorPath;
 import org.hibernate.search.mapper.pojo.model.path.impl.BoundPojoModelPathValueNode;
+import org.hibernate.search.util.common.data.impl.LinkedNode;
 
 /**
  * A node representing a value in a dependency collector,
@@ -93,9 +94,9 @@ public class PojoIndexingDependencyCollectorPolymorphicDirectValueNode<P, V>
 
 	@Override
 	void doCollectDependency(
-			PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?> initialNodeCollectingDependency) {
+			LinkedNode<PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?>> derivedDependencyPath) {
 		for ( PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?> node : monomorphicValueNodes ) {
-			node.doCollectDependency( initialNodeCollectingDependency );
+			node.doCollectDependency( derivedDependencyPath );
 		}
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/PojoIndexingDependencyCollectorPolymorphicDirectValueNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/PojoIndexingDependencyCollectorPolymorphicDirectValueNode.java
@@ -29,13 +29,12 @@ public class PojoIndexingDependencyCollectorPolymorphicDirectValueNode<P, V>
 
 	static <P, V> AbstractPojoIndexingDependencyCollectorDirectValueNode<P, V> create(
 			PojoIndexingDependencyCollectorPropertyNode<?, P> parentNode,
-			BoundPojoModelPathValueNode<?, P, V> modelPathFromLastTypeNode,
 			BoundPojoModelPathValueNode<?, P, V> modelPathFromLastEntityNode,
 			PojoImplicitReindexingResolverBuildingHelper buildingHelper) {
 		List<? extends PojoIndexingDependencyCollectorTypeNode<?>> holderSubTypeNodes =
 				parentNode.parentNode().polymorphic();
 		String propertyName = parentNode.modelPathFromParentNode().getPropertyModel().name();
-		BoundContainerExtractorPath<? super P, V> boundExtractorPath = modelPathFromLastTypeNode.getBoundExtractorPath();
+		BoundContainerExtractorPath<? super P, V> boundExtractorPath = modelPathFromLastEntityNode.getBoundExtractorPath();
 		List<PojoIndexingDependencyCollectorMonomorphicDirectValueNode<? extends P, V>> monomorphicValueNodes =
 				new ArrayList<>();
 		Metadata parentTypeMetadata = Metadata.create(
@@ -61,7 +60,7 @@ public class PojoIndexingDependencyCollectorPolymorphicDirectValueNode<P, V>
 		else {
 			// No need to use polymorphism; just return the value as it is on the (super) holder type.
 			return new PojoIndexingDependencyCollectorMonomorphicDirectValueNode<>( parentNode,
-					modelPathFromLastTypeNode, modelPathFromLastEntityNode, parentTypeMetadata, buildingHelper
+					modelPathFromLastEntityNode, parentTypeMetadata, buildingHelper
 			);
 		}
 	}
@@ -93,8 +92,7 @@ public class PojoIndexingDependencyCollectorPolymorphicDirectValueNode<P, V>
 	}
 
 	@Override
-	void doCollectDependency(
-			LinkedNode<PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?>> derivedDependencyPath) {
+	void doCollectDependency(LinkedNode<DerivedDependencyWalkingInfo> derivedDependencyPath) {
 		for ( PojoIndexingDependencyCollectorMonomorphicDirectValueNode<?, ?> node : monomorphicValueNodes ) {
 			node.doCollectDependency( derivedDependencyPath );
 		}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/PojoIndexingDependencyCollectorPropertyNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/PojoIndexingDependencyCollectorPropertyNode.java
@@ -41,7 +41,6 @@ public class PojoIndexingDependencyCollectorPropertyNode<T, P> extends PojoIndex
 			BoundContainerExtractorPath<? super P, V> boundExtractorPath) {
 		return PojoIndexingDependencyCollectorPolymorphicDirectValueNode.create(
 				this,
-				modelPathFromParentNode.value( boundExtractorPath ),
 				modelPathFromLastEntityNode.value( boundExtractorPath ),
 				buildingHelper
 		);
@@ -61,7 +60,6 @@ public class PojoIndexingDependencyCollectorPropertyNode<T, P> extends PojoIndex
 			BoundContainerExtractorPath<? super P, V> boundExtractorPath) {
 		return PojoIndexingDependencyCollectorMonomorphicDirectValueNode.create(
 				this,
-				modelPathFromParentNode.value( boundExtractorPath ),
 				modelPathFromLastEntityNode.value( boundExtractorPath ),
 				buildingHelper
 		);

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/impl/PojoImplicitReindexingResolverMultiNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/impl/PojoImplicitReindexingResolverMultiNode.java
@@ -34,11 +34,7 @@ public class PojoImplicitReindexingResolverMultiNode<T> extends PojoImplicitRein
 
 	@Override
 	public void appendTo(ToStringTreeBuilder builder) {
-		builder.startList();
-		for ( PojoImplicitReindexingResolverNode<?> element : elements ) {
-			builder.value( element );
-		}
-		builder.endList();
+		builder.attribute( null, elements );
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
@@ -31,7 +31,7 @@ import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.common.logging.impl.ClassFormatter;
 import org.hibernate.search.util.common.logging.impl.MessageConstants;
 import org.hibernate.search.util.common.logging.impl.SimpleNameClassFormatter;
-import org.hibernate.search.util.common.logging.impl.ToStringTreeAppendableMultilineFormatter;
+import org.hibernate.search.util.common.logging.impl.ToStringTreeMultilineFormatter;
 import org.hibernate.search.util.common.logging.impl.TypeFormatter;
 import org.hibernate.search.util.common.reporting.EventContext;
 
@@ -223,7 +223,7 @@ public interface Log extends BasicLogger {
 			value = "Type manager for indexed type '%1$s': %2$s")
 	void indexedTypeManager(
 			@FormatWith(PojoTypeModelFormatter.class) PojoRawTypeModel<?> typeModel,
-			@FormatWith(ToStringTreeAppendableMultilineFormatter.class) PojoIndexedTypeManager<?, ?> typeManager);
+			@FormatWith(ToStringTreeMultilineFormatter.class) PojoIndexedTypeManager<?, ?> typeManager);
 
 	@LogMessage(level = Logger.Level.DEBUG)
 	@Message(id = ID_OFFSET + 18,
@@ -235,7 +235,7 @@ public interface Log extends BasicLogger {
 			value = "Type manager for contained type '%1$s': %2$s")
 	void containedTypeManager(
 			@FormatWith(PojoTypeModelFormatter.class) PojoRawTypeModel<?> typeModel,
-			@FormatWith(ToStringTreeAppendableMultilineFormatter.class) PojoContainedTypeManager<?, ?> typeManager);
+			@FormatWith(ToStringTreeMultilineFormatter.class) PojoContainedTypeManager<?, ?> typeManager);
 
 	@Message(id = ID_OFFSET + 20,
 			value = "Unable to find the inverse side of the association on type '%2$s' at path '%3$s'."

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeOptionsStep;
+import org.hibernate.search.mapper.pojo.automaticindexing.building.impl.DerivedDependencyWalkingInfo;
 import org.hibernate.search.mapper.pojo.common.annotation.impl.SearchProcessingWithContextException;
 import org.hibernate.search.mapper.pojo.extractor.ContainerExtractor;
 import org.hibernate.search.mapper.pojo.logging.spi.PojoModelPathFormatter;
@@ -28,6 +29,7 @@ import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeModel;
 import org.hibernate.search.mapper.pojo.model.spi.PojoTypeModel;
 import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.common.data.impl.LinkedNode;
 import org.hibernate.search.util.common.logging.impl.ClassFormatter;
 import org.hibernate.search.util.common.logging.impl.MessageConstants;
 import org.hibernate.search.util.common.logging.impl.SimpleNameClassFormatter;
@@ -289,7 +291,8 @@ public interface Log extends BasicLogger {
 
 	@Message(id = ID_OFFSET + 30,
 			value = "Unable to resolve dependencies of a derived property:"
-					+ " there is a cyclic dependency involving path '%2$s' on type '%1$s'."
+					+ " there is a cyclic dependency starting from type '%1$s'.\n"
+					+ "Derivation chain starting from that type and ending with a cycle:%2$s\n"
 					+ " A derived property cannot be marked as derived from itself, even indirectly through other "
 					+ " derived properties."
 					+ " If your model actually contains such cyclic dependency, "
@@ -298,7 +301,7 @@ public interface Log extends BasicLogger {
 	)
 	SearchException infiniteRecursionForDerivedFrom(
 			@FormatWith(PojoTypeModelFormatter.class) PojoRawTypeModel<?> typeModel,
-			@FormatWith(PojoModelPathFormatter.class) PojoModelPathValueNode path);
+			@FormatWith(ToStringTreeMultilineFormatter.class) LinkedNode<DerivedDependencyWalkingInfo> cycle);
 
 	@Message(id = ID_OFFSET + 31,
 			value = "Unable to apply property mapping:"

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/path/impl/PojobTypeAndModelPath.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/path/impl/PojobTypeAndModelPath.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.model.path.impl;
+
+import org.hibernate.search.engine.mapper.model.spi.MappableTypeModel;
+import org.hibernate.search.mapper.pojo.model.path.PojoModelPath;
+
+public final class PojobTypeAndModelPath {
+	public final MappableTypeModel type;
+	public final PojoModelPath path;
+
+	public PojobTypeAndModelPath(MappableTypeModel type, PojoModelPath path) {
+		this.type = type;
+		this.path = path;
+	}
+
+	@Override
+	public String toString() {
+		return type.name() + "#" + path;
+	}
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/processing/impl/PojoIndexingProcessorMultiNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/processing/impl/PojoIndexingProcessorMultiNode.java
@@ -35,11 +35,7 @@ public class PojoIndexingProcessorMultiNode<T> extends PojoIndexingProcessor<T> 
 
 	@Override
 	public void appendTo(ToStringTreeBuilder builder) {
-		builder.startList();
-		for ( PojoIndexingProcessor<? super T> element : elements ) {
-			builder.value( element );
-		}
-		builder.endList();
+		builder.attribute( null, elements );
 	}
 
 	@Override

--- a/util/common/src/main/java/org/hibernate/search/util/common/data/impl/LinkedNode.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/data/impl/LinkedNode.java
@@ -1,0 +1,106 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.common.data.impl;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+
+import org.hibernate.search.util.common.impl.Contracts;
+
+/**
+ * A very simple, immutable data structure to represent singly linked lists.
+ *
+ * @param <T> The type of values stored in the list.
+ */
+public final class LinkedNode<T> implements Iterable<T> {
+	public static <T> LinkedNode<T> of(T value) {
+		return new LinkedNode<>( value, null );
+	}
+
+	@SafeVarargs
+	public static <T> LinkedNode<T> of(T... values) {
+		Contracts.assertNotNullNorEmpty( values, "values" );
+		LinkedNode<T> tail = null;
+		for ( int i = values.length - 1; i >= 0; i-- ) {
+			tail = new LinkedNode<>( values[i], tail );
+		}
+		return tail;
+	}
+
+	public final T value;
+	private final LinkedNode<T> tail;
+
+	// For quick access
+	public final LinkedNode<T> last;
+
+	private LinkedNode(T value, LinkedNode<T> tail) {
+		this.value = value;
+		this.tail = tail;
+		this.last = tail == null ? this : tail.last;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append( '[' );
+		boolean first = true;
+		for ( Iterator<T> it = iterator(); it.hasNext(); ) {
+			if ( first ) {
+				first = false;
+			}
+			else {
+				sb.append( " => " );
+			}
+			sb.append( it.next() );
+		}
+		return sb.append( ']' ).toString();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( obj == this ) {
+			return true;
+		}
+		if ( !( obj instanceof LinkedNode ) ) {
+			return false;
+		}
+		LinkedNode<?> other = (LinkedNode<?>) obj;
+		return Objects.equals( value, other.value ) && Objects.equals( tail, other.tail );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( value, tail );
+	}
+
+	@Override
+	public Iterator<T> iterator() {
+		return new Iterator<T>() {
+			private LinkedNode<T> next = LinkedNode.this;
+
+			@Override
+			public boolean hasNext() {
+				return next != null;
+			}
+
+			@Override
+			public T next() {
+				if ( next == null ) {
+					throw new NoSuchElementException();
+				}
+				T value = next.value;
+				next = next.tail;
+				return value;
+			}
+		};
+	}
+
+	public LinkedNode<T> withHead(T headValue) {
+		return new LinkedNode<>( headValue, this );
+	}
+}

--- a/util/common/src/main/java/org/hibernate/search/util/common/impl/ToStringTreeBuilder.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/impl/ToStringTreeBuilder.java
@@ -42,6 +42,13 @@ public class ToStringTreeBuilder {
 			endStructure( StructureType.OBJECT, style.endObject );
 			endEntry();
 		}
+		else if ( value instanceof Iterable ) {
+			startList( name );
+			for ( Object element : (Iterable<?>) value ) {
+				value( element );
+			}
+			endList();
+		}
 		else {
 			startEntry( name, null );
 			if ( value == null ) {

--- a/util/common/src/main/java/org/hibernate/search/util/common/impl/ToStringTreeBuilder.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/impl/ToStringTreeBuilder.java
@@ -44,7 +44,19 @@ public class ToStringTreeBuilder {
 		}
 		else {
 			startEntry( name, null );
-			builder.append( value );
+			if ( value == null ) {
+				builder.append( value );
+			}
+			else {
+				String[] lines = value.toString().split( "\n" );
+				for ( int i = 0; i < lines.length; i++ ) {
+					if ( i != 0 ) {
+						appendNewline();
+						appendIndentIfNecessary();
+					}
+					builder.append( lines[i] );
+				}
+			}
 			endEntry();
 		}
 		return this;

--- a/util/common/src/main/java/org/hibernate/search/util/common/logging/impl/ToStringTreeMultilineFormatter.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/logging/impl/ToStringTreeMultilineFormatter.java
@@ -7,25 +7,24 @@
 package org.hibernate.search.util.common.logging.impl;
 
 import org.hibernate.search.util.common.impl.ToStringStyle;
-import org.hibernate.search.util.common.impl.ToStringTreeAppendable;
 import org.hibernate.search.util.common.impl.ToStringTreeBuilder;
 
 /**
- * Used with JBoss Logging's {@link org.jboss.logging.annotations.FormatWith} to display
- * {@link ToStringTreeAppendable} objects in log messages.
+ * Used with JBoss Logging's {@link org.jboss.logging.annotations.FormatWith} to format
+ * objects using a {@link ToStringTreeBuilder}.
  */
-public final class ToStringTreeAppendableMultilineFormatter {
+public final class ToStringTreeMultilineFormatter {
 
-	private final ToStringTreeAppendable appendable;
+	private final Object object;
 
-	public ToStringTreeAppendableMultilineFormatter(ToStringTreeAppendable appendable) {
-		this.appendable = appendable;
+	public ToStringTreeMultilineFormatter(Object object) {
+		this.object = object;
 	}
 
 	@Override
 	public String toString() {
 		return new ToStringTreeBuilder( ToStringStyle.multilineIndentStructure() )
-				.value( appendable )
+				.value( object )
 				.toString();
 	}
 }

--- a/util/common/src/test/java/org/hibernate/search/util/common/data/impl/LinkedNodeTest.java
+++ b/util/common/src/test/java/org/hibernate/search/util/common/data/impl/LinkedNodeTest.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.common.data.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Predicate;
+
+import org.junit.Test;
+
+public class LinkedNodeTest {
+
+	@Test
+	public void testToString() {
+		assertThat( LinkedNode.of( 42 ).toString() )
+				.isEqualTo( "[42]" );
+		assertThat( LinkedNode.of( 42, 1, 2, 3 ).toString() )
+				.isEqualTo( "[42 => 1 => 2 => 3]" );
+	}
+
+	@Test
+	public void testEqualsAndHashCode() {
+		assertThat( LinkedNode.of( 42 ) )
+				.isEqualTo( LinkedNode.of( 42 ) );
+		assertThat( LinkedNode.of( 42 ).hashCode() )
+				.isEqualTo( LinkedNode.of( 42 ).hashCode() );
+
+		assertThat( LinkedNode.of( 42, 1, 2, 3 ).hashCode() )
+				.isEqualTo( LinkedNode.of( 42, 1, 2, 3 ).hashCode() );
+		assertThat( LinkedNode.of( 42, 1, 2, 3 ).hashCode() )
+				.isEqualTo( LinkedNode.of( 42, 1, 2, 3 ).hashCode() );
+
+		assertThat( LinkedNode.of( 42 ) )
+				.isNotEqualTo( LinkedNode.of( 43 ) );
+		assertThat( LinkedNode.of( 42 ) )
+				.isNotEqualTo( LinkedNode.of( 42, 1 ) );
+		assertThat( LinkedNode.of( 42, 1, 2, 3 ) )
+				.isNotEqualTo( LinkedNode.of( 42, 1, 32, 3 ) );
+	}
+
+}

--- a/util/common/src/test/java/org/hibernate/search/util/common/data/impl/LinkedNodeTest.java
+++ b/util/common/src/test/java/org/hibernate/search/util/common/data/impl/LinkedNodeTest.java
@@ -42,4 +42,44 @@ public class LinkedNodeTest {
 				.isNotEqualTo( LinkedNode.of( 42, 1, 32, 3 ) );
 	}
 
+	@Test
+	public void findAndReverse() {
+		Predicate<Integer> is42 = Predicate.isEqual( 42 );
+
+		// First matching is first element
+		assertThat( LinkedNode.of( 42, 1, 2, 3 )
+				.findAndReverse( is42 ) )
+				.hasValue( LinkedNode.of( 42 ) );
+
+		// First matching is somewhere in the middle
+		assertThat( LinkedNode.of( 1, 42, 2, 3 )
+				.findAndReverse( is42 ) )
+				.hasValue( LinkedNode.of( 42, 1 ) );
+
+		// First matching is last element
+		assertThat( LinkedNode.of( 1, 2, 3, 42 )
+				.findAndReverse( is42 ) )
+				.hasValue( LinkedNode.of( 42, 3, 2, 1 ) );
+
+		// No match
+		assertThat( LinkedNode.of( 1, 2, 3 )
+				.findAndReverse( is42 ) )
+				.isEmpty();
+
+		// Multiple matches
+		assertThat( LinkedNode.of( 1, 42, 42, 2, 3, 42 )
+				.findAndReverse( is42 ) )
+				.hasValue( LinkedNode.of( 42, 1 ) );
+
+		// Matching singleton
+		assertThat( LinkedNode.of( 42 )
+				.findAndReverse( is42 ) )
+				.hasValue( LinkedNode.of( 42 ) );
+
+		// Non-matching singleton
+		assertThat( LinkedNode.of( 1 )
+				.findAndReverse( is42 ) )
+				.isEmpty();
+	}
+
 }

--- a/util/common/src/test/java/org/hibernate/search/util/common/impl/ToStringTreeBuilderTest.java
+++ b/util/common/src/test/java/org/hibernate/search/util/common/impl/ToStringTreeBuilderTest.java
@@ -8,6 +8,8 @@ package org.hibernate.search.util.common.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
+
 import org.junit.Test;
 
 public class ToStringTreeBuilderTest {
@@ -17,11 +19,11 @@ public class ToStringTreeBuilderTest {
 		assertThat( toString( ToStringStyle.inlineDelimiterStructure() ) )
 				.isEqualTo(
 						"foo=value, children={"
-						+ " childrenFoo=23, child1={ child1Foo=customToString, [ foo, 42 ] }, emptyChild={ },"
+						+ " childrenFoo=23, child1={ child1Foo=customToString, [ foo, 42 ], [ foo2, 43 ] }, emptyChild={ },"
 						+ " appendable={ attr=val, nested={ attr=val2 } },"
 						+ " appendableAsObject={ attr=val, nested={ attr=val2 } },"
 						+ " nullAppendable=null,"
-						+ " list=[ { name=foo }, object={ name=foo, attr=bar }, { nestedList=[ first, second ], name=bar } ]"
+						+ " list=[ { name=foo }, object={ name=foo, attr=bar }, { nestedList=[ first, second ], name=bar, nestedList2=[ first, second ] } ]"
 						+ " }, bar=value"
 				);
 		assertThat( new ToStringTreeBuilder().toString() ).isEqualTo( "" );
@@ -41,6 +43,10 @@ public class ToStringTreeBuilderTest {
 						+ "\t\t[\n"
 						+ "\t\t\tfoo\n"
 						+ "\t\t\t42\n"
+						+ "\t\t]\n"
+						+ "\t\t[\n"
+						+ "\t\t\tfoo2\n"
+						+ "\t\t\t43\n"
 						+ "\t\t]\n"
 						+ "\t}\n"
 						+ "\temptyChild={\n"
@@ -72,6 +78,10 @@ public class ToStringTreeBuilderTest {
 						+ "\t\t\t\tsecond\n"
 						+ "\t\t\t]\n"
 						+ "\t\t\tname=bar\n"
+						+ "\t\t\tnestedList2=[\n"
+						+ "\t\t\t\tfirst\n"
+						+ "\t\t\t\tsecond\n"
+						+ "\t\t\t]\n"
 						+ "\t\t}\n"
 						+ "\t]\n"
 						+ "}\n"
@@ -94,6 +104,8 @@ public class ToStringTreeBuilderTest {
 						+ "    child1Foo: customToString\n"
 						+ "      - foo\n"
 						+ "      - 42\n"
+						+ "      - foo2\n"
+						+ "      - 43\n"
 						+ "  emptyChild: \n"
 						+ "  appendable: \n"
 						+ "    attr: val\n"
@@ -113,6 +125,9 @@ public class ToStringTreeBuilderTest {
 						+ "        - first\n"
 						+ "        - second\n"
 						+ "      name: bar\n"
+						+ "      nestedList2: \n"
+						+ "        - first\n"
+						+ "        - second\n"
 						+ "bar: value"
 				);
 		assertThat( new ToStringTreeBuilder( style ).toString() ).isEqualTo( "" );
@@ -136,6 +151,7 @@ public class ToStringTreeBuilderTest {
 							.value( "foo" )
 							.value( 42 )
 							.endList()
+						.attribute( null, Arrays.asList( "foo2", 43 ) )
 						.endObject()
 					.startObject( "emptyChild" )
 						.endObject()
@@ -156,6 +172,7 @@ public class ToStringTreeBuilderTest {
 								.value( "second" )
 								.endList()
 							.attribute( "name", "bar" )
+							.attribute( "nestedList2", Arrays.asList( "first", "second" ) )
 							.endObject()
 						.endList()
 					.endObject()

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/reporting/FailureReportChecker.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/reporting/FailureReportChecker.java
@@ -145,7 +145,15 @@ public class FailureReportChecker implements Consumer<Throwable> {
 		lastPatternWasFailure = true;
 		elementsToMatch.add( new ElementToMatch( "\\n\\h+-\\h" ) );
 		for ( String contained : literalStringsContainedInFailureMessageInOrder ) {
-			elementsToMatch.add( new ElementToMatch( "[\\S\\s]*" + "\\Q" + contained + "\\E" ) );
+			String[] lines = contained.split( "\n" );
+			for ( int i = 0; i < lines.length; i++ ) {
+				if ( i == 0 ) {
+					elementsToMatch.add( new ElementToMatch( ".*(\\n\\h+.*)?" + "\\Q" + lines[i] + "\\E" ) );
+				}
+				else {
+					elementsToMatch.add( new ElementToMatch( "\\n\\h+" + "\\Q" + lines[i] + "\\E" ) );
+				}
+			}
 		}
 		// Match the rest of the line
 		// We can't match multiple lines here, or we would run the risk of


### PR DESCRIPTION
* [HSEARCH-4611](https://hibernate.atlassian.net/browse/HSEARCH-4611): Improve exception and log messages involving multi-valued elements
* [HSEARCH-4565](https://hibernate.atlassian.net/browse/HSEARCH-4565): Cyclic dependency detection for IndexingDependency(derivedFrom = ...) does not detect "buried" cycles

Backport of #3112 to branch 6.1.