### PR TITLE
Backport HSEARCH-4648 + HSEARCH-4649 to branch 6.1 - Follow-up: orm6/jakarta integration test fixes

### DIFF
--- a/integrationtest/backend/elasticsearch/pom.xml
+++ b/integrationtest/backend/elasticsearch/pom.xml
@@ -13,7 +13,7 @@
     <description>Hibernate Search integration tests for the Elasticsearch backend, running the Backend TCK in particular</description>
 
     <properties>
-        <surefire.integration>elasticsearch</surefire.integration>
+        <surefire.module>elasticsearch</surefire.module>
 
         <test.elasticsearch.run.skip>${test.elasticsearch.connection.uris.defined}</test.elasticsearch.run.skip>
 
@@ -79,7 +79,7 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
-                            <!-- WARNING: When using <dependenciesToScan>, be sure to set the Maven property surefire.integration -->
+                            <!-- WARNING: When using <dependenciesToScan>, be sure to set the Maven property surefire.module -->
                             <dependenciesToScan>
                                 <dependency>${project.groupId}:hibernate-search-integrationtest-backend-tck</dependency>
                             </dependenciesToScan>

--- a/integrationtest/backend/lucene/pom.xml
+++ b/integrationtest/backend/lucene/pom.xml
@@ -13,7 +13,7 @@
     <description>Hibernate Search integration tests for the Lucene backend, running the Backend TCK in particular</description>
 
     <properties>
-        <surefire.integration>lucene</surefire.integration>
+        <surefire.module>lucene</surefire.module>
     </properties>
 
     <dependencies>
@@ -52,7 +52,7 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
-                            <!-- WARNING: When using <dependenciesToScan>, be sure to set the Maven property surefire.integration -->
+                            <!-- WARNING: When using <dependenciesToScan>, be sure to set the Maven property surefire.module -->
                             <dependenciesToScan>
                                 <dependency>${project.groupId}:hibernate-search-integrationtest-backend-tck</dependency>
                             </dependenciesToScan>

--- a/integrationtest/mapper/orm-coordination-outbox-polling/pom.xml
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/pom.xml
@@ -13,7 +13,7 @@
     <description>Hibernate Search integration tests for the Hibernate ORM integration using outbox polling as coordination strategy</description>
 
     <properties>
-        <surefire.integration>coord-outbox</surefire.integration>
+        <surefire.module>coord-outbox</surefire.module>
 
         <test.database.run.skip>false</test.database.run.skip>
     </properties>
@@ -72,7 +72,7 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
-                            <!-- WARNING: When using <dependenciesToScan>, be sure to set the Maven property surefire.integration -->
+                            <!-- WARNING: When using <dependenciesToScan>, be sure to set the Maven property surefire.module -->
                             <dependenciesToScan>
                                 <dependency>${project.groupId}:hibernate-search-integrationtest-mapper-orm</dependency>
                             </dependenciesToScan>

--- a/jakarta/integrationtest/mapper/orm-coordination-outbox-polling/pom.xml
+++ b/jakarta/integrationtest/mapper/orm-coordination-outbox-polling/pom.xml
@@ -13,7 +13,7 @@
     <description>Hibernate Search integration tests for the Hibernate ORM integration using outbox polling as coordination strategy - Jakarta EE version</description>
 
     <properties>
-        <surefire.integration>coord-outbox</surefire.integration>
+        <surefire.module>coord-outbox</surefire.module>
 
         <transform.original.pathFromRoot>integrationtest/mapper/orm-coordination-outbox-polling</transform.original.pathFromRoot>
 
@@ -78,7 +78,7 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
-                            <!-- WARNING: When using <dependenciesToScan>, be sure to set the Maven property surefire.integration -->
+                            <!-- WARNING: When using <dependenciesToScan>, be sure to set the Maven property surefire.module -->
                             <dependenciesToScan>
                                 <dependency>${project.groupId}:hibernate-search-integrationtest-mapper-orm</dependency>
                             </dependenciesToScan>

--- a/jakarta/integrationtest/mapper/orm-coordination-outbox-polling/pom.xml
+++ b/jakarta/integrationtest/mapper/orm-coordination-outbox-polling/pom.xml
@@ -13,6 +13,8 @@
     <description>Hibernate Search integration tests for the Hibernate ORM integration using outbox polling as coordination strategy - Jakarta EE version</description>
 
     <properties>
+        <surefire.integration>coord-outbox</surefire.integration>
+
         <transform.original.pathFromRoot>integrationtest/mapper/orm-coordination-outbox-polling</transform.original.pathFromRoot>
 
         <test.database.run.skip>false</test.database.run.skip>
@@ -76,6 +78,7 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
+                            <!-- WARNING: When using <dependenciesToScan>, be sure to set the Maven property surefire.integration -->
                             <dependenciesToScan>
                                 <dependency>${project.groupId}:hibernate-search-integrationtest-mapper-orm</dependency>
                             </dependenciesToScan>

--- a/jakarta/integrationtest/mapper/orm-coordination-outbox-polling/pom.xml
+++ b/jakarta/integrationtest/mapper/orm-coordination-outbox-polling/pom.xml
@@ -75,6 +75,31 @@
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
+                        <configuration>
+                            <dependenciesToScan>
+                                <dependency>${project.groupId}:hibernate-search-integrationtest-mapper-orm</dependency>
+                            </dependenciesToScan>
+                            <includes>
+                                <!-- Include all tests from this module -->
+                                <include>%regex[org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/.*IT\.class]</include>
+                                <!-- Include tests from integrationtest-mapper-orm that are related to automatic indexing -->
+                                <include>%regex[org/hibernate/search/integrationtest/mapper/orm/automaticindexing/.*IT\.class]</include>
+                            </includes>
+                            <excludes>
+                                <!-- Exclude tests from integrationtest-mapper-orm that just cannot work with the outbox polling strategy: -->
+                                <!-- * Synchronization strategies can only be used with the "session" automatic indexing strategy -->
+                                <exclude>AutomaticIndexingSynchronizationStrategyIT</exclude>
+                                <!-- * Sending events outside of transactions, during a flush, doesn't work for some reason;
+                                       entities are only visible from other sessions after the original session is closed. -->
+                                <exclude>AutomaticIndexingOutOfTransactionIT</exclude>
+                                <!-- * We do not send events for the creation of contained entities,
+                                       and as a result one particular use case involving queries instead of associations
+                                       cannot work.
+                                       We will address that someday with explicit support for queries;
+                                       see https://hibernate.atlassian.net/browse/HSEARCH-1937 . -->
+                                <exclude>AutomaticIndexingBridgeExplicitReindexingFunctionalIT</exclude>
+                            </excludes>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/jakarta/parents/integrationtest/pom.xml
+++ b/jakarta/parents/integrationtest/pom.xml
@@ -21,6 +21,8 @@
     <description>Common build configuration for all Jakarta EE integration test artifacts (including documentation)</description>
 
     <properties>
+        <surefire.integration>jakarta</surefire.integration>
+
         <!-- JQAssistant does not seem to work correctly on these artifacts for some reason -->
         <jqassistant.skip>true</jqassistant.skip>
         <!-- Prevent these modules from artificially affecting Sonar metrics -->

--- a/jakarta/parents/internal/pom.xml
+++ b/jakarta/parents/internal/pom.xml
@@ -21,6 +21,8 @@
     <description>Common build configuration for all internal (non-published) artifacts - Jakarta EE version</description>
 
     <properties>
+        <surefire.integration>jakarta</surefire.integration>
+
         <!-- JQAssistant does not seem to work correctly on these artifacts for some reason -->
         <jqassistant.skip>true</jqassistant.skip>
         <!-- Prevent these modules from artificially affecting Sonar metrics -->

--- a/jakarta/parents/public/pom.xml
+++ b/jakarta/parents/public/pom.xml
@@ -21,6 +21,8 @@
     <description>Common build configuration for all Jakarta EE public artifacts</description>
 
     <properties>
+        <surefire.integration>jakarta</surefire.integration>
+
         <!-- JQAssistant does not seem to work correctly on these artifacts for some reason -->
         <jqassistant.skip>true</jqassistant.skip>
         <!-- Prevent these modules from artificially affecting Sonar metrics -->

--- a/orm6/integrationtest/mapper/orm-coordination-outbox-polling/pom.xml
+++ b/orm6/integrationtest/mapper/orm-coordination-outbox-polling/pom.xml
@@ -13,6 +13,8 @@
     <description>Hibernate Search integration tests for the Hibernate ORM integration using outbox polling as coordination strategy - ORM6 version</description>
 
     <properties>
+        <surefire.integration>coord-outbox</surefire.integration>
+
         <transform.original.pathFromRoot>integrationtest/mapper/orm-coordination-outbox-polling</transform.original.pathFromRoot>
 
         <test.database.run.skip>false</test.database.run.skip>
@@ -76,6 +78,7 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
+                            <!-- WARNING: When using <dependenciesToScan>, be sure to set the Maven property surefire.integration -->
                             <dependenciesToScan>
                                 <dependency>${project.groupId}:hibernate-search-integrationtest-mapper-orm</dependency>
                             </dependenciesToScan>

--- a/orm6/integrationtest/mapper/orm-coordination-outbox-polling/pom.xml
+++ b/orm6/integrationtest/mapper/orm-coordination-outbox-polling/pom.xml
@@ -75,6 +75,31 @@
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
+                        <configuration>
+                            <dependenciesToScan>
+                                <dependency>${project.groupId}:hibernate-search-integrationtest-mapper-orm</dependency>
+                            </dependenciesToScan>
+                            <includes>
+                                <!-- Include all tests from this module -->
+                                <include>%regex[org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/.*IT\.class]</include>
+                                <!-- Include tests from integrationtest-mapper-orm that are related to automatic indexing -->
+                                <include>%regex[org/hibernate/search/integrationtest/mapper/orm/automaticindexing/.*IT\.class]</include>
+                            </includes>
+                            <excludes>
+                                <!-- Exclude tests from integrationtest-mapper-orm that just cannot work with the outbox polling strategy: -->
+                                <!-- * Synchronization strategies can only be used with the "session" automatic indexing strategy -->
+                                <exclude>AutomaticIndexingSynchronizationStrategyIT</exclude>
+                                <!-- * Sending events outside of transactions, during a flush, doesn't work for some reason;
+                                       entities are only visible from other sessions after the original session is closed. -->
+                                <exclude>AutomaticIndexingOutOfTransactionIT</exclude>
+                                <!-- * We do not send events for the creation of contained entities,
+                                       and as a result one particular use case involving queries instead of associations
+                                       cannot work.
+                                       We will address that someday with explicit support for queries;
+                                       see https://hibernate.atlassian.net/browse/HSEARCH-1937 . -->
+                                <exclude>AutomaticIndexingBridgeExplicitReindexingFunctionalIT</exclude>
+                            </excludes>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/orm6/integrationtest/mapper/orm-coordination-outbox-polling/pom.xml
+++ b/orm6/integrationtest/mapper/orm-coordination-outbox-polling/pom.xml
@@ -13,7 +13,7 @@
     <description>Hibernate Search integration tests for the Hibernate ORM integration using outbox polling as coordination strategy - ORM6 version</description>
 
     <properties>
-        <surefire.integration>coord-outbox</surefire.integration>
+        <surefire.module>coord-outbox</surefire.module>
 
         <transform.original.pathFromRoot>integrationtest/mapper/orm-coordination-outbox-polling</transform.original.pathFromRoot>
 
@@ -78,7 +78,7 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
-                            <!-- WARNING: When using <dependenciesToScan>, be sure to set the Maven property surefire.integration -->
+                            <!-- WARNING: When using <dependenciesToScan>, be sure to set the Maven property surefire.module -->
                             <dependenciesToScan>
                                 <dependency>${project.groupId}:hibernate-search-integrationtest-mapper-orm</dependency>
                             </dependenciesToScan>

--- a/orm6/parents/integrationtest/pom.xml
+++ b/orm6/parents/integrationtest/pom.xml
@@ -21,6 +21,8 @@
     <description>Common build configuration for all ORM6 integration test artifacts (including documentation)</description>
 
     <properties>
+        <surefire.integration>orm6</surefire.integration>
+
         <!-- JQAssistant does not seem to work correctly on these artifacts for some reason -->
         <jqassistant.skip>true</jqassistant.skip>
         <!-- Forbiddenapis fails when some forbidden methods are not found, and some forbidden methods were removed in ORM 6 -->

--- a/orm6/parents/internal/pom.xml
+++ b/orm6/parents/internal/pom.xml
@@ -21,6 +21,8 @@
     <description>Common build configuration for all internal (non-published) artifacts - ORM6 version</description>
 
     <properties>
+        <surefire.integration>orm6</surefire.integration>
+
         <!-- JQAssistant does not seem to work correctly on these artifacts for some reason -->
         <jqassistant.skip>true</jqassistant.skip>
         <!-- Forbiddenapis fails when some forbidden methods are not found, and some forbidden methods were removed in ORM 6 -->

--- a/orm6/parents/public/pom.xml
+++ b/orm6/parents/public/pom.xml
@@ -21,6 +21,8 @@
     <description>Common build configuration for all ORM6 public artifacts</description>
 
     <properties>
+        <surefire.integration>orm6</surefire.integration>
+
         <!-- JQAssistant does not seem to work correctly on these artifacts for some reason -->
         <jqassistant.skip>true</jqassistant.skip>
         <!-- Forbiddenapis fails when some forbidden methods are not found, and some forbidden methods were removed in ORM 6 -->

--- a/pom.xml
+++ b/pom.xml
@@ -517,12 +517,12 @@
         <failsafe.spring.skip>${skipITs}</failsafe.spring.skip>
 
         <!-- This allows us to distinguish between multiple executions of the same test in test reports. -->
-        <surefire.reportNameSuffix>${surefire.integration}-${surefire.environment}</surefire.reportNameSuffix>
+        <surefire.reportNameSuffix>${surefire.module}-${surefire.environment}</surefire.reportNameSuffix>
         <!-- This should be set from the command line by CI jobs that execute the same tests in multiple environments -->
         <surefire.environment>default</surefire.environment>
         <!-- This should be set in modules that re-execute tests imported from a dependency (using <dependenciesToScan>)
              to differentiate multiple executions of the same tests in multiple modules. -->
-        <surefire.integration>default</surefire.integration>
+        <surefire.module>default</surefire.module>
 
         <!-- Containers executions tests properties -->
         <test.containers.run.skip>false</test.containers.run.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -517,12 +517,15 @@
         <failsafe.spring.skip>${skipITs}</failsafe.spring.skip>
 
         <!-- This allows us to distinguish between multiple executions of the same test in test reports. -->
-        <surefire.reportNameSuffix>${surefire.module}-${surefire.environment}</surefire.reportNameSuffix>
+        <surefire.reportNameSuffix>${surefire.module}-${surefire.integration}-${surefire.environment}</surefire.reportNameSuffix>
         <!-- This should be set from the command line by CI jobs that execute the same tests in multiple environments -->
         <surefire.environment>default</surefire.environment>
         <!-- This should be set in modules that re-execute tests imported from a dependency (using <dependenciesToScan>)
              to differentiate multiple executions of the same tests in multiple modules. -->
         <surefire.module>default</surefire.module>
+        <!-- This should be set in modules that transform Hibernate Search code for a different integration
+             (Jakarta EE, ORM 6, ...). -->
+        <surefire.integration>default</surefire.integration>
 
         <!-- Containers executions tests properties -->
         <test.containers.run.skip>false</test.containers.run.skip>


### PR DESCRIPTION
* [HSEARCH-4649](https://hibernate.atlassian.net/browse/HSEARCH-4649): Fix "File name too long" errors when creating test reports
* [HSEARCH-4648](https://hibernate.atlassian.net/browse/HSEARCH-4648): Restore execution of many automatic indexing tests when testing outbox polling

Follows up on #3151 