### PR TITLE
Backport HSEARCH-4652 to branch 6.1 - Schema validation fails if search analyzer is set explicitly to the same value as the analyzer

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/validation/impl/LeafValidator.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/validation/impl/LeafValidator.java
@@ -27,8 +27,18 @@ abstract class LeafValidator<T> {
 	public final void validateWithDefault(ValidationErrorCollector errorCollector,
 			ValidationContextType type, String name,
 			T expected, T actual, T defaultValueForNulls) {
-		T defaultedExpected = expected == null ? defaultValueForNulls : expected;
-		T defaultedActual = actual == null ? defaultValueForNulls : actual;
+		validateWithDefault( errorCollector, type, name, expected, actual, defaultValueForNulls, defaultValueForNulls );
+	}
+
+	/*
+	 * Validate that two values are equal, using a given default value when null is encountered on either value.
+	 * Useful to take into account the fact that Elasticsearch has default values for attributes.
+	 */
+	public final void validateWithDefault(ValidationErrorCollector errorCollector,
+			ValidationContextType type, String name,
+			T expected, T actual, T defaultValueForExpectedNull, T defaultValueForActualNull) {
+		T defaultedExpected = expected == null ? defaultValueForExpectedNull : expected;
+		T defaultedActual = actual == null ? defaultValueForActualNull : actual;
 		if ( defaultedExpected == defaultedActual ) {
 			// Covers null == null
 			return;

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/validation/impl/PropertyMappingValidator.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/validation/impl/PropertyMappingValidator.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.DataTypes;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.PropertyMapping;
+import org.hibernate.search.engine.backend.analysis.AnalyzerNames;
 import org.hibernate.search.util.common.impl.CollectionHelper;
 
 class PropertyMappingValidator extends AbstractTypeMappingValidator<PropertyMapping> {
@@ -68,11 +69,13 @@ class PropertyMappingValidator extends AbstractTypeMappingValidator<PropertyMapp
 	private void validateAnalyzerOptions(ValidationErrorCollector errorCollector, PropertyMapping expectedMapping, PropertyMapping actualMapping) {
 		LeafValidators.EQUAL.validateWithDefault(
 				errorCollector, ValidationContextType.MAPPING_ATTRIBUTE, "analyzer",
-				expectedMapping.getAnalyzer(), actualMapping.getAnalyzer(), "default"
+				expectedMapping.getAnalyzer(), actualMapping.getAnalyzer(), AnalyzerNames.DEFAULT
 		);
-		LeafValidators.EQUAL.validate(
+		LeafValidators.EQUAL.validateWithDefault(
 				errorCollector, ValidationContextType.MAPPING_ATTRIBUTE, "search_analyzer",
-				expectedMapping.getSearchAnalyzer(), actualMapping.getSearchAnalyzer()
+				expectedMapping.getSearchAnalyzer(), actualMapping.getSearchAnalyzer(),
+				expectedMapping.getAnalyzer() == null ? AnalyzerNames.DEFAULT : expectedMapping.getAnalyzer(),
+				actualMapping.getAnalyzer() == null ? AnalyzerNames.DEFAULT : actualMapping.getAnalyzer()
 		);
 		LeafValidators.EQUAL.validate(
 				errorCollector, ValidationContextType.MAPPING_ATTRIBUTE, "normalizer",

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerValidationMappingAttributeIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerValidationMappingAttributeIT.java
@@ -29,6 +29,7 @@ import org.hibernate.search.util.common.impl.Futures;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.rule.TestElasticsearchClient;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappedIndex;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingSchemaManagementStrategy;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -574,6 +575,57 @@ public class ElasticsearchIndexSchemaManagerValidationMappingAttributeIT {
 						.indexFieldContext( "myField" )
 						.mappingAttributeContext( "search_analyzer" )
 						.failure( "Invalid value. Expected 'italian', actual is 'english'" ) );
+	}
+
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4652")
+	public void attribute_searchAnalyzer_sameAsAnalyzer_valid() {
+		StubMappedIndex index = StubMappedIndex.ofNonRetrievable(
+				root -> root.field( "myField", f -> f.asString()
+						.analyzer( "keyword" ).searchAnalyzer( "keyword" ) ).toReference()
+		);
+
+		elasticSearchClient.index( index.name() ).deleteAndCreate();
+		elasticSearchClient.index( index.name() ).type().putMapping(
+				simpleMappingForInitialization(
+						"'myField': {"
+								+ "'type': 'text',"
+								+ "'index': true,"
+								+ "'analyzer': 'keyword',"
+								+ "'search_analyzer': 'keyword'"
+								+ "}"
+				)
+		);
+
+		setupAndValidate( index );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4652")
+	public void attribute_searchAnalyzer_sameAsAnalyzer_invalid() {
+		StubMappedIndex index = StubMappedIndex.ofNonRetrievable(
+				root -> root.field( "myField", f -> f.asString().analyzer( "keyword" ).searchAnalyzer( "keyword" ) ).toReference()
+		);
+
+		elasticSearchClient.index( index.name() ).deleteAndCreate();
+		elasticSearchClient.index( index.name() ).type().putMapping(
+				simpleMappingForInitialization(
+						"'myField': {"
+								+ "'type': 'text',"
+								+ "'index': true,"
+								+ "'analyzer': 'keyword',"
+								+ "'search_analyzer': 'english'"
+								+ "}"
+				)
+		);
+
+		assertThatThrownBy( () -> setupAndValidate( index ) )
+				.isInstanceOf( Exception.class )
+				.satisfies( hasValidationFailureReport()
+						.indexFieldContext( "myField" )
+						.mappingAttributeContext( "search_analyzer" )
+						.failure( "Invalid value. Expected 'keyword', actual is 'english'" ) );
 	}
 
 	@Test


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4652

Backport of #3158 to branch 6.1