### PR TITLE
Backport HSEARCH-4634 + HSEARCH-4644 + HSEARCH-4647 to branch 6.1 - Fix and test CockroachDB compatibility

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -209,7 +209,9 @@ stage('Configure') {
                     new DatabaseBuildEnvironment(dbName: 'db2', mavenProfile: 'ci-db2',
                             condition: TestCondition.AFTER_MERGE),
                     new DatabaseBuildEnvironment(dbName: 'mssql', mavenProfile: 'ci-mssql',
-                            condition: TestCondition.AFTER_MERGE)
+                            condition: TestCondition.AFTER_MERGE),
+                    new DatabaseBuildEnvironment(dbName: 'cockroachdb', mavenProfile: 'ci-cockroachdb',
+                            condition: TestCondition.AFTER_MERGE),
 			],
 			esLocal: [
 					// --------------------------------------------

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/limitations/ConcurrentEmbeddedUpdateLimitationIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/limitations/ConcurrentEmbeddedUpdateLimitationIT.java
@@ -25,6 +25,7 @@ import javax.persistence.OneToMany;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.search.integrationtest.mapper.orm.realbackend.testsupport.BackendConfigurations;
 import org.hibernate.search.mapper.orm.Search;
@@ -61,7 +62,11 @@ public class ConcurrentEmbeddedUpdateLimitationIT {
 				// This is absolutely necessary to avoid false positives in this test
 				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_SYNCHRONIZATION_STRATEGY, "sync" )
 				.skipTestForDialect( SQLServerDialect.class,
-						"The execution could provoke a deadlock on SQLServer, which will abort our requests upon detecting the deadlock, and will make the tests fail." )
+						"The execution could provoke a failure caused by a deadlock on SQLServer, "
+						+ "which will abort our requests and will make the tests fail." )
+				.skipTestForDialect( CockroachDB192Dialect.class,
+						"The execution could provoke a 'failed preemptive refresh due to a conflict' on CockroachDB,"
+						+ " which will abort our requests and will make the tests fail." )
 				.setup( Book.class, Author.class, BookEdition.class );
 
 		reproducer();

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AbstractAgentClusterLink.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AbstractAgentClusterLink.java
@@ -86,7 +86,7 @@ abstract class AbstractAgentClusterLink<R> {
 			agentRepository.delete( timedOutAgents );
 			log.infof( "Agent '%s': reassessing the new situation in the next pulse",
 					selfReference(), now );
-			return instructCommitAndRetryPulseASAP( now );
+			return instructCommitAndRetryPulseAfterDelay( now, pollingInterval );
 		}
 
 		// Delay expiration in each pulse
@@ -98,7 +98,18 @@ abstract class AbstractAgentClusterLink<R> {
 	protected abstract R doPulse(AgentRepository agentRepository, Instant now,
 			List<Agent> allAgentsInIdOrder, Agent self);
 
-	protected abstract R instructCommitAndRetryPulseASAP(Instant now);
+	/**
+	 * Instructs the processor to commit the transaction, wait for the given delay, then pulse again.
+	 * <p>
+	 * Use with:
+	 * <ul>
+	 * <li>pollingInterval to apply a minimal delay before the next pulse, to avoid hitting the database continuously.
+	 *     Useful when waiting for external changes.</li>
+	 * <li>pulseInterval to apply a large delay before the next pulse.
+	 *     Useful when suspended and waiting for a reason to resume.</li>
+	 * </ul>
+	 */
+	protected abstract R instructCommitAndRetryPulseAfterDelay(Instant now, Duration delay);
 
 	public final void leaveCluster(AgentRepository agentRepository) {
 		agentPersister.leaveCluster( agentRepository );

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AbstractAgentClusterLink.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AbstractAgentClusterLink.java
@@ -11,13 +11,13 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.hibernate.search.engine.reporting.FailureHandler;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.Agent;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.AgentPersister;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.AgentReference;
-import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.AgentRepository;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.logging.impl.Log;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
@@ -29,9 +29,8 @@ abstract class AbstractAgentClusterLink<R> {
 	protected final Duration pollingInterval;
 	protected final Duration pulseInterval;
 	protected final Duration pulseExpiration;
+	private final AgentPersister agentPersister;
 
-	// Accessible for test purposes
-	final AgentPersister agentPersister;
 
 	public AbstractAgentClusterLink(AgentPersister agentPersister,
 			FailureHandler failureHandler, Clock clock,
@@ -48,11 +47,8 @@ abstract class AbstractAgentClusterLink<R> {
 		Agent self = ensureRegistered( context );
 
 		// In order to avoid transaction deadlocks with some RDBMS (yes, I mean SQL Server),
-		// we make sure that *all* reads (listing all agents) happen before the write (updating self).
-		// I'm not entirely sure, but I think it goes like this:
-		// if we read, then write, then read again, then the second read can trigger a deadlock,
-		// with each transaction holding a write lock on some rows
-		// while waiting for a read lock on the whole table.
+		// we make sure that reads listing other agents always happen in a different transaction
+		// than writes.
 		List<Agent> allAgentsInIdOrder = context.agentRepository().findAllOrderById();
 
 		Instant now = clock.instant();
@@ -69,44 +65,61 @@ abstract class AbstractAgentClusterLink<R> {
 		// then the first agent tries to delete the second agent because it expired,
 		// then the second agent tries to delete the first agent because it expired,
 		// all in the same transaction,  well... here you have a deadlock.
+		Instant expirationLimit = now;
 		List<Agent> timedOutAgents = allAgentsInIdOrder.stream()
-				.filter( a -> !a.equals( self ) && a.getExpiration().isBefore( now ) )
+				.filter( Predicate.isEqual( self ).negate() ) // Ignore self: if expired, we'll correct that.
+				.filter( a -> a.getExpiration().isBefore( expirationLimit ) )
 				.collect( Collectors.toList() );
 		if ( !timedOutAgents.isEmpty() ) {
 			log.removingTimedOutAgents( selfReference(), timedOutAgents );
 			context.agentRepository().delete( timedOutAgents );
-			log.infof( "Agent '%s': reassessing the new situation in the next pulse",
-					selfReference(), now
-			);
+			log.infof( "Agent '%s': reassessing the new situation in the next pulse", selfReference() );
 			return instructCommitAndRetryPulseAfterDelay( now, pollingInterval );
 		}
 
-		// Delay expiration in each pulse
-		self.setExpiration( newExpiration );
+		// Determine what needs to be done
+		WriteAction<R> pulseResult = doPulse( allAgentsInIdOrder, self );
 
-		return doPulse( context.agentRepository(), now, allAgentsInIdOrder, self );
+		// Write actions are always executed in a new transaction,
+		// so that the risk of deadlocks (see above) is minimal,
+		// and transactions are shorter (for lower transaction contention,
+		// important on CockroachDB in particular:
+		// https://www.cockroachlabs.com/docs/v22.1/transactions#transaction-contention ).
+		context.commitAndBeginNewTransaction();
+		now = clock.instant();
+		self = findSelfExpectRegistered( context );
+		// Delay expiration with each write
+		self.setExpiration( now.plus( pulseExpiration ) );
+		R instructions = pulseResult.applyAndReturnInstructions( now, self, agentPersister );
+		log.tracef( "Agent '%s': ending pulse at %s with self = %s",
+				selfReference(), now, self );
+		return instructions;
 	}
 
 	private Agent ensureRegistered(AgentClusterLinkContext context) {
-		Instant now = clock.instant();
 		Agent self = agentPersister.findSelf( context.agentRepository() );
 		if ( self == null ) {
+			Instant now = clock.instant();
 			agentPersister.createSelf( context.agentRepository(), now.plus( pulseExpiration ) );
 			// Make sure the transaction *only* registers the agent,
 			// so that the risk of deadlocks (see below) is minimal
 			// and other agents are made aware of this agent as soon as possible.
 			// This avoids unnecessary rebalancing when multiple nodes start in quick succession.
 			context.commitAndBeginNewTransaction();
-			self = agentPersister.findSelf( context.agentRepository() );
-			if ( self == null ) {
-				throw log.agentRegistrationIneffective( selfReference() );
-			}
+			self = findSelfExpectRegistered( context );
 		}
 		return self;
 	}
 
-	protected abstract R doPulse(AgentRepository agentRepository, Instant now,
-			List<Agent> allAgentsInIdOrder, Agent self);
+	private Agent findSelfExpectRegistered(AgentClusterLinkContext context) {
+		Agent self = agentPersister.findSelf( context.agentRepository() );
+		if ( self == null ) {
+			throw log.agentRegistrationIneffective( selfReference() );
+		}
+		return self;
+	}
+
+	protected abstract WriteAction<R> doPulse(List<Agent> allAgentsInIdOrder, Agent self);
 
 	/**
 	 * Instructs the processor to commit the transaction, wait for the given delay, then pulse again.
@@ -129,4 +142,11 @@ abstract class AbstractAgentClusterLink<R> {
 		return agentPersister.selfReference();
 	}
 
+	final AgentPersister getAgentPersisterForTests() {
+		return agentPersister;
+	}
+
+	protected interface WriteAction<R> {
+		R applyAndReturnInstructions(Instant now, Agent self, AgentPersister agentPersister);
+	}
 }

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AgentClusterLinkContext.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AgentClusterLinkContext.java
@@ -1,0 +1,63 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl;
+
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.search.mapper.orm.common.spi.SessionHelper;
+import org.hibernate.search.mapper.orm.common.spi.TransactionHelper;
+import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.AgentRepository;
+import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.AgentRepositoryProvider;
+import org.hibernate.search.util.common.impl.Closer;
+import org.hibernate.search.util.common.impl.SuppressingCloser;
+
+public class AgentClusterLinkContext {
+
+	private final TransactionHelper transactionHelper;
+	private final SessionHelper sessionHelper;
+	private final AgentRepositoryProvider agentRepositoryProvider;
+
+	private SessionImplementor session;
+	private AgentRepository agentRepository;
+
+	public AgentClusterLinkContext(TransactionHelper transactionHelper, SessionHelper sessionHelper,
+			AgentRepositoryProvider agentRepositoryProvider) {
+		this.transactionHelper = transactionHelper;
+		this.sessionHelper = sessionHelper;
+		this.agentRepositoryProvider = agentRepositoryProvider;
+	}
+
+	void begin() {
+		session = sessionHelper.openSession();
+		transactionHelper.begin( session );
+		agentRepository = agentRepositoryProvider.create( session );
+	}
+
+	public AgentRepository agentRepository() {
+		return agentRepository;
+	}
+
+	public void commitAndBeginNewTransaction() {
+		commit();
+		begin();
+	}
+
+	void commit() {
+		try ( Closer<RuntimeException> closer = new Closer<>() ) {
+			closer.push( transactionHelper::commit, session );
+			closer.push( SessionImplementor::close, session );
+			session = null;
+			agentRepository = null;
+		}
+	}
+
+	void rollbackLatestTransactionSafely(Throwable t) {
+		new SuppressingCloser( t )
+				.push( s -> transactionHelper.rollbackSafely( s, t ), session )
+				.push( SessionImplementor::close, session );
+	}
+
+}

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AgentClusterLinkContextProvider.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AgentClusterLinkContextProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.hibernate.search.mapper.orm.common.spi.SessionHelper;
+import org.hibernate.search.mapper.orm.common.spi.TransactionHelper;
+import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.AgentRepositoryProvider;
+
+public class AgentClusterLinkContextProvider {
+
+	private final TransactionHelper transactionHelper;
+	private final SessionHelper sessionHelper;
+	private final AgentRepositoryProvider agentRepositoryProvider;
+
+	public AgentClusterLinkContextProvider(TransactionHelper transactionHelper, SessionHelper sessionHelper,
+			AgentRepositoryProvider agentRepositoryProvider) {
+		this.transactionHelper = transactionHelper;
+		this.sessionHelper = sessionHelper;
+		this.agentRepositoryProvider = agentRepositoryProvider;
+	}
+
+	public final void inTransaction(Consumer<AgentClusterLinkContext> action) {
+		inTransaction( context -> {
+			action.accept( context );
+			return null;
+		} );
+	}
+
+	public <T> T inTransaction(Function<AgentClusterLinkContext, T> action) {
+		AgentClusterLinkContext context = new AgentClusterLinkContext( transactionHelper, sessionHelper,
+				agentRepositoryProvider );
+		T result;
+		try {
+			context.begin();
+			result = action.apply( context );
+		}
+		catch (Throwable t) {
+			context.rollbackLatestTransactionSafely( t );
+			throw t;
+		}
+		context.commit();
+		return result;
+	}
+
+}

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxEventLoader.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxEventLoader.java
@@ -15,27 +15,39 @@ import javax.persistence.OptimisticLockException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.Session;
+import org.hibernate.dialect.Dialect;
 import org.hibernate.query.Query;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.logging.impl.Log;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
-public final class OutboxEventLoader {
+abstract class OutboxEventLoader {
 
 	private static final String LOAD_QUERY = "select e from OutboxEvent e where e.id in (:ids)";
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private OutboxEventLoader() {
+	public static OutboxEventLoader create(Dialect dialect) {
+		if ( dialect.supportsSkipLocked() ) {
+			return new SkipLockedOutboxEventLoader();
+		}
+		// If SKIP_LOCKED is not supported, we just do basic locking and hope for the best
+		// (in particular we hope for transaction deadlocks to be detected by the database and result in a failure,
+		// so that we can try again later).
+		// See also the javadoc of LockAllOutboxEventLoader.
+		return new LockAllOutboxEventLoader();
 	}
 
-	static List<OutboxEvent> loadLocking(Session session, Set<Long> ids, String processorName) {
+	OutboxEventLoader() {
+	}
+
+	List<OutboxEvent> loadLocking(Session session, Set<Long> ids, String processorName) {
 		try {
 			return tryLoadLocking( session, ids );
 		}
 		catch (OptimisticLockException lockException) {
 			// Don't be fooled by the exception type, this is actually a *pessimistic* lock failure.
 			// It can happen with some databases (Mariadb before 10.6, perhaps others) that do not support
-			// skipping locked rows (see LockOptions.SKIP).
+			// skipping locked rows (see LockOptions.SKIP_LOCKED).
 			// If that happens, we will just log something and try again later.
 			// See also https://jira.mariadb.org/browse/MDEV-13115
 			log.outboxEventProcessorUnableToLock( processorName, lockException );
@@ -43,26 +55,47 @@ public final class OutboxEventLoader {
 		}
 	}
 
-	private static List<OutboxEvent> tryLoadLocking(Session session, Set<Long> ids) {
-		Query<OutboxEvent> query = session.createQuery( LOAD_QUERY, OutboxEvent.class );
-		query.setParameter( "ids", ids );
+	protected abstract List<OutboxEvent> tryLoadLocking(Session session, Set<Long> ids);
 
-		// HSEARCH-4289: some databases encounter deadlocks when multiple processors query or delete events
-		// in concurrent transactions.
-		// The deadlocks are mostly caused by lock escalation,
-		// e.g. MS SQL deciding it does not have enough resources to perform row-level locks
-		// and thus locking whole pages instead. This means that even though processors deal
-		// with strictly distinct subsets of the outbox events (thanks to sharding),
-		// they will actually end up locking more than their subset,
-		// and then conflicts *can* occur.
-		// Disabling locks is not an option: we cannot disable locking during deletes.
-		// Thus, our last option is to actually enforce locks ahead of time (LockModeType.PESSIMISTIC_WRITE),
-		// and to avoid conflicts by simply never working on events that are already locked (LockOptions.SKIP_LOCKED).
-		// That's possible because event processing is not sensitive to processing order,
-		// so we can afford to just skip events that are already locked,
-		// and process them later when they are no longer locked.
-		query.setLockOptions( new LockOptions( LockMode.PESSIMISTIC_WRITE ).setTimeOut( LockOptions.SKIP_LOCKED ) );
+	// HSEARCH-4289: some databases encounter deadlocks when multiple processors query or delete events
+	// in concurrent transactions.
+	// The deadlocks are mostly caused by lock escalation,
+	// e.g. MS SQL deciding it does not have enough resources to perform row-level locks
+	// and thus locking whole pages instead. This means that even though processors deal
+	// with strictly distinct subsets of the outbox events (thanks to sharding),
+	// they will actually end up locking more than their subset,
+	// and then conflicts *can* occur.
+	// Disabling locks is not an option: we cannot disable locking during deletes.
+	// Thus, our last option is to actually enforce locks ahead of time (LockModeType.PESSIMISTIC_WRITE),
+	// and to avoid conflicts by simply never working on events that are already locked (LockOptions.SKIP_LOCKED).
+	// That's possible because event processing is not sensitive to processing order,
+	// so we can afford to just skip events that are already locked,
+	// and process them later when they are no longer locked.
+	private static class SkipLockedOutboxEventLoader extends OutboxEventLoader {
+		@Override
+		protected List<OutboxEvent> tryLoadLocking(Session session, Set<Long> ids) {
+			Query<OutboxEvent> query = session.createQuery( LOAD_QUERY, OutboxEvent.class );
+			query.setParameter( "ids", ids );
 
-		return query.getResultList();
+			query.setLockOptions( new LockOptions( LockMode.PESSIMISTIC_WRITE ).setTimeOut( LockOptions.SKIP_LOCKED ) );
+
+			return query.getResultList();
+		}
+	}
+
+	// HSEARCH-4634: CockroachDB doesn't support SKIP_LOCKED (https://github.com/cockroachdb/cockroach/issues/40476?version=v22.1),
+	// but fortunately it doesn't suffer from lock escalation,
+	// so as long as we target a distinct set of events in each processor (we do),
+	// locking shouldn't trigger any deadlocks.
+	private static class LockAllOutboxEventLoader extends OutboxEventLoader {
+		@Override
+		protected List<OutboxEvent> tryLoadLocking(Session session, Set<Long> ids) {
+			Query<OutboxEvent> query = session.createQuery( LOAD_QUERY, OutboxEvent.class );
+			query.setParameter( "ids", ids );
+
+			query.setLockOptions( new LockOptions( LockMode.PESSIMISTIC_WRITE ) );
+
+			return query.getResultList();
+		}
 	}
 }

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxEventUpdater.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxEventUpdater.java
@@ -26,6 +26,7 @@ public class OutboxEventUpdater {
 	private static final int MAX_RETRIES = 3;
 
 	private final FailureHandler failureHandler;
+	private final OutboxEventLoader loader;
 	private final OutboxEventProcessingPlan processingPlan;
 	private final SessionImplementor session;
 	private final String processorName;
@@ -33,9 +34,10 @@ public class OutboxEventUpdater {
 	private final Set<Long> eventsIds;
 	private final Set<Long> failedEventIds;
 
-	public OutboxEventUpdater(FailureHandler failureHandler, OutboxEventProcessingPlan processingPlan,
-			SessionImplementor session, String processorName, int retryAfter) {
+	public OutboxEventUpdater(FailureHandler failureHandler, OutboxEventLoader loader,
+			OutboxEventProcessingPlan processingPlan, SessionImplementor session, String processorName, int retryAfter) {
 		this.failureHandler = failureHandler;
+		this.loader = loader;
 		this.processingPlan = processingPlan;
 		this.session = session;
 		this.processorName = processorName;
@@ -51,7 +53,7 @@ public class OutboxEventUpdater {
 	}
 
 	public void process() {
-		List<OutboxEvent> lockedEvents = OutboxEventLoader.loadLocking( session, eventsIds, processorName );
+		List<OutboxEvent> lockedEvents = loader.loadLocking( session, eventsIds, processorName );
 		List<OutboxEvent> eventToDelete = new ArrayList<>( lockedEvents );
 
 		for ( OutboxEvent event : lockedEvents ) {

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingEventProcessorClusterLink.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingEventProcessorClusterLink.java
@@ -184,6 +184,10 @@ public final class OutboxPollingEventProcessorClusterLink
 	}
 
 	private boolean excludedAgentsAreOutOfCluster(List<Agent> excludedAgents) {
+		if ( excludedAgents.isEmpty() ) {
+			return true;
+		}
+
 		AgentState expectedState = AgentState.SUSPENDED;
 		for ( Agent agent : excludedAgents ) {
 			if ( !expectedState.equals( agent.getState() ) ) {

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingMassIndexerAgent.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingMassIndexerAgent.java
@@ -200,7 +200,7 @@ public final class OutboxPollingMassIndexerAgent implements PojoMassIndexerAgent
 			}
 
 			try ( SessionImplementor session = openSession() ) {
-				transactionHelper.inTransaction( session, s -> {
+				transactionHelper.inTransaction( session, () -> {
 					if ( instructions == null || !instructions.isStillValid() ) {
 						AgentRepository agentRepository = agentRepositoryProvider.create( session );
 						instructions = clusterLink.pulse( agentRepository );

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingMassIndexerAgent.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingMassIndexerAgent.java
@@ -134,7 +134,7 @@ public final class OutboxPollingMassIndexerAgent implements PojoMassIndexerAgent
 		this.agentRepositoryProvider = agentRepositoryProvider;
 		this.clusterLink = clusterLink;
 
-		transactionHelper = new TransactionHelper( mapping.sessionFactory() );
+		transactionHelper = new TransactionHelper( mapping.sessionFactory(), null );
 		worker = new Worker();
 		processingTask = new SingletonTask(
 				name,
@@ -170,7 +170,7 @@ public final class OutboxPollingMassIndexerAgent implements PojoMassIndexerAgent
 
 	private void leaveCluster() {
 		try ( SessionImplementor session = openSession() ) {
-			transactionHelper.begin( session, null );
+			transactionHelper.begin( session );
 			try {
 				AgentRepository agentRepository = agentRepositoryProvider.create( session );
 				clusterLink.leaveCluster( agentRepository );
@@ -200,7 +200,7 @@ public final class OutboxPollingMassIndexerAgent implements PojoMassIndexerAgent
 			}
 
 			try ( SessionImplementor session = openSession() ) {
-				transactionHelper.inTransaction( session, null, s -> {
+				transactionHelper.inTransaction( session, s -> {
 					if ( instructions == null || !instructions.isStillValid() ) {
 						AgentRepository agentRepository = agentRepositoryProvider.create( session );
 						instructions = clusterLink.pulse( agentRepository );

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/logging/impl/Log.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/logging/impl/Log.java
@@ -160,4 +160,9 @@ public interface Log extends BasicLogger {
 			value = "Multi-tenancy is not enabled but a tenant id is specified. Trying to use the tenant id: '%1$s'.")
 	SearchException multiTenancyNotEnabled(String tenantId);
 
+	@Message(id = ID_OFFSET + 28, value = "Agent '%1$s': could not find the agent after starting a new transaction."
+			+ " The agent was present just a moment ago."
+			+ " Either this problem is a rare occurrence, or the pulse expiration delay is too short.")
+	SearchException agentRegistrationIneffective(AgentReference agentReference);
+
 }

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/mapping/impl/OutboxPollingSearchMappingImpl.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/mapping/impl/OutboxPollingSearchMappingImpl.java
@@ -49,7 +49,7 @@ public class OutboxPollingSearchMappingImpl implements OutboxPollingSearchMappin
 		checkNoTenant();
 
 		try ( Session session = sessionFactory.openSession() ) {
-			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, s -> {
+			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, () -> {
 				Query<Long> query = session.createQuery( COUNT_EVENTS_WITH_STATUS, Long.class );
 				query.setParameter( "status", OutboxEvent.Status.ABORTED );
 				return query.getSingleResult();
@@ -62,7 +62,7 @@ public class OutboxPollingSearchMappingImpl implements OutboxPollingSearchMappin
 		checkTenant( tenantId );
 
 		try ( Session session = sessionFactory.withOptions().tenantIdentifier( tenantId ).openSession() ) {
-			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, s -> {
+			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, () -> {
 				Query<Long> query = session.createQuery( COUNT_EVENTS_WITH_STATUS, Long.class );
 				query.setParameter( "status", OutboxEvent.Status.ABORTED );
 				return query.getSingleResult();
@@ -75,7 +75,7 @@ public class OutboxPollingSearchMappingImpl implements OutboxPollingSearchMappin
 		checkNoTenant();
 
 		try ( Session session = sessionFactory.openSession() ) {
-			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, s -> {
+			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, () -> {
 				Query<?> query = session.createQuery( UPDATE_EVENTS_WITH_STATUS );
 				query.setParameter( "status", OutboxEvent.Status.ABORTED );
 				query.setParameter( "newStatus", OutboxEvent.Status.PENDING );
@@ -89,7 +89,7 @@ public class OutboxPollingSearchMappingImpl implements OutboxPollingSearchMappin
 		checkTenant( tenantId );
 
 		try ( Session session = sessionFactory.withOptions().tenantIdentifier( tenantId ).openSession() ) {
-			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, s -> {
+			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, () -> {
 				Query<?> query = session.createQuery( UPDATE_EVENTS_WITH_STATUS );
 				query.setParameter( "status", OutboxEvent.Status.ABORTED );
 				query.setParameter( "newStatus", OutboxEvent.Status.PENDING );
@@ -103,7 +103,7 @@ public class OutboxPollingSearchMappingImpl implements OutboxPollingSearchMappin
 		checkNoTenant();
 
 		try ( Session session = sessionFactory.openSession() ) {
-			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, s -> {
+			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, () -> {
 				Query<?> query = session.createQuery( DELETE_EVENTS_WITH_STATUS );
 				query.setParameter( "status", OutboxEvent.Status.ABORTED );
 				return query.executeUpdate();
@@ -116,7 +116,7 @@ public class OutboxPollingSearchMappingImpl implements OutboxPollingSearchMappin
 		checkTenant( tenantId );
 
 		try ( Session session = sessionFactory.withOptions().tenantIdentifier( tenantId ).openSession() ) {
-			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, s -> {
+			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, () -> {
 				Query<?> query = session.createQuery( DELETE_EVENTS_WITH_STATUS );
 				query.setParameter( "status", OutboxEvent.Status.ABORTED );
 				return query.executeUpdate();

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/mapping/impl/OutboxPollingSearchMappingImpl.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/mapping/impl/OutboxPollingSearchMappingImpl.java
@@ -39,7 +39,7 @@ public class OutboxPollingSearchMappingImpl implements OutboxPollingSearchMappin
 	public OutboxPollingSearchMappingImpl(CoordinationStrategyStartContext context,
 			TenancyConfiguration tenancyConfiguration) {
 		this.sessionFactory = context.mapping().sessionFactory();
-		this.transactionHelper = new TransactionHelper( sessionFactory );
+		this.transactionHelper = new TransactionHelper( sessionFactory, null );
 		this.tenancyConfiguration = tenancyConfiguration;
 		this.tenantIds = this.tenancyConfiguration.tenantIdsOrFail();
 	}
@@ -49,7 +49,7 @@ public class OutboxPollingSearchMappingImpl implements OutboxPollingSearchMappin
 		checkNoTenant();
 
 		try ( Session session = sessionFactory.openSession() ) {
-			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, null, s -> {
+			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, s -> {
 				Query<Long> query = session.createQuery( COUNT_EVENTS_WITH_STATUS, Long.class );
 				query.setParameter( "status", OutboxEvent.Status.ABORTED );
 				return query.getSingleResult();
@@ -62,7 +62,7 @@ public class OutboxPollingSearchMappingImpl implements OutboxPollingSearchMappin
 		checkTenant( tenantId );
 
 		try ( Session session = sessionFactory.withOptions().tenantIdentifier( tenantId ).openSession() ) {
-			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, null, s -> {
+			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, s -> {
 				Query<Long> query = session.createQuery( COUNT_EVENTS_WITH_STATUS, Long.class );
 				query.setParameter( "status", OutboxEvent.Status.ABORTED );
 				return query.getSingleResult();
@@ -75,7 +75,7 @@ public class OutboxPollingSearchMappingImpl implements OutboxPollingSearchMappin
 		checkNoTenant();
 
 		try ( Session session = sessionFactory.openSession() ) {
-			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, null, s -> {
+			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, s -> {
 				Query<?> query = session.createQuery( UPDATE_EVENTS_WITH_STATUS );
 				query.setParameter( "status", OutboxEvent.Status.ABORTED );
 				query.setParameter( "newStatus", OutboxEvent.Status.PENDING );
@@ -89,7 +89,7 @@ public class OutboxPollingSearchMappingImpl implements OutboxPollingSearchMappin
 		checkTenant( tenantId );
 
 		try ( Session session = sessionFactory.withOptions().tenantIdentifier( tenantId ).openSession() ) {
-			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, null, s -> {
+			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, s -> {
 				Query<?> query = session.createQuery( UPDATE_EVENTS_WITH_STATUS );
 				query.setParameter( "status", OutboxEvent.Status.ABORTED );
 				query.setParameter( "newStatus", OutboxEvent.Status.PENDING );
@@ -103,7 +103,7 @@ public class OutboxPollingSearchMappingImpl implements OutboxPollingSearchMappin
 		checkNoTenant();
 
 		try ( Session session = sessionFactory.openSession() ) {
-			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, null, s -> {
+			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, s -> {
 				Query<?> query = session.createQuery( DELETE_EVENTS_WITH_STATUS );
 				query.setParameter( "status", OutboxEvent.Status.ABORTED );
 				return query.executeUpdate();
@@ -116,7 +116,7 @@ public class OutboxPollingSearchMappingImpl implements OutboxPollingSearchMappin
 		checkTenant( tenantId );
 
 		try ( Session session = sessionFactory.withOptions().tenantIdentifier( tenantId ).openSession() ) {
-			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, null, s -> {
+			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, s -> {
 				Query<?> query = session.createQuery( DELETE_EVENTS_WITH_STATUS );
 				query.setParameter( "status", OutboxEvent.Status.ABORTED );
 				return query.executeUpdate();

--- a/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AbstractEventProcessorClusterLinkBaseTest.java
+++ b/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AbstractEventProcessorClusterLinkBaseTest.java
@@ -9,6 +9,8 @@ package org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
+
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.AgentRepository;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.AgentType;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.AgentState;
@@ -63,22 +65,15 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 		return expect( selfStaticShardAssignment(), link );
 	}
 
-	protected final EventProcessorClusterLinkPulseExpectations expectSuspendedAndPulseASAP() {
-		return expect().pulseAgain( NOW.plus( POLLING_INTERVAL ) )
+	protected final EventProcessorClusterLinkPulseExpectations expectSuspendedAndPulseAfterDelay(Duration delay) {
+		return expect().pulseAgain( NOW.plus( delay ) )
 				.agent( SELF_ID, AgentState.SUSPENDED )
 				.shardAssignment( selfStaticShardAssignment() )
 				.build();
 	}
 
-	protected final EventProcessorClusterLinkPulseExpectations expectSuspendedAndPulseLater() {
-		return expect().pulseAgain( NOW.plus( PULSE_INTERVAL ) )
-				.agent( SELF_ID, AgentState.SUSPENDED )
-				.shardAssignment( selfStaticShardAssignment() )
-				.build();
-	}
-
-	protected final EventProcessorClusterLinkPulseExpectations expectInitialStateAndPulseASAP() {
-		return expect().pulseAgain( NOW.plus( POLLING_INTERVAL ) )
+	protected final EventProcessorClusterLinkPulseExpectations expectInitialStateAndPulseAfterDelay(Duration delay) {
+		return expect().pulseAgain( NOW.plus( delay ) )
 				.agent( SELF_ID, repositoryMockHelper.selfInitialState() != null
 						// If self created before this pulse:
 						? repositoryMockHelper.selfInitialState()
@@ -193,7 +188,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 		// Do not update the agent, in order to avoid locks on Oracle in particular (maybe others);
 		// see the comment in AbstractAgentClusterLink#pulse.
 		// We will assess the situation in the next pulse.
-		expectInitialStateAndPulseASAP().verify( link.pulse( repositoryMock ) );
+		expectInitialStateAndPulseAfterDelay( POLLING_INTERVAL ).verify( link.pulse( repositoryMock ) );
 
 		verify( repositoryMock ).delete( repositoryMockHelper.agentsInIdOrder( other2Id(), other3Id() ) );
 	}
@@ -303,7 +298,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 		// Do not update the agent, in order to avoid locks on Oracle in particular (maybe others);
 		// see the comment in AbstractAgentClusterLink#pulse.
 		// We will assess the situation in the next pulse.
-		expectInitialStateAndPulseASAP().verify( link.pulse( repositoryMock ) );
+		expectInitialStateAndPulseAfterDelay( POLLING_INTERVAL ).verify( link.pulse( repositoryMock ) );
 
 		// Cleaning up expired agents takes precedence over suspending because a mass indexing agent exists.
 		verify( repositoryMock ).delete( repositoryMockHelper.agentsInIdOrder( other2Id(), other3Id() ) );
@@ -322,7 +317,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 
 		// The presence of a mass indexing agent is more important than rebalancing:
 		// we expect the agent to suspend itself.
-		expectSuspendedAndPulseLater().verify( link.pulse( repositoryMock ) );
+		expectSuspendedAndPulseAfterDelay( PULSE_INTERVAL ).verify( link.pulse( repositoryMock ) );
 	}
 
 	@Test
@@ -336,7 +331,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 						otherShardAssignmentIn4NodeCluster( 3 ) )
 				.other( MASS_INDEXING_ID, AgentType.MASS_INDEXING, LATER, AgentState.RUNNING );
 
-		expectSuspendedAndPulseLater().verify( link.pulse( repositoryMock ) );
+		expectSuspendedAndPulseAfterDelay( PULSE_INTERVAL ).verify( link.pulse( repositoryMock ) );
 	}
 
 	@Test
@@ -353,7 +348,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 		// Suspended mass indexing agents should not exist,
 		// but just for the sake of fully defining the behavior,
 		// we'll say they prevent automatic indexing too.
-		expectSuspendedAndPulseLater().verify( link.pulse( repositoryMock ) );
+		expectSuspendedAndPulseAfterDelay( PULSE_INTERVAL ).verify( link.pulse( repositoryMock ) );
 	}
 
 	@Test
@@ -370,7 +365,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 		// Rebalancing mass indexing agents should not exist,
 		// but just for the sake of fully defining the behavior,
 		// we'll say they prevent automatic indexing too.
-		expectSuspendedAndPulseLater().verify( link.pulse( repositoryMock ) );
+		expectSuspendedAndPulseAfterDelay( PULSE_INTERVAL ).verify( link.pulse( repositoryMock ) );
 	}
 
 	@Test
@@ -387,7 +382,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 		// Do not update the agent, in order to avoid locks on Oracle in particular (maybe others);
 		// see the comment in AbstractAgentClusterLink#pulse.
 		// We will assess the situation in the next pulse.
-		expectInitialStateAndPulseASAP().verify( link.pulse( repositoryMock ) );
+		expectInitialStateAndPulseAfterDelay( POLLING_INTERVAL ).verify( link.pulse( repositoryMock ) );
 
 		verify( repositoryMock ).delete( repositoryMockHelper.agentsInIdOrder( MASS_INDEXING_ID ) );
 	}

--- a/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AbstractEventProcessorClusterLinkBaseTest.java
+++ b/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AbstractEventProcessorClusterLinkBaseTest.java
@@ -172,7 +172,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 	public void noOtherAgent() {
 		repositoryMockHelper.defineOtherAgents();
 
-		onNoOtherAgents().verify( link.pulse( repositoryMock ) );
+		onNoOtherAgents().verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -188,7 +188,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 		// Do not update the agent, in order to avoid locks on Oracle in particular (maybe others);
 		// see the comment in AbstractAgentClusterLink#pulse.
 		// We will assess the situation in the next pulse.
-		expectInitialStateAndPulseAfterDelay( POLLING_INTERVAL ).verify( link.pulse( repositoryMock ) );
+		expectInitialStateAndPulseAfterDelay( POLLING_INTERVAL ).verify( link.pulse( contextMock ) );
 
 		verify( repositoryMock ).delete( repositoryMockHelper.agentsInIdOrder( other2Id(), other3Id() ) );
 	}
@@ -203,7 +203,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 				.other( other3Id(), other3Type(), LATER, AgentState.WAITING,
 						otherShardAssignmentIn4NodeCluster( 3 ) );
 
-		expectWaiting( selfShardAssignmentIn4NodeCluster() ).verify( link.pulse( repositoryMock ) );
+		expectWaiting( selfShardAssignmentIn4NodeCluster() ).verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -216,7 +216,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 				.other( other3Id(), other3Type(), LATER, AgentState.RUNNING,
 						otherShardAssignmentIn4NodeCluster( 3 ) );
 
-		expectWaiting( selfShardAssignmentIn4NodeCluster() ).verify( link.pulse( repositoryMock ) );
+		expectWaiting( selfShardAssignmentIn4NodeCluster() ).verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -229,7 +229,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 				.other( other3Id(), other3Type(), LATER, AgentState.WAITING,
 						otherShardAssignmentIn4NodeCluster( 3 ) );
 
-		onClusterWith4NodesAllOther3NodesReady().verify( link.pulse( repositoryMock ) );
+		onClusterWith4NodesAllOther3NodesReady().verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -242,7 +242,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 				.other( other3Id(), other3Type(), LATER, AgentState.WAITING,
 						otherShardAssignmentIn4NodeCluster( 3 ) );
 
-		expectWaiting( selfShardAssignmentIn4NodeCluster() ).verify( link.pulse( repositoryMock ) );
+		expectWaiting( selfShardAssignmentIn4NodeCluster() ).verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -255,7 +255,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 				.other( other3Id(), other3Type(), LATER, AgentState.SUSPENDED,
 						isOther3Static() ? otherShardAssignmentIn4NodeCluster( 3 ) : null );
 
-		expectWaiting( selfShardAssignmentIn4NodeCluster() ).verify( link.pulse( repositoryMock ) );
+		expectWaiting( selfShardAssignmentIn4NodeCluster() ).verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -268,7 +268,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 				.other( other3Id(), other3Type(), LATER, AgentState.WAITING,
 						otherShardAssignmentIn4NodeCluster( 3 ) );
 
-		onClusterWith4NodesAllOther3NodesReady().verify( link.pulse( repositoryMock ) );
+		onClusterWith4NodesAllOther3NodesReady().verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -281,7 +281,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 				.other( other3Id(), other3Type(), LATER, AgentState.RUNNING,
 						otherShardAssignmentIn4NodeCluster( 3 ) );
 
-		onClusterWith4NodesAllOther3NodesReady().verify( link.pulse( repositoryMock ) );
+		onClusterWith4NodesAllOther3NodesReady().verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -298,7 +298,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 		// Do not update the agent, in order to avoid locks on Oracle in particular (maybe others);
 		// see the comment in AbstractAgentClusterLink#pulse.
 		// We will assess the situation in the next pulse.
-		expectInitialStateAndPulseAfterDelay( POLLING_INTERVAL ).verify( link.pulse( repositoryMock ) );
+		expectInitialStateAndPulseAfterDelay( POLLING_INTERVAL ).verify( link.pulse( contextMock ) );
 
 		// Cleaning up expired agents takes precedence over suspending because a mass indexing agent exists.
 		verify( repositoryMock ).delete( repositoryMockHelper.agentsInIdOrder( other2Id(), other3Id() ) );
@@ -317,7 +317,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 
 		// The presence of a mass indexing agent is more important than rebalancing:
 		// we expect the agent to suspend itself.
-		expectSuspendedAndPulseAfterDelay( PULSE_INTERVAL ).verify( link.pulse( repositoryMock ) );
+		expectSuspendedAndPulseAfterDelay( PULSE_INTERVAL ).verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -331,7 +331,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 						otherShardAssignmentIn4NodeCluster( 3 ) )
 				.other( MASS_INDEXING_ID, AgentType.MASS_INDEXING, LATER, AgentState.RUNNING );
 
-		expectSuspendedAndPulseAfterDelay( PULSE_INTERVAL ).verify( link.pulse( repositoryMock ) );
+		expectSuspendedAndPulseAfterDelay( PULSE_INTERVAL ).verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -348,7 +348,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 		// Suspended mass indexing agents should not exist,
 		// but just for the sake of fully defining the behavior,
 		// we'll say they prevent automatic indexing too.
-		expectSuspendedAndPulseAfterDelay( PULSE_INTERVAL ).verify( link.pulse( repositoryMock ) );
+		expectSuspendedAndPulseAfterDelay( PULSE_INTERVAL ).verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -365,7 +365,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 		// Rebalancing mass indexing agents should not exist,
 		// but just for the sake of fully defining the behavior,
 		// we'll say they prevent automatic indexing too.
-		expectSuspendedAndPulseAfterDelay( PULSE_INTERVAL ).verify( link.pulse( repositoryMock ) );
+		expectSuspendedAndPulseAfterDelay( PULSE_INTERVAL ).verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -382,7 +382,7 @@ abstract class AbstractEventProcessorClusterLinkBaseTest extends AbstractEventPr
 		// Do not update the agent, in order to avoid locks on Oracle in particular (maybe others);
 		// see the comment in AbstractAgentClusterLink#pulse.
 		// We will assess the situation in the next pulse.
-		expectInitialStateAndPulseAfterDelay( POLLING_INTERVAL ).verify( link.pulse( repositoryMock ) );
+		expectInitialStateAndPulseAfterDelay( POLLING_INTERVAL ).verify( link.pulse( contextMock ) );
 
 		verify( repositoryMock ).delete( repositoryMockHelper.agentsInIdOrder( MASS_INDEXING_ID ) );
 	}

--- a/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AbstractEventProcessorClusterLinkTest.java
+++ b/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AbstractEventProcessorClusterLinkTest.java
@@ -6,7 +6,9 @@
  */
 package org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl;
 
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -66,6 +68,9 @@ abstract class AbstractEventProcessorClusterLinkTest {
 	@Mock
 	public AgentRepository repositoryMock;
 
+	@Mock(stubOnly = true, lenient = true)
+	public AgentClusterLinkContext contextMock;
+
 	protected final OutboxEventFinderProvider eventFinderProviderStub = new OutboxEventFinderProvider() {
 		@Override
 		public OutboxEventFinder create(Optional<OutboxEventPredicate> predicate) {
@@ -81,6 +86,10 @@ abstract class AbstractEventProcessorClusterLinkTest {
 	public final void initMocks() {
 		repositoryMockHelper = new AgentRepositoryMockingHelper( repositoryMock );
 		Collections.addAll( allMocks, failureHandlerMock, clockMock, eventFinderMock, repositoryMock );
+
+		when( contextMock.agentRepository() ).thenReturn( repositoryMock );
+		// We're not interested in transaction control here
+		doNothing().when( contextMock ).commitAndBeginNewTransaction();
 	}
 
 	@After

--- a/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AbstractEventProcessorClusterLinkTest.java
+++ b/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AbstractEventProcessorClusterLinkTest.java
@@ -98,13 +98,13 @@ abstract class AbstractEventProcessorClusterLinkTest {
 	}
 
 	protected void defineSelfNotCreatedYet(OutboxPollingEventProcessorClusterLink link) {
-		link.agentPersister.setSelfReferenceForTests( null );
+		link.getAgentPersisterForTests().setSelfReferenceForTests( null );
 		repositoryMockHelper.defineSelfCreatedByPulse( SELF_ID );
 	}
 
 	protected void defineSelfCreatedAndStillPresent(OutboxPollingEventProcessorClusterLink link,
 			AgentState state, ShardAssignmentDescriptor shardAssignment) {
-		link.agentPersister.setSelfReferenceForTests( SELF_REF );
+		link.getAgentPersisterForTests().setSelfReferenceForTests( SELF_REF );
 		AgentType type;
 		if ( link.shardAssignmentIsStatic ) {
 			type = AgentType.EVENT_PROCESSING_STATIC_SHARDING;

--- a/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AbstractMassIndexerAgentClusterLinkBaseTest.java
+++ b/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AbstractMassIndexerAgentClusterLinkBaseTest.java
@@ -127,7 +127,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 	public void noOtherAgent() {
 		repositoryMockHelper.defineOtherAgents();
 
-		onNoOtherAgents().verify( link.pulse( repositoryMock ) );
+		onNoOtherAgents().verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -143,7 +143,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 		// Do not update the agent, in order to avoid locks on Oracle in particular (maybe others);
 		// see the comment in AbstractAgentClusterLink#pulse.
 		// We will assess the situation in the next pulse.
-		expectInitialStateAndPulseAfterDelay( POLLING_INTERVAL ).verify( link.pulse( repositoryMock ) );
+		expectInitialStateAndPulseAfterDelay( POLLING_INTERVAL ).verify( link.pulse( contextMock ) );
 
 		verify( repositoryMock ).delete( repositoryMockHelper.agentsInIdOrder( other2Id(), other3Id() ) );
 	}
@@ -158,7 +158,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 				.other( other3Id(), otherType(), LATER, AgentState.WAITING,
 						otherShardAssignmentIn4NodeCluster( 3 ) );
 
-		expectWaiting().verify( link.pulse( repositoryMock ) );
+		expectWaiting().verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -171,7 +171,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 				.other( other3Id(), otherType(), LATER, AgentState.RUNNING,
 						otherShardAssignmentIn4NodeCluster( 3 ) );
 
-		expectWaiting().verify( link.pulse( repositoryMock ) );
+		expectWaiting().verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -184,7 +184,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 				.other( other3Id(), otherType(), LATER, AgentState.WAITING,
 						otherShardAssignmentIn4NodeCluster( 3 ) );
 
-		expectWaiting().verify( link.pulse( repositoryMock ) );
+		expectWaiting().verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -197,7 +197,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 				.other( other3Id(), otherType(), LATER, AgentState.WAITING,
 						otherShardAssignmentIn4NodeCluster( 3 ) );
 
-		expectWaiting().verify( link.pulse( repositoryMock ) );
+		expectWaiting().verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -210,7 +210,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 				.other( other3Id(), otherType(), LATER, AgentState.SUSPENDED,
 						isOtherStatic() ? otherShardAssignmentIn4NodeCluster( 3 ) : null );
 
-		onClusterWith3NodesAll3NodesSuspended().verify( link.pulse( repositoryMock ) );
+		onClusterWith3NodesAll3NodesSuspended().verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -223,7 +223,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 				.other( other3Id(), otherType(), LATER, AgentState.WAITING,
 						otherShardAssignmentIn4NodeCluster( 3 ) );
 
-		expectWaiting().verify( link.pulse( repositoryMock ) );
+		expectWaiting().verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -236,7 +236,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 				.other( other3Id(), otherType(), LATER, AgentState.RUNNING,
 						otherShardAssignmentIn4NodeCluster( 3 ) );
 
-		expectWaiting().verify( link.pulse( repositoryMock ) );
+		expectWaiting().verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -253,7 +253,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 		// Do not update the agent, in order to avoid locks on Oracle in particular (maybe others);
 		// see the comment in AbstractAgentClusterLink#pulse.
 		// We will assess the situation in the next pulse.
-		expectInitialStateAndPulseAfterDelay( POLLING_INTERVAL ).verify( link.pulse( repositoryMock ) );
+		expectInitialStateAndPulseAfterDelay( POLLING_INTERVAL ).verify( link.pulse( contextMock ) );
 
 		// Cleaning up expired agents takes precedence over suspending because a mass indexing agent exists.
 		verify( repositoryMock ).delete( repositoryMockHelper.agentsInIdOrder( other2Id(), other3Id() ) );
@@ -272,7 +272,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 
 		// The presence of a mass indexing agent is more important than rebalancing:
 		// we expect the agent to suspend itself.
-		expectWaiting().verify( link.pulse( repositoryMock ) );
+		expectWaiting().verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -288,7 +288,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 
 		// We should ignore concurrent mass indexer agents:
 		// the user is responsible for checking they don't reindex the same entity concurrently.
-		onClusterWith3NodesAll3NodesSuspended().verify( link.pulse( repositoryMock ) );
+		onClusterWith3NodesAll3NodesSuspended().verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -305,7 +305,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 		// Suspended mass indexing agents should not exist,
 		// but just for the sake of fully defining the behavior,
 		// we'll say we ignore them.
-		onClusterWith3NodesAll3NodesSuspended().verify( link.pulse( repositoryMock ) );
+		onClusterWith3NodesAll3NodesSuspended().verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -322,7 +322,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 		// Rebalancing mass indexing agents should not exist,
 		// but just for the sake of fully defining the behavior,
 		// we'll say we ignore them.
-		onClusterWith3NodesAll3NodesSuspended().verify( link.pulse( repositoryMock ) );
+		onClusterWith3NodesAll3NodesSuspended().verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -339,7 +339,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 		// Do not update the agent, in order to avoid locks on Oracle in particular (maybe others);
 		// see the comment in AbstractAgentClusterLink#pulse.
 		// We will assess the situation in the next pulse.
-		expectInitialStateAndPulseAfterDelay( POLLING_INTERVAL ).verify( link.pulse( repositoryMock ) );
+		expectInitialStateAndPulseAfterDelay( POLLING_INTERVAL ).verify( link.pulse( contextMock ) );
 
 		verify( repositoryMock ).delete( repositoryMockHelper.agentsInIdOrder( MASS_INDEXING_ID ) );
 	}
@@ -355,7 +355,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 						otherShardAssignmentIn4NodeCluster( 3 ) )
 				.other( MASS_INDEXING_ID, AgentType.MASS_INDEXING, LATER, AgentState.RUNNING );
 
-		expectWaiting().verify( link.pulse( repositoryMock ) );
+		expectWaiting().verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -372,7 +372,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 		// Suspended mass indexing agents should not exist,
 		// but just for the sake of fully defining the behavior,
 		// we'll say we ignore them.
-		expectWaiting().verify( link.pulse( repositoryMock ) );
+		expectWaiting().verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -389,7 +389,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 		// Rebalancing mass indexing agents should not exist,
 		// but just for the sake of fully defining the behavior,
 		// we'll say we ignore them.
-		expectWaiting().verify( link.pulse( repositoryMock ) );
+		expectWaiting().verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -406,7 +406,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 		// Do not update the agent, in order to avoid locks on Oracle in particular (maybe others);
 		// see the comment in AbstractAgentClusterLink#pulse.
 		// We will assess the situation in the next pulse.
-		expectInitialStateAndPulseAfterDelay( POLLING_INTERVAL ).verify( link.pulse( repositoryMock ) );
+		expectInitialStateAndPulseAfterDelay( POLLING_INTERVAL ).verify( link.pulse( contextMock ) );
 
 		verify( repositoryMock ).delete( repositoryMockHelper.agentsInIdOrder( MASS_INDEXING_ID ) );
 	}

--- a/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AbstractMassIndexerAgentClusterLinkBaseTest.java
+++ b/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AbstractMassIndexerAgentClusterLinkBaseTest.java
@@ -9,6 +9,8 @@ package org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
+
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.AgentRepository;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.AgentState;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.AgentType;
@@ -61,8 +63,8 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 		return expect( link );
 	}
 
-	protected final MassIndexerAgentClusterLinkPulseExpectations expectInitialStateAndPulseASAP() {
-		return expect().pulseAgain( NOW.plus( POLLING_INTERVAL ) )
+	protected final MassIndexerAgentClusterLinkPulseExpectations expectInitialStateAndPulseAfterDelay(Duration delay) {
+		return expect().pulseAgain( NOW.plus( delay ) )
 				.agent( SELF_ID, repositoryMockHelper.selfInitialState() != null
 						// If self created before this pulse:
 						? repositoryMockHelper.selfInitialState()
@@ -141,7 +143,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 		// Do not update the agent, in order to avoid locks on Oracle in particular (maybe others);
 		// see the comment in AbstractAgentClusterLink#pulse.
 		// We will assess the situation in the next pulse.
-		expectInitialStateAndPulseASAP().verify( link.pulse( repositoryMock ) );
+		expectInitialStateAndPulseAfterDelay( POLLING_INTERVAL ).verify( link.pulse( repositoryMock ) );
 
 		verify( repositoryMock ).delete( repositoryMockHelper.agentsInIdOrder( other2Id(), other3Id() ) );
 	}
@@ -251,7 +253,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 		// Do not update the agent, in order to avoid locks on Oracle in particular (maybe others);
 		// see the comment in AbstractAgentClusterLink#pulse.
 		// We will assess the situation in the next pulse.
-		expectInitialStateAndPulseASAP().verify( link.pulse( repositoryMock ) );
+		expectInitialStateAndPulseAfterDelay( POLLING_INTERVAL ).verify( link.pulse( repositoryMock ) );
 
 		// Cleaning up expired agents takes precedence over suspending because a mass indexing agent exists.
 		verify( repositoryMock ).delete( repositoryMockHelper.agentsInIdOrder( other2Id(), other3Id() ) );
@@ -337,7 +339,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 		// Do not update the agent, in order to avoid locks on Oracle in particular (maybe others);
 		// see the comment in AbstractAgentClusterLink#pulse.
 		// We will assess the situation in the next pulse.
-		expectInitialStateAndPulseASAP().verify( link.pulse( repositoryMock ) );
+		expectInitialStateAndPulseAfterDelay( POLLING_INTERVAL ).verify( link.pulse( repositoryMock ) );
 
 		verify( repositoryMock ).delete( repositoryMockHelper.agentsInIdOrder( MASS_INDEXING_ID ) );
 	}
@@ -404,7 +406,7 @@ abstract class AbstractMassIndexerAgentClusterLinkBaseTest extends AbstractMassI
 		// Do not update the agent, in order to avoid locks on Oracle in particular (maybe others);
 		// see the comment in AbstractAgentClusterLink#pulse.
 		// We will assess the situation in the next pulse.
-		expectInitialStateAndPulseASAP().verify( link.pulse( repositoryMock ) );
+		expectInitialStateAndPulseAfterDelay( POLLING_INTERVAL ).verify( link.pulse( repositoryMock ) );
 
 		verify( repositoryMock ).delete( repositoryMockHelper.agentsInIdOrder( MASS_INDEXING_ID ) );
 	}

--- a/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AbstractMassIndexerAgentClusterLinkTest.java
+++ b/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AbstractMassIndexerAgentClusterLinkTest.java
@@ -6,7 +6,9 @@
  */
 package org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl;
 
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -61,6 +63,9 @@ abstract class AbstractMassIndexerAgentClusterLinkTest {
 	@Mock
 	public AgentRepository repositoryMock;
 
+	@Mock(stubOnly = true, lenient = true)
+	public AgentClusterLinkContext contextMock;
+
 	private final List<Object> allMocks = new ArrayList<>();
 
 	protected AgentRepositoryMockingHelper repositoryMockHelper;
@@ -69,6 +74,10 @@ abstract class AbstractMassIndexerAgentClusterLinkTest {
 	public final void initMocks() {
 		repositoryMockHelper = new AgentRepositoryMockingHelper( repositoryMock );
 		Collections.addAll( allMocks, failureHandlerMock, clockMock, repositoryMock );
+
+		when( contextMock.agentRepository() ).thenReturn( repositoryMock );
+		// We're not interested in transaction control here
+		doNothing().when( contextMock ).commitAndBeginNewTransaction();
 	}
 
 	@After

--- a/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AbstractMassIndexerAgentClusterLinkTest.java
+++ b/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/AbstractMassIndexerAgentClusterLinkTest.java
@@ -86,13 +86,13 @@ abstract class AbstractMassIndexerAgentClusterLinkTest {
 	}
 
 	protected void defineSelfNotCreatedYet(OutboxPollingMassIndexerAgentClusterLink link) {
-		link.agentPersister.setSelfReferenceForTests( null );
+		link.getAgentPersisterForTests().setSelfReferenceForTests( null );
 		repositoryMockHelper.defineSelfCreatedByPulse( SELF_ID );
 	}
 
 	protected void defineSelfCreatedAndStillPresent(OutboxPollingMassIndexerAgentClusterLink link,
 			AgentState state) {
-		link.agentPersister.setSelfReferenceForTests( SELF_REF );
+		link.getAgentPersisterForTests().setSelfReferenceForTests( SELF_REF );
 		Agent self = new Agent( AgentType.MASS_INDEXING, SELF_REF.name, NOW, state, null );
 		self.setId( SELF_ID );
 		repositoryMockHelper.defineSelfPreExisting( self );

--- a/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/EventProcessorClusterLinkDynamicShardingBaseTest.java
+++ b/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/EventProcessorClusterLinkDynamicShardingBaseTest.java
@@ -69,7 +69,7 @@ public class EventProcessorClusterLinkDynamicShardingBaseTest {
 					.other( other3Id(), other3Type(), LATER, AgentState.WAITING,
 							new ShardAssignmentDescriptor( 3, 2 ) );
 
-			expectWaiting( selfShardAssignmentIn4NodeCluster() ).verify( link.pulse( repositoryMock ) );
+			expectWaiting( selfShardAssignmentIn4NodeCluster() ).verify( link.pulse( contextMock ) );
 		}
 
 		@Test
@@ -82,7 +82,7 @@ public class EventProcessorClusterLinkDynamicShardingBaseTest {
 					.other( other3Id(), other3Type(), LATER, AgentState.RUNNING,
 							new ShardAssignmentDescriptor( 3, 2 ) );
 
-			expectWaiting( selfShardAssignmentIn4NodeCluster() ).verify( link.pulse( repositoryMock ) );
+			expectWaiting( selfShardAssignmentIn4NodeCluster() ).verify( link.pulse( contextMock ) );
 		}
 	}
 

--- a/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/EventProcessorClusterLinkLeaveClusterTest.java
+++ b/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/EventProcessorClusterLinkLeaveClusterTest.java
@@ -11,12 +11,10 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 
-import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.AgentRepository;
-
 import org.junit.Test;
 
 /**
- * Tests for {@link OutboxPollingEventProcessorClusterLink#leaveCluster(AgentRepository)}.
+ * Tests for {@link OutboxPollingEventProcessorClusterLink#leaveCluster(AgentClusterLinkContextProvider)}.
  */
 public class EventProcessorClusterLinkLeaveClusterTest extends AbstractEventProcessorClusterLinkTest {
 	final OutboxPollingEventProcessorClusterLink setupLink() {
@@ -30,7 +28,7 @@ public class EventProcessorClusterLinkLeaveClusterTest extends AbstractEventProc
 	@Test
 	public void didNotJoin() {
 		OutboxPollingEventProcessorClusterLink link = setupLink();
-		link.leaveCluster( repositoryMock );
+		link.leaveCluster( contextMock );
 	}
 
 	@Test
@@ -40,10 +38,10 @@ public class EventProcessorClusterLinkLeaveClusterTest extends AbstractEventProc
 		repositoryMockHelper.defineOtherAgents();
 		when( repositoryMock.findAllOrderById() ).thenAnswer( ignored -> repositoryMockHelper.allAgentsInIdOrder() );
 		when( clockMock.instant() ).thenReturn( NOW );
-		link.pulse( repositoryMock );
+		link.pulse( contextMock );
 
 		when( repositoryMock.find( SELF_ID ) ).thenReturn( repositoryMockHelper.self() );
-		link.leaveCluster( repositoryMock );
+		link.leaveCluster( contextMock );
 		verify( repositoryMock ).delete( Collections.singletonList( repositoryMockHelper.self() ) );
 	}
 
@@ -54,10 +52,10 @@ public class EventProcessorClusterLinkLeaveClusterTest extends AbstractEventProc
 		repositoryMockHelper.defineOtherAgents();
 		when( repositoryMock.findAllOrderById() ).thenAnswer( ignored -> repositoryMockHelper.allAgentsInIdOrder() );
 		when( clockMock.instant() ).thenReturn( NOW );
-		link.pulse( repositoryMock );
+		link.pulse( contextMock );
 
 		when( repositoryMock.find( SELF_ID ) ).thenReturn( null );
-		link.leaveCluster( repositoryMock );
+		link.leaveCluster( contextMock );
 	}
 
 }

--- a/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/EventProcessorClusterLinkMixedSharding4ShardSelfStaticBaseTest.java
+++ b/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/EventProcessorClusterLinkMixedSharding4ShardSelfStaticBaseTest.java
@@ -79,7 +79,7 @@ public class EventProcessorClusterLinkMixedSharding4ShardSelfStaticBaseTest {
 
 		@Override
 		protected EventProcessorClusterLinkPulseExpectations onNoOtherAgents() {
-			return expectSuspendedAndPulseASAP();
+			return expectSuspendedAndPulseAfterDelay( POLLING_INTERVAL );
 		}
 
 		@Override
@@ -96,7 +96,7 @@ public class EventProcessorClusterLinkMixedSharding4ShardSelfStaticBaseTest {
 
 		@Override
 		protected EventProcessorClusterLinkPulseExpectations onNoOtherAgents() {
-			return expectSuspendedAndPulseASAP();
+			return expectSuspendedAndPulseAfterDelay( POLLING_INTERVAL );
 		}
 
 		@Override
@@ -114,7 +114,7 @@ public class EventProcessorClusterLinkMixedSharding4ShardSelfStaticBaseTest {
 
 		@Override
 		protected EventProcessorClusterLinkPulseExpectations onNoOtherAgents() {
-			return expectSuspendedAndPulseASAP();
+			return expectSuspendedAndPulseAfterDelay( POLLING_INTERVAL );
 		}
 
 		@Override
@@ -132,7 +132,7 @@ public class EventProcessorClusterLinkMixedSharding4ShardSelfStaticBaseTest {
 
 		@Override
 		protected EventProcessorClusterLinkPulseExpectations onNoOtherAgents() {
-			return expectSuspendedAndPulseASAP();
+			return expectSuspendedAndPulseAfterDelay( POLLING_INTERVAL );
 		}
 
 		@Override

--- a/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/EventProcessorClusterLinkStaticSharding4ShardBaseTest.java
+++ b/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/EventProcessorClusterLinkStaticSharding4ShardBaseTest.java
@@ -73,7 +73,7 @@ public class EventProcessorClusterLinkStaticSharding4ShardBaseTest {
 
 		@Override
 		protected EventProcessorClusterLinkPulseExpectations onNoOtherAgents() {
-			return expectSuspendedAndPulseASAP();
+			return expectSuspendedAndPulseAfterDelay( POLLING_INTERVAL );
 		}
 
 		@Override
@@ -90,7 +90,7 @@ public class EventProcessorClusterLinkStaticSharding4ShardBaseTest {
 
 		@Override
 		protected EventProcessorClusterLinkPulseExpectations onNoOtherAgents() {
-			return expectSuspendedAndPulseASAP();
+			return expectSuspendedAndPulseAfterDelay( POLLING_INTERVAL );
 		}
 
 		@Override
@@ -108,7 +108,7 @@ public class EventProcessorClusterLinkStaticSharding4ShardBaseTest {
 
 		@Override
 		protected EventProcessorClusterLinkPulseExpectations onNoOtherAgents() {
-			return expectSuspendedAndPulseASAP();
+			return expectSuspendedAndPulseAfterDelay( POLLING_INTERVAL );
 		}
 
 		@Override
@@ -126,7 +126,7 @@ public class EventProcessorClusterLinkStaticSharding4ShardBaseTest {
 
 		@Override
 		protected EventProcessorClusterLinkPulseExpectations onNoOtherAgents() {
-			return expectSuspendedAndPulseASAP();
+			return expectSuspendedAndPulseAfterDelay( POLLING_INTERVAL );
 		}
 
 		@Override

--- a/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/EventProcessorClusterLinkStaticShardingEdgeCasesTest.java
+++ b/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/EventProcessorClusterLinkStaticShardingEdgeCasesTest.java
@@ -64,7 +64,7 @@ public class EventProcessorClusterLinkStaticShardingEdgeCasesTest
 				.agent( SELF_ID, AgentState.WAITING )
 				.shardAssignment( new ShardAssignmentDescriptor( 4, 0 ) )
 				.build()
-				.verify( link.pulse( repositoryMock ) );
+				.verify( link.pulse( contextMock ) );
 
 		verifyNoMoreInvocationsOnAllMocks();
 
@@ -77,7 +77,7 @@ public class EventProcessorClusterLinkStaticShardingEdgeCasesTest
 				.agent( newId, AgentState.WAITING )
 				.shardAssignment( new ShardAssignmentDescriptor( 4, 3 ) )
 				.build()
-				.verify( link.pulse( repositoryMock ) );
+				.verify( link.pulse( contextMock ) );
 
 		verify( repositoryMock ).create( repositoryMockHelper.self() );
 	}
@@ -102,7 +102,7 @@ public class EventProcessorClusterLinkStaticShardingEdgeCasesTest
 				.agent( SELF_ID, AgentState.SUSPENDED )
 				.shardAssignment( selfStaticShardAssignment )
 				.build()
-				.verify( link.pulse( repositoryMock ) );
+				.verify( link.pulse( contextMock ) );
 
 		ArgumentCaptor<FailureContext> failureCaptor = ArgumentCaptor.forClass( FailureContext.class );
 		verify( failureHandlerMock ).handle( failureCaptor.capture() );
@@ -142,7 +142,7 @@ public class EventProcessorClusterLinkStaticShardingEdgeCasesTest
 				.agent( SELF_ID, AgentState.SUSPENDED )
 				.shardAssignment( selfStaticShardAssignment )
 				.build()
-				.verify( link.pulse( repositoryMock ) );
+				.verify( link.pulse( contextMock ) );
 
 		ArgumentCaptor<FailureContext> failureCaptor = ArgumentCaptor.forClass( FailureContext.class );
 		verify( failureHandlerMock ).handle( failureCaptor.capture() );
@@ -186,7 +186,7 @@ public class EventProcessorClusterLinkStaticShardingEdgeCasesTest
 				.agent( SELF_ID, AgentState.RUNNING )
 				.shardAssignment( selfStaticShardAssignment )
 				.build()
-				.verify( link.pulse( repositoryMock ) );
+				.verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -212,7 +212,7 @@ public class EventProcessorClusterLinkStaticShardingEdgeCasesTest
 				.agent( SELF_ID, AgentState.WAITING )
 				.shardAssignment( selfStaticShardAssignment )
 				.build()
-				.verify( link.pulse( repositoryMock ) );
+				.verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -238,7 +238,7 @@ public class EventProcessorClusterLinkStaticShardingEdgeCasesTest
 				.agent( SELF_ID, AgentState.WAITING )
 				.shardAssignment( selfStaticShardAssignment )
 				.build()
-				.verify( link.pulse( repositoryMock ) );
+				.verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -264,7 +264,7 @@ public class EventProcessorClusterLinkStaticShardingEdgeCasesTest
 				.agent( SELF_ID, AgentState.WAITING )
 				.shardAssignment( selfStaticShardAssignment )
 				.build()
-				.verify( link.pulse( repositoryMock ) );
+				.verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -291,7 +291,7 @@ public class EventProcessorClusterLinkStaticShardingEdgeCasesTest
 				.agent( SELF_ID, AgentState.WAITING )
 				.shardAssignment( selfStaticShardAssignment )
 				.build()
-				.verify( link.pulse( repositoryMock ) );
+				.verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -318,7 +318,7 @@ public class EventProcessorClusterLinkStaticShardingEdgeCasesTest
 				.agent( SELF_ID, AgentState.WAITING )
 				.shardAssignment( selfStaticShardAssignment )
 				.build()
-				.verify( link.pulse( repositoryMock ) );
+				.verify( link.pulse( contextMock ) );
 	}
 
 	@Test
@@ -343,7 +343,7 @@ public class EventProcessorClusterLinkStaticShardingEdgeCasesTest
 				.pulseAgain( NOW.plus( PULSE_INTERVAL ) )
 				.agent( SELF_ID, AgentState.SUSPENDED )
 				.build()
-				.verify( link.pulse( repositoryMock ) );
+				.verify( link.pulse( contextMock ) );
 	}
 
 }

--- a/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/MassIndexerAgentClusterLinkLeaveClusterTest.java
+++ b/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/MassIndexerAgentClusterLinkLeaveClusterTest.java
@@ -11,12 +11,10 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 
-import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.AgentRepository;
-
 import org.junit.Test;
 
 /**
- * Tests for {@link OutboxPollingMassIndexerAgentClusterLink#leaveCluster(AgentRepository)}.
+ * Tests for {@link OutboxPollingMassIndexerAgentClusterLink#leaveCluster(AgentClusterLinkContextProvider)}.
  */
 public class MassIndexerAgentClusterLinkLeaveClusterTest extends AbstractMassIndexerAgentClusterLinkTest {
 	final OutboxPollingMassIndexerAgentClusterLink setupLink() {
@@ -29,7 +27,7 @@ public class MassIndexerAgentClusterLinkLeaveClusterTest extends AbstractMassInd
 	@Test
 	public void didNotJoin() {
 		OutboxPollingMassIndexerAgentClusterLink link = setupLink();
-		link.leaveCluster( repositoryMock );
+		link.leaveCluster( contextMock );
 	}
 
 	@Test
@@ -39,10 +37,10 @@ public class MassIndexerAgentClusterLinkLeaveClusterTest extends AbstractMassInd
 		repositoryMockHelper.defineOtherAgents();
 		when( repositoryMock.findAllOrderById() ).thenAnswer( ignored -> repositoryMockHelper.allAgentsInIdOrder() );
 		when( clockMock.instant() ).thenReturn( NOW );
-		link.pulse( repositoryMock );
+		link.pulse( contextMock );
 
 		when( repositoryMock.find( SELF_ID ) ).thenReturn( repositoryMockHelper.self() );
-		link.leaveCluster( repositoryMock );
+		link.leaveCluster( contextMock );
 		verify( repositoryMock ).delete( Collections.singletonList( repositoryMockHelper.self() ) );
 	}
 
@@ -53,10 +51,10 @@ public class MassIndexerAgentClusterLinkLeaveClusterTest extends AbstractMassInd
 		repositoryMockHelper.defineOtherAgents();
 		when( repositoryMock.findAllOrderById() ).thenAnswer( ignored -> repositoryMockHelper.allAgentsInIdOrder() );
 		when( clockMock.instant() ).thenReturn( NOW );
-		link.pulse( repositoryMock );
+		link.pulse( contextMock );
 
 		when( repositoryMock.find( SELF_ID ) ).thenReturn( null );
-		link.leaveCluster( repositoryMock );
+		link.leaveCluster( contextMock );
 	}
 
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/common/spi/SessionHelper.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/common/spi/SessionHelper.java
@@ -6,9 +6,6 @@
  */
 package org.hibernate.search.mapper.orm.common.spi;
 
-import java.util.function.Consumer;
-
-import org.hibernate.Session;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 
@@ -32,11 +29,5 @@ public final class SessionHelper {
 
 	public SessionImplementor openSession() {
 		return (SessionImplementor) sessionFactory.withOptions().tenantIdentifier( tenantId ).openSession();
-	}
-
-	public void inSessionAndTransaction(Consumer<Session> action) {
-		try ( SessionImplementor session = openSession() ) {
-			transactionHelper.inTransaction( session, () -> action.accept( session ) );
-		}
 	}
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/common/spi/SessionHelper.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/common/spi/SessionHelper.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.orm.common.spi;
+
+import java.util.function.Consumer;
+
+import org.hibernate.Session;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
+
+/**
+ * A helper to abstract away all the complexity of wrapping sections of code in a session (and transaction).
+ * <p>
+ * Particularly useful for unit testing of code that abstracts away from Hibernate ORM sessions.
+ */
+public final class SessionHelper {
+
+	private final SessionFactoryImplementor sessionFactory;
+	private final TransactionHelper transactionHelper;
+	private final String tenantId;
+
+	public SessionHelper(SessionFactoryImplementor sessionFactory, TransactionHelper transactionHelper,
+			String tenantId) {
+		this.sessionFactory = sessionFactory;
+		this.transactionHelper = transactionHelper;
+		this.tenantId = tenantId;
+	}
+
+	public SessionImplementor openSession() {
+		return (SessionImplementor) sessionFactory.withOptions().tenantIdentifier( tenantId ).openSession();
+	}
+
+	public void inSessionAndTransaction(Consumer<Session> action) {
+		try ( SessionImplementor session = openSession() ) {
+			transactionHelper.inTransaction( session, () -> action.accept( session ) );
+		}
+	}
+}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/common/spi/TransactionHelper.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/common/spi/TransactionHelper.java
@@ -7,8 +7,7 @@
 package org.hibernate.search.mapper.orm.common.spi;
 
 import java.lang.invoke.MethodHandles;
-import java.util.function.Consumer;
-import java.util.function.Function;
+import java.util.function.Supplier;
 import javax.transaction.HeuristicMixedException;
 import javax.transaction.HeuristicRollbackException;
 import javax.transaction.NotSupportedException;
@@ -49,11 +48,10 @@ public final class TransactionHelper {
 		this.transactionTimeout = transactionTimeout;
 	}
 
-	public void inTransaction(SharedSessionContractImplementor session,
-			Consumer<SharedSessionContractImplementor> procedure) {
+	public void inTransaction(SharedSessionContractImplementor session, Runnable action) {
 		begin( session );
 		try {
-			procedure.accept( session );
+			action.run();
 		}
 		catch (Exception e) {
 			rollbackSafely( session, e );
@@ -62,13 +60,12 @@ public final class TransactionHelper {
 		commit( session );
 	}
 
-	public <T> T inTransaction(SharedSessionContractImplementor session,
-			Function<SharedSessionContractImplementor, T> function) {
+	public <T> T inTransaction(SharedSessionContractImplementor session, Supplier<T> action) {
 		begin( session );
 
 		T result;
 		try {
-			result = function.apply( session );
+			result = action.get();
 		}
 		catch (Exception e) {
 			rollbackSafely( session, e );

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/HibernateOrmMassEntityLoader.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/HibernateOrmMassEntityLoader.java
@@ -34,7 +34,7 @@ public final class HibernateOrmMassEntityLoader<E, I> implements PojoMassEntityL
 		this.options = options;
 		this.sink = sink;
 		this.session = session;
-		this.transactionHelper = new TransactionHelper( session.getSessionFactory() );
+		this.transactionHelper = new TransactionHelper( session.getSessionFactory(), null );
 	}
 
 	@Override
@@ -44,7 +44,7 @@ public final class HibernateOrmMassEntityLoader<E, I> implements PojoMassEntityL
 
 	@Override
 	public void load(List<I> identifiers) throws InterruptedException {
-		transactionHelper.begin( session, null );
+		transactionHelper.begin( session );
 		try {
 			sink.accept( typeQueryLoader.uniquePropertyIsTheEntityId() ?
 					multiLoad( identifiers ) : queryByIds( identifiers ) );

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/HibernateOrmMassIdentifierLoader.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/HibernateOrmMassIdentifierLoader.java
@@ -38,9 +38,9 @@ public final class HibernateOrmMassIdentifierLoader<E, I> implements PojoMassIde
 		this.options = options;
 		this.sink = sink;
 		this.session = session;
-		this.transactionHelper = new TransactionHelper( session.getFactory() );
+		this.transactionHelper = new TransactionHelper( session.getFactory(), options.idLoadingTransactionTimeout() );
 
-		transactionHelper.begin( session, options.idLoadingTransactionTimeout() );
+		transactionHelper.begin( session );
 
 		try {
 			long objectsLimit = options.objectsLimit();

--- a/orm6/integrationtest/mapper/orm-realbackend/ant-src-changes.patch
+++ b/orm6/integrationtest/mapper/orm-realbackend/ant-src-changes.patch
@@ -1,0 +1,22 @@
+diff --git a/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/limitations/ConcurrentEmbeddedUpdateLimitationIT.java b/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/limitations/ConcurrentEmbeddedUpdateLimitationIT.java
+index ddf6d1caac..e19bbad6ec 100644
+--- a/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/limitations/ConcurrentEmbeddedUpdateLimitationIT.java
++++ b/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/limitations/ConcurrentEmbeddedUpdateLimitationIT.java
+@@ -25,7 +25,7 @@
+ import org.hibernate.Session;
+ import org.hibernate.SessionFactory;
+ import org.hibernate.Transaction;
+-import org.hibernate.dialect.CockroachDB192Dialect;
++import org.hibernate.dialect.CockroachDialect;
+ import org.hibernate.dialect.SQLServerDialect;
+ import org.hibernate.search.integrationtest.mapper.orm.realbackend.testsupport.BackendConfigurations;
+ import org.hibernate.search.mapper.orm.Search;
+@@ -64,7 +64,7 @@ public void indexingStrategySession() throws Throwable {
+ 				.skipTestForDialect( SQLServerDialect.class,
+ 						"The execution could provoke a failure caused by a deadlock on SQLServer, "
+ 						+ "which will abort our requests and will make the tests fail." )
+-				.skipTestForDialect( CockroachDB192Dialect.class,
++				.skipTestForDialect( CockroachDialect.class,
+ 						"The execution could provoke a 'failed preemptive refresh due to a conflict' on CockroachDB,"
+ 						+ " which will abort our requests and will make the tests fail." )
+ 				.setup( Book.class, Author.class, BookEdition.class );

--- a/orm6/mapper/orm-coordination-outbox-polling/ant-src-changes.patch
+++ b/orm6/mapper/orm-coordination-outbox-polling/ant-src-changes.patch
@@ -61,7 +61,7 @@ index 085409d2b8..3f497919bb 100644
  	}
  }
 diff --git a/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/mapping/impl/OutboxPollingSearchMappingImpl.java b/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/mapping/impl/OutboxPollingSearchMappingImpl.java
-index 9052de4cec..f8c90756e0 100644
+index 8af4b57c48..b350b8eb45 100644
 --- a/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/mapping/impl/OutboxPollingSearchMappingImpl.java
 +++ b/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/mapping/impl/OutboxPollingSearchMappingImpl.java
 @@ -14,6 +14,7 @@
@@ -75,7 +75,7 @@ index 9052de4cec..f8c90756e0 100644
 @@ -76,7 +77,7 @@ public int reprocessAbortedEvents() {
  
  		try ( Session session = sessionFactory.openSession() ) {
- 			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, null, s -> {
+ 			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, () -> {
 -				Query<?> query = session.createQuery( UPDATE_EVENTS_WITH_STATUS );
 +				MutationQuery query = session.createMutationQuery( UPDATE_EVENTS_WITH_STATUS );
  				query.setParameter( "status", OutboxEvent.Status.ABORTED );
@@ -84,7 +84,7 @@ index 9052de4cec..f8c90756e0 100644
 @@ -90,7 +91,7 @@ public int reprocessAbortedEvents(String tenantId) {
  
  		try ( Session session = sessionFactory.withOptions().tenantIdentifier( tenantId ).openSession() ) {
- 			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, null, s -> {
+ 			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, () -> {
 -				Query<?> query = session.createQuery( UPDATE_EVENTS_WITH_STATUS );
 +				MutationQuery query = session.createMutationQuery( UPDATE_EVENTS_WITH_STATUS );
  				query.setParameter( "status", OutboxEvent.Status.ABORTED );
@@ -93,7 +93,7 @@ index 9052de4cec..f8c90756e0 100644
 @@ -104,7 +105,7 @@ public int clearAllAbortedEvents() {
  
  		try ( Session session = sessionFactory.openSession() ) {
- 			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, null, s -> {
+ 			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, () -> {
 -				Query<?> query = session.createQuery( DELETE_EVENTS_WITH_STATUS );
 +				MutationQuery query = session.createMutationQuery( DELETE_EVENTS_WITH_STATUS );
  				query.setParameter( "status", OutboxEvent.Status.ABORTED );
@@ -102,7 +102,7 @@ index 9052de4cec..f8c90756e0 100644
 @@ -117,7 +118,7 @@ public int clearAllAbortedEvents(String tenantId) {
  
  		try ( Session session = sessionFactory.withOptions().tenantIdentifier( tenantId ).openSession() ) {
- 			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, null, s -> {
+ 			return transactionHelper.inTransaction( (SharedSessionContractImplementor) session, () -> {
 -				Query<?> query = session.createQuery( DELETE_EVENTS_WITH_STATUS );
 +				MutationQuery query = session.createMutationQuery( DELETE_EVENTS_WITH_STATUS );
  				query.setParameter( "status", OutboxEvent.Status.ABORTED );

--- a/orm6/mapper/orm/ant-src-changes.patch
+++ b/orm6/mapper/orm/ant-src-changes.patch
@@ -132,7 +132,7 @@ index 21503d08be..45b9fc0a50 100644
  		}
  		return result;
 diff --git a/main/java/org/hibernate/search/mapper/orm/loading/impl/HibernateOrmMassIdentifierLoader.java b/main/java/org/hibernate/search/mapper/orm/loading/impl/HibernateOrmMassIdentifierLoader.java
-index 39df0c5a24..159eb3207c 100644
+index 61cf2863dc..033ccecf9e 100644
 --- a/main/java/org/hibernate/search/mapper/orm/loading/impl/HibernateOrmMassIdentifierLoader.java
 +++ b/main/java/org/hibernate/search/mapper/orm/loading/impl/HibernateOrmMassIdentifierLoader.java
 @@ -29,7 +29,7 @@
@@ -581,10 +581,10 @@ index 355980c45a..6489423a9c 100644
  					|| isWholePath && isAssociation( containedValueClass ) ) {
  				pathsAsStrings.add( propertyNode.toPropertyString() );
 diff --git a/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java b/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java
-index c8ca89a1e0..9b2ef89c32 100644
+index c8ca89a1e0..f7140b4d52 100644
 --- a/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java
 +++ b/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java
-@@ -7,52 +7,45 @@
+@@ -7,52 +7,48 @@
  package org.hibernate.search.mapper.orm.search.query.impl;
  
  import java.lang.invoke.MethodHandles;
@@ -636,24 +636,25 @@ index c8ca89a1e0..9b2ef89c32 100644
  import org.hibernate.search.mapper.orm.search.query.spi.HibernateOrmSearchScrollableResultsAdapter;
 -import org.hibernate.search.mapper.orm.search.query.spi.HibernateOrmSearchScrollableResultsAdapter.ScrollHitExtractor;
  import org.hibernate.search.util.common.SearchTimeoutException;
--import org.hibernate.search.util.common.annotation.impl.SuppressForbiddenApis;
+ import org.hibernate.search.util.common.annotation.impl.SuppressForbiddenApis;
  import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 -import org.hibernate.transform.ResultTransformer;
 -import org.hibernate.type.Type;
  
 -@SuppressForbiddenApis(reason = "We need to extend the internal AbstractProducedQuery"
--		+ " in order to implement a org.hibernate.query.Query")
 +import jakarta.persistence.LockModeType;
 +import jakarta.persistence.PersistenceException;
 +import jakarta.persistence.QueryTimeoutException;
 +
++@SuppressForbiddenApis(reason = "We need to use the internal QueryOptionsImpl"
+ 		+ " in order to implement a org.hibernate.query.Query")
  @SuppressWarnings("unchecked") // For some reason javac issues warnings for all methods returning this; IDEA doesn't.
 -public final class HibernateOrmSearchQueryAdapter<R> extends AbstractProducedQuery<R> {
 +public final class HibernateOrmSearchQueryAdapter<R> extends AbstractQuery<R> {
  
  	public static <R> HibernateOrmSearchQueryAdapter<R> create(SearchQuery<R> query) {
  		return query.extension( HibernateOrmSearchQueryAdapterExtension.get() );
-@@ -61,15 +54,16 @@ public static <R> HibernateOrmSearchQueryAdapter<R> create(SearchQuery<R> query)
+@@ -61,15 +57,16 @@ public static <R> HibernateOrmSearchQueryAdapter<R> create(SearchQuery<R> query)
  	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
  
  	private final SearchQueryImplementor<R> delegate;
@@ -674,7 +675,7 @@ index c8ca89a1e0..9b2ef89c32 100644
  		this.loadingOptions = loadingOptions;
  	}
  
-@@ -84,83 +78,26 @@ public String toString() {
+@@ -84,83 +81,26 @@ public String toString() {
  
  	@Override
  	@SuppressWarnings("unchecked")
@@ -765,7 +766,7 @@ index c8ca89a1e0..9b2ef89c32 100644
  	}
  
  	@Override
-@@ -168,6 +105,11 @@ public String getQueryString() {
+@@ -168,6 +108,11 @@ public String getQueryString() {
  		return delegate.queryString();
  	}
  
@@ -777,7 +778,7 @@ index c8ca89a1e0..9b2ef89c32 100644
  	@Override
  	public HibernateOrmSearchQueryAdapter<R> setHint(String hintName, Object value) {
  		switch ( hintName ) {
-@@ -180,14 +122,12 @@ public HibernateOrmSearchQueryAdapter<R> setHint(String hintName, Object value)
+@@ -180,14 +125,12 @@ public HibernateOrmSearchQueryAdapter<R> setHint(String hintName, Object value)
  				break;
  			case HibernateOrmSearchQueryHints.JAVAX_FETCHGRAPH:
  			case HibernateOrmSearchQueryHints.JAKARTA_FETCHGRAPH:
@@ -794,7 +795,7 @@ index c8ca89a1e0..9b2ef89c32 100644
  				break;
  		}
  		return this;
-@@ -200,148 +140,104 @@ public HibernateOrmSearchQueryAdapter<R> setTimeout(int timeout) {
+@@ -200,148 +143,104 @@ public HibernateOrmSearchQueryAdapter<R> setTimeout(int timeout) {
  	}
  
  	@Override
@@ -995,7 +996,7 @@ index c8ca89a1e0..9b2ef89c32 100644
  		throw parametersNoSupported();
  	}
  
-@@ -350,18 +246,16 @@ private UnsupportedOperationException parametersNoSupported() {
+@@ -350,18 +249,16 @@ private UnsupportedOperationException parametersNoSupported() {
  	}
  
  	@Override
@@ -1019,7 +1020,7 @@ index c8ca89a1e0..9b2ef89c32 100644
  		return new UnsupportedOperationException( "Result transformers are not supported in Hibernate Search queries" );
  	}
  
-@@ -391,7 +285,12 @@ private UnsupportedOperationException lockOptionsNotSupported() {
+@@ -391,7 +288,12 @@ private UnsupportedOperationException lockOptionsNotSupported() {
  	}
  
  	@Override
@@ -1033,7 +1034,7 @@ index c8ca89a1e0..9b2ef89c32 100644
  		throw new UnsupportedOperationException( "executeUpdate is not supported in Hibernate Search queries" );
  	}
  
-@@ -400,30 +299,6 @@ public HibernateOrmSearchQueryAdapter<R> setLockMode(String alias, LockMode lock
+@@ -400,30 +302,6 @@ public HibernateOrmSearchQueryAdapter<R> setLockMode(String alias, LockMode lock
  		throw lockOptionsNotSupported();
  	}
  
@@ -1064,7 +1065,7 @@ index c8ca89a1e0..9b2ef89c32 100644
  	private static long hintValueToLong(Object value) {
  		if ( value instanceof Number ) {
  			return ( (Number) value ).longValue();
-@@ -442,8 +317,4 @@ private static int hintValueToInteger(Object value) {
+@@ -442,8 +320,4 @@ private static int hintValueToInteger(Object value) {
  		}
  	}
  

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -322,6 +322,42 @@
                                     </wait>
                                 </run>
                             </image>
+                            <image>
+                                <name>${test.database.run.cockroachdb.image.name}:${test.database.run.cockroachdb.image.tag}</name>
+                                <alias>cockroachdb</alias>
+                                <run>
+                                    <skip>${test.database.run.cockroachdb.skip}</skip>
+                                    <cmd>
+                                        <exec>
+                                            <arg>start-single-node</arg>
+                                            <arg>--insecure</arg>
+                                        </exec>
+                                    </cmd>
+                                    <ulimits>
+                                        <ulimit>
+                                            <name>nofile</name>
+                                            <hard>1956</hard>
+                                            <soft>1956</soft>
+                                        </ulimit>
+                                    </ulimits>
+                                    <env>
+                                        <POSTGRES_USER>hibernate_orm_test</POSTGRES_USER>
+                                        <POSTGRES_PASSWORD>hibernate_orm_test</POSTGRES_PASSWORD>
+                                        <POSTGRES_DB>hibernate_orm_test</POSTGRES_DB>
+                                    </env>
+                                    <ports>
+                                        <port>26257:26257</port>
+                                    </ports>
+                                    <log>
+                                        <prefix>CockroachDB: </prefix>
+                                        <date>default</date>
+                                        <color>blue</color>
+                                    </log>
+                                    <wait>
+                                        <log>CockroachDB node starting at</log>
+                                    </wait>
+                                </run>
+                            </image>
                         </images>
                     </configuration>
                     <executions>
@@ -738,6 +774,25 @@
                 <jdbc.url>jdbc:sqlserver://localhost:1433;databaseName=tempdb</jdbc.url>
                 <jdbc.user>sa</jdbc.user>
                 <jdbc.pass>ActuallyRequired11Complexity</jdbc.pass>
+            </properties>
+        </profile>
+
+        <!-- CockroachDB Docker container for tests -->
+        <!-- See test.database.run.cockroachdb.image.tag for the server version in use -->
+        <profile>
+            <id>ci-cockroachdb</id>
+            <properties>
+                <test.database.run.cockroachdb.skip>${test.database.run.skip}</test.database.run.cockroachdb.skip>
+                <db.dialect>org.hibernate.dialect.CockroachDB201Dialect</db.dialect>
+                <!-- CockroachDB uses the same client protocol as PostgreSQL (pgwire), so the driver is the same. -->
+                <jdbc.driver.groupId>org.postgresql</jdbc.driver.groupId>
+                <jdbc.driver.artifactId>postgresql</jdbc.driver.artifactId>
+                <jdbc.driver.version>42.2.19</jdbc.driver.version>
+                <jdbc.driver>org.postgresql.Driver</jdbc.driver>
+                <jdbc.url>jdbc:postgresql://localhost:26257/defaultdb?sslmode=disable</jdbc.url>
+                <jdbc.user>root</jdbc.user>
+                <jdbc.pass></jdbc.pass>
+                <jdbc.isolation />
             </properties>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -602,6 +602,10 @@
         <test.database.run.mssql.skip>true</test.database.run.mssql.skip>
         <test.database.run.mssql.image.name>mcr.microsoft.com/mssql/server</test.database.run.mssql.image.name>
         <test.database.run.mssql.image.tag>2019-CU8-ubuntu-16.04</test.database.run.mssql.image.tag>
+        <!-- CockroachDB -->
+        <test.database.run.cockroachdb.skip>true</test.database.run.cockroachdb.skip>
+        <test.database.run.cockroachdb.image.name>cockroachdb/cockroach</test.database.run.cockroachdb.image.name>
+        <test.database.run.cockroachdb.image.tag>v22.1.4</test.database.run.cockroachdb.image.tag>
 
         <!-- Eclipse plugin options -->
 
@@ -2219,6 +2223,9 @@
                                     }
                                     if ( isFalseString( '${test.database.run.mssql.skip}' ) ) {
                                         images += '${test.database.run.mssql.image.name}:${test.database.run.mssql.image.tag}'
+                                    }
+                                    if ( isFalseString( '${test.database.run.cockroachdb.skip}' ) ) {
+                                        images += '${test.database.run.cockroachdb.image.name}:${test.database.run.cockroachdb.image.tag}'
                                     }
                                     new File('${containerImagesListFile}').append( images.join('\n') + '\n' )
                                 ]]></script>


### PR DESCRIPTION
* [HSEARCH-4647](https://hibernate.atlassian.net/browse/HSEARCH-4647): High transaction contention in outbox-polling processes
* [HSEARCH-4644](https://hibernate.atlassian.net/browse/HSEARCH-4644): Test against CockroachDB in continuous integration
* [HSEARCH-4634](https://hibernate.atlassian.net/browse/HSEARCH-4634): Executing task 'Outbox event processor' fail with CockroachDB v22.1.1 SKIP LOCKED lock wait policy is not supported

Backport of #3166 to branch 6.1.
