### PR TITLE
HSEARCH-4612 Disable purgeAllOnStart by default in MassIndexer when dropAndCreateSchemaOnStart is enabled

### DIFF
--- a/documentation/src/main/asciidoc/reference/indexing-massindexer.asciidoc
+++ b/documentation/src/main/asciidoc/reference/indexing-massindexer.asciidoc
@@ -217,7 +217,8 @@ you can also use a schema manager to manage schemas manually at the time of your
 <<schema-management-manager>>.
 
 |`purgeAllOnStart(boolean)`
-|`true`
+|Default value depends on <<indexing-massindexer-parameters-drop-and-create-schema,`dropAndCreateSchemaOnStart(boolean)`>>.
+Defaults to `false` if the mass indexer is configured to drop and create the schema on start, to `true` otherwise.
 |Removes all entities from the indexes before indexing.
 
 Only set this to `false` if you know the index is already empty;

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingBaseIT.java
@@ -144,11 +144,9 @@ public class MassIndexingBaseIT {
 			backendMock.expectSchemaManagementWorks( Book.INDEX )
 					.work( StubSchemaManagementWork.Type.DROP_AND_CREATE );
 
-			// purgeAtStart and mergeSegmentsAfterPurge are enabled by default,
-			// so we expect 1 purge, 1 optimize and 1 flush calls in this order:
+			// because we set dropAndCreateSchemaOnStart = true and do not explicitly set the purge value
+			// it means that purge will default to false hence only flush and refresh are expected:
 			backendMock.expectIndexScaleWorks( Book.INDEX, searchSession.tenantIdentifier() )
-					.purge()
-					.mergeSegments()
 					.flush()
 					.refresh();
 
@@ -196,6 +194,56 @@ public class MassIndexingBaseIT {
 			backendMock.expectIndexScaleWorks( Book.INDEX, searchSession.tenantIdentifier() )
 					.purge()
 					.mergeSegments()
+					.mergeSegments()
+					.flush()
+					.refresh();
+
+			try {
+				indexer.startAndWait();
+			}
+			catch (InterruptedException e) {
+				fail( "Unexpected InterruptedException: " + e.getMessage() );
+			}
+
+		}
+
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void dropAndCreateSchemaOnStartAndPurgeBothEnabled() {
+		try ( SearchSession searchSession = mapping.createSession() ) {
+			MassIndexer indexer = searchSession.massIndexer()
+					// Simulate passing information to connect to a DB, ...
+					.context( StubLoadingContext.class, loadingContext )
+					.dropAndCreateSchemaOnStart( true )
+					.purgeAllOnStart( true );
+
+			// add operations on indexes can follow any random order,
+			// since they are executed by different threads
+			backendMock.expectWorks(
+							Book.INDEX, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
+					)
+					.add( "1", b -> b
+							.field( "title", TITLE_1 )
+							.field( "author", AUTHOR_1 )
+					)
+					.add( "2", b -> b
+							.field( "title", TITLE_2 )
+							.field( "author", AUTHOR_2 )
+					)
+					.add( "3", b -> b
+							.field( "title", TITLE_3 )
+							.field( "author", AUTHOR_3 )
+					);
+
+			backendMock.expectSchemaManagementWorks( Book.INDEX )
+					.work( StubSchemaManagementWork.Type.DROP_AND_CREATE );
+
+			// as purgeAllOnStart is explicitly set to true, and merge is true by default
+			// it means that both purge and merge will be triggered:
+			backendMock.expectIndexScaleWorks( Book.INDEX, searchSession.tenantIdentifier() )
+					.purge()
 					.mergeSegments()
 					.flush()
 					.refresh();

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
@@ -724,4 +724,10 @@ public interface Log extends BasicLogger {
 			value = "Exception while retrieving the Jandex index for JAR '%1$s': %2$s")
 	SearchException errorDiscoveringJandexIndex(Path jarPath, String causeMessage, @Cause Exception cause);
 
+	@LogMessage(level = Logger.Level.WARN)
+	@Message(id = ID_OFFSET + 120,
+			value = "Both \"dropAndCreateSchemaOnStart()\" and \"purgeAllOnStart()\" are enabled. " +
+					"Consider having just one setting enabled as after the index is recreated there is nothing to purge.")
+	void redundantPurgeAfterDrop();
+
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/spi/PojoMassIndexer.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/spi/PojoMassIndexer.java
@@ -84,7 +84,8 @@ public interface PojoMassIndexer {
 	 * Set this to false only if you know there are no
 	 * entities in the indexes: otherwise search results may be duplicated.
 	 * <p>
-	 * Defaults to {@code true}.
+	 * Default value depends on {@link #dropAndCreateSchemaOnStart(boolean)}. Defaults to {@code false} if the mass indexer
+	 * is configured to drop and create the schema on start, to {@code true} otherwise.
 	 * @param purgeAll if {@code true} all entities will be removed from the indexes before starting the indexing
 	 * @return {@code this} for method chaining
 	 */

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/massindexing/MassIndexer.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/massindexing/MassIndexer.java
@@ -96,7 +96,8 @@ public interface MassIndexer {
 	 * Set this to false only if you know there are no
 	 * entities in the indexes: otherwise search results may be duplicated.
 	 * <p>
-	 * Defaults to {@code true}.
+	 * Default value depends on {@link #dropAndCreateSchemaOnStart(boolean)}. Defaults to {@code false} if the mass indexer
+	 * is configured to drop and create the schema on start, to {@code true} otherwise.
 	 * @param purgeAll if {@code true} all entities will be removed from the indexes before starting the indexing
 	 * @return {@code this} for method chaining
 	 */


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HSEARCH-4612

Hey! I thought that it would also be good to log a message if someone enables two settings at the same time, but wasn't sure about the log level... not much else to add about the changes 😃 

Also is this something that we should document in the migration guide? Or as in the end, the results are still the same we don't want to clutter the doc?