### PR TITLE
HSEARCH-4642 + HSEARCH-4659 + HSEARCH-4660 + HSEARCH-4661 Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -413,7 +413,7 @@
         <version.asciidoctor.plugin>2.2.2</version.asciidoctor.plugin>
         <version.org.hibernate.infra.hibernate-asciidoctor-theme>1.0.4.Final</version.org.hibernate.infra.hibernate-asciidoctor-theme>
         <version.org.jruby>9.3.2.0</version.org.jruby>
-        <version.org.asciidoctor.asciidoctorj>2.5.4</version.org.asciidoctor.asciidoctorj>
+        <version.org.asciidoctor.asciidoctorj>2.5.5</version.org.asciidoctor.asciidoctorj>
         <version.org.asciidoctor.asciidoctorj-pdf>1.5.0-alpha.18</version.org.asciidoctor.asciidoctorj-pdf>
 
         <!-- Maven Central repository -->

--- a/pom.xml
+++ b/pom.xml
@@ -406,7 +406,7 @@
         <version.scripting.plugin>3.0.0</version.scripting.plugin>
         <version.gpg.plugin>3.0.1</version.gpg.plugin>
         <version.org.codehaus.groovy-jsr223>3.0.12</version.org.codehaus.groovy-jsr223>
-        <version.com.puppycrawl.tools.checkstyle>10.3.1</version.com.puppycrawl.tools.checkstyle>
+        <version.com.puppycrawl.tools.checkstyle>10.3.2</version.com.puppycrawl.tools.checkstyle>
 
         <!-- Asciidoctor -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -365,7 +365,7 @@
         <version.assembly.plugin>3.1.0</version.assembly.plugin>
         <version.buildhelper.plugin>3.3.0</version.buildhelper.plugin>
         <version.checkstyle.plugin>3.1.2</version.checkstyle.plugin>
-        <version.bundle.plugin>5.1.7</version.bundle.plugin>
+        <version.bundle.plugin>5.1.8</version.bundle.plugin>
         <version.clean.plugin>3.2.0</version.clean.plugin>
         <!-- Needing 3.6.2 at least because of MCOMPILER-294 -->
         <version.compiler.plugin>3.10.1</version.compiler.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -400,7 +400,7 @@
         <version.jacoco.plugin>0.8.8</version.jacoco.plugin>
         <version.coveralls.plugin>4.3.0</version.coveralls.plugin>
         <version.com.buschmais.jqassistant.plugin>1.12.0</version.com.buschmais.jqassistant.plugin>
-        <version.docker.maven.plugin>0.40.1</version.docker.maven.plugin>
+        <version.docker.maven.plugin>0.40.2</version.docker.maven.plugin>
         <version.moditect.plugin>1.0.0.RC2</version.moditect.plugin>
         <version.sonar.plugin>3.9.1.2184</version.sonar.plugin>
         <version.scripting.plugin>3.0.0</version.scripting.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
         <version.org.opensearch.latest-1.2>1.2.1</version.org.opensearch.latest-1.2>
         <version.org.opensearch.latest-1.0>1.0.0</version.org.opensearch.latest-1.0>
 
-        <version.com.google.code.gson>2.9.0</version.com.google.code.gson>
+        <version.com.google.code.gson>2.9.1</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.17.94</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, the AWS SDK and in tests (wiremock, ...) -->
         <version.com.fasterxml.jackson>2.13.3</version.com.fasterxml.jackson>

--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
         <version.com.github.tomakehurst.wiremock>2.27.2</version.com.github.tomakehurst.wiremock>
         <version.org.apache.commons.lang3>3.12.0</version.org.apache.commons.lang3>
         <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
-        <version.org.apache.avro>1.11.0</version.org.apache.avro>
+        <version.org.apache.avro>1.11.1</version.org.apache.avro>
         <version.org.jboss.weld>3.1.9.Final</version.org.jboss.weld>
         <version.org.jboss.weld.jakarta>4.0.3.Final</version.org.jboss.weld.jakarta>
 

--- a/pom.xml
+++ b/pom.xml
@@ -389,7 +389,7 @@
         <version.processor.plugin>4.5-jdk8</version.processor.plugin>
         <version.project-info.plugin>3.4.0</version.project-info.plugin>
         <version.release.plugin>2.5.3</version.release.plugin>
-        <version.resources.plugin>3.2.0</version.resources.plugin>
+        <version.resources.plugin>3.3.0</version.resources.plugin>
         <version.shade.plugin>3.3.0</version.shade.plugin>
         <version.site.plugin>3.12.0</version.site.plugin>
         <version.source.plugin>3.2.1</version.source.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
         <!-- >>> JSR 352 -->
         <version.javax.batch>1.0.1</version.javax.batch>
         <version.jakarta.batch>2.1.1</version.jakarta.batch>
-        <version.org.jberet>1.4.7.Final</version.org.jberet>
+        <version.org.jberet>1.4.8.Final</version.org.jberet>
         <version.org.jberet.jakarta>2.0.4.Final</version.org.jberet.jakarta>
 
         <!-- >>> Java EE/Jakarta EE dependencies -->


### PR DESCRIPTION
* [HSEARCH-4661](https://hibernate.atlassian.net/browse/HSEARCH-4661): Upgrade to JBeret 1.4.8.Final
* [HSEARCH-4660](https://hibernate.atlassian.net/browse/HSEARCH-4660): Upgrade to GSON 2.9.1
* [HSEARCH-4659](https://hibernate.atlassian.net/browse/HSEARCH-4659): Upgrade to Avro 1.11.1
* [HSEARCH-4642](https://hibernate.atlassian.net/browse/HSEARCH-4642): Upgrade build dependencies to the latest version


For [HSEARCH-4642](https://hibernate.atlassian.net/browse/HSEARCH-4642), folllows up on #3146, #3148, #3157