### PR TITLE
Backport HSEARCH-4654 to branch 6.1 - Deadlock in RootFailureCollector when exceeding the failure limit (100) with concurrent failures from different threads

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
@@ -119,9 +119,10 @@ public interface Log extends BasicLogger {
 	IllegalArgumentException invalidGeoPolygonFirstPointNotIdenticalToLastPoint(GeoPoint firstPoint, GeoPoint lastPoint);
 
 	@Message(id = ID_OFFSET + 19,
-			value = "Hibernate Search encountered failures during %1$s. Stopped collecting failures after '%3$s' failures."
-					+ " Failures:\n%2$s")
-	SearchException collectedFailureLimitReached(String process, String renderedFailures, int failureCount);
+			value = "Hibernate Search encountered failures during %1$s. Stopped collecting failures after %2$s failures."
+					+ " Currently at %3$s failures and counting."
+					+ " Failures:\n%4$s")
+	SearchException collectedFailureLimitReached(String process, int failureLimit, int failureCount, String renderedFailures);
 
 	@Message(id = ID_OFFSET + 20,
 			value = "Hibernate Search encountered failures during %1$s."

--- a/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
@@ -119,10 +119,10 @@ public interface Log extends BasicLogger {
 	IllegalArgumentException invalidGeoPolygonFirstPointNotIdenticalToLastPoint(GeoPoint firstPoint, GeoPoint lastPoint);
 
 	@Message(id = ID_OFFSET + 19,
-			value = "Hibernate Search encountered failures during %1$s. Stopped collecting failures after %2$s failures."
-					+ " Currently at %3$s failures and counting."
-					+ " Failures:\n%4$s")
-	SearchException collectedFailureLimitReached(String process, int failureLimit, int failureCount, String renderedFailures);
+			value = "Hibernate Search encountered %3$s failures during %1$s."
+						+ " Only the first %2$s failures are displayed here."
+						+ " See the logs for extra failures.")
+	String collectedFailureLimitReached(String process, int failureLimit, int failureCount);
 
 	@Message(id = ID_OFFSET + 20,
 			value = "Hibernate Search encountered failures during %1$s."

--- a/engine/src/main/java/org/hibernate/search/engine/reporting/spi/RootFailureCollector.java
+++ b/engine/src/main/java/org/hibernate/search/engine/reporting/spi/RootFailureCollector.java
@@ -7,16 +7,18 @@
 package org.hibernate.search.engine.reporting.spi;
 
 import java.lang.invoke.MethodHandles;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.hibernate.search.engine.logging.impl.Log;
 import org.hibernate.search.engine.reporting.impl.EngineEventContextMessages;
 import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.common.data.impl.InsertionOrder;
 import org.hibernate.search.util.common.impl.ToStringStyle;
 import org.hibernate.search.util.common.impl.ToStringTreeBuilder;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
@@ -87,8 +89,10 @@ public final class RootFailureCollector implements FailureCollector {
 
 	private static class NonRootFailureCollector implements FailureCollector {
 		protected final RootFailureCollector root;
-		// Use a LinkedHashMap for deterministic iteration
-		private final Map<EventContextElement, ContextualFailureCollectorImpl> children = new LinkedHashMap<>();
+		private final InsertionOrder<EventContextElement> childrenInsertionOrder = new InsertionOrder<>();
+		// Avoiding blocking implementations because we access this from reactive event loops
+		private final Map<InsertionOrder.Key<EventContextElement>, ContextualFailureCollectorImpl> children =
+				new ConcurrentSkipListMap<>();
 
 		private NonRootFailureCollector(RootFailureCollector root) {
 			this.root = root;
@@ -99,7 +103,7 @@ public final class RootFailureCollector implements FailureCollector {
 		}
 
 		@Override
-		public synchronized ContextualFailureCollectorImpl withContext(EventContext context) {
+		public ContextualFailureCollectorImpl withContext(EventContext context) {
 			if ( context == null ) {
 				return withDefaultContext();
 			}
@@ -120,13 +124,13 @@ public final class RootFailureCollector implements FailureCollector {
 		}
 
 		@Override
-		public synchronized ContextualFailureCollectorImpl withContext(EventContextElement contextElement) {
+		public ContextualFailureCollectorImpl withContext(EventContextElement contextElement) {
 			if ( contextElement == null ) {
 				return withDefaultContext();
 			}
 			return children.computeIfAbsent(
-					contextElement,
-					element -> new ContextualFailureCollectorImpl( this, element )
+					childrenInsertionOrder.wrapKey( contextElement ),
+					key -> new ContextualFailureCollectorImpl( this, key.get() )
 			);
 		}
 
@@ -138,7 +142,7 @@ public final class RootFailureCollector implements FailureCollector {
 			// Nothing to do
 		}
 
-		final synchronized void appendChildrenFailuresTo(ToStringTreeBuilder builder) {
+		final void appendChildrenFailuresTo(ToStringTreeBuilder builder) {
 			for ( ContextualFailureCollectorImpl child : children.values() ) {
 				// Some contexts may have been mentioned without any failure being ever reported.
 				// Only display contexts that had at least one failure reported.
@@ -148,8 +152,8 @@ public final class RootFailureCollector implements FailureCollector {
 			}
 		}
 
-		final Map<EventContextElement, ContextualFailureCollectorImpl> children() {
-			return children;
+		final Collection<ContextualFailureCollectorImpl> children() {
+			return children.values();
 		}
 	}
 
@@ -157,7 +161,8 @@ public final class RootFailureCollector implements FailureCollector {
 		private final NonRootFailureCollector parent;
 		private final EventContextElement context;
 
-		private final List<String> failureMessages = new ArrayList<>();
+		// Avoiding blocking implementations because we access this from reactive event loops
+		private final Collection<String> failureMessages = new ConcurrentLinkedDeque<>();
 
 		private ContextualFailureCollectorImpl(NonRootFailureCollector parent, EventContextElement context) {
 			super( parent );
@@ -166,11 +171,11 @@ public final class RootFailureCollector implements FailureCollector {
 		}
 
 		@Override
-		public synchronized boolean hasFailure() {
+		public boolean hasFailure() {
 			if ( !failureMessages.isEmpty() ) {
 				return true;
 			}
-			for ( ContextualFailureCollectorImpl child : children().values() ) {
+			for ( ContextualFailureCollectorImpl child : children() ) {
 				if ( child.hasFailure() ) {
 					return true;
 				}
@@ -211,7 +216,7 @@ public final class RootFailureCollector implements FailureCollector {
 			joiner.add( context.render() );
 		}
 
-		synchronized void appendFailuresTo(ToStringTreeBuilder builder) {
+		void appendFailuresTo(ToStringTreeBuilder builder) {
 			builder.startObject( context.render() );
 			if ( !failureMessages.isEmpty() ) {
 				builder.attribute( EngineEventContextMessages.INSTANCE.failureReportFailures(), failureMessages );
@@ -220,7 +225,7 @@ public final class RootFailureCollector implements FailureCollector {
 			builder.endObject();
 		}
 
-		private synchronized void doAdd(Throwable failure, String failureMessage) {
+		private void doAdd(Throwable failure, String failureMessage) {
 			StringJoiner contextJoiner = new StringJoiner( CommonEventContextMessages.INSTANCE.contextSeparator() );
 			appendContextTo( contextJoiner );
 			log.newCollectedFailure( root.process, contextJoiner.toString(), failure );
@@ -228,7 +233,7 @@ public final class RootFailureCollector implements FailureCollector {
 			doAdd( failureMessage );
 		}
 
-		private synchronized void doAdd(String failureMessage) {
+		private void doAdd(String failureMessage) {
 			if ( root.shouldAddFailure() ) {
 				failureMessages.add( failureMessage );
 			}

--- a/engine/src/main/java/org/hibernate/search/engine/reporting/spi/RootFailureCollector.java
+++ b/engine/src/main/java/org/hibernate/search/engine/reporting/spi/RootFailureCollector.java
@@ -33,7 +33,8 @@ public final class RootFailureCollector implements FailureCollector {
 	 * which could be a problem when there is something fundamentally wrong
 	 * that will cause almost every operation to fail.
 	 */
-	private static final int FAILURE_LIMIT = 100;
+	// Exposed for tests
+	static final int FAILURE_LIMIT = 100;
 
 	private final String process;
 	private final NonRootFailureCollector delegate;
@@ -77,9 +78,9 @@ public final class RootFailureCollector implements FailureCollector {
 
 	private void onAddFailure() {
 		int theFailureCount = failureCount.incrementAndGet();
-		if ( theFailureCount >= FAILURE_LIMIT ) {
+		if ( theFailureCount > FAILURE_LIMIT ) {
 			String renderedFailures = renderFailures();
-			throw log.collectedFailureLimitReached( process, renderedFailures, theFailureCount );
+			throw log.collectedFailureLimitReached( process, FAILURE_LIMIT, theFailureCount, renderedFailures );
 		}
 	}
 
@@ -234,9 +235,9 @@ public final class RootFailureCollector implements FailureCollector {
 		}
 
 		private synchronized void doAdd(String failureMessage) {
-			failureMessages.add( failureMessage );
-
+			// Do this FIRST, so that we actually stop collecting failures.
 			root.onAddFailure();
+			failureMessages.add( failureMessage );
 		}
 	}
 

--- a/engine/src/test/java/org/hibernate/search/engine/reporting/spi/RootFailureCollectorTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/reporting/spi/RootFailureCollectorTest.java
@@ -8,6 +8,14 @@ package org.hibernate.search.engine.reporting.spi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.junit.Test;
 
@@ -35,6 +43,51 @@ public class RootFailureCollectorTest {
 				// Check that we mention that some failures are not being reported
 				.hasMessageContainingAll( "Hibernate Search encountered " + ( RootFailureCollector.FAILURE_LIMIT + 10 )
 						+ " failures during RootName",
+						"Only the first " + RootFailureCollector.FAILURE_LIMIT + " failures are displayed here",
+						"See the logs for extra failures" )
+				// Check that we didn't report failures after the limit was reached
+				.message().satisfies( message -> {
+					assertThat( countOccurrences( message, "Error #" ) )
+							.as( "Number of errors reported" ).isEqualTo( RootFailureCollector.FAILURE_LIMIT );
+				} );
+	}
+
+	/**
+	 * Triggers many more failures than the failure limit
+	 * in concurrent tasks that create contextual failure collectors then add a failure.
+	 * <p>
+	 * This used to lead to a deadlock, because we would:
+	 * <ul>
+	 *     <li>lock on a child to add a failure</li>
+	 *     <li>check on the root whether there are more failures than the limit</li>
+	 *     <li>lock on the root to access the children</li>
+	 *     <li>try to lock on each child one after the other,
+	 *     to render their failures and include that in the "failure limit reached" exception message</li>
+	 * </ul>
+	 * Do that concurrently from two different children, and you're likely to end up with a deadlock.
+	 */
+	@Test
+	public void failureLimit_concurrency() {
+		RootFailureCollector rootFailureCollector = new RootFailureCollector( "RootName" );
+		List<Runnable> runnables = IntStream.range( 0, RootFailureCollector.FAILURE_LIMIT + 1000 )
+				.mapToObj( i -> (Runnable) () -> {
+					ContextualFailureCollector failureCollector = rootFailureCollector.withContext(
+							EventContexts.fromType( "Type #" + i ) );
+					failureCollector.add( "Error #" + i );
+				} )
+				.collect( Collectors.toList() );
+		ForkJoinPool pool = new ForkJoinPool( 10 );
+		List<ForkJoinTask<?>> tasks = runnables.stream().map( pool::submit )
+				.collect( Collectors.toList() );
+		await().atMost( 2, TimeUnit.SECONDS ).until( pool::isQuiescent );
+		pool.shutdownNow();
+		assertThat( tasks )
+				.hasSameSizeAs( runnables )
+				.allSatisfy( task -> assertThat( task ).isDone() );
+		assertThatThrownBy( rootFailureCollector::checkNoFailure )
+				// Check that we mention that some failures are not being reported
+				.hasMessageContainingAll( "Hibernate Search encountered " + ( RootFailureCollector.FAILURE_LIMIT + 1000 )
+								+ " failures during RootName",
 						"Only the first " + RootFailureCollector.FAILURE_LIMIT + " failures are displayed here",
 						"See the logs for extra failures" )
 				// Check that we didn't report failures after the limit was reached

--- a/engine/src/test/java/org/hibernate/search/engine/reporting/spi/RootFailureCollectorTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/reporting/spi/RootFailureCollectorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.reporting.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.hibernate.search.util.common.SearchException;
+
+import org.junit.Test;
+
+public class RootFailureCollectorTest {
+
+	/**
+	 * Triggers many more failures than the failure limit.
+	 * <p>
+	 * Only the first {@value RootFailureCollector#FAILURE_LIMIT} failures should be reported.
+	 */
+	@Test
+	public void failureLimit() {
+		RootFailureCollector rootFailureCollector = new RootFailureCollector( "RootName" );
+		for ( int i = 0; i < RootFailureCollector.FAILURE_LIMIT; i++ ) {
+			ContextualFailureCollector failureCollector = rootFailureCollector.withContext(
+					EventContexts.fromType( "Type #" + i ) );
+			failureCollector.add( "Error #" + i );
+		}
+		for ( int i = 0; i < 10; i++ ) {
+			ContextualFailureCollector failureCollector = rootFailureCollector.withContext(
+					EventContexts.fromType( "Type #" + i ) );
+			int finalI = i;
+			assertThatThrownBy( () -> failureCollector.add( "Error #" + finalI ) )
+					.isInstanceOf( SearchException.class )
+					.hasMessageContainingAll( "Hibernate Search encountered failures during RootName",
+							"Stopped collecting failures after " + RootFailureCollector.FAILURE_LIMIT + " failures",
+							"Currently at " + ( RootFailureCollector.FAILURE_LIMIT + i + 1 ) + " failures and counting",
+							"Failures:" );
+		}
+		// Check that we didn't report failures after the limit was reached
+		assertThatThrownBy( rootFailureCollector::checkNoFailure )
+				.message().satisfies( message -> {
+					assertThat( countOccurrences( message, "Error #" ) )
+							.as( "Number of errors reported" ).isEqualTo( RootFailureCollector.FAILURE_LIMIT );
+				} );
+	}
+
+	private int countOccurrences(String message, String substring) {
+		int count = 0;
+		int currentIndex = message.indexOf( substring );
+		while ( currentIndex >= 0 ) {
+			++count;
+			currentIndex = message.indexOf( substring, currentIndex + 1 );
+		}
+		return count;
+	}
+
+}

--- a/util/common/src/main/java/org/hibernate/search/util/common/data/impl/InsertionOrder.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/data/impl/InsertionOrder.java
@@ -1,0 +1,71 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.common.data.impl;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+/**
+ * A helper to generate map keys that can be sorted according to their insertion order.
+ * <p>
+ * Useful with {@link java.util.concurrent.ConcurrentSkipListMap} in particular,
+ * to get insertion order instead of natural key order.
+ * <p>
+ * Do not use with maps whose keys can be removed: this class cannot forget about keys,
+ * so it can lead to memory leaks in that case.
+ */
+public final class InsertionOrder<T> {
+
+	private final AtomicInteger indexProvider = new AtomicInteger();
+	private final Map<T, Key<T>> keys = new ConcurrentHashMap<>();
+	private final Function<? super T, Key<T>> createNewKey =
+			key -> new Key<>( indexProvider.getAndIncrement(), key );
+
+	public Key<T> wrapKey(T key) {
+		return keys.computeIfAbsent( key, createNewKey );
+	}
+
+	public static final class Key<T> implements Comparable<Key<?>> {
+		private final int index;
+		private final T wrapped;
+
+		private Key(int index, T wrapped) {
+			this.index = index;
+			this.wrapped = wrapped;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			Key<?> key = (Key<?>) o;
+			return index == key.index;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( index );
+		}
+
+		@Override
+		public int compareTo(Key<?> o) {
+			return Integer.compare( index, o.index );
+		}
+
+		public T get() {
+			return wrapped;
+		}
+	}
+
+}

--- a/util/common/src/test/java/org/hibernate/search/util/common/data/impl/InsertionOrderTest.java
+++ b/util/common/src/test/java/org/hibernate/search/util/common/data/impl/InsertionOrderTest.java
@@ -1,0 +1,81 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.common.data.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+
+public class InsertionOrderTest {
+
+	@Test
+	public void stableGet() {
+		InsertionOrder<MyKey> insertionOrder = new InsertionOrder<>();
+
+		MyKey key1 = new MyKey( 42 );
+		MyKey key2 = new MyKey( 1 );
+		InsertionOrder.Key<MyKey> key1Wrapper = insertionOrder.wrapKey( key1 );
+		InsertionOrder.Key<MyKey> key2Wrapper = insertionOrder.wrapKey( key2 );
+		assertThat( key1Wrapper ).isLessThan( key2Wrapper );
+		assertThat( key2Wrapper ).isGreaterThan( key1Wrapper );
+
+		MyKey keyEqualTo1 = new MyKey( 42 );
+		InsertionOrder.Key<MyKey> keyEqualTo1Wrapper = insertionOrder.wrapKey( keyEqualTo1 );
+		assertThat( keyEqualTo1Wrapper ).isSameAs( key1Wrapper );
+	}
+
+	@Test
+	public void concurrentSkipListMap() {
+		InsertionOrder<MyKey> insertionOrder = new InsertionOrder<>();
+
+		ConcurrentSkipListMap<InsertionOrder.Key<MyKey>, Integer> map = new ConcurrentSkipListMap<>();
+		for ( int i = 0; i < 2000; i++ ) {
+			MyKey key = new MyKey( i );
+			map.put( insertionOrder.wrapKey( key ), i );
+
+			assertThat( map.entrySet() )
+					.extracting( e -> Map.entry( e.getKey().get(), e.getValue() ) )
+					// Expect the map to contain entries MyKey(j) => j for j from 0 to i, in this exact order
+					.containsExactlyElementsOf(
+							IntStream.range( 0, i + 1 )
+									.mapToObj( j -> Map.entry( new MyKey( j ), j ) )
+									.collect( Collectors.toList() ) );
+		}
+	}
+
+	private static class MyKey {
+		final int i;
+
+		private MyKey(int i) {
+			this.i = i;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			MyKey myKey = (MyKey) o;
+			return i == myKey.i;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( i );
+		}
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4654

Backport of #3162 to branch 6.1.