### PR TITLE
HSEARCH-4484 + HSEARCH-4628 + HSEARCH-4631 Upgrade dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,3 +50,7 @@ updates:
       # See https://db.apache.org/derby/derby_downloads.html
       - dependency-name: "org.apache.derby:*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # maven-assembly-plugin 3.3+ behaves in a significantly different way, which makes the upgrade quite complex
+      # TODO HSEARCH-4380 Remove this when upgrading
+      - dependency-name: "org.apache.maven.plugins:maven-assembly-plugin"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
         <version.org.slf4j>1.7.36</version.org.slf4j>
 
         <!-- >>> ORM -->
-        <version.org.hibernate>5.6.9.Final</version.org.hibernate>
+        <version.org.hibernate>5.6.10.Final</version.org.hibernate>
         <javadoc.org.hibernate.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.majorVersion}.${parsed-version.org.hibernate.minorVersion}/javadocs/</javadoc.org.hibernate.url>
         <documentation.org.hibernate.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.majorVersion}.${parsed-version.org.hibernate.minorVersion}/userguide/html_single/Hibernate_User_Guide.html</documentation.org.hibernate.url>
         <version.org.hibernate.commons.annotations>5.1.2.Final</version.org.hibernate.commons.annotations>

--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
         <!-- Test dependencies -->
 
         <!-- >>> Common -->
-        <version.log4j>2.17.2</version.log4j>
+        <version.log4j>2.18.0</version.log4j>
         <version.junit>4.13.2</version.junit>
         <version.org.osgi.core>6.0.0</version.org.osgi.core>
 

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.3+ -->
-        <version.org.elasticsearch.client>8.3.1</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>8.3.2</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-8.3) becomes the default. -->

--- a/pom.xml
+++ b/pom.xml
@@ -406,7 +406,7 @@
         <version.scripting.plugin>3.0.0</version.scripting.plugin>
         <version.gpg.plugin>3.0.1</version.gpg.plugin>
         <version.org.codehaus.groovy-jsr223>3.0.11</version.org.codehaus.groovy-jsr223>
-        <version.com.puppycrawl.tools.checkstyle>10.3</version.com.puppycrawl.tools.checkstyle>
+        <version.com.puppycrawl.tools.checkstyle>10.3.1</version.com.puppycrawl.tools.checkstyle>
 
         <!-- Asciidoctor -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,7 @@
         <version.org.mockito>4.6.1</version.org.mockito>
         <version.org.assertj.assertj-core>3.23.1</version.org.assertj.assertj-core>
         <version.org.awaitily>4.2.0</version.org.awaitily>
-        <version.org.skyscreamer.jsonassert>1.5.0</version.org.skyscreamer.jsonassert>
+        <version.org.skyscreamer.jsonassert>1.5.1</version.org.skyscreamer.jsonassert>
         <version.io.takari.junit>1.2.7</version.io.takari.junit>
         <version.com.h2database>2.1.214</version.com.h2database>
         <version.com.github.tomakehurst.wiremock>2.27.2</version.com.github.tomakehurst.wiremock>

--- a/pom.xml
+++ b/pom.xml
@@ -380,7 +380,7 @@
         <version.help.plugin>3.2.0</version.help.plugin>
         <version.install.plugin>2.5.2</version.install.plugin>
         <version.io.takari.maven>0.7.7</version.io.takari.maven>
-        <version.jandex.plugin>1.2.2</version.jandex.plugin>
+        <version.jandex.plugin>1.2.3</version.jandex.plugin>
         <version.japicmp.plugin>0.15.7</version.japicmp.plugin>
         <version.jar.plugin>3.2.2</version.jar.plugin>
         <version.javadoc.plugin>3.4.0</version.javadoc.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -399,7 +399,7 @@
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
         <version.jacoco.plugin>0.8.8</version.jacoco.plugin>
         <version.coveralls.plugin>4.3.0</version.coveralls.plugin>
-        <version.com.buschmais.jqassistant.plugin>1.11.1</version.com.buschmais.jqassistant.plugin>
+        <version.com.buschmais.jqassistant.plugin>1.12.0</version.com.buschmais.jqassistant.plugin>
         <version.docker.maven.plugin>0.40.1</version.docker.maven.plugin>
         <version.moditect.plugin>1.0.0.RC2</version.moditect.plugin>
         <version.sonar.plugin>3.9.1.2184</version.sonar.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
         <version.org.elasticsearch.compatible.not-regularly-tested.text>7.0 or 8.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest micro of each Elasticsearch release line -->
-        <version.org.elasticsearch.latest-8.3>8.3.1</version.org.elasticsearch.latest-8.3>
+        <version.org.elasticsearch.latest-8.3>8.3.2</version.org.elasticsearch.latest-8.3>
         <version.org.elasticsearch.latest-8.2>8.2.3</version.org.elasticsearch.latest-8.2>
         <version.org.elasticsearch.latest-8.1>8.1.3</version.org.elasticsearch.latest-8.1>
         <version.org.elasticsearch.latest-8.0>8.0.1</version.org.elasticsearch.latest-8.0>


### PR DESCRIPTION
* [HSEARCH-4631](https://hibernate.atlassian.net/browse/HSEARCH-4631): Upgrade to Elasticsearch client 8.3.2 and test against Elasticsearch 8.3.2
* [HSEARCH-4628](https://hibernate.atlassian.net/browse/HSEARCH-4628): Upgrade to Hibernate ORM 5.6.10.Final
* [HSEARCH-4484](https://hibernate.atlassian.net/browse/HSEARCH-4484): Upgrade build dependencies to the latest version

For HSEARCH-4484, follows up on https://github.com/hibernate/hibernate-search/pull/2895, https://github.com/hibernate/hibernate-search/pull/2902, https://github.com/hibernate/hibernate-search/pull/2904, #2913, #2931, #2941, #2954, #2293 #2983, #3021, #3028, #3041, #3052, #3066, #3083, #3092, #3100, #3110, #3118.
