### PR TITLE
HSEARCH-4622 + HSEARCH-4623 Add compatibility with Elasticsearch 8.3.0 + Upgrade to Elasticsearch client 8.3.0

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
@@ -166,7 +166,7 @@ public class ElasticsearchDialectFactory {
 	}
 
 	private ElasticsearchProtocolDialect createProtocolDialectElasticV8(ElasticsearchVersion version, int minor) {
-		if ( minor > 2 ) {
+		if ( minor > 3 ) {
 			log.unknownElasticsearchVersion( version );
 		}
 		else if ( minor == 0 ) {

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -643,19 +643,37 @@ public class ElasticsearchDialectFactoryTest {
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4559")
+	@TestForIssue(jiraKey = "HSEARCH-4623")
 	public void elastic_8_3() {
-		testSuccessWithWarning(
+		testSuccess(
 				ElasticsearchDistributionName.ELASTIC, "8.3", "8.3.0",
 				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
 		);
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4559")
+	@TestForIssue(jiraKey = "HSEARCH-4623")
 	public void elastic_8_3_0() {
-		testSuccessWithWarning(
+		testSuccess(
 				ElasticsearchDistributionName.ELASTIC, "8.3.0", "8.3.0",
+				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4623")
+	public void elastic_8_4() {
+		testSuccessWithWarning(
+				ElasticsearchDistributionName.ELASTIC, "8.4", "8.4.0",
+				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4623")
+	public void elastic_8_4_0() {
+		testSuccessWithWarning(
+				ElasticsearchDistributionName.ELASTIC, "8.4.0", "8.4.0",
 				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
 		);
 	}

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -603,7 +603,7 @@
             <properties>
                 <test.elasticsearch.run.elastic.skip>${test.elasticsearch.run.skip}</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.distribution>elastic</test.elasticsearch.connection.distribution>
-                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-8.2}</test.elasticsearch.connection.version>
+                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-8.3}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch712TestDialect</test.elasticsearch.testdialect>
             </properties>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.2+ -->
-        <version.org.elasticsearch.client>8.2.3</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>8.3.0</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-8.3) becomes the default. -->

--- a/pom.xml
+++ b/pom.xml
@@ -206,15 +206,16 @@
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-8.3) becomes the default. -->
-        <version.org.elasticsearch.compatible.main>${version.org.elasticsearch.latest-8.2}</version.org.elasticsearch.compatible.main>
+        <version.org.elasticsearch.compatible.main>${version.org.elasticsearch.latest-8.3}</version.org.elasticsearch.compatible.main>
         <documentation.org.elasticsearch.url>https://www.elastic.co/guide/en/elasticsearch/reference/${parsed-version.org.elasticsearch.compatible.main.majorVersion}.${parsed-version.org.elasticsearch.compatible.main.minorVersion}</documentation.org.elasticsearch.url>
         <!-- The versions of Elasticsearch/OpenSearch advertised as compatible with Hibernate Search -->
         <!-- Make sure that 7.10 stays explicitly mentioned here, because that's the last open-source version -->
-        <version.org.elasticsearch.compatible.regularly-tested.text>5.6, 6.8, 7.10, 7.17 or 8.2</version.org.elasticsearch.compatible.regularly-tested.text>
+        <version.org.elasticsearch.compatible.regularly-tested.text>5.6, 6.8, 7.10, 7.17 or 8.3</version.org.elasticsearch.compatible.regularly-tested.text>
         <version.org.opensearch.compatible.regularly-tested.text>1.0 or 1.2</version.org.opensearch.compatible.regularly-tested.text>
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
         <version.org.elasticsearch.compatible.not-regularly-tested.text>7.0 or 8.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest micro of each Elasticsearch branch -->
+        <version.org.elasticsearch.latest-8.3>8.3.0</version.org.elasticsearch.latest-8.3>
         <version.org.elasticsearch.latest-8.2>8.2.3</version.org.elasticsearch.latest-8.2>
         <version.org.elasticsearch.latest-8.1>8.1.3</version.org.elasticsearch.latest-8.1>
         <version.org.elasticsearch.latest-8.0>8.0.1</version.org.elasticsearch.latest-8.0>

--- a/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/rule/log4j/LogChecker.java
+++ b/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/rule/log4j/LogChecker.java
@@ -29,16 +29,19 @@ public class LogChecker {
 			description.appendText( "Expected at least " + expectation.getMinExpectedCount() + " time(s) " );
 			expectation.getMatcher().describeTo( description );
 			description.appendText( " but only got " + count + " such event(s)." );
-			description.appendText( " Matching events: " );
+			description.appendText( newline );
+			description.appendText( "Matching events: " );
 			appendEvents( description, newline, matchingEvents );
 		}
 		if ( expectation.getMaxExpectedCount() != null && expectation.getMaxExpectedCount() < count ) {
 			description.appendText( "Expected at most " + expectation.getMaxExpectedCount() + " time(s) " );
 			expectation.getMatcher().describeTo( description );
 			description.appendText( " but got " + count + " such event(s)." );
-			description.appendText( " Extra events: " );
+			description.appendText( newline );
+			description.appendText( "Extra events: " );
 			appendEvents( description, newline, extraEvents );
-			description.appendText( " Matching events: " );
+			description.appendText( newline );
+			description.appendText( "Matching events: " );
 			appendEvents( description, newline, matchingEvents );
 		}
 	}


### PR DESCRIPTION
* [HSEARCH-4623](https://hibernate.atlassian.net/browse/HSEARCH-4623): Upgrade to Elasticsearch client 8.3.0
* [HSEARCH-4622](https://hibernate.atlassian.net/browse/HSEARCH-4622): Add compatibility with Elasticsearch 8.3.0

