### PR TITLE
HSEARCH-4601 Syntactic sugar for OR/AND predicates

### DIFF
--- a/documentation/src/main/asciidoc/reference/search-dsl-predicate.asciidoc
+++ b/documentation/src/main/asciidoc/reference/search-dsl-predicate.asciidoc
@@ -784,11 +784,143 @@ but can be <<search-dsl-predicate-common-boost,boosted>>,
 either on a per-field basis with a call to `.boost(...)` just after `.field(...)`/`.fields(...)`
 or for the whole predicate with a call to `.boost(...)` after `.matchingAny(...)` or `.matchingAll(...)`.
 
+[[search-dsl-predicate-and]]
+== `and`: match all clauses
+
+The `and` predicate matches documents that match **all** of its inner predicates, called "clauses".
+
+Matching "and" clauses are taken into account during <<search-dsl-predicate-common-score,score>> computation.
+
+.Matching a document that matches all the multiple given predicates (~`AND` operator)
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java[tags=and]
+----
+<1> The hits *must* have a `title` field matching the text `robot`,
+independently of other clauses in the same boolean predicate.
+<2> The hits *must* have a `description` field matching the text `crime`,
+independently of other clauses in the same boolean predicate.
+<3> All returned hits will match *all* the clauses above:
+they will have a `title` field matching the text `robot`
+*and* they will have a `description` field matching the text `crime`.
+====
+
+[[search-dsl-predicate-and-lambda]]
+=== Adding clauses dynamically with the lambda syntax
+
+It is possible to define the `and` predicate inside a lambda expression.
+This is especially useful when clauses need to be added dynamically to the `and` predicate,
+for example based on user input.
+
+.Easily adding clauses dynamically using `.where(...)` and the lambda syntax
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java[tags=and-dynamicParameters-root]
+----
+<1> Get a custom object holding the search parameters provided by the user through a web form, for example.
+<2> Call `.where(Function)`.
+The function, implemented by a lambda expression, will receive a predicate factory, use it to build an `and` predicate,
+invoke the `with(Consumer)` method and return this predicate. The consumer, implemented by a lambda expression,
+will receive a clause collector for the `and` predicate as an argument, and will add clauses to that collector as necessary.
+<3> By default, a boolean predicate will match nothing if there is no clause.
+To match every document when there is no clause, add an `and` clause that matches everything.
+<4> Inside the lambda, the code is free to use any Java language constructs, such as `if` or `for`,
+to control the addition of clauses.
+In this case, we only add clauses if the relevant parameter was filled in by the user.
+====
+
+Another syntax relying on the method `with(...)` can be useful when the boolean predicate is not the root predicate,
+see <<example-and-or-dynamicParameters-with,this example>>.
+
+[[search-dsl-predicate-and-other]]
+=== Options
+
+* The score of an `and` predicate is variable by default,
+but can be <<search-dsl-predicate-common-constantScore,made constant with `.constantScore()`>>.
+* The score of an `and` predicate can be <<search-dsl-predicate-common-boost,boosted>>
+with a call to `.boost(...)`.
+
+[[search-dsl-predicate-or]]
+== `or`: match any clause
+
+The `or` predicate matches documents that match **any** of its inner predicates, called "clauses".
+
+Matching `or` clauses are taken into account during <<search-dsl-predicate-common-score,score>> computation.
+
+.Matching a document that matches any of multiple given predicates (~`OR` operator)
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java[tags=or]
+----
+<1> The hits *should* have a `title` field matching the text `robot`,
+*or* they should match any other clause in the same boolean predicate.
+<2> The hits *should* have a `description` field matching the text `investigation`,
+*or* they should match any other clause in the same boolean predicate.
+<3> All returned hits will match *at least one* of the clauses above:
+they will have a `title` field matching the text `robot`
+*or* they will have a `description` field matching the text `investigation`.
+====
+
+[[search-dsl-predicate-or-lambda]]
+=== Adding clauses dynamically with the lambda syntax
+
+It is possible to define the `or` predicate inside a lambda expression.
+This is especially useful when clauses need to be added dynamically to the `or` predicate,
+for example based on user input.
+
+.Easily adding clauses dynamically using `.where(...)` and the lambda syntax
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java[tags=or-dynamicParameters-root]
+----
+<1> Get a custom object holding the search parameters provided by the user through a web form, for example.0
+<2> Call `.where(Function)`.
+The function, implemented by a lambda expression, will receive a predicate factory, use it to build an `or` predicate,
+invoke the `with(Consumer)` method and return this predicate. The consumer, implemented by a lambda expression,
+will receive a clause collector for the `or` predicate as an argument, and will add clauses to that collector as necessary.
+<3> Inside the lambda, the code is free to use any Java language constructs, such as `if` or `for`,
+to control the addition of clauses.
+In this case, we only add clauses if the relevant parameter was filled in by the user.
+====
+
+Another syntax relying on the method `with(...)` can be useful when the boolean predicate is not the root predicate:
+
+.[[example-and-or-dynamicParameters-with]]Easily adding clauses dynamically using `with(...)` and the lambda syntax
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java[tags=and-or-dynamicParameters-with]
+----
+<1> Get a custom object holding the search parameters provided by the user through a web form, for example.
+<2> Call `.where(Function)` to create the root predicate, which is not the one we're interested in here.
+<3> Call `.or().with(Consumer)` to create an inner, non-root predicate.
+The consumer, implemented by a lambda expression, will receive a collector as an argument
+and will add clauses to that collector as necessary.
+<4> Inside the lambda, the code is free to use any Java language constructs, such as `if` or `for`,
+to control the addition of clauses.
+In this case, we add one clause per author filter.
+====
+
+[[search-dsl-predicate-or-other]]
+=== Options
+
+* The score of an `or` predicate is variable by default,
+but can be <<search-dsl-predicate-common-constantScore,made constant with `.constantScore()`>>.
+* The score of an `or` predicate can be <<search-dsl-predicate-common-boost,boosted>>
+with a call to `.boost(...)`.
+
 [[search-dsl-predicate-boolean]]
-== [[_combining_queries]] `bool`: combine predicates (or/and/...)
+== `bool`: advanced combinations of predicates (or/and/...)
+
+The `bool` predicate allows combining inner predicates in a more complex fashion than with simpler
+<<search-dsl-predicate-and,`and`>>/<<search-dsl-predicate-or,`or`>> predicates.
 
 The `bool` predicate matches documents that match one or more inner predicates, called "clauses".
-It can be used in particular to build `AND`/`OR` operators.
+It can be used in particular to build `AND`/`OR` operators with additional settings.
 
 Inner predicates are added as clauses of one of the following types:
 
@@ -825,42 +957,14 @@ and are simply used for scoring.
 [[search-dsl-predicate-boolean-or]]
 === Emulating an `OR` operator
 
-A `bool` predicate with only `should` clauses will behave as an `OR` operator.
-
-.Matching a document that matches any of multiple given predicates (~`OR` operator)
-====
-[source, JAVA, indent=0, subs="+callouts"]
-----
-include::{sourcedir}/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java[tags=bool-or]
-----
-<1> The hits *should* have a `title` field matching the text `robot`,
-*or* they should match any other clause in the same boolean predicate.
-<2> The hits *should* have a `description` field matching the text `investigation`,
-*or* they should match any other clause in the same boolean predicate.
-<3> All returned hits will match *at least one* of the clauses above:
-they will have a `title` field matching the text `robot`
-*or* they will have a `description` field matching the text `investigation`.
-====
+A `bool` predicate with only `should` clauses and no `minimumShouldMatch` specification will behave as an `OR` operator.
+In such case, using the simpler <<search-dsl-predicate-or,`or`>> syntax is recommended.
 
 [[search-dsl-predicate-boolean-and]]
 === Emulating an `AND` operator
 
 A `bool` predicate with only `must` clauses will behave as an `AND` operator.
-
-.Matching a document that matches all the multiple given predicates (~`AND` operator)
-====
-[source, JAVA, indent=0, subs="+callouts"]
-----
-include::{sourcedir}/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java[tags=bool-and]
-----
-<1> The hits *must* have a `title` field matching the text `robot`,
-independently of other clauses in the same boolean predicate.
-<2> The hits *must* have a `description` field matching the text `crime`,
-independently of other clauses in the same boolean predicate.
-<3> All returned hits will match *all* the clauses above:
-they will have a `title` field matching the text `robot`
-*and* they will have a `description` field matching the text `crime`.
-====
+In such case, using the simpler <<search-dsl-predicate-and,`and`>> syntax is recommended.
 
 [[search-dsl-predicate-boolean-mustNot]]
 === `mustNot`: excluding documents that match a given predicate

--- a/documentation/src/main/asciidoc/reference/search-dsl-predicate.asciidoc
+++ b/documentation/src/main/asciidoc/reference/search-dsl-predicate.asciidoc
@@ -813,7 +813,7 @@ It is possible to define the `and` predicate inside a lambda expression.
 This is especially useful when clauses need to be added dynamically to the `and` predicate,
 for example based on user input.
 
-.Easily adding clauses dynamically using `.where(...)` and the lambda syntax
+.Easily adding clauses dynamically using `with(...)` and the lambda syntax
 ====
 [source, JAVA, indent=0, subs="+callouts"]
 ----
@@ -830,9 +830,6 @@ To match every document when there is no clause, add an `and` clause that matche
 to control the addition of clauses.
 In this case, we only add clauses if the relevant parameter was filled in by the user.
 ====
-
-Another syntax relying on the method `with(...)` can be useful when the boolean predicate is not the root predicate,
-see <<example-and-or-dynamicParameters-with,this example>>.
 
 [[search-dsl-predicate-and-other]]
 === Options
@@ -871,7 +868,7 @@ It is possible to define the `or` predicate inside a lambda expression.
 This is especially useful when clauses need to be added dynamically to the `or` predicate,
 for example based on user input.
 
-.Easily adding clauses dynamically using `.where(...)` and the lambda syntax
+.Easily adding clauses dynamically using `with(...)` and the lambda syntax
 ====
 [source, JAVA, indent=0, subs="+callouts"]
 ----
@@ -887,23 +884,6 @@ to control the addition of clauses.
 In this case, we only add clauses if the relevant parameter was filled in by the user.
 ====
 
-Another syntax relying on the method `with(...)` can be useful when the boolean predicate is not the root predicate:
-
-.[[example-and-or-dynamicParameters-with]]Easily adding clauses dynamically using `with(...)` and the lambda syntax
-====
-[source, JAVA, indent=0, subs="+callouts"]
-----
-include::{sourcedir}/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java[tags=and-or-dynamicParameters-with]
-----
-<1> Get a custom object holding the search parameters provided by the user through a web form, for example.
-<2> Call `.where(Function)` to create the root predicate, which is not the one we're interested in here.
-<3> Call `.or().with(Consumer)` to create an inner, non-root predicate.
-The consumer, implemented by a lambda expression, will receive a collector as an argument
-and will add clauses to that collector as necessary.
-<4> Inside the lambda, the code is free to use any Java language constructs, such as `if` or `for`,
-to control the addition of clauses.
-In this case, we add one clause per author filter.
-====
 
 [[search-dsl-predicate-or-other]]
 === Options
@@ -914,7 +894,7 @@ but can be <<search-dsl-predicate-common-constantScore,made constant with `.cons
 with a call to `.boost(...)`.
 
 [[search-dsl-predicate-boolean]]
-== `bool`: advanced combinations of predicates (or/and/...)
+== [[_combining_queries]] `bool`: advanced combinations of predicates (or/and/...)
 
 The `bool` predicate allows combining inner predicates in a more complex fashion than with simpler
 <<search-dsl-predicate-and,`and`>>/<<search-dsl-predicate-or,`or`>> predicates.
@@ -957,7 +937,7 @@ and are simply used for scoring.
 [[search-dsl-predicate-boolean-or]]
 === Emulating an `OR` operator
 
-A `bool` predicate with only `should` clauses and no `minimumShouldMatch` specification will behave as an `OR` operator.
+A `bool` predicate with only `should` clauses and no <<search-dsl-predicate-boolean-minimumshouldmatch,`minimumShouldMatch` specification>> will behave as an `OR` operator.
 In such case, using the simpler <<search-dsl-predicate-or,`or`>> syntax is recommended.
 
 [[search-dsl-predicate-boolean-and]]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/namedpredicate/SkuIdentifierBinder.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/namedpredicate/SkuIdentifierBinder.java
@@ -95,22 +95,22 @@ public class SkuIdentifierBinder implements PropertyBinder {
 
 			String pattern = (String) context.param( "pattern" ); // <3>
 
-			return f.and().with( b -> { // <4>
+			return f.and().with( and -> { // <4>
 				// An SKU identifier pattern is formatted this way: "<department code>.<collection code>.<item code>".
 				// Each part supports * and ? wildcards.
 				String[] patternParts = pattern.split( "\\." );
 				if ( patternParts.length > 0 ) {
-					b.add( f.wildcard()
+					and.add( f.wildcard()
 							.field( "departmentCode" ) // <5>
 							.matching( patternParts[0] ) );
 				}
 				if ( patternParts.length > 1 ) {
-					b.add( f.wildcard()
+					and.add( f.wildcard()
 							.field( "collectionCode" )
 							.matching( patternParts[1] ) );
 				}
 				if ( patternParts.length > 2 ) {
-					b.add( f.wildcard()
+					and.add( f.wildcard()
 							.field( "itemCode" )
 							.matching( patternParts[2] ) );
 				}

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/namedpredicate/SkuIdentifierBinder.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/namedpredicate/SkuIdentifierBinder.java
@@ -95,22 +95,22 @@ public class SkuIdentifierBinder implements PropertyBinder {
 
 			String pattern = (String) context.param( "pattern" ); // <3>
 
-			return f.bool().with( b -> { // <4>
+			return f.and().with( b -> { // <4>
 				// An SKU identifier pattern is formatted this way: "<department code>.<collection code>.<item code>".
 				// Each part supports * and ? wildcards.
 				String[] patternParts = pattern.split( "\\." );
 				if ( patternParts.length > 0 ) {
-					b.must( f.wildcard()
+					b.add( f.wildcard()
 							.field( "departmentCode" ) // <5>
 							.matching( patternParts[0] ) );
 				}
 				if ( patternParts.length > 1 ) {
-					b.must( f.wildcard()
+					b.add( f.wildcard()
 							.field( "collectionCode" )
 							.matching( patternParts[1] ) );
 				}
 				if ( patternParts.length > 2 ) {
-					b.must( f.wildcard()
+					b.add( f.wildcard()
 							.field( "itemCode" )
 							.matching( patternParts[2] ) );
 				}

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/flattened/IndexedEmbeddedStructureFlattenedIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/structure/flattened/IndexedEmbeddedStructureFlattenedIT.java
@@ -89,9 +89,10 @@ public class IndexedEmbeddedStructureFlattenedIT {
 
 			// tag::include[]
 			List<Book> hits = searchSession.search( Book.class )
-					.where( f -> f.bool()
-							.must( f.match().field( "authors.firstName" ).matching( "Ty" ) ) // <1>
-							.must( f.match().field( "authors.lastName" ).matching( "Abraham" ) ) ) // <1>
+					.where( f -> f.and(
+							f.match().field( "authors.firstName" ).matching( "Ty" ), // <1>
+							f.match().field( "authors.lastName" ).matching( "Abraham" ) // <1>
+					) )
 					.fetchHits( 20 );
 
 			assertThat( hits ).isNotEmpty(); // <2>

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/paths/FieldPathsIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/paths/FieldPathsIT.java
@@ -117,11 +117,12 @@ public class FieldPathsIT {
 	// tag::withRoot_method[]
 	private SearchPredicate matchFirstAndLastName(SearchPredicateFactory f,
 			String firstName, String lastName) {
-		return f.bool()
-				.must( f.match().field( "firstName" ) // <1>
-						.matching( firstName ) )
-				.must( f.match().field( "lastName" )
-						.matching( lastName ) )
+		return f.and(
+						f.match().field( "firstName" ) // <1>
+								.matching( firstName ),
+						f.match().field( "lastName" )
+								.matching( lastName )
+				)
 				.toPredicate();
 	}
 	// end::withRoot_method[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
@@ -190,18 +190,18 @@ public class PredicateDslIT {
 			// tag::and-dynamicParameters-root[]
 			MySearchParameters searchParameters = getSearchParameters(); // <1>
 			List<Book> hits = searchSession.search( Book.class )
-					.where( f -> f.and().with( b -> { // <2>
-						b.add( f.matchAll() ); // <3>
+					.where( f -> f.and().with( and -> { // <2>
+						and.add( f.matchAll() ); // <3>
 						if ( searchParameters.getGenreFilter() != null ) { // <4>
-							b.add( f.match().field( "genre" )
+							and.add( f.match().field( "genre" )
 									.matching( searchParameters.getGenreFilter() ) );
 						}
 						if ( searchParameters.getFullTextFilter() != null ) {
-							b.add( f.match().fields( "title", "description" )
+							and.add( f.match().fields( "title", "description" )
 									.matching( searchParameters.getFullTextFilter() ) );
 						}
 						if ( searchParameters.getPageCountMaxFilter() != null ) {
-							b.add( f.range().field( "pageCount" )
+							and.add( f.range().field( "pageCount" )
 									.atMost( searchParameters.getPageCountMaxFilter() ) );
 						}
 					} ) )
@@ -237,10 +237,10 @@ public class PredicateDslIT {
 			// tag::or-dynamicParameters-root[]
 			MySearchParameters searchParameters = getSearchParameters(); // <1>
 			List<Book> hits = searchSession.search( Book.class )
-					.where( f -> f.or().with( b -> { // <2>
+					.where( f -> f.or().with( or -> { // <2>
 						if ( !searchParameters.getAuthorFilters().isEmpty() ) {
 							for ( String authorFilter : searchParameters.getAuthorFilters() ) { // <3>
-								b.add( f.match().fields( "authors.firstName", "authors.lastName" )
+								or.add( f.match().fields( "authors.firstName", "authors.lastName" )
 										.matching( authorFilter ) );
 							}
 						}

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
@@ -212,31 +212,6 @@ public class PredicateDslIT {
 					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID );
 		} );
 
-		withinSearchSession( searchSession -> {
-			// tag::and-or-dynamicParameters-with[]
-			MySearchParameters searchParameters = getSearchParameters(); // <1>
-			List<Book> hits = searchSession.search( Book.class )
-					.where( f -> f.and().with( b -> { // <2>
-						b.add( f.matchAll() );
-						if ( searchParameters.getGenreFilter() != null ) {
-							b.add( f.match().field( "genre" )
-									.matching( searchParameters.getGenreFilter() ) );
-						}
-						if ( !searchParameters.getAuthorFilters().isEmpty() ) {
-							b.add( f.or().with( b2 -> { // <3>
-								for ( String authorFilter : searchParameters.getAuthorFilters() ) { // <4>
-									b2.add( f.match().fields( "authors.firstName", "authors.lastName" )
-											.matching( authorFilter ) );
-								}
-							} ) );
-						}
-					} ) )
-					.fetchHits( 20 );
-			// end::and-or-dynamicParameters-with[]
-			assertThat( hits )
-					.extracting( Book::getId )
-					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID, BOOK3_ID );
-		} );
 	}
 
 	@Test

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/GenericSimpleBooleanOperatorPredicateClausesStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/GenericSimpleBooleanOperatorPredicateClausesStep.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.predicate.dsl;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+
+/**
+ * A generic superinterface for "simple predicate" DSL steps that involve collecting clauses.
+ * <p>
+ * See also {@link PredicateScoreStep} or {@link PredicateFinalStep}.
+ *
+ * @param <S> The "self" type (the actual exposed type of this collector).
+ * @param <C> The "collector" type (the type of collector passed to the consumer in {@link #with(Consumer)}).
+ */
+public interface GenericSimpleBooleanOperatorPredicateClausesStep
+		<
+			S extends C,
+			C extends SimpleBooleanOperatorPredicateClausesCollector<?>
+		>
+		extends SimpleBooleanOperatorPredicateClausesCollector<C> {
+	@Override
+	default S add(PredicateFinalStep searchPredicate)
+	{
+		return add( searchPredicate.toPredicate() );
+	}
+
+	@Override
+	S add(SearchPredicate searchPredicate);
+
+	@Override
+	S add(Function<? super SearchPredicateFactory, ? extends PredicateFinalStep> clauseContributor);
+
+	@Override
+	S with(Consumer<? super C> contributor);
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/SearchPredicateFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/SearchPredicateFactory.java
@@ -11,6 +11,7 @@ import java.util.function.Consumer;
 
 import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.engine.search.common.BooleanOperator;
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.common.annotation.Incubating;
 
@@ -81,6 +82,55 @@ public interface SearchPredicateFactory {
 	 */
 	@Deprecated
 	PredicateFinalStep bool(Consumer<? super BooleanPredicateClausesStep<?>> clauseContributor);
+
+	/**
+	 * Match documents if they match all inner clauses.
+	 *
+	 * @return The initial step of a DSL where predicates that must match can be added and options can be set.
+	 * @see GenericSimpleBooleanOperatorPredicateClausesStep
+	 */
+	SimpleBooleanOperatorPredicateClausesStep<?> and();
+
+	/**
+	 * Match documents if they match all previously-built {@link SearchPredicate}.
+	 *
+	 * @return The step of a DSL where options can be set.
+	 */
+	SimpleBooleanOperatorPredicateOptionsStep<?> and(
+			SearchPredicate firstSearchPredicate,
+			SearchPredicate... otherSearchPredicates);
+
+	/**
+	 * Match documents if they match all clauses.
+	 *
+	 * @return The step of a DSL where options can be set.
+	 */
+	SimpleBooleanOperatorPredicateOptionsStep<?> and(PredicateFinalStep firstSearchPredicate,
+			PredicateFinalStep... otherSearchPredicates);
+
+	/**
+	 * Match documents if they match any inner clause.
+	 *
+	 * @return The initial step of a DSL where predicates that should match can be added and options can be set.
+	 * @see GenericSimpleBooleanOperatorPredicateClausesStep
+	 */
+	SimpleBooleanOperatorPredicateClausesStep<?> or();
+
+	/**
+	 * Match documents if they match any previously-built {@link SearchPredicate}.
+	 *
+	 * @return The step of a DSL where options can be set.
+	 */
+	SimpleBooleanOperatorPredicateOptionsStep<?> or(SearchPredicate firstSearchPredicate,
+			SearchPredicate... otherSearchPredicates);
+
+	/**
+	 * Match documents if they match any clause.
+	 *
+	 * @return The step of a DSL where options can be set.
+	 */
+	SimpleBooleanOperatorPredicateOptionsStep<?> or(PredicateFinalStep firstSearchPredicate,
+			PredicateFinalStep... otherSearchPredicates);
 
 	/**
 	 * Match documents where targeted fields have a value that "matches" a given single value.

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/SimpleBooleanOperatorPredicateClausesCollector.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/SimpleBooleanOperatorPredicateClausesCollector.java
@@ -1,0 +1,60 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.predicate.dsl;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+
+/**
+ * A generic superinterface for "simple predicate" DSL steps that involve collecting clauses.
+ * <p>
+ * See also {@link PredicateScoreStep} or {@link PredicateFinalStep}.
+ *
+ * @param <S> The "self" type (the actual exposed type of this collector).
+ */
+public interface SimpleBooleanOperatorPredicateClausesCollector<S extends SimpleBooleanOperatorPredicateClausesCollector<?>> {
+	/**
+	 * Adds the specified predicate to the list of clauses.
+	 *
+	 * @return {@code this}, for method chaining.
+	 */
+	S add(PredicateFinalStep searchPredicate);
+
+	/**
+	 * Adds the specified previously-built {@link SearchPredicate} to the list of clauses.
+	 *
+	 * @return {@code this}, for method chaining.
+	 */
+	S add(SearchPredicate searchPredicate);
+
+	/**
+	 * Adds a clause to be defined by the given function.
+	 * <p>
+	 * Best used with lambda expressions.
+	 *
+	 * @param clauseContributor A function that will use the factory passed in parameter to create a predicate,
+	 * returning the final step in the predicate DSL.
+	 * Should generally be a lambda expression.
+	 *
+	 * @return {@code this}, for method chaining.
+	 */
+	S add(Function<? super SearchPredicateFactory, ? extends PredicateFinalStep> clauseContributor);
+
+	/**
+	 * Delegates setting clauses and options to a given consumer.
+	 * <p>
+	 * Best used with lambda expressions.
+	 *
+	 * @param contributor A consumer that will add clauses and options to the collector that it consumes.
+	 * Should generally be a lambda expression.
+	 *
+	 * @return {@code this}, for method chaining.
+	 */
+	S with(Consumer<? super S> contributor);
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/SimpleBooleanOperatorPredicateClausesStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/SimpleBooleanOperatorPredicateClausesStep.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.predicate.dsl;
+
+/**
+ * The initial and final step in a "simple predicate" definition, where clauses can be added and options can be set.
+ *
+ * @param <S> The "self" type (the actual exposed type of this step).
+ */
+public interface SimpleBooleanOperatorPredicateClausesStep<S extends SimpleBooleanOperatorPredicateClausesStep<?>>
+		extends GenericSimpleBooleanOperatorPredicateClausesStep<S, SimpleBooleanOperatorPredicateClausesCollector<?>>,
+		SimpleBooleanOperatorPredicateOptionsStep<S> {
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/SimpleBooleanOperatorPredicateOptionsStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/SimpleBooleanOperatorPredicateOptionsStep.java
@@ -1,0 +1,17 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.predicate.dsl;
+
+/**
+ * The initial and final step in a "simple predicate" definition, where options can be set.
+ *
+ * @param <S> The "self" type (the actual exposed type of this step).
+ */
+public interface SimpleBooleanOperatorPredicateOptionsStep<S extends SimpleBooleanOperatorPredicateOptionsStep<?>>
+		extends PredicateScoreStep<S>, PredicateFinalStep {
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/impl/SimpleBooleanOperatorPredicateClausesStepImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/impl/SimpleBooleanOperatorPredicateClausesStepImpl.java
@@ -1,0 +1,116 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.predicate.dsl.impl;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.engine.search.predicate.dsl.PredicateFinalStep;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
+import org.hibernate.search.engine.search.predicate.dsl.SimpleBooleanOperatorPredicateClausesCollector;
+import org.hibernate.search.engine.search.predicate.dsl.SimpleBooleanOperatorPredicateClausesStep;
+import org.hibernate.search.engine.search.predicate.dsl.spi.AbstractPredicateFinalStep;
+import org.hibernate.search.engine.search.predicate.dsl.spi.SearchPredicateDslContext;
+import org.hibernate.search.engine.search.predicate.spi.BooleanPredicateBuilder;
+
+public final class SimpleBooleanOperatorPredicateClausesStepImpl
+		extends AbstractPredicateFinalStep
+		implements SimpleBooleanOperatorPredicateClausesStep<SimpleBooleanOperatorPredicateClausesStepImpl> {
+
+	public enum SimpleBooleanPredicateOperator
+			implements BiConsumer<BooleanPredicateBuilder, SearchPredicate> {
+		AND {
+			@Override
+			public void accept(BooleanPredicateBuilder builder,
+					SearchPredicate searchPredicate) {
+				builder.must( searchPredicate );
+			}
+		},
+		OR {
+			@Override
+			public void accept(BooleanPredicateBuilder builder,
+					SearchPredicate searchPredicate) {
+				builder.should( searchPredicate );
+			}
+		}
+	}
+
+	private final SimpleBooleanPredicateOperator operator;
+
+	private final BooleanPredicateBuilder builder;
+
+	private final SearchPredicateFactory factory;
+
+	public SimpleBooleanOperatorPredicateClausesStepImpl(SimpleBooleanPredicateOperator operator,
+			SearchPredicateDslContext<?> dslContext,
+			SearchPredicateFactory factory) {
+		super( dslContext );
+		this.operator = operator;
+		this.builder = dslContext.scope().predicateBuilders().bool();
+		this.factory = factory;
+	}
+
+	public SimpleBooleanOperatorPredicateClausesStepImpl(SimpleBooleanPredicateOperator operator,
+			SearchPredicateDslContext<?> dslContext,
+			SearchPredicateFactory factory,
+			SearchPredicate firstSearchPredicate,
+			SearchPredicate... otherSearchPredicates) {
+		this( operator, dslContext, factory );
+		add( firstSearchPredicate );
+		for ( SearchPredicate step : otherSearchPredicates ) {
+			add( step );
+		}
+	}
+
+	public SimpleBooleanOperatorPredicateClausesStepImpl(SimpleBooleanPredicateOperator operator,
+			SearchPredicateDslContext<?> dslContext,
+			SearchPredicateFactory factory,
+			PredicateFinalStep firstSearchPredicate,
+			PredicateFinalStep... otherSearchPredicates) {
+		this( operator, dslContext, factory );
+		add( firstSearchPredicate.toPredicate() );
+		for ( PredicateFinalStep step : otherSearchPredicates ) {
+			add( step.toPredicate() );
+		}
+	}
+
+	@Override
+	public SimpleBooleanOperatorPredicateClausesStepImpl add(SearchPredicate searchPredicate) {
+		operator.accept( builder, searchPredicate );
+		return this;
+	}
+
+	@Override
+	public SimpleBooleanOperatorPredicateClausesStepImpl add(
+			Function<? super SearchPredicateFactory, ? extends PredicateFinalStep> clauseContributor) {
+		return add( clauseContributor.apply( factory ) );
+	}
+
+	public SimpleBooleanOperatorPredicateClausesStepImpl boost(float boost) {
+		builder.boost( boost );
+		return this;
+	}
+
+	public SimpleBooleanOperatorPredicateClausesStepImpl constantScore() {
+		builder.constantScore();
+		return this;
+	}
+
+	@Override
+	public SimpleBooleanOperatorPredicateClausesStepImpl with(
+			Consumer<? super SimpleBooleanOperatorPredicateClausesCollector<?>> contributor) {
+		contributor.accept( this );
+		return this;
+	}
+
+	@Override
+	protected SearchPredicate build() {
+		return builder.build();
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/spi/AbstractSearchPredicateFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/spi/AbstractSearchPredicateFactory.java
@@ -6,10 +6,14 @@
  */
 package org.hibernate.search.engine.search.predicate.dsl.spi;
 
+import static org.hibernate.search.engine.search.predicate.dsl.impl.SimpleBooleanOperatorPredicateClausesStepImpl.SimpleBooleanPredicateOperator.AND;
+import static org.hibernate.search.engine.search.predicate.dsl.impl.SimpleBooleanOperatorPredicateClausesStepImpl.SimpleBooleanPredicateOperator.OR;
+
 import java.util.function.Consumer;
 
 import org.hibernate.search.engine.backend.common.spi.FieldPaths;
 import org.hibernate.search.engine.common.dsl.spi.DslExtensionState;
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
 import org.hibernate.search.engine.search.predicate.dsl.BooleanPredicateClausesStep;
 import org.hibernate.search.engine.search.predicate.dsl.ExistsPredicateFieldStep;
 import org.hibernate.search.engine.search.predicate.dsl.ExtendedSearchPredicateFactory;
@@ -20,11 +24,13 @@ import org.hibernate.search.engine.search.predicate.dsl.MatchPredicateFieldStep;
 import org.hibernate.search.engine.search.predicate.dsl.NamedPredicateOptionsStep;
 import org.hibernate.search.engine.search.predicate.dsl.NestedPredicateClausesStep;
 import org.hibernate.search.engine.search.predicate.dsl.PhrasePredicateFieldStep;
+import org.hibernate.search.engine.search.predicate.dsl.PredicateFinalStep;
 import org.hibernate.search.engine.search.predicate.dsl.RangePredicateFieldStep;
 import org.hibernate.search.engine.search.predicate.dsl.RegexpPredicateFieldStep;
 import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactoryExtension;
 import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactoryExtensionIfSupportedStep;
-import org.hibernate.search.engine.search.predicate.dsl.PredicateFinalStep;
+import org.hibernate.search.engine.search.predicate.dsl.SimpleBooleanOperatorPredicateClausesStep;
+import org.hibernate.search.engine.search.predicate.dsl.SimpleBooleanOperatorPredicateOptionsStep;
 import org.hibernate.search.engine.search.predicate.dsl.SimpleQueryStringPredicateFieldStep;
 import org.hibernate.search.engine.search.predicate.dsl.SpatialPredicateInitialStep;
 import org.hibernate.search.engine.search.predicate.dsl.TermsPredicateFieldStep;
@@ -41,6 +47,7 @@ import org.hibernate.search.engine.search.predicate.dsl.impl.PhrasePredicateFiel
 import org.hibernate.search.engine.search.predicate.dsl.impl.RangePredicateFieldStepImpl;
 import org.hibernate.search.engine.search.predicate.dsl.impl.RegexpPredicateFieldStepImpl;
 import org.hibernate.search.engine.search.predicate.dsl.impl.SearchPredicateFactoryExtensionStep;
+import org.hibernate.search.engine.search.predicate.dsl.impl.SimpleBooleanOperatorPredicateClausesStepImpl;
 import org.hibernate.search.engine.search.predicate.dsl.impl.SimpleQueryStringPredicateFieldStepImpl;
 import org.hibernate.search.engine.search.predicate.dsl.impl.SpatialPredicateInitialStepImpl;
 import org.hibernate.search.engine.search.predicate.dsl.impl.TermsPredicateFieldStepImpl;
@@ -79,6 +86,41 @@ public abstract class AbstractSearchPredicateFactory<
 	@Override
 	public BooleanPredicateClausesStep<?> bool() {
 		return new BooleanPredicateClausesStepImpl( dslContext, this );
+	}
+
+	@Override
+	public SimpleBooleanOperatorPredicateClausesStep<?> and() {
+		return new SimpleBooleanOperatorPredicateClausesStepImpl( AND, dslContext, this );
+	}
+
+	@Override
+	public SimpleBooleanOperatorPredicateOptionsStep<?> and(
+			SearchPredicate firstSearchPredicate,
+			SearchPredicate... otherSearchPredicates) {
+		return new SimpleBooleanOperatorPredicateClausesStepImpl( AND, dslContext, this, firstSearchPredicate, otherSearchPredicates );
+	}
+
+	@Override
+	public SimpleBooleanOperatorPredicateOptionsStep<?> and(PredicateFinalStep firstSearchPredicate,
+			PredicateFinalStep... otherSearchPredicate) {
+		return new SimpleBooleanOperatorPredicateClausesStepImpl( AND, dslContext, this, firstSearchPredicate, otherSearchPredicate );
+	}
+
+	@Override
+	public SimpleBooleanOperatorPredicateClausesStep<?> or() {
+		return new SimpleBooleanOperatorPredicateClausesStepImpl( OR, dslContext, this );
+	}
+
+	@Override
+	public SimpleBooleanOperatorPredicateOptionsStep<?> or(SearchPredicate firstSearchPredicate,
+			SearchPredicate... otherSearchPredicate) {
+		return new SimpleBooleanOperatorPredicateClausesStepImpl( OR, dslContext, this, firstSearchPredicate, otherSearchPredicate );
+	}
+
+	@Override
+	public SimpleBooleanOperatorPredicateOptionsStep<?> or(PredicateFinalStep firstSearchPredicate,
+			PredicateFinalStep... otherSearchPredicate) {
+		return new SimpleBooleanOperatorPredicateClausesStepImpl( OR, dslContext, this, firstSearchPredicate, otherSearchPredicate );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AndPredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AndPredicateBaseIT.java
@@ -1,0 +1,152 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.search.predicate;
+
+import org.hibernate.search.engine.search.predicate.dsl.PredicateFinalStep;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappedIndex;
+import org.hibernate.search.util.impl.test.runner.nested.Nested;
+import org.hibernate.search.util.impl.test.runner.nested.NestedRunner;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(NestedRunner.class)
+public class AndPredicateBaseIT {
+
+	@ClassRule
+	public static SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	@BeforeClass
+	public static void setup() {
+		setupHelper.start()
+				.withIndexes(
+						ScoreIT.index,
+						AddScoreIT.index
+				)
+				.setup();
+
+		final BulkIndexer scoreIndexer = ScoreIT.index.bulkIndexer();
+		ScoreIT.dataSet.contribute( scoreIndexer );
+
+		final BulkIndexer addScoreIndexer = AddScoreIT.index.bulkIndexer();
+		AddScoreIT.dataSet.contribute( addScoreIndexer );
+
+		scoreIndexer.join();
+		addScoreIndexer.join();
+	}
+
+	@Test
+	public void takariCpSuiteWorkaround() {
+		// Workaround to get Takari-CPSuite to run this test.
+	}
+
+	@Nested
+	public static class ScoreIT extends AbstractPredicateScoreIT {
+		private static final DataSet dataSet = new DataSet();
+
+		private static final StubMappedIndex index = StubMappedIndex.withoutFields().name( "score" );
+
+		public ScoreIT() {
+			super( index, dataSet );
+		}
+
+		@Override
+		protected PredicateFinalStep predicate(SearchPredicateFactory f, int matchingDocOrdinal) {
+			return f.and( f.id().matching( dataSet.docId( matchingDocOrdinal ) ) );
+		}
+
+		@Override
+		protected PredicateFinalStep predicateWithBoost(SearchPredicateFactory f, int matchingDocOrdinal,
+				float boost) {
+			return f.and( f.id().matching( dataSet.docId( matchingDocOrdinal ) ) )
+					.boost( boost );
+		}
+
+		@Override
+		protected PredicateFinalStep predicateWithConstantScore(SearchPredicateFactory f, int matchingDocOrdinal) {
+			return f.and( f.id().matching( dataSet.docId( matchingDocOrdinal ) ) )
+					.constantScore();
+		}
+
+		@Override
+		protected PredicateFinalStep predicateWithConstantScoreAndBoost(SearchPredicateFactory f,
+				int matchingDocOrdinal, float boost) {
+			return f.and( f.id().matching( dataSet.docId( matchingDocOrdinal ) ) )
+					.constantScore()
+					.boost( boost );
+		}
+
+		private static class DataSet extends AbstractPredicateDataSet {
+			protected DataSet() {
+				super( "singleRoutingKey" );
+			}
+
+			public void contribute(BulkIndexer scoreIndexer) {
+				scoreIndexer.add( docId( 0 ), routingKey, document -> { } );
+				scoreIndexer.add( docId( 1 ), routingKey, document -> { } );
+				scoreIndexer.add( docId( 2 ), routingKey, document -> { } );
+			}
+		}
+	}
+
+	@Nested
+	public static class AddScoreIT extends AbstractPredicateScoreIT {
+		private static final DataSet dataSet = new DataSet();
+
+		private static final StubMappedIndex index = StubMappedIndex.withoutFields().name( "addscore" );
+
+		public AddScoreIT() {
+			super( index, dataSet );
+		}
+
+		@Override
+		protected PredicateFinalStep predicate(SearchPredicateFactory f, int matchingDocOrdinal) {
+			return f.and()
+					.add( f.id().matching( dataSet.docId( matchingDocOrdinal ) ) );
+		}
+
+		@Override
+		protected PredicateFinalStep predicateWithBoost(SearchPredicateFactory f, int matchingDocOrdinal,
+				float boost) {
+			return f.and( f.id().matching( dataSet.docId( matchingDocOrdinal ) ) )
+					.boost( boost );
+		}
+
+		@Override
+		protected PredicateFinalStep predicateWithConstantScore(SearchPredicateFactory f, int matchingDocOrdinal) {
+			return f.and()
+					.add( f.id().matching( dataSet.docId( matchingDocOrdinal ) ) )
+					.constantScore();
+		}
+
+		@Override
+		protected PredicateFinalStep predicateWithConstantScoreAndBoost(SearchPredicateFactory f,
+				int matchingDocOrdinal, float boost) {
+			return f.and()
+					.add( f.id().matching( dataSet.docId( matchingDocOrdinal ) ) )
+					.constantScore()
+					.boost( boost );
+		}
+
+		private static class DataSet extends AbstractPredicateDataSet {
+			protected DataSet() {
+				super( "singleRoutingKey" );
+			}
+
+			public void contribute(BulkIndexer scoreIndexer) {
+				scoreIndexer.add( docId( 0 ), routingKey, document -> { } );
+				scoreIndexer.add( docId( 1 ), routingKey, document -> { } );
+				scoreIndexer.add( docId( 2 ), routingKey, document -> { } );
+			}
+		}
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AndPredicateSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AndPredicateSpecificsIT.java
@@ -197,20 +197,20 @@ public class AndPredicateSpecificsIT {
 	@Test
 	public void with() {
 		assertThatQuery( index.query()
-				.where( f -> f.and().with( b -> b.add( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) ) ) ) )
+				.where( f -> f.and().with( and -> and.add( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) ) ) ) )
 				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
 
 		assertThatQuery( index.query()
-				.where( f -> f.and().with( b -> {
-					b.add( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) );
-					b.add( f.match().field( "field2" ).matching( FIELD2_VALUE2 ) );
+				.where( f -> f.and().with( and -> {
+					and.add( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) );
+					and.add( f.match().field( "field2" ).matching( FIELD2_VALUE2 ) );
 				} ) ) )
 				.hasNoHits();
 
 		assertThatQuery( index.query()
 				.where( f -> f.and()
-						.with( b -> b.add( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) ) )
-						.with( b -> b.add( f.match().field( "field2" ).matching( FIELD2_VALUE1 ) ) ) ) )
+						.with( and -> and.add( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) ) )
+						.with( and -> and.add( f.match().field( "field2" ).matching( FIELD2_VALUE1 ) ) ) ) )
 				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AndPredicateSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AndPredicateSpecificsIT.java
@@ -1,0 +1,258 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.search.predicate;
+
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
+
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactory;
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class AndPredicateSpecificsIT {
+
+	private static final String DOCUMENT_1 = "1";
+	private static final String DOCUMENT_2 = "2";
+	private static final String DOCUMENT_3 = "3";
+
+	// Document 1
+
+	private static final String FIELD1_VALUE1 = "Irving";
+	private static final Integer FIELD2_VALUE1 = 3;
+	private static final Integer FIELD3_VALUE1 = 4;
+	private static final Integer FIELD4_VALUE1AND2 = 1_000;
+	private static final Integer FIELD5_VALUE1AND2 = 2_000;
+
+	// Document 2
+
+	private static final String FIELD1_VALUE2 = "Auster";
+	private static final Integer FIELD2_VALUE2 = 13;
+	private static final Integer FIELD3_VALUE2 = 14;
+	// Field 4: Same as document 1
+	// Field 5: Same as document 1
+
+	// Document 3
+
+	private static final String FIELD1_VALUE3 = "Coe";
+	private static final Integer FIELD2_VALUE3 = 25;
+	private static final Integer FIELD3_VALUE3 = 42;
+	private static final Integer FIELD4_VALUE3 = 42_000; // Different from document 1
+	private static final Integer FIELD5_VALUE3 = 142_000; // Different from document 1
+
+	@ClassRule
+	public static final SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private static final SimpleMappedIndex<IndexBinding> index = SimpleMappedIndex.of( IndexBinding::new );
+
+	@BeforeClass
+	public static void setup() {
+		setupHelper.start().withIndex( index ).setup();
+
+		initData();
+	}
+
+	@Test
+	public void empty() {
+		assertThatQuery( index.query()
+				.where( f -> f.and() ) )
+				.hasNoHits();
+	}
+
+	@Test
+	public void and() {
+		assertThatQuery( index.query()
+				.where( f -> f.and( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+
+		assertThatQuery( index.query()
+				.where( f -> f.and(
+						f.match().field( "field1" ).matching( FIELD1_VALUE1 ),
+						f.match().field( "field2" ).matching( FIELD2_VALUE2 )
+				) ) )
+				.hasNoHits();
+
+		assertThatQuery( index.query()
+				.where( f -> f.and(
+						f.match().field( "field1" ).matching( FIELD1_VALUE1 ),
+						f.match().field( "field2" ).matching( FIELD2_VALUE1 )
+				) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+	}
+
+	@Test
+	public void and_separatePredicateObject() {
+		StubMappingScope scope = index.createScope();
+
+		SearchPredicate predicate1 = scope.predicate().match().field( "field1" ).matching( FIELD1_VALUE1 ).toPredicate();
+		SearchPredicate predicate2 = scope.predicate().match().field( "field2" ).matching( FIELD2_VALUE1 ).toPredicate();
+		SearchPredicate predicate3 = scope.predicate().match().field( "field2" ).matching( FIELD2_VALUE2 ).toPredicate();
+
+		assertThatQuery( scope.query()
+				.where( f -> f.and( predicate1 ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+
+		assertThatQuery( index.query()
+				.where( f -> f.and(
+						predicate1,
+						predicate3
+				) ) )
+				.hasNoHits();
+
+		assertThatQuery( index.query()
+				.where( f -> f.and(
+						predicate1,
+						predicate2
+				) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+	}
+
+	@Test
+	public void nested() {
+		assertThatQuery( index.query()
+				.where( f -> f.and( f.or(
+						f.match().field( "field1" ).matching( FIELD1_VALUE1 ),
+						f.match().field( "field1" ).matching( FIELD1_VALUE3 )
+				) ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1, DOCUMENT_3 );
+	}
+
+	@Test
+	public void add() {
+		assertThatQuery( index.query()
+				.where( f -> f.and()
+						.add( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+
+		assertThatQuery( index.query()
+				.where( f -> f.and()
+						.add( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) )
+						.add( f.match().field( "field2" ).matching( FIELD2_VALUE2 ) ) ) )
+				.hasNoHits();
+
+		assertThatQuery( index.query()
+				.where( f -> f.and()
+						.add( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) )
+						.add( f.match().field( "field2" ).matching( FIELD2_VALUE1 ) ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+	}
+
+	@Test
+	public void add_separatePredicateObject() {
+		StubMappingScope scope = index.createScope();
+
+		SearchPredicate predicate1 = scope.predicate().match().field( "field1" ).matching( FIELD1_VALUE1 ).toPredicate();
+		SearchPredicate predicate2 = scope.predicate().match().field( "field2" ).matching( FIELD2_VALUE1 ).toPredicate();
+		SearchPredicate predicate3 = scope.predicate().match().field( "field2" ).matching( FIELD2_VALUE2 ).toPredicate();
+
+		assertThatQuery( index.query()
+				.where( f -> f.and()
+						.add( predicate1 ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+
+		assertThatQuery( index.query()
+				.where( f -> f.and()
+						.add( predicate1 )
+						.add( predicate3 ) ) )
+				.hasNoHits();
+
+		assertThatQuery( index.query()
+				.where( f -> f.and()
+						.add( predicate1 )
+						.add( predicate2 ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+	}
+
+	@Test
+	public void add_function() {
+		assertThatQuery( index.query()
+				.where( f -> f.and()
+						.add( f2 -> f2.match().field( "field1" ).matching( FIELD1_VALUE1 ) ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+
+		assertThatQuery( index.query()
+				.where( f -> f.and()
+						.add( f2 -> f2.match().field( "field1" ).matching( FIELD1_VALUE1 ) )
+						.add( f2 -> f2.match().field( "field2" ).matching( FIELD2_VALUE2 ) ) ) )
+				.hasNoHits();
+
+		assertThatQuery( index.query()
+				.where( f -> f.and()
+						.add( f2 -> f2.match().field( "field1" ).matching( FIELD1_VALUE1 ) )
+						.add( f2 -> f2.match().field( "field2" ).matching( FIELD2_VALUE1 ) ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+	}
+
+	@Test
+	public void with() {
+		assertThatQuery( index.query()
+				.where( f -> f.and().with( b -> b.add( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) ) ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+
+		assertThatQuery( index.query()
+				.where( f -> f.and().with( b -> {
+					b.add( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) );
+					b.add( f.match().field( "field2" ).matching( FIELD2_VALUE2 ) );
+				} ) ) )
+				.hasNoHits();
+
+		assertThatQuery( index.query()
+				.where( f -> f.and()
+						.with( b -> b.add( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) ) )
+						.with( b -> b.add( f.match().field( "field2" ).matching( FIELD2_VALUE1 ) ) ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+	}
+
+	private static void initData() {
+		BulkIndexer indexer = index.bulkIndexer();
+		indexer.add( DOCUMENT_1, document -> {
+			document.addValue( index.binding().field1, FIELD1_VALUE1 );
+			document.addValue( index.binding().field2, FIELD2_VALUE1 );
+			document.addValue( index.binding().field3, FIELD3_VALUE1 );
+			document.addValue( index.binding().field4, FIELD4_VALUE1AND2 );
+			document.addValue( index.binding().field5, FIELD5_VALUE1AND2 );
+		} );
+		indexer.add( DOCUMENT_2, document -> {
+			document.addValue( index.binding().field1, FIELD1_VALUE2 );
+			document.addValue( index.binding().field2, FIELD2_VALUE2 );
+			document.addValue( index.binding().field3, FIELD3_VALUE2 );
+			document.addValue( index.binding().field4, FIELD4_VALUE1AND2 );
+			document.addValue( index.binding().field5, FIELD5_VALUE1AND2 );
+		} );
+		indexer.add( DOCUMENT_3, document -> {
+			document.addValue( index.binding().field1, FIELD1_VALUE3 );
+			document.addValue( index.binding().field2, FIELD2_VALUE3 );
+			document.addValue( index.binding().field3, FIELD3_VALUE3 );
+			document.addValue( index.binding().field4, FIELD4_VALUE3 );
+			document.addValue( index.binding().field5, FIELD5_VALUE3 );
+		} );
+		indexer.join();
+	}
+
+	private static class IndexBinding {
+		final IndexFieldReference<String> field1;
+		final IndexFieldReference<Integer> field2;
+		final IndexFieldReference<Integer> field3;
+		final IndexFieldReference<Integer> field4;
+		final IndexFieldReference<Integer> field5;
+
+		IndexBinding(IndexSchemaElement root) {
+			field1 = root.field( "field1", IndexFieldTypeFactory::asString ).toReference();
+			field2 = root.field( "field2", IndexFieldTypeFactory::asInteger ).toReference();
+			field3 = root.field( "field3", IndexFieldTypeFactory::asInteger ).toReference();
+			field4 = root.field( "field4", IndexFieldTypeFactory::asInteger ).toReference();
+			field5 = root.field( "field5", IndexFieldTypeFactory::asInteger ).toReference();
+		}
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/OrPredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/OrPredicateBaseIT.java
@@ -1,0 +1,153 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.search.predicate;
+
+import org.hibernate.search.engine.search.predicate.dsl.PredicateFinalStep;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappedIndex;
+import org.hibernate.search.util.impl.test.runner.nested.Nested;
+import org.hibernate.search.util.impl.test.runner.nested.NestedRunner;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(NestedRunner.class)
+public class OrPredicateBaseIT {
+
+	@ClassRule
+	public static SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	@BeforeClass
+	public static void setup() {
+		setupHelper.start()
+				.withIndexes(
+						ScoreIT.index,
+						AddScoreIT.index
+				)
+				.setup();
+
+		final BulkIndexer scoreIndexer = ScoreIT.index.bulkIndexer();
+		ScoreIT.dataSet.contribute( scoreIndexer );
+
+		final BulkIndexer addScoreIndexer = AddScoreIT.index.bulkIndexer();
+		AddScoreIT.dataSet.contribute( addScoreIndexer );
+
+		scoreIndexer.join();
+		addScoreIndexer.join();
+	}
+
+	@Test
+	public void takariCpSuiteWorkaround() {
+		// Workaround to get Takari-CPSuite to run this test.
+	}
+
+	@Nested
+	public static class ScoreIT extends AbstractPredicateScoreIT {
+		private static final DataSet dataSet = new DataSet();
+
+		private static final StubMappedIndex index = StubMappedIndex.withoutFields().name( "score" );
+
+		public ScoreIT() {
+			super( index, dataSet );
+		}
+
+		@Override
+		protected PredicateFinalStep predicate(SearchPredicateFactory f, int matchingDocOrdinal) {
+			return f.or( f.id().matching( dataSet.docId( matchingDocOrdinal ) ) );
+		}
+
+		@Override
+		protected PredicateFinalStep predicateWithBoost(SearchPredicateFactory f, int matchingDocOrdinal,
+				float boost) {
+			return f.or( f.id().matching( dataSet.docId( matchingDocOrdinal ) ) )
+					.boost( boost );
+		}
+
+		@Override
+		protected PredicateFinalStep predicateWithConstantScore(SearchPredicateFactory f, int matchingDocOrdinal) {
+			return f.or( f.id().matching( dataSet.docId( matchingDocOrdinal ) ) )
+					.constantScore();
+		}
+
+		@Override
+		protected PredicateFinalStep predicateWithConstantScoreAndBoost(SearchPredicateFactory f,
+				int matchingDocOrdinal, float boost) {
+			return f.or( f.id().matching( dataSet.docId( matchingDocOrdinal ) ) )
+					.constantScore()
+					.boost( boost );
+		}
+
+		private static class DataSet extends AbstractPredicateDataSet {
+			protected DataSet() {
+				super( "singleRoutingKey" );
+			}
+
+			public void contribute(BulkIndexer scoreIndexer) {
+				scoreIndexer.add( docId( 0 ), routingKey, document -> { } );
+				scoreIndexer.add( docId( 1 ), routingKey, document -> { } );
+				scoreIndexer.add( docId( 2 ), routingKey, document -> { } );
+			}
+		}
+	}
+
+	@Nested
+	public static class AddScoreIT extends AbstractPredicateScoreIT {
+		private static final DataSet dataSet = new DataSet();
+
+		private static final StubMappedIndex index = StubMappedIndex.withoutFields().name( "addscore" );
+
+		public AddScoreIT() {
+			super( index, dataSet );
+		}
+
+		@Override
+		protected PredicateFinalStep predicate(SearchPredicateFactory f, int matchingDocOrdinal) {
+			return f.or()
+					.add( f.id().matching( dataSet.docId( matchingDocOrdinal ) ) );
+		}
+
+		@Override
+		protected PredicateFinalStep predicateWithBoost(SearchPredicateFactory f, int matchingDocOrdinal,
+				float boost) {
+			return f.or()
+					.add( f.id().matching( dataSet.docId( matchingDocOrdinal ) ) )
+					.boost( boost );
+		}
+
+		@Override
+		protected PredicateFinalStep predicateWithConstantScore(SearchPredicateFactory f, int matchingDocOrdinal) {
+			return f.or()
+					.add( f.id().matching( dataSet.docId( matchingDocOrdinal ) ) )
+					.constantScore();
+		}
+
+		@Override
+		protected PredicateFinalStep predicateWithConstantScoreAndBoost(SearchPredicateFactory f,
+				int matchingDocOrdinal, float boost) {
+			return f.or()
+					.add( f.id().matching( dataSet.docId( matchingDocOrdinal ) ) )
+					.constantScore()
+					.boost( boost );
+		}
+
+		private static class DataSet extends AbstractPredicateDataSet {
+			protected DataSet() {
+				super( "singleRoutingKey" );
+			}
+
+			public void contribute(BulkIndexer scoreIndexer) {
+				scoreIndexer.add( docId( 0 ), routingKey, document -> { } );
+				scoreIndexer.add( docId( 1 ), routingKey, document -> { } );
+				scoreIndexer.add( docId( 2 ), routingKey, document -> { } );
+			}
+		}
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/OrPredicateSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/OrPredicateSpecificsIT.java
@@ -1,0 +1,219 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.search.predicate;
+
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
+
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactory;
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class OrPredicateSpecificsIT {
+
+	private static final String DOCUMENT_1 = "1";
+	private static final String DOCUMENT_2 = "2";
+	private static final String DOCUMENT_3 = "3";
+
+	// Document 1
+
+	private static final String FIELD1_VALUE1 = "Irving";
+	private static final Integer FIELD2_VALUE1 = 3;
+	private static final Integer FIELD3_VALUE1 = 4;
+	private static final Integer FIELD4_VALUE1AND2 = 1_000;
+	private static final Integer FIELD5_VALUE1AND2 = 2_000;
+
+	// Document 2
+
+	private static final String FIELD1_VALUE2 = "Auster";
+	private static final Integer FIELD2_VALUE2 = 13;
+	private static final Integer FIELD3_VALUE2 = 14;
+	// Field 4: Same as document 1
+	// Field 5: Same as document 1
+
+	// Document 3
+
+	private static final String FIELD1_VALUE3 = "Coe";
+	private static final Integer FIELD2_VALUE3 = 25;
+	private static final Integer FIELD3_VALUE3 = 42;
+	private static final Integer FIELD4_VALUE3 = 42_000; // Different from document 1
+	private static final Integer FIELD5_VALUE3 = 142_000; // Different from document 1
+
+	@ClassRule
+	public static final SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private static final SimpleMappedIndex<IndexBinding> index = SimpleMappedIndex.of( IndexBinding::new );
+
+	@BeforeClass
+	public static void setup() {
+		setupHelper.start().withIndex( index ).setup();
+
+		initData();
+	}
+
+	@Test
+	public void empty() {
+		assertThatQuery( index.query()
+				.where( f -> f.or() ) )
+				.hasNoHits();
+	}
+
+	@Test
+	public void or() {
+		assertThatQuery( index.query()
+				.where( f -> f.or( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+
+		assertThatQuery( index.query()
+				.where( f -> f.or(
+						f.match().field( "field1" ).matching( FIELD1_VALUE1 ),
+						f.match().field( "field1" ).matching( FIELD1_VALUE2 )
+				) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1, DOCUMENT_2 );
+	}
+
+	@Test
+	public void or_separatePredicateObject() {
+		StubMappingScope scope = index.createScope();
+
+		SearchPredicate predicate1 = scope.predicate().match().field( "field1" ).matching( FIELD1_VALUE1 )
+				.toPredicate();
+		SearchPredicate predicate2 = scope.predicate().match().field( "field1" ).matching( FIELD1_VALUE3 )
+				.toPredicate();
+
+		assertThatQuery( scope.query()
+				.where( f -> f.or(
+								predicate1,
+								predicate2
+						)
+				) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1, DOCUMENT_3 );
+	}
+
+	@Test
+	public void nested() {
+		assertThatQuery( index.query()
+				.where( f -> f.or(
+						f.and( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) ),
+						f.and( f.match().field( "field1" ).matching( FIELD1_VALUE3 ) )
+				) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1, DOCUMENT_3 );
+	}
+
+	@Test
+	public void add() {
+		assertThatQuery( index.query()
+				.where( f -> f.or()
+						.add( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+
+		assertThatQuery( index.query()
+				.where( f -> f.or()
+						.add( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) )
+						.add( f.match().field( "field1" ).matching( FIELD1_VALUE2 ) ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1, DOCUMENT_2 );
+	}
+
+	@Test
+	public void add_separatePredicateObject() {
+		StubMappingScope scope = index.createScope();
+
+		SearchPredicate predicate1 = scope.predicate().match().field( "field1" ).matching( FIELD1_VALUE1 )
+				.toPredicate();
+		SearchPredicate predicate2 = scope.predicate().match().field( "field1" ).matching( FIELD1_VALUE2 )
+				.toPredicate();
+
+		assertThatQuery( index.query()
+				.where( f -> f.or()
+						.add( predicate1 ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+
+		assertThatQuery( index.query()
+				.where( f -> f.or()
+						.add( predicate1 )
+						.add( predicate2 ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1, DOCUMENT_2 );
+	}
+
+	@Test
+	public void add_function() {
+		assertThatQuery( index.query()
+				.where( f -> f.or()
+						.add( f2 -> f2.match().field( "field1" ).matching( FIELD1_VALUE1 ) ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+
+		assertThatQuery( index.query()
+				.where( f -> f.or()
+						.add( f2 -> f2.match().field( "field1" ).matching( FIELD1_VALUE1 ) )
+						.add( f2 -> f2.match().field( "field1" ).matching( FIELD1_VALUE2 ) ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1, DOCUMENT_2 );
+	}
+
+	@Test
+	public void with() {
+		assertThatQuery( index.query()
+				.where( f -> f.or()
+						.with( b -> b.add( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) ) ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+
+		assertThatQuery( index.query()
+				.where( f -> f.or()
+						.with( b -> b.add( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) ) )
+						.with( b -> b.add( f.match().field( "field1" ).matching( FIELD1_VALUE2 ) ) ) ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1, DOCUMENT_2 );
+	}
+
+	private static void initData() {
+		BulkIndexer indexer = index.bulkIndexer();
+		indexer.add( DOCUMENT_1, document -> {
+			document.addValue( index.binding().field1, FIELD1_VALUE1 );
+			document.addValue( index.binding().field2, FIELD2_VALUE1 );
+			document.addValue( index.binding().field3, FIELD3_VALUE1 );
+			document.addValue( index.binding().field4, FIELD4_VALUE1AND2 );
+			document.addValue( index.binding().field5, FIELD5_VALUE1AND2 );
+		} );
+		indexer.add( DOCUMENT_2, document -> {
+			document.addValue( index.binding().field1, FIELD1_VALUE2 );
+			document.addValue( index.binding().field2, FIELD2_VALUE2 );
+			document.addValue( index.binding().field3, FIELD3_VALUE2 );
+			document.addValue( index.binding().field4, FIELD4_VALUE1AND2 );
+			document.addValue( index.binding().field5, FIELD5_VALUE1AND2 );
+		} );
+		indexer.add( DOCUMENT_3, document -> {
+			document.addValue( index.binding().field1, FIELD1_VALUE3 );
+			document.addValue( index.binding().field2, FIELD2_VALUE3 );
+			document.addValue( index.binding().field3, FIELD3_VALUE3 );
+			document.addValue( index.binding().field4, FIELD4_VALUE3 );
+			document.addValue( index.binding().field5, FIELD5_VALUE3 );
+		} );
+		indexer.join();
+	}
+
+	private static class IndexBinding {
+		final IndexFieldReference<String> field1;
+		final IndexFieldReference<Integer> field2;
+		final IndexFieldReference<Integer> field3;
+		final IndexFieldReference<Integer> field4;
+		final IndexFieldReference<Integer> field5;
+
+		IndexBinding(IndexSchemaElement root) {
+			field1 = root.field( "field1", IndexFieldTypeFactory::asString ).toReference();
+			field2 = root.field( "field2", IndexFieldTypeFactory::asInteger ).toReference();
+			field3 = root.field( "field3", IndexFieldTypeFactory::asInteger ).toReference();
+			field4 = root.field( "field4", IndexFieldTypeFactory::asInteger ).toReference();
+			field5 = root.field( "field5", IndexFieldTypeFactory::asInteger ).toReference();
+		}
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/OrPredicateSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/OrPredicateSpecificsIT.java
@@ -165,13 +165,13 @@ public class OrPredicateSpecificsIT {
 	public void with() {
 		assertThatQuery( index.query()
 				.where( f -> f.or()
-						.with( b -> b.add( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) ) ) ) )
+						.with( or -> or.add( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) ) ) ) )
 				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
 
 		assertThatQuery( index.query()
 				.where( f -> f.or()
-						.with( b -> b.add( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) ) )
-						.with( b -> b.add( f.match().field( "field1" ).matching( FIELD1_VALUE2 ) ) ) ) )
+						.with( or -> or.add( f.match().field( "field1" ).matching( FIELD1_VALUE1 ) ) )
+						.with( or -> or.add( f.match().field( "field1" ).matching( FIELD1_VALUE2 ) ) ) ) )
 				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1, DOCUMENT_2 );
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4601

Hi!

So, I went back to this PR and I hope I got it right this time after my initial botching.

I have added support for basic n-ary or(...) / and(...) constructs _à la_
```
f.or( f.match().field("foo").matching("val1"),
      f.match().field("bar").matching("val2") )
f.and( f.match().field("foo").matching("val1"),
       f.match().field("bar").matching("val2") )
```

I haven't yet added builder-style constructs with `.add(...)` and `with(...)`.
I guess that should be done.

I haven't updated the documentation yet either.

Before I take the next step, is this going in the right direction?  ;-)

I have added new tests in `BoolPredicateSpecificsIT`, as they are more or less cloned from `bool()` ones.
This makes the file name not very relevant...
Shall I add a new IT file of its own, at the risk of more duplicated code?
If not, shall "duplicated" methods be grouped further, e.g. in `@Nested` test classes?
Also, aren't the tests in `SmokeIT` a bit redundant/pointless?  Maybe they should not be added there...

So far, `AndPredicateClausesStep` and `OrPredicateClausesStep` don't implement `PredicateScoreStep`, which would allow calling `boost(...)` and `constantScore()` on the overall filter.
Shouldn't they?

Similarly, so far, `OrPredicateClausesStep` doesn't support any of the `minimumShouldMatch` constraints.  Shall it?
That looks to me a bit far away from the expected semantic of an `OR` (with `minimumShouldMatch == 1`), so maybe such a feature should be reserved to more complex `bool()`-based predicates.

(If nothing should be added, the Javadoc "@return The initial step of a DSL" should be revised.)

Shall something be done to support `mustNot`?
Again, I'd leave that to `bool()`...

Shall `SearchPredicateFactory.and(...)` and `or(...)` be tagged as `@Incubating` at first?

As usual, using varargs with a parameterized type requires a lot of `@SuppresssWarnings("unchecked")`, including in calling code...  :'-(
Would you happen to have anything better to suggest?
(Besides n overloads for all possible arities. ;-))

Best regards,
          Yannis