### PR TITLE
HSEARCH-4551 + HSEARCH-4554 + HSEARCH-4646 + HSEARCH-4653 + HSEARCH-4658 Documentation improvements

### DIFF
--- a/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
+++ b/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
@@ -223,14 +223,11 @@ Expects a string value.
 This property has no default and must be provided for the AWS authentication to work.
 
 By default, Hibernate Search will rely on the default credentials provider from the AWS SDK.
-This provider will look for credentials in the following place and in the following order:
-
-1. Java System Properties: `aws.accessKeyId` and `aws.secretKey`.
-2. Environment Variables: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
-3. Credential profiles file at the default location (`~/.aws/credentials`) shared by all AWS SDKs and the AWS CLI.
-4. Credentials delivered through the Amazon EC2 container service if `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment
-   variable is set and security manager has permission to access the variable.
-5. Instance profile credentials delivered through the Amazon EC2 metadata service.
+This provider will look for credentials in various places
+(Java system properties, environment variables, AWS-specific configuration, ...).
+For more information about how the default credentials provider works,
+see
+https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html#credentials-default[its official documentation].
 
 Optionally, you can set static credentials with the following options:
 

--- a/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
+++ b/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
@@ -1009,9 +1009,35 @@ The Elasticsearch backend comes with several built-in analyzers.
 The exact list depends on the version of Elasticsearch and can be found
 link:{elasticsearchDocUrl}/analysis-analyzers.html[here].
 
-One important built-in analyzer is the one named `default`:
-it is used by default with <<mapping-directfieldmapping-annotations-fulltextfield,`@FullTextField`>>.
-Unless overridden explicitly, this analyzer uses a `standard` tokenizer and a `lowercase` filter.
+Regardless of the Elasticsearch version;
+analyzers whose name is listed as a constant in `org.hibernate.search.engine.backend.analysis.AnalyzerNames`
+are always available:
+
+`default`::
+The analyzer used by default with <<mapping-directfieldmapping-annotations-fulltextfield,`@FullTextField`>>.
++
+This is just an alias for `standard` by default.
+`standard`::
+Default behavior: first, tokenize using the standard tokenizer, which follows Word Break rules from the
+Unicode Text Segmentation algorithm, as specified in http://unicode.org/reports/tr29/[Unicode Standard Annex #29].
+Then, lowercase each token.
+`simple`::
+Default behavior: first, split the text at non-letter characters.
+Then, lowercase each token.
+`whitespace`::
+Default behavior: split the text at whitespace characters.
+Do not change the tokens.
+`stop`::
+Default behavior: first, split the text at non-letter characters.
+Then, lowercase each token.
+Finally, remove English stop words.
+`keyword`::
+Default behavior: do not change the text in any way.
++
+With this analyzer a full text field would behave similarly to a keyword field,
+but with fewer features: no terms aggregations, for example.
++
+Consider using a <<mapping-directfieldmapping-annotations-keywordfield,`@KeywordField`>> instead.
 
 [[backend-elasticsearch-analysis-builtin-normalizer]]
 === Built-in normalizers
@@ -1067,6 +1093,33 @@ refer to the documentation:
 {elasticsearchDocUrl}/analysis-charfilters.html[character filters],
 {elasticsearchDocUrl}/analysis-tokenizers.html[tokenizers],
 {elasticsearchDocUrl}/analysis-tokenfilters.html[token filters].
+
+[[backend-elasticsearch-analysis-analyzers-default]]
+=== Overriding the default analyzer
+
+The default analyzer when using <<mapping-directfieldmapping-annotations-fulltextfield,`@FullTextField`>>
+without specifying an analyzer explicitly, is named `default`.
+
+Like any other <<backend-elasticsearch-analysis-builtin,built-in analyzer>>, it is possible to override the default analyzer
+by defining a <<backend-elasticsearch-analysis-analyzers,custom analyzer>> with the same name:
+
+.Overriding the default analyzer in the Elasticsearch backend
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/analysis/MyElasticsearchAnalysisConfigurer.java[tags=include]
+----
+<1> Start the definition of a custom analyzer that happens to be named `default`.
+Here we rely on constants from `org.hibernate.search.engine.backend.analysis.AnalyzerNames` to use the correct name,
+but hardcoding `"default"` would work just as well.
+<2> Continue the analyzer definition <<backend-elasticsearch-analysis-analyzers,as we would for any other custom analyzer>>.
+
+[source, XML, indent=0, subs="+callouts"]
+----
+include::{resourcesdir}/analysis/elasticsearch-default-override.properties[]
+----
+<1> Assign the configurer to the backend using a Hibernate Search configuration property.
+====
 
 [[backend-elasticsearch-configuration-index-settings]]
 == [[_custom_index_settings]] Custom index settings

--- a/documentation/src/main/asciidoc/reference/backend-lucene.asciidoc
+++ b/documentation/src/main/asciidoc/reference/backend-lucene.asciidoc
@@ -593,7 +593,8 @@ See below for examples.
 Built-in analyzers are available out-of-the-box and don't require explicit configuration.
 If necessary, they can be overridden by defining your own analyzer with the same name.
 
-The Lucene backend comes with a series of built-in analyzer:
+The Lucene backend comes with a series of built-in analyzer;
+their names are listed as constants in `org.hibernate.search.engine.backend.analysis.AnalyzerNames`:
 
 `default`::
 The analyzer used by default with <<mapping-directfieldmapping-annotations-fulltextfield,`@FullTextField`>>.
@@ -722,6 +723,33 @@ It is also possible to assign a name to an analyzer instance:
 ----
 include::{sourcedir}/org/hibernate/search/documentation/analysis/AdvancedLuceneAnalysisConfigurer.java[tags=instance]
 ----
+====
+
+[[backend-lucene-analysis-analyzers-default]]
+=== Overriding the default analyzer
+
+The default analyzer when using <<mapping-directfieldmapping-annotations-fulltextfield,`@FullTextField`>>
+without specifying an analyzer explicitly, is named `default`.
+
+Like any other <<backend-lucene-analysis-builtin,built-in analyzer>>, it is possible to override the default analyzer
+by defining a <<backend-lucene-analysis-analyzers,custom analyzer>> with the same name:
+
+.Overriding the default analyzer in the Lucene backend
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/analysis/MyLuceneAnalysisConfigurer.java[tags=include]
+----
+<1> Start the definition of a custom analyzer that happens to be named `default`.
+Here we rely on constants from `org.hibernate.search.engine.backend.analysis.AnalyzerNames` to use the correct name,
+but hardcoding `"default"` would work just as well.
+<2> Continue the analyzer definition <<backend-lucene-analysis-analyzers,as we would for any other custom analyzer>>.
+
+[source, XML, indent=0, subs="+callouts"]
+----
+include::{resourcesdir}/analysis/lucene-default-override.properties[]
+----
+<1> Assign the configurer to the backend using a Hibernate Search configuration property.
 ====
 
 [[backend-lucene-analysis-similarity]]

--- a/documentation/src/main/asciidoc/reference/compatibility.asciidoc
+++ b/documentation/src/main/asciidoc/reference/compatibility.asciidoc
@@ -152,6 +152,31 @@ so that Hibernate Search doesn't even try to use Spring to retrieve the componen
 and thus avoids the deadlock in Spring.
 See <<configuration-bean-reference-parsing,this section>> for more information.
 
+[[compatibility-framework-spring-boot-elasticsearch-auto-configuration]]
+==== Spring Boot's Elasticsearch client and auto-configuration
+
+As you may know, Spring Boot includes "auto-configuration" that triggers as soon as a dependency is detected in the classpath.
+
+This may lead to problems in some cases when dependencies are used by the application, but not through Spring Boot.
+
+In particular, Hibernate Search transitively brings in a dependency to Elasticsearch's low-level REST Client.
+Spring Boot, through link:https://docs.spring.io/spring-boot/docs/{testSpringBootVersion}/api/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientAutoConfiguration.html[`ElasticsearchRestClientAutoConfiguration`],
+will automatically set up an Elasticsearch REST client targeting (by default) `http://localhost:9200`
+as soon as it detects that dependency to the Elasticsearch REST Client JAR.
+
+If your Elasticsearch cluster is not reachable at `http://localhost:9200`,
+this might lead to errors on startup.
+
+To get rid of these errors, either
+link:https://docs.spring.io/spring-boot/docs/{testSpringBootVersion}/reference/html/features.html#features.nosql.elasticsearch.connecting-using-rest[configure Spring's Elasticsearch client manually],
+or https://www.baeldung.com/spring-data-disable-auto-config[disable this specific auto-configuration].
+
+[NOTE]
+====
+Spring Boot's Elasticsearch client is completely separate from Hibernate Search:
+the configuration of one won't affect the other.
+====
+
 [[compatibility-framework-other]]
 === [[gettingstarted-framework-other]] Other
 

--- a/documentation/src/main/asciidoc/reference/components/field-aggregation-important.asciidoc
+++ b/documentation/src/main/asciidoc/reference/components/field-aggregation-important.asciidoc
@@ -1,0 +1,8 @@
+[IMPORTANT]
+====
+In order to use aggregations based on the value of a given field,
+you need to mark the field as <<mapping-directfieldmapping-aggregable,aggregable>> in the mapping.
+
+This is not possible for full-text fields, in particular;
+see <<mapping-directfieldmapping-annotations-fulltextfield,here>> for an explanation and some solutions.
+====

--- a/documentation/src/main/asciidoc/reference/components/field-projection-important.asciidoc
+++ b/documentation/src/main/asciidoc/reference/components/field-projection-important.asciidoc
@@ -1,0 +1,8 @@
+[IMPORTANT]
+====
+In order to use projections based on the value of a given field,
+you need to mark the field as <<mapping-directfieldmapping-projectable,projectable>> in the mapping.
+
+This is optional with the <<backend-elasticsearch,Elasticsearch backend>>,
+where all fields are projectable by default.
+====

--- a/documentation/src/main/asciidoc/reference/components/field-sort-important.asciidoc
+++ b/documentation/src/main/asciidoc/reference/components/field-sort-important.asciidoc
@@ -1,0 +1,8 @@
+[IMPORTANT]
+====
+In order to use sorts based on the value of a given field,
+you need to mark the field as <<mapping-directfieldmapping-sortable,sortable>> in the mapping.
+
+This is not possible for full-text fields (multi-word text fields), in particular;
+see <<mapping-directfieldmapping-annotations-fulltextfield,here>> for an explanation and some solutions.
+====

--- a/documentation/src/main/asciidoc/reference/indexing-massindexer.asciidoc
+++ b/documentation/src/main/asciidoc/reference/indexing-massindexer.asciidoc
@@ -134,7 +134,12 @@ A `CompletionStage` is returned.
 
 include::components/mapper-orm-only-note.asciidoc[]
 
-You can select a subset of target entities to be reindexed.
+You can select a subset of target entities to be reindexed
+by passing a condition as string to the mass indexer.
+The condition will be applied when querying the database for entities to index.
+
+The condition string is expected to follow the link:{hibernateDocUrl}#query-language[Hibernate Query Language (HQL)] syntax.
+Accessible entity properties are those of the entity being reindexed (and nothing more).
 
 .Use of conditional reindexing
 ====

--- a/documentation/src/main/asciidoc/reference/mapping-directfieldmapping.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapping-directfieldmapping.asciidoc
@@ -74,6 +74,9 @@ match fields ignoring diacritics,
 Full-text fields should be assigned an <<mapping-directfieldmapping-analyzer,analyzer>>, referenced by its name.
 By default, the analyzer named `default` will be used.
 See <<concepts-analysis>> for more details about analyzers and full-text analysis.
+For instructions on how to change the default analyzer,
+see the dedicated section in the documentation of your backend:
+<<>>
 +
 Note you can also define <<mapping-directfieldmapping-search-analyzer,a search analyzer>>
 to analyze searched terms differently.

--- a/documentation/src/main/asciidoc/reference/mapping-directfieldmapping.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapping-directfieldmapping.asciidoc
@@ -78,12 +78,13 @@ See <<concepts-analysis>> for more details about analyzers and full-text analysi
 Note you can also define <<mapping-directfieldmapping-search-analyzer,a search analyzer>>
 to analyze searched terms differently.
 +
-IMPORTANT: Full-text fields cannot be sorted on.
-If you need to sort on the value of a property,
+IMPORTANT: Full-text fields cannot be sorted on nor aggregated.
+If you need to sort on, or aggregate on, the value of a property,
 it is recommended to use `@KeywordField`, with a normalizer if necessary (see below).
 Note that multiple fields can be added to the same property,
 so you can use both `@FullTextField` and `@KeywordField` if you need both
-full-text search and sorting.
+full-text search and sorting:
+you will just need to use a distinct <<mapper-orm-directfieldmapping-name,name>> for each of those two fields.
 
 [[mapping-directfieldmapping-annotations-keywordfield]] [[mapper-orm-directfieldmapping-annotations-keywordfield]] `@KeywordField`::
 A text field whose value is considered as a single keyword.
@@ -91,7 +92,8 @@ Only works for `String` fields.
 +
 Keyword fields allow <<search-dsl-predicate-match-analysis,more subtle matches>>, similarly to full-text fields,
 with the limitation that keyword fields only contain one token.
-On the other hand, this limitation allows keyword fields to be <<mapping-directfieldmapping-sortable,sorted on>>.
+On the other hand, this limitation allows keyword fields to be <<mapping-directfieldmapping-sortable,sorted on>>
+and <<mapping-directfieldmapping-aggregable,aggregated>>.
 +
 Keyword fields may be assigned a <<mapping-directfieldmapping-normalizer,normalizer>>, referenced by its name.
 See <<concepts-analysis>> for more details about normalizers and full-text analysis.
@@ -175,6 +177,12 @@ i.e. whether the field value is stored in a specific data structure in the index
 to allow aggregations later when querying.
 +
 Value: `Aggregable.YES`, `Aggregable.NO`, `Aggregable.DEFAULT`.
++
+[IMPORTANT]
+====
+This option is not available for `@FullTextField`.
+See <<mapping-directfieldmapping-annotations-fulltextfield,here>> for an explanation and some solutions.
+====
 
 `searchable`::
 Whether the field can be searched on.

--- a/documentation/src/main/asciidoc/reference/search-dsl-aggregation.asciidoc
+++ b/documentation/src/main/asciidoc/reference/search-dsl-aggregation.asciidoc
@@ -55,12 +55,7 @@ include::{sourcedir}/org/hibernate/search/documentation/search/aggregation/Aggre
 
 // Search 5 anchors backward compatibility
 [[example-faceting-entity]]
-[NOTE]
-====
-There are a few constraints regarding aggregations.
-In particular, in order for a field to be "aggregable", it must be <<mapping-directfieldmapping-aggregable,marked as such in the mapping>>,
-so that it is correctly stored in the index.
-====
+include::components/field-aggregation-important.asciidoc[]
 
 // Search 5 anchors backward compatibility
 [[example-restricting-query-results]]
@@ -83,6 +78,8 @@ refer to the following sections.
 == [[discrete-faceting-request]] `terms`: group by the value of a field
 
 The `terms` aggregation returns a count of documents for each term value of a given field.
+
+include::components/field-aggregation-important.asciidoc[]
 
 [NOTE]
 ====
@@ -232,9 +229,11 @@ but that can be <<search-dsl-aggregation-common-filter,controlled explicitly wit
 
 The `range` aggregation returns a count of documents for given ranges of values of a given field.
 
+include::components/field-aggregation-important.asciidoc[]
+
 [NOTE]
 ====
-The `range` aggregation is not available on text fields or geo-point fields.
+The `range` aggregation is not available on geo-point fields.
 ====
 
 .Counting hits grouped by range of values for a field

--- a/documentation/src/main/asciidoc/reference/search-dsl-projection.asciidoc
+++ b/documentation/src/main/asciidoc/reference/search-dsl-projection.asciidoc
@@ -34,13 +34,7 @@ include::{sourcedir}/org/hibernate/search/documentation/search/projection/Projec
 ----
 ====
 
-[NOTE]
-====
-There are a few constraints regarding `field` projections.
-In particular, in order for a field to be "projectable", it must either be <<mapping-directfieldmapping-projectable,explicitly marked as such in the mapping>>,
-or be implicitly projectable based on the underlying backend (Elasticsearch),
-so that it is correctly stored in the index.
-====
+include::components/field-projection-important.asciidoc[]
 
 While `field` projections are certainly the most common,
 they are not the only type of projection.
@@ -178,10 +172,7 @@ The total hit count, however, will not take this omission into account.
 The `field` projection returns the value of a given field for the matched document.
 
 [[search-dsl-projection-field-prerequisites]]
-=== Prerequisites
-
-In order for the `field` projection to be available on a given field,
-you need to mark the field as <<mapping-directfieldmapping-projectable,projectable>> in the mapping.
+include::components/field-projection-important.asciidoc[]
 
 [[search-dsl-projection-field-syntax]]
 === Syntax
@@ -282,10 +273,7 @@ The `distance` projection returns the distance between a given point
 and the geo-point value of a given field for the matched document.
 
 [[search-dsl-projection-distance-prerequisites]]
-=== Prerequisites
-
-In order for the `distance` projection to be available on a given field,
-you need to mark the field as <<mapping-directfieldmapping-projectable,projectable>> in the mapping.
+include::components/field-projection-important.asciidoc[]
 
 [[search-dsl-projection-distance-syntax]]
 === Syntax

--- a/documentation/src/main/asciidoc/reference/search-dsl-sort.asciidoc
+++ b/documentation/src/main/asciidoc/reference/search-dsl-sort.asciidoc
@@ -31,12 +31,7 @@ include::{sourcedir}/org/hibernate/search/documentation/search/sort/SortDslIT.ja
 ----
 ====
 
-[NOTE]
-====
-There are a few constraints regarding sorts by field.
-In particular, in order for a field to be "sortable", it must be <<mapping-directfieldmapping-sortable,marked as such in the mapping>>,
-so that the correct data structures are available in the index.
-====
+include::components/field-sort-important.asciidoc[]
 
 The sort DSL offers more sort types, and multiple options for each type of sort.
 To learn more about the `field` sort, and all the other types of sort,
@@ -107,6 +102,19 @@ See <<search-dsl-sort-stabilize>> for a solution to unstable sorts.
 
 `field` sorts on the value of a given field for each document.
 
+[[search-dsl-sort-field-prerequisites]]
+include::components/field-sort-important.asciidoc[]
+
+[NOTE]
+====
+The values of <<mapping-geopoint,GeoPoint>> fields cannot be compared directly
+and thus the `field` sort cannot be used on those fields.
+
+Refer to the <<search-dsl-sort-distance,distance sort>> for these fields.
+====
+
+The sort order is defined as follows:
+
 * in ascending order (the default), documents with a lower value appear first in the list of hits.
 * in descending order, documents with a higher value appear first in the list of hits.
 
@@ -114,22 +122,6 @@ See <<search-dsl-sort-stabilize>> for a solution to unstable sorts.
 ====
 For text fields, "lower" means "lower in the alphabetical order".
 ====
-
-[[search-dsl-sort-field-prerequisites]]
-=== Prerequisites
-
-In order for the `field` sort to be available on a given field,
-you need to mark the field as <<mapping-directfieldmapping-sortable,sortable>> in the mapping.
-
-<<mapping-geopoint,GeoPoint>> fields cannot be marked as sortable;
-refer to the <<search-dsl-sort-distance,distance sort>> for these fields.
-
-<<mapping-directfieldmapping-annotations-fulltextfield,full-text fields>> (multi-word text fields)
-cannot be marked as sortable;
-you need to use <<mapping-directfieldmapping-annotations-keywordfield,keyword fields>> for text sorts.
-Remember you can <<mapping-directfieldmapping-basics,map a single property to multiple fields with different names>>,
-so you can have a full-text field for predicates along with a keyword field for sorts,
-all for the same property.
 
 [[search-dsl-sort-field-syntax]]
 === Syntax

--- a/documentation/src/test/java/org/hibernate/search/documentation/analysis/DefaultOverridingElasticsearchAnalysisConfigurer.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/analysis/DefaultOverridingElasticsearchAnalysisConfigurer.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+// tag::include[]
+package org.hibernate.search.documentation.analysis;
+
+import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
+import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
+import org.hibernate.search.engine.backend.analysis.AnalyzerNames;
+
+public class DefaultOverridingElasticsearchAnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
+	@Override
+	public void configure(ElasticsearchAnalysisConfigurationContext context) {
+		context.analyzer( AnalyzerNames.DEFAULT ) // <1>
+				.custom() // <2>
+				.tokenizer( "standard" )
+				.tokenFilters( "lowercase", "snowball_french", "asciifolding" );
+
+		context.tokenFilter( "snowball_french" )
+				.type( "snowball" )
+				.param( "language", "French" );
+	}
+}
+// end::include[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/analysis/DefaultOverridingLuceneAnalysisConfigurer.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/analysis/DefaultOverridingLuceneAnalysisConfigurer.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+// tag::include[]
+package org.hibernate.search.documentation.analysis;
+
+import org.hibernate.search.backend.lucene.analysis.LuceneAnalysisConfigurationContext;
+import org.hibernate.search.backend.lucene.analysis.LuceneAnalysisConfigurer;
+import org.hibernate.search.engine.backend.analysis.AnalyzerNames;
+
+public class DefaultOverridingLuceneAnalysisConfigurer implements LuceneAnalysisConfigurer {
+	@Override
+	public void configure(LuceneAnalysisConfigurationContext context) {
+		context.analyzer( AnalyzerNames.DEFAULT ) // <1>
+				.custom() // <2>
+				.tokenizer( "standard" )
+				.tokenFilter( "lowercase" )
+				.tokenFilter( "snowballPorter" )
+						.param( "language", "French" )
+				.tokenFilter( "asciiFolding" );
+	}
+}
+// end::include[]

--- a/documentation/src/test/resources/analysis/elasticsearch-default-override.properties
+++ b/documentation/src/test/resources/analysis/elasticsearch-default-override.properties
@@ -1,0 +1,2 @@
+# <1>
+hibernate.search.backend.analysis.configurer = class:org.hibernate.search.documentation.analysis.DefaultOverridingElasticsearchAnalysisConfigurer

--- a/documentation/src/test/resources/analysis/lucene-default-override.properties
+++ b/documentation/src/test/resources/analysis/lucene-default-override.properties
@@ -1,0 +1,2 @@
+# <1>
+hibernate.search.backend.analysis.configurer = class:org.hibernate.search.documentation.analysis.DefaultOverridingLuceneAnalysisConfigurer

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/FullTextField.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/FullTextField.java
@@ -40,7 +40,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing
  * </ul>
  * <p>
  * If you want to index a non-String value, use the {@link GenericField} annotation instead.
- * If you want to index a String value, but don't want the field to be analyzed, or want it to be sortable,
+ * If you want to index a String value, but don't want the field to be analyzed, or want it to be sortable or aggregable,
  * use the {@link KeywordField} annotation instead.
  */
 @Documented

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/FullTextField.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/FullTextField.java
@@ -91,7 +91,7 @@ public @interface FullTextField {
 
 	/**
 	 * @return Whether this field should be searchable.
-	 * @see GenericField#sortable()
+	 * @see GenericField#searchable()
 	 * @see Searchable
 	 */
 	Searchable searchable() default Searchable.DEFAULT;


### PR DESCRIPTION
* [HSEARCH-4658](https://hibernate.atlassian.net/browse/HSEARCH-4658): Document the syntax of conditions passed to the mass indexer
* [HSEARCH-4653](https://hibernate.atlassian.net/browse/HSEARCH-4653): Document built-in analyzers and how to override them
* [HSEARCH-4646](https://hibernate.atlassian.net/browse/HSEARCH-4646): Document that Spring Boot may create a (wrong) Elasticsearch client just because Hibernate Search adds the Elasticsearch client to the classpath
* [HSEARCH-4554](https://hibernate.atlassian.net/browse/HSEARCH-4554): Update documentation of default credentials provider chain for Elasticsearch AWS
* [HSEARCH-4551](https://hibernate.atlassian.net/browse/HSEARCH-4551): Make the mapping requirements of sorts/projections/aggregations more visible in the documentation

