### PR TITLE
HSEARCH-4619 Inconsistent behavior of boolean predicate when not adding any clause

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchBooleanPredicate.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchBooleanPredicate.java
@@ -210,6 +210,11 @@ class ElasticsearchBooleanPredicate extends AbstractElasticsearchPredicate {
 
 		@Override
 		public SearchPredicate build() {
+			if ( mustClauses == null && shouldClauses == null && mustNotClauses == null && filterClauses == null ) {
+				// HSEARCH-4619: a boolean predicate without any clause must not match anything.
+				return new ElasticsearchMatchNonePredicate( this );
+			}
+
 			// Forcing to Lucene's defaults. See HSEARCH-3534
 			if ( minimumShouldMatchConstraints == null && hasAtLeastOneMustOrFilterPredicate() ) {
 				minimumShouldMatchNumber( 0, 0 );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchMatchNonePredicate.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchMatchNonePredicate.java
@@ -20,7 +20,7 @@ class ElasticsearchMatchNonePredicate extends AbstractElasticsearchPredicate {
 	private static final JsonObjectAccessor MATCH_NONE_ACCESSOR = JsonAccessor.root().property( "match_none" )
 			.asObject();
 
-	private ElasticsearchMatchNonePredicate(Builder builder) {
+	ElasticsearchMatchNonePredicate(AbstractBuilder builder) {
 		super( builder );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/BoolPredicateSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/BoolPredicateSpecificsIT.java
@@ -70,6 +70,13 @@ public class BoolPredicateSpecificsIT {
 	}
 
 	@Test
+	public void noClause() {
+		assertThatQuery( index.query()
+				.where( f -> f.bool() ) )
+				.hasNoHits();
+	}
+
+	@Test
 	public void must() {
 		assertThatQuery( index.query()
 				.where( f -> f.bool()


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4619
