### PR TITLE
HSEARCH-4642 Upgrade build dependencies to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -400,7 +400,7 @@
         <version.release.plugin>2.5.3</version.release.plugin>
         <version.resources.plugin>3.3.0</version.resources.plugin>
         <version.shade.plugin>3.3.0</version.shade.plugin>
-        <version.site.plugin>3.12.0</version.site.plugin>
+        <version.site.plugin>3.12.1</version.site.plugin>
         <version.source.plugin>3.2.1</version.source.plugin>
         <!-- Surefire versions are a minefield of bugs: be careful with upgrades -->
         <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -350,7 +350,7 @@
         <version.org.postgresql>42.2.19</version.org.postgresql>
         <version.org.mariadb.jdbc>2.2.4</version.org.mariadb.jdbc>
         <version.mysql.mysql-connector-java>8.0.17</version.mysql.mysql-connector-java>
-        <version.com.ibm.db2.jcc>11.5.5.0</version.com.ibm.db2.jcc>
+        <version.com.ibm.db2.jcc>11.5.7.0</version.com.ibm.db2.jcc>
         <version.com.oracle.database.jdbc>21.1.0.0</version.com.oracle.database.jdbc>
         <version.com.microsoft.sqlserver.mssql-jdbc>9.2.1.jre11</version.com.microsoft.sqlserver.mssql-jdbc>
 

--- a/pom.xml
+++ b/pom.xml
@@ -347,7 +347,7 @@
         <!-- Sticking to Derby 10.14 for now since later versions require JDK 9+, and we need to test with JDK 8.
              See https://db.apache.org/derby/derby_downloads.html -->
         <version.org.apache.derby>10.14.2.0</version.org.apache.derby>
-        <version.org.postgresql>42.2.19</version.org.postgresql>
+        <version.org.postgresql>42.4.1</version.org.postgresql>
         <version.org.mariadb.jdbc>3.0.7</version.org.mariadb.jdbc>
         <version.mysql.mysql-connector-java>8.0.30</version.mysql.mysql-connector-java>
         <version.com.ibm.db2.jcc>11.5.7.0</version.com.ibm.db2.jcc>

--- a/pom.xml
+++ b/pom.xml
@@ -351,7 +351,7 @@
         <version.org.mariadb.jdbc>2.2.4</version.org.mariadb.jdbc>
         <version.mysql.mysql-connector-java>8.0.17</version.mysql.mysql-connector-java>
         <version.com.ibm.db2.jcc>11.5.7.0</version.com.ibm.db2.jcc>
-        <version.com.oracle.database.jdbc>21.1.0.0</version.com.oracle.database.jdbc>
+        <version.com.oracle.database.jdbc>21.6.0.0.1</version.com.oracle.database.jdbc>
         <version.com.microsoft.sqlserver.mssql-jdbc>9.2.1.jre11</version.com.microsoft.sqlserver.mssql-jdbc>
 
         <!-- >>> Performance tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,7 @@
              See https://db.apache.org/derby/derby_downloads.html -->
         <version.org.apache.derby>10.14.2.0</version.org.apache.derby>
         <version.org.postgresql>42.2.19</version.org.postgresql>
-        <version.org.mariadb.jdbc>2.2.4</version.org.mariadb.jdbc>
+        <version.org.mariadb.jdbc>3.0.7</version.org.mariadb.jdbc>
         <version.mysql.mysql-connector-java>8.0.30</version.mysql.mysql-connector-java>
         <version.com.ibm.db2.jcc>11.5.7.0</version.com.ibm.db2.jcc>
         <version.com.oracle.database.jdbc>21.6.0.0.1</version.com.oracle.database.jdbc>

--- a/pom.xml
+++ b/pom.xml
@@ -349,7 +349,7 @@
         <version.org.apache.derby>10.14.2.0</version.org.apache.derby>
         <version.org.postgresql>42.2.19</version.org.postgresql>
         <version.org.mariadb.jdbc>2.2.4</version.org.mariadb.jdbc>
-        <version.mysql.mysql-connector-java>8.0.17</version.mysql.mysql-connector-java>
+        <version.mysql.mysql-connector-java>8.0.30</version.mysql.mysql-connector-java>
         <version.com.ibm.db2.jcc>11.5.7.0</version.com.ibm.db2.jcc>
         <version.com.oracle.database.jdbc>21.6.0.0.1</version.com.oracle.database.jdbc>
         <version.com.microsoft.sqlserver.mssql-jdbc>9.2.1.jre11</version.com.microsoft.sqlserver.mssql-jdbc>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4642


For [HSEARCH-4642](https://hibernate.atlassian.net/browse/HSEARCH-4642), folllows up on #3146, #3148, #3157, #3176