### PR TITLE
Backport HSEARCH-4540 to branch 6.1 - Upgrade to the latest version of Jakarta dependencies in -orm6/-jakarta artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
 
         <!-- >>> JSR 352 -->
         <version.javax.batch>1.0.1</version.javax.batch>
-        <version.jakarta.batch>2.1.0</version.jakarta.batch>
+        <version.jakarta.batch>2.1.1</version.jakarta.batch>
         <version.org.jberet>1.4.0.Final</version.org.jberet>
         <version.org.jberet.jakarta>2.0.4.Final</version.org.jberet.jakarta>
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4540

Follows up on #3008

Partial backport of #3118