### PR TITLE
HSEARCH-4627 + HSEARCH-4635 Upgrade to Hibernate ORM 6.1.1.Final for -orm6 artifacts

### DIFF
--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
@@ -245,4 +245,19 @@ public interface Log extends BasicLogger {
 			+ " which should be set to a comma-separated string containing all possible tenant identifiers."
 			+ " Currently configured tenant identifiers: %2$s." )
 	SearchException invalidTenantId(String tenantId, Set<String> allTenantIds, String tenantIdsConfigurationPropertyKey);
+
+	// NOTE: This is used in -orm6 modules
+	@SuppressWarnings("unused")
+	@LogMessage(level = Logger.Level.INFO)
+	@Message(id = ID_OFFSET + 56, value = "Ignoring unrecognized query hint [%s]")
+	void ignoringUnrecognizedQueryHint(String hintName);
+
+	// NOTE: This is used in -orm6 modules
+	@SuppressWarnings("unused")
+	@Message(id = ID_OFFSET + 57, value = "Cannot set the fetch size of Hibernate Search ScrollableResults after having created them."
+			+ " If you want to define the size of batches for entity loading, set loading options when defining the query instead,"
+			+ " for example with .loading(o -> o.fetchSize(50))."
+			+ " See the reference documentation for more information.")
+	SearchException cannotSetFetchSize();
+
 }

--- a/orm6/documentation/ant-src-changes.patch
+++ b/orm6/documentation/ant-src-changes.patch
@@ -1,5 +1,5 @@
 diff --git a/test/java/org/hibernate/search/documentation/search/query/QueryDslIT.java b/test/java/org/hibernate/search/documentation/search/query/QueryDslIT.java
-index a5c0c91e51..2522ee732a 100644
+index 6185209396..b7736775f3 100644
 --- a/test/java/org/hibernate/search/documentation/search/query/QueryDslIT.java
 +++ b/test/java/org/hibernate/search/documentation/search/query/QueryDslIT.java
 @@ -61,7 +61,7 @@ public class QueryDslIT {

--- a/orm6/mapper/orm/ant-src-changes.patch
+++ b/orm6/mapper/orm/ant-src-changes.patch
@@ -223,19 +223,24 @@ index 82c86985ab..3abdf72591 100644
  		}
  		else {
 diff --git a/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java b/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
-index e794e21dc6..d36abb098d 100644
+index 9f1bcb8256..30de76aa99 100644
 --- a/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
 +++ b/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
-@@ -245,4 +245,9 @@ SearchException foundMultipleEntitiesForDocumentId(String entityName, String doc
- 			+ " which should be set to a comma-separated string containing all possible tenant identifiers."
+@@ -246,14 +246,10 @@ SearchException foundMultipleEntitiesForDocumentId(String entityName, String doc
  			+ " Currently configured tenant identifiers: %2$s." )
  	SearchException invalidTenantId(String tenantId, Set<String> allTenantIds, String tenantIdsConfigurationPropertyKey);
-+
-+	@LogMessage(level = Logger.Level.INFO)
-+	@Message(id = ID_OFFSET + 56, value = "Ignoring unrecognized query hint [%s]")
-+	void ignoringUnrecognizedQueryHint(String hintName);
-+
- }
+ 
+-	// NOTE: This is used in -orm6 modules
+-	@SuppressWarnings("unused")
+ 	@LogMessage(level = Logger.Level.INFO)
+ 	@Message(id = ID_OFFSET + 56, value = "Ignoring unrecognized query hint [%s]")
+ 	void ignoringUnrecognizedQueryHint(String hintName);
+ 
+-	// NOTE: This is used in -orm6 modules
+-	@SuppressWarnings("unused")
+ 	@Message(id = ID_OFFSET + 57, value = "Cannot set the fetch size of Hibernate Search ScrollableResults after having created them."
+ 			+ " If you want to define the size of batches for entity loading, set loading options when defining the query instead,"
+ 			+ " for example with .loading(o -> o.fetchSize(50))."
 diff --git a/main/java/org/hibernate/search/mapper/orm/mapping/impl/AbstractHibernateOrmTypeContext.java b/main/java/org/hibernate/search/mapper/orm/mapping/impl/AbstractHibernateOrmTypeContext.java
 index 17e33f2c15..565a56d897 100644
 --- a/main/java/org/hibernate/search/mapper/orm/mapping/impl/AbstractHibernateOrmTypeContext.java
@@ -577,10 +582,10 @@ index 355980c45a..6489423a9c 100644
  					|| isWholePath && isAssociation( containedValueClass ) ) {
  				pathsAsStrings.add( propertyNode.toPropertyString() );
 diff --git a/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java b/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java
-index c8ca89a1e0..b6a7fb955e 100644
+index c8ca89a1e0..9b2ef89c32 100644
 --- a/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java
 +++ b/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java
-@@ -7,52 +7,48 @@
+@@ -7,52 +7,45 @@
  package org.hibernate.search.mapper.orm.search.query.impl;
  
  import java.lang.invoke.MethodHandles;
@@ -632,24 +637,24 @@ index c8ca89a1e0..b6a7fb955e 100644
  import org.hibernate.search.mapper.orm.search.query.spi.HibernateOrmSearchScrollableResultsAdapter;
 -import org.hibernate.search.mapper.orm.search.query.spi.HibernateOrmSearchScrollableResultsAdapter.ScrollHitExtractor;
  import org.hibernate.search.util.common.SearchTimeoutException;
- import org.hibernate.search.util.common.annotation.impl.SuppressForbiddenApis;
+-import org.hibernate.search.util.common.annotation.impl.SuppressForbiddenApis;
  import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 -import org.hibernate.transform.ResultTransformer;
 -import org.hibernate.type.Type;
-+
+ 
+-@SuppressForbiddenApis(reason = "We need to extend the internal AbstractProducedQuery"
+-		+ " in order to implement a org.hibernate.query.Query")
 +import jakarta.persistence.LockModeType;
 +import jakarta.persistence.PersistenceException;
 +import jakarta.persistence.QueryTimeoutException;
- 
- @SuppressForbiddenApis(reason = "We need to extend the internal AbstractProducedQuery"
- 		+ " in order to implement a org.hibernate.query.Query")
++
  @SuppressWarnings("unchecked") // For some reason javac issues warnings for all methods returning this; IDEA doesn't.
 -public final class HibernateOrmSearchQueryAdapter<R> extends AbstractProducedQuery<R> {
 +public final class HibernateOrmSearchQueryAdapter<R> extends AbstractQuery<R> {
  
  	public static <R> HibernateOrmSearchQueryAdapter<R> create(SearchQuery<R> query) {
  		return query.extension( HibernateOrmSearchQueryAdapterExtension.get() );
-@@ -61,15 +57,16 @@ public static <R> HibernateOrmSearchQueryAdapter<R> create(SearchQuery<R> query)
+@@ -61,15 +54,16 @@ public static <R> HibernateOrmSearchQueryAdapter<R> create(SearchQuery<R> query)
  	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
  
  	private final SearchQueryImplementor<R> delegate;
@@ -670,7 +675,7 @@ index c8ca89a1e0..b6a7fb955e 100644
  		this.loadingOptions = loadingOptions;
  	}
  
-@@ -84,83 +81,26 @@ public String toString() {
+@@ -84,83 +78,26 @@ public String toString() {
  
  	@Override
  	@SuppressWarnings("unchecked")
@@ -761,7 +766,7 @@ index c8ca89a1e0..b6a7fb955e 100644
  	}
  
  	@Override
-@@ -168,6 +108,11 @@ public String getQueryString() {
+@@ -168,6 +105,11 @@ public String getQueryString() {
  		return delegate.queryString();
  	}
  
@@ -773,7 +778,7 @@ index c8ca89a1e0..b6a7fb955e 100644
  	@Override
  	public HibernateOrmSearchQueryAdapter<R> setHint(String hintName, Object value) {
  		switch ( hintName ) {
-@@ -180,14 +125,12 @@ public HibernateOrmSearchQueryAdapter<R> setHint(String hintName, Object value)
+@@ -180,14 +122,12 @@ public HibernateOrmSearchQueryAdapter<R> setHint(String hintName, Object value)
  				break;
  			case HibernateOrmSearchQueryHints.JAVAX_FETCHGRAPH:
  			case HibernateOrmSearchQueryHints.JAKARTA_FETCHGRAPH:
@@ -790,7 +795,7 @@ index c8ca89a1e0..b6a7fb955e 100644
  				break;
  		}
  		return this;
-@@ -200,148 +143,104 @@ public HibernateOrmSearchQueryAdapter<R> setTimeout(int timeout) {
+@@ -200,148 +140,104 @@ public HibernateOrmSearchQueryAdapter<R> setTimeout(int timeout) {
  	}
  
  	@Override
@@ -991,7 +996,7 @@ index c8ca89a1e0..b6a7fb955e 100644
  		throw parametersNoSupported();
  	}
  
-@@ -350,18 +249,16 @@ private UnsupportedOperationException parametersNoSupported() {
+@@ -350,18 +246,16 @@ private UnsupportedOperationException parametersNoSupported() {
  	}
  
  	@Override
@@ -1015,7 +1020,7 @@ index c8ca89a1e0..b6a7fb955e 100644
  		return new UnsupportedOperationException( "Result transformers are not supported in Hibernate Search queries" );
  	}
  
-@@ -391,7 +288,12 @@ private UnsupportedOperationException lockOptionsNotSupported() {
+@@ -391,7 +285,12 @@ private UnsupportedOperationException lockOptionsNotSupported() {
  	}
  
  	@Override
@@ -1029,7 +1034,7 @@ index c8ca89a1e0..b6a7fb955e 100644
  		throw new UnsupportedOperationException( "executeUpdate is not supported in Hibernate Search queries" );
  	}
  
-@@ -400,30 +302,6 @@ public HibernateOrmSearchQueryAdapter<R> setLockMode(String alias, LockMode lock
+@@ -400,30 +299,6 @@ public HibernateOrmSearchQueryAdapter<R> setLockMode(String alias, LockMode lock
  		throw lockOptionsNotSupported();
  	}
  
@@ -1060,7 +1065,7 @@ index c8ca89a1e0..b6a7fb955e 100644
  	private static long hintValueToLong(Object value) {
  		if ( value instanceof Number ) {
  			return ( (Number) value ).longValue();
-@@ -442,8 +320,4 @@ private static int hintValueToInteger(Object value) {
+@@ -442,8 +317,4 @@ private static int hintValueToInteger(Object value) {
  		}
  	}
  
@@ -1070,7 +1075,7 @@ index c8ca89a1e0..b6a7fb955e 100644
 -
  }
 diff --git a/main/java/org/hibernate/search/mapper/orm/search/query/spi/HibernateOrmSearchScrollableResultsAdapter.java b/main/java/org/hibernate/search/mapper/orm/search/query/spi/HibernateOrmSearchScrollableResultsAdapter.java
-index 069f97d042..5774325d80 100644
+index 069f97d042..8d034d8a17 100644
 --- a/main/java/org/hibernate/search/mapper/orm/search/query/spi/HibernateOrmSearchScrollableResultsAdapter.java
 +++ b/main/java/org/hibernate/search/mapper/orm/search/query/spi/HibernateOrmSearchScrollableResultsAdapter.java
 @@ -7,14 +7,7 @@
@@ -1129,7 +1134,18 @@ index 069f97d042..5774325d80 100644
  	@Override
  	public boolean setRowNumber(int rowNumber) {
  		checkNotClosed();
-@@ -203,126 +201,12 @@ public boolean isClosed() {
+@@ -197,132 +195,23 @@ public boolean setRowNumber(int rowNumber) {
+ 		return scroll( rowNumber - currentIndexInScroll );
+ 	}
+ 
++	// We cannot use @Override here because this method only exists in ORM 6.1.2+
++	public void setFetchSize(int i) {
++		throw log.cannotSetFetchSize();
++	}
++
+ 	@Override
+ 	public boolean isClosed() {
+ 		return closed;
  	}
  
  	@Override
@@ -1258,7 +1274,7 @@ index 069f97d042..5774325d80 100644
  	}
  
  	private SearchScrollResult<H> nextChunk() {
-@@ -334,42 +218,10 @@ private SearchScrollResult<H> nextChunk() {
+@@ -334,42 +223,10 @@ private SearchScrollResult<H> nextChunk() {
  		}
  	}
  

--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@
         <version.net.bytebuddy>1.12.9</version.net.bytebuddy>
 
         <!-- >>> ORM 6 / Jakarta Persistence -->
-        <version.org.hibernate.orm>6.1.0.Final</version.org.hibernate.orm>
+        <version.org.hibernate.orm>6.1.1.Final</version.org.hibernate.orm>
         <javadoc.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/javadocs/</javadoc.org.hibernate.orm.url>
         <documentation.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/userguide/html_single/Hibernate_User_Guide.html</documentation.org.hibernate.orm.url>
         <version.org.hibernate.commons.annotations.orm6>6.0.2.Final</version.org.hibernate.commons.annotations.orm6>


### PR DESCRIPTION
* [HSEARCH-4635](https://hibernate.atlassian.net/browse/HSEARCH-4635): Prepare -orm6 artifacts for changes coming in Hibernate ORM 6.1.2.Final
* [HSEARCH-4627](https://hibernate.atlassian.net/browse/HSEARCH-4627): Upgrade to Hibernate ORM 6.1.1.Final for -orm6 artifacts
