### PR TITLE
HSEARCH-4636 + HSEARCH-4637 Update migration guide for 6.2

### DIFF
--- a/documentation/src/main/asciidoc/migration/index.asciidoc
+++ b/documentation/src/main/asciidoc/migration/index.asciidoc
@@ -44,7 +44,19 @@ To address that, either:
 [[configuration]]
 == Configuration changes
 
-The configuration properties are backward-compatible with Hibernate Search {hibernateSearchPreviousStableVersionShort}.
+The configuration properties are for the most part backward-compatible with Hibernate Search {hibernateSearchPreviousStableVersionShort}.
+
+However, some changes may have an impact on exotic configuration:
+
+* Configuration properties expecting references to "configurer" beans now accept multiple references, separated by commas.
+If your bean reference contains a comma, it may no longer be interpreted correctly.
++
+The suggested workaround is to avoid using commas in bean names.
++
+This affects the following configuration properties:
+** `hibernate.search.backend.analysis.configurer`
+** `hibernate.search.backend.query.caching.configurer`
+** `hibernate.search.mapping.configurer`
 
 [[api]]
 == API changes
@@ -82,6 +94,10 @@ is mostly backward-compatible with Hibernate Search {hibernateSearchPreviousStab
 Below are the most notable SPI changes:
 
 * `PojoGenericTypeModel` no longer exists; its methods moved to `PojoTypeModel`.
+* `org.hibernate.search.mapper.pojo.mapping.spi.AbstractPojoMappingInitiator#annotatedTypeDiscoveryEnabled` is deprecated.
+Use `.annotationMapping().discoverAnnotationsFromReferencedTypes(...)` instead.
+* `org.hibernate.search.util.common.reflect.spi.ValueReadHandleFactory` is deprecated.
+Use/implement `org.hibernate.search.util.common.reflect.spi.ValueHandleFactory` instead.
 
 [[behavior]]
 == Behavior changes

--- a/documentation/src/main/asciidoc/migration/index.asciidoc
+++ b/documentation/src/main/asciidoc/migration/index.asciidoc
@@ -86,4 +86,8 @@ Below are the most notable SPI changes:
 [[behavior]]
 == Behavior changes
 
-No behavior changes to report.
+Due to bugfixes, parts of Hibernate Search now behave differently:
+
+* The boolean predicate, `SearchPredicateFactory#bool()`, when used without any clause,
+used to match no documents with the Lucene backend, but all documents with the Elasticsearch backend.
+A boolean predicate with no clause will now consistently match no documents regardless of the backend.

--- a/mapper/orm/src/test/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmBootstrapIntrospectorAnnotationReadingTest.java
+++ b/mapper/orm/src/test/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmBootstrapIntrospectorAnnotationReadingTest.java
@@ -26,7 +26,7 @@ public class HibernateOrmBootstrapIntrospectorAnnotationReadingTest
 	@Test
 	public void singleAnnotation() {
 		HibernateOrmBootstrapIntrospector introspector = createIntrospector( EntityWithSingleFieldAnnotation.class );
-		AnnotationHelper annotationHelper = new AnnotationHelper( introspector.annotationValueReadHandleFactory() );
+		AnnotationHelper annotationHelper = new AnnotationHelper( introspector.annotationValueHandleFactory() );
 
 		PojoRawTypeModel<EntityWithSingleFieldAnnotation> typeModel =
 				introspector.typeModel( EntityWithSingleFieldAnnotation.class );
@@ -47,7 +47,7 @@ public class HibernateOrmBootstrapIntrospectorAnnotationReadingTest
 	@TestForIssue(jiraKey = "HSEARCH-3614")
 	public void repeatedAnnotation() {
 		HibernateOrmBootstrapIntrospector introspector = createIntrospector( EntityWithRepeatedFieldAnnotation.class );
-		AnnotationHelper annotationHelper = new AnnotationHelper( introspector.annotationValueReadHandleFactory() );
+		AnnotationHelper annotationHelper = new AnnotationHelper( introspector.annotationValueHandleFactory() );
 
 		PojoRawTypeModel<EntityWithRepeatedFieldAnnotation> typeModel =
 				introspector.typeModel( EntityWithRepeatedFieldAnnotation.class );

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationMappingConfigurationContextImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationMappingConfigurationContextImpl.java
@@ -106,7 +106,7 @@ public class AnnotationMappingConfigurationContextImpl implements AnnotationMapp
 			MappingConfigurationCollector<PojoTypeMetadataContributor> collector) {
 		BeanResolver beanResolver = buildContext.beanResolver();
 		FailureCollector failureCollector = buildContext.failureCollector();
-		AnnotationHelper annotationHelper = new AnnotationHelper( introspector.annotationValueReadHandleFactory() );
+		AnnotationHelper annotationHelper = new AnnotationHelper( introspector.annotationValueHandleFactory() );
 		AnnotationPojoTypeMetadataContributorFactory contributorFactory =
 				new AnnotationPojoTypeMetadataContributorFactory( beanResolver, failureCollector, configurationContext,
 						annotationHelper );

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/hcann/spi/AbstractPojoHCAnnBootstrapIntrospector.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/hcann/spi/AbstractPojoHCAnnBootstrapIntrospector.java
@@ -22,6 +22,7 @@ import org.hibernate.annotations.common.reflection.XAnnotatedElement;
 import org.hibernate.annotations.common.reflection.XClass;
 import org.hibernate.annotations.common.reflection.XProperty;
 import org.hibernate.search.mapper.pojo.model.spi.PojoBootstrapIntrospector;
+import org.hibernate.search.util.common.AssertionFailure;
 import org.hibernate.search.util.common.impl.StreamHelper;
 import org.hibernate.search.util.common.reflect.spi.ValueCreateHandle;
 import org.hibernate.search.util.common.reflect.spi.ValueHandleFactory;
@@ -40,7 +41,7 @@ public abstract class AbstractPojoHCAnnBootstrapIntrospector implements PojoBoot
 	}
 
 	@Override
-	public ValueHandleFactory annotationValueReadHandleFactory() {
+	public ValueHandleFactory annotationValueHandleFactory() {
 		return valueHandleFactory;
 	}
 
@@ -70,8 +71,11 @@ public abstract class AbstractPojoHCAnnBootstrapIntrospector implements PojoBoot
 		return typeOrdering.descendingSuperTypes( xClass ).map( this::toClass );
 	}
 
-	protected abstract <T> ValueCreateHandle<T> createValueCreateHandle(Constructor<T> constructor)
-			throws IllegalAccessException;
+	protected <T> ValueCreateHandle<T> createValueCreateHandle(Constructor<T> constructor)
+			throws IllegalAccessException {
+		throw new AssertionFailure( this + " doesn't support constructor handles."
+				+ " '" + getClass().getName() + " should be updated to implement createValueCreateHandle(Constructor)." );
+	}
 
 	public Class<?> toClass(XClass xClass) {
 		return reflectionManager.toClass( xClass );

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/spi/PojoBootstrapIntrospector.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/spi/PojoBootstrapIntrospector.java
@@ -29,6 +29,15 @@ public interface PojoBootstrapIntrospector {
 	/**
 	 * @return A {@link ValueHandleFactory} for reading annotation attributes.
 	 */
-	ValueHandleFactory annotationValueReadHandleFactory();
+	ValueHandleFactory annotationValueHandleFactory();
+
+	/**
+	 * @return A {@link ValueHandleFactory} for reading annotation attributes.
+	 * @deprecated Use/implement {@link #annotationValueHandleFactory()} instead.
+	 */
+	@Deprecated
+	default org.hibernate.search.util.common.reflect.spi.ValueReadHandleFactory annotationValueReadHandleFactory() {
+		return (org.hibernate.search.util.common.reflect.spi.ValueReadHandleFactory) annotationValueHandleFactory();
+	}
 
 }

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/model/impl/StandalonePojoBootstrapIntrospector.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/model/impl/StandalonePojoBootstrapIntrospector.java
@@ -71,11 +71,6 @@ public class StandalonePojoBootstrapIntrospector extends AbstractPojoHCAnnBootst
 	}
 
 	@Override
-	public ValueHandleFactory annotationValueReadHandleFactory() {
-		return valueHandleFactory;
-	}
-
-	@Override
 	protected <T> ValueCreateHandle<T> createValueCreateHandle(Constructor<T> constructor) throws IllegalAccessException {
 		setAccessible( constructor );
 		return valueHandleFactory.createForConstructor( constructor );

--- a/util/common/src/main/java/org/hibernate/search/util/common/reflect/spi/MemberValueHandleFactory.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/reflect/spi/MemberValueHandleFactory.java
@@ -14,7 +14,8 @@ import org.hibernate.search.util.common.reflect.impl.ConstructorValueCreateHandl
 import org.hibernate.search.util.common.reflect.impl.FieldValueReadHandle;
 import org.hibernate.search.util.common.reflect.impl.MethodValueReadHandle;
 
-final class MemberValueHandleFactory implements ValueHandleFactory {
+@SuppressWarnings("deprecation")
+final class MemberValueHandleFactory implements ValueHandleFactory, ValueReadHandleFactory {
 	@Override
 	public <T> ValueCreateHandle<T> createForConstructor(Constructor<T> constructor) {
 		return new ConstructorValueCreateHandle<>( constructor );

--- a/util/common/src/main/java/org/hibernate/search/util/common/reflect/spi/MethodHandleValueHandleFactory.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/reflect/spi/MethodHandleValueHandleFactory.java
@@ -15,9 +15,10 @@ import org.hibernate.search.util.common.annotation.impl.SuppressForbiddenApis;
 import org.hibernate.search.util.common.reflect.impl.MethodHandleValueCreateHandle;
 import org.hibernate.search.util.common.reflect.impl.MethodHandleValueReadHandle;
 
+@SuppressWarnings("deprecation")
 @SuppressForbiddenApis(reason = "MethodHandles don't always work, but usage of this class is configurable,"
 		+ " so it should only be used in contexts where MethodHandles actually work.")
-final class MethodHandleValueHandleFactory implements ValueHandleFactory {
+final class MethodHandleValueHandleFactory implements ValueHandleFactory, ValueReadHandleFactory {
 
 	private final MethodHandles.Lookup lookup;
 

--- a/util/common/src/main/java/org/hibernate/search/util/common/reflect/spi/ValueReadHandleFactory.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/reflect/spi/ValueReadHandleFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.common.reflect.spi;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.hibernate.search.util.common.AssertionFailure;
+
+/**
+ * @deprecated Use/implement {@link ValueHandleFactory} instead.
+ */
+@Deprecated
+public interface ValueReadHandleFactory extends ValueHandleFactory {
+
+	@Override
+	default <T> ValueCreateHandle<T> createForConstructor(Constructor<T> constructor) throws IllegalAccessException {
+		throw new AssertionFailure( this + " doesn't support constructor handles."
+				+ " '" + getClass().getName() + " should be updated to implement createForConstructor(Constructor)." );
+	}
+
+	/**
+	 * @return A factory producing value handles that rely on {@code java.lang.reflect}
+	 * to get the value of a field/method,
+	 * i.e {@link Method#invoke(Object, Object...)} and {@link Field#get(Object)}.
+	 * @deprecated Use {@link ValueHandleFactory#usingJavaLangReflect()} instead.
+	 */
+	@Deprecated
+	static ValueReadHandleFactory usingJavaLangReflect() {
+		return new MemberValueHandleFactory();
+	}
+
+	/**
+	 * @param lookup A lookup with sufficient access rights to access all relevant fields and methods.
+	 * @return A factory producing value handles that rely on {@link java.lang.invoke.MethodHandle}
+	 * to get the value of a field/method.
+	 * @deprecated Use {@link ValueHandleFactory#usingMethodHandle(MethodHandles.Lookup)} instead.
+	 */
+	@Deprecated
+	static ValueReadHandleFactory usingMethodHandle(MethodHandles.Lookup lookup) {
+		return new MethodHandleValueHandleFactory( lookup );
+	}
+}


### PR DESCRIPTION
* [HSEARCH-4637](https://hibernate.atlassian.net/browse/HSEARCH-4637): Document API/SPI changes for 6.2.0.Alpha1
* [HSEARCH-4636](https://hibernate.atlassian.net/browse/HSEARCH-4636): Document behavior change in the migration guide for boolean predicates with no clause with the Elasticsearch backend

