### PR TITLE
HSEARCH-4484 + HSEARCH-4540 Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,7 +347,7 @@
         <version.org.apache.derby>10.14.2.0</version.org.apache.derby>
 
         <!-- >>> JSR 352: JBeret SE dependencies -->
-        <version.org.jboss.marshalling>2.0.12.Final</version.org.jboss.marshalling>
+        <version.org.jboss.marshalling>2.1.0.Final</version.org.jboss.marshalling>
         <version.org.wildfly.security.wildfly-security-manager>1.1.2.Final</version.org.wildfly.security.wildfly-security-manager>
         <version.org.google.guava>31.1-jre</version.org.google.guava>
 

--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@
 
         <!-- >>> JSR 352 -->
         <version.javax.batch>1.0.1</version.javax.batch>
-        <version.jakarta.batch>2.1.0</version.jakarta.batch>
+        <version.jakarta.batch>2.1.1</version.jakarta.batch>
         <version.org.jberet>1.4.7.Final</version.org.jberet>
         <version.org.jberet.jakarta>2.0.4.Final</version.org.jberet.jakarta>
 


### PR DESCRIPTION
* [HSEARCH-4540](https://hibernate.atlassian.net/browse/HSEARCH-4540): Upgrade to the latest version of Jakarta dependencies in -orm6/-jakarta artifacts
* [HSEARCH-4484](https://hibernate.atlassian.net/browse/HSEARCH-4484): Upgrade build dependencies to the latest version

For HSEARCH-4540, follows up on #3007.

For HSEARCH-4484, follows up on https://github.com/hibernate/hibernate-search/pull/2895, https://github.com/hibernate/hibernate-search/pull/2902, https://github.com/hibernate/hibernate-search/pull/2904, #2913, #2931, #2941, #2954, #2293 #2983, #3021, #3028, #3041, #3052, #3066, #3083, #3092, #3100, #3110.