### PR TITLE
HSEARCH-4680 + HSEARCH-4681 Upgrade to Elasticsearch 8.4

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
@@ -166,7 +166,7 @@ public class ElasticsearchDialectFactory {
 	}
 
 	private ElasticsearchProtocolDialect createProtocolDialectElasticV8(ElasticsearchVersion version, int minor) {
-		if ( minor > 3 ) {
+		if ( minor > 4 ) {
 			log.unknownElasticsearchVersion( version );
 		}
 		else if ( minor == 0 ) {

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -9,6 +9,9 @@ package org.hibernate.search.backend.elasticsearch.dialect.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.hibernate.search.backend.elasticsearch.ElasticsearchDistributionName;
 import org.hibernate.search.backend.elasticsearch.ElasticsearchVersion;
 import org.hibernate.search.backend.elasticsearch.dialect.model.impl.Elasticsearch56ModelDialect;
@@ -26,866 +29,487 @@ import org.hibernate.search.backend.elasticsearch.dialect.protocol.impl.Elastics
 import org.hibernate.search.backend.elasticsearch.dialect.protocol.impl.Elasticsearch81ProtocolDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.protocol.impl.ElasticsearchProtocolDialect;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 import org.hibernate.search.util.impl.test.rule.ExpectedLog4jLog;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith( Parameterized.class )
 public class ElasticsearchDialectFactoryTest {
+
+	private enum ExpectedOutcome {
+		UNSUPPORTED,
+		AMBIGUOUS,
+		SUCCESS_WITH_WARNING,
+		SUCCESS
+	}
+
+	@Parameterized.Parameters(name = "{0} {1}/{2} => {3}")
+	public static List<Object[]> params() {
+		return Arrays.asList(
+				unsupported( ElasticsearchDistributionName.ELASTIC, "0.90.12" ),
+				unsupported( ElasticsearchDistributionName.ELASTIC, "0.90.12" ),
+				unsupported( ElasticsearchDistributionName.ELASTIC, "1.0.0" ),
+				unsupported( ElasticsearchDistributionName.ELASTIC, "2.0.0" ),
+				unsupported( ElasticsearchDistributionName.ELASTIC, "2.4.4" ),
+				unsupported( ElasticsearchDistributionName.ELASTIC, "5.0.0" ),
+				unsupported( ElasticsearchDistributionName.ELASTIC, "5.2.0" ),
+				ambiguous( ElasticsearchDistributionName.ELASTIC, "5" ),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "5.6", "5.6.12",
+						Elasticsearch56ModelDialect.class, Elasticsearch56ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "5.6.12", "5.6.12",
+						Elasticsearch56ModelDialect.class, Elasticsearch56ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.ELASTIC, "5.7.0", "5.7.0",
+						Elasticsearch56ModelDialect.class, Elasticsearch56ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "6", "6.0.0",
+						Elasticsearch6ModelDialect.class, Elasticsearch60ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "6", "6.3.0",
+						Elasticsearch6ModelDialect.class, Elasticsearch63ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "6", "6.7.0",
+						Elasticsearch6ModelDialect.class, Elasticsearch67ProtocolDialect.class
+				),
+
+				success(
+						ElasticsearchDistributionName.ELASTIC, "6.0", "6.0.0",
+						Elasticsearch6ModelDialect.class, Elasticsearch60ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "6.0.0", "6.0.0",
+						Elasticsearch6ModelDialect.class, Elasticsearch60ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "6.3", "6.3.0",
+						Elasticsearch6ModelDialect.class, Elasticsearch63ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "6.3.0", "6.3.0",
+						Elasticsearch6ModelDialect.class, Elasticsearch63ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "6.4", "6.4.0",
+						Elasticsearch6ModelDialect.class, Elasticsearch64ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "6.4.0", "6.4.0",
+						Elasticsearch6ModelDialect.class, Elasticsearch64ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "6.6", "6.6.0",
+						Elasticsearch6ModelDialect.class, Elasticsearch64ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "6.6.0", "6.6.0",
+						Elasticsearch6ModelDialect.class, Elasticsearch64ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "6.7", "6.7.0",
+						Elasticsearch6ModelDialect.class, Elasticsearch67ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "6.7.0", "6.7.0",
+						Elasticsearch6ModelDialect.class, Elasticsearch67ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "6.8.0", "6.8.0",
+						Elasticsearch6ModelDialect.class, Elasticsearch67ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.ELASTIC, "6.9.0", "6.9.0",
+						Elasticsearch6ModelDialect.class, Elasticsearch67ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.0.0-beta1", "7.0.0-beta1",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7", "7.16.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.0", "7.0.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.0.0", "7.0.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.1", "7.1.1",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.1.1", "7.1.1",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.2", "7.2.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.2.0", "7.2.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.3", "7.3.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.3.0", "7.3.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.4", "7.4.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.4.0", "7.4.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.5", "7.5.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.5.0", "7.5.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.6", "7.6.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.6.0", "7.6.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.6.2", "7.6.2",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.7", "7.7.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.7.0", "7.7.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.8", "7.8.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.8.0", "7.8.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.9", "7.9.2",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.9.0", "7.9.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.9.2", "7.9.2",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.10", "7.10.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.10.0", "7.10.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.11", "7.11.1",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.11.0", "7.11.00",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.11.1", "7.11.1",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.12", "7.12.1",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.12.0", "7.12.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.12.1", "7.12.1",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.13", "7.13.2",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.13.0", "7.13.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.13.2", "7.13.2",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.16", "7.16.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.16.0", "7.16.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.17", "7.17.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "7.17.0", "7.17.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.ELASTIC, "7.18.0", "7.18.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "8", "8.2.0",
+						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "8.0", "8.0.0",
+						Elasticsearch8ModelDialect.class, Elasticsearch80ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "8.0.0", "8.0.0",
+						Elasticsearch8ModelDialect.class, Elasticsearch80ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "8.1", "8.1.0",
+						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "8.1.0", "8.1.0",
+						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "8.2", "8.2.0",
+						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "8.2.0", "8.2.0",
+						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "8.3", "8.3.0",
+						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.ELASTIC, "8.3.0", "8.3.0",
+						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.ELASTIC, "8.4", "8.4.0",
+						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.ELASTIC, "8.4.0", "8.4.0",
+						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.ELASTIC, "9.0.0", "9.0.0",
+						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.OPENSEARCH, "1", "1.2.1",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.OPENSEARCH, "1.0", "1.0.0-rc1",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.OPENSEARCH, "1.0.0-rc1", "1.0.0-rc1",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.OPENSEARCH, "1.0.0", "1.0.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.OPENSEARCH, "1.0.1", "1.0.1",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.OPENSEARCH, "1.2", "1.2.1",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.OPENSEARCH, "1.2.0", "1.2.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.OPENSEARCH, "1.2.1", "1.2.1",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.OPENSEARCH, "1.3", "1.3.1",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.OPENSEARCH, "1.3.0", "1.3.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.OPENSEARCH, "1.3.1", "1.3.1",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.OPENSEARCH, "1.4", "1.4.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.OPENSEARCH, "1.4.0", "1.4.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.OPENSEARCH, "2", "2.0.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.OPENSEARCH, "2.0", "2.0.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				success(
+						ElasticsearchDistributionName.OPENSEARCH, "2.0.0", "2.0.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.OPENSEARCH, "3", "3.0.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.OPENSEARCH, "3.0", "3.0.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.OPENSEARCH, "3.0.0", "3.0.0",
+						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				)
+		);
+	}
+
+	private static Object[] unsupported(ElasticsearchDistributionName distribution, String configuredVersionString) {
+		return new Object[] {
+				distribution, configuredVersionString, null, ExpectedOutcome.UNSUPPORTED, null, null
+		};
+	}
+
+	private static Object[] ambiguous(ElasticsearchDistributionName distribution, String configuredVersionString) {
+		return new Object[] {
+				distribution, configuredVersionString, null, ExpectedOutcome.AMBIGUOUS, null, null
+		};
+	}
+
+	private static Object[] successWithWarning(ElasticsearchDistributionName distribution,
+			String configuredVersionString, String actualVersionString,
+			Class<? extends ElasticsearchModelDialect> expectedModelDialectClass,
+			Class<? extends ElasticsearchProtocolDialect> expectedProtocolDialectClass) {
+		return new Object[] {
+				distribution, configuredVersionString, actualVersionString,
+				ExpectedOutcome.SUCCESS_WITH_WARNING, expectedModelDialectClass, expectedProtocolDialectClass
+		};
+	}
+
+	private static Object[] success(ElasticsearchDistributionName distribution,
+			String configuredVersionString, String actualVersionString,
+			Class<? extends ElasticsearchModelDialect> expectedModelDialectClass,
+			Class<? extends ElasticsearchProtocolDialect> expectedProtocolDialectClass) {
+		return new Object[] {
+				distribution, configuredVersionString, actualVersionString,
+				ExpectedOutcome.SUCCESS, expectedModelDialectClass, expectedProtocolDialectClass
+		};
+	}
 
 	@Rule
 	public ExpectedLog4jLog logged = ExpectedLog4jLog.create();
 
 	private final ElasticsearchDialectFactory dialectFactory = new ElasticsearchDialectFactory();
 
-	@Test
-	public void elastic_0_90_12() {
-		testUnsupported( ElasticsearchDistributionName.ELASTIC, "0.90.12" );
-	}
-
-	@Test
-	public void elastic_1_0_0() {
-		testUnsupported( ElasticsearchDistributionName.ELASTIC, "1.0.0" );
-	}
-
-	@Test
-	public void elastic_2_0_0() {
-		testUnsupported( ElasticsearchDistributionName.ELASTIC, "2.0.0" );
-	}
-
-	@Test
-	public void elastic_2_4_4() {
-		testUnsupported( ElasticsearchDistributionName.ELASTIC, "2.4.4" );
-	}
-
-	@Test
-	public void elastic_5_0_0() {
-		testUnsupported( ElasticsearchDistributionName.ELASTIC, "5.0.0" );
-	}
-
-	@Test
-	public void elastic_5_2_0() {
-		testUnsupported( ElasticsearchDistributionName.ELASTIC, "5.2.0" );
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3563")
-	public void elastic_5() {
-		testAmbiguous( ElasticsearchDistributionName.ELASTIC, "5" );
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3563")
-	public void elastic_5_6() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "5.6", "5.6.12",
-				Elasticsearch56ModelDialect.class, Elasticsearch56ProtocolDialect.class
-		);
-	}
-
-	@Test
-	public void elastic_5_6_12() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "5.6.12", "5.6.12",
-				Elasticsearch56ModelDialect.class, Elasticsearch56ProtocolDialect.class
-		);
-	}
-
-	@Test
-	public void elastic_5_7_0() {
-		testSuccessWithWarning(
-				ElasticsearchDistributionName.ELASTIC, "5.7.0", "5.7.0",
-				Elasticsearch56ModelDialect.class, Elasticsearch56ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3563")
-	public void elastic_6() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "6", "6.0.0",
-				Elasticsearch6ModelDialect.class, Elasticsearch60ProtocolDialect.class
-		);
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "6", "6.3.0",
-				Elasticsearch6ModelDialect.class, Elasticsearch63ProtocolDialect.class
-		);
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "6", "6.7.0",
-				Elasticsearch6ModelDialect.class, Elasticsearch67ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3563")
-	public void elastic_6_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "6.0", "6.0.0",
-				Elasticsearch6ModelDialect.class, Elasticsearch60ProtocolDialect.class
-		);
-	}
-
-	@Test
-	public void elastic_6_0_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "6.0.0", "6.0.0",
-				Elasticsearch6ModelDialect.class, Elasticsearch60ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3352")
-	public void elastic_6_3() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "6.3", "6.3.0",
-				Elasticsearch6ModelDialect.class, Elasticsearch63ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3352")
-	public void elastic_6_3_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "6.3.0", "6.3.0",
-				Elasticsearch6ModelDialect.class, Elasticsearch63ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3791")
-	public void elastic_6_4() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "6.4", "6.4.0",
-				Elasticsearch6ModelDialect.class, Elasticsearch64ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3791")
-	public void elastic_6_4_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "6.4.0", "6.4.0",
-				Elasticsearch6ModelDialect.class, Elasticsearch64ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3563")
-	public void elastic_6_6() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "6.6", "6.6.0",
-				Elasticsearch6ModelDialect.class, Elasticsearch64ProtocolDialect.class
-		);
-	}
-
-	@Test
-	public void elastic_6_6_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "6.6.0", "6.6.0",
-				Elasticsearch6ModelDialect.class, Elasticsearch64ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3563")
-	public void elastic_6_7() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "6.7", "6.7.0",
-				Elasticsearch6ModelDialect.class, Elasticsearch67ProtocolDialect.class
-		);
-	}
-
-	@Test
-	public void elastic_6_7_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "6.7.0", "6.7.0",
-				Elasticsearch6ModelDialect.class, Elasticsearch67ProtocolDialect.class
-		);
-	}
-
-	@Test
-	public void elastic_6_8_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "6.8.0", "6.8.0",
-				Elasticsearch6ModelDialect.class, Elasticsearch67ProtocolDialect.class
-		);
-	}
-
-	@Test
-	public void elastic_6_9_0() {
-		testSuccessWithWarning(
-				ElasticsearchDistributionName.ELASTIC, "6.9.0", "6.9.0",
-				Elasticsearch6ModelDialect.class, Elasticsearch67ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3490")
-	public void elastic_7_0_0_beta1() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.0.0-beta1", "7.0.0-beta1",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3563")
-	public void elastic_7() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7", "7.16.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3563")
-	public void elastic_7_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.0", "7.0.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3490")
-	public void elastic_7_0_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.0.0", "7.0.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3592")
-	public void elastic_7_1() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.1", "7.1.1",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3592")
-	public void elastic_7_1_1() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.1.1", "7.1.1",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3625")
-	public void elastic_7_2() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.2", "7.2.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3625")
-	public void elastic_7_2_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.2.0", "7.2.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3660")
-	public void elastic_7_3() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.3", "7.3.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3660")
-	public void elastic_7_3_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.3.0", "7.3.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3723")
-	public void elastic_7_4() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.4", "7.4.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3723")
-	public void elastic_7_4_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.4.0", "7.4.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3782")
-	public void elastic_7_5() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.5", "7.5.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3782")
-	public void elastic_7_5_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.5.0", "7.5.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3829")
-	public void elastic_7_6() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.6", "7.6.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3829")
-	public void elastic_7_6_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.6.0", "7.6.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3918")
-	public void elastic_7_6_2() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.6.2", "7.6.2",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3918")
-	public void elastic_7_7() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.7", "7.7.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3918")
-	public void elastic_7_7_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.7.0", "7.7.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3956")
-	public void elastic_7_8() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.8", "7.8.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3956")
-	public void elastic_7_8_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.8.0", "7.8.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3984")
-	public void elastic_7_9() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.9", "7.9.2",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3984")
-	public void elastic_7_9_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.9.0", "7.9.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4040")
-	public void elastic_7_9_2() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.9.2", "7.9.2",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4104")
-	public void elastic_7_1_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.10", "7.10.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4104")
-	public void elastic_7_10_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.10.0", "7.10.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4170")
-	public void elastic_7_11() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.11", "7.11.1",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4170")
-	public void elastic_7_11_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.11.0", "7.11.00",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4170")
-	public void elastic_7_11_1() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.11.1", "7.11.1",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4201")
-	public void elastic_7_12() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.12", "7.12.1",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4201")
-	public void elastic_7_12_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.12.0", "7.12.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4201")
-	public void elastic_7_12_1() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.12.1", "7.12.1",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4235")
-	public void elastic_7_13() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.13", "7.13.2",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4235")
-	public void elastic_7_13_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.13.0", "7.13.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4235")
-	public void elastic_7_13_2() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.13.2", "7.13.2",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4340")
-	public void elastic_7_16() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.16", "7.16.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4340")
-	public void elastic_7_16_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.16.0", "7.16.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4473")
-	public void elastic_7_17() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.17", "7.17.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4473")
-	public void elastic_7_17_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "7.17.0", "7.17.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	public void elastic_7_18_0() {
-		testSuccessWithWarning(
-				ElasticsearchDistributionName.ELASTIC, "7.18.0", "7.18.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4475")
-	public void elastic_8() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "8", "8.2.0",
-				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4475")
-	public void elastic_8_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "8.0", "8.0.0",
-				Elasticsearch8ModelDialect.class, Elasticsearch80ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4475")
-	public void elastic_8_0_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "8.0.0", "8.0.0",
-				Elasticsearch8ModelDialect.class, Elasticsearch80ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4505")
-	public void elastic_8_1() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "8.1", "8.1.0",
-				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4505")
-	public void elastic_8_1_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "8.1.0", "8.1.0",
-				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4559")
-	public void elastic_8_2() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "8.2", "8.2.0",
-				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4559")
-	public void elastic_8_2_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "8.2.0", "8.2.0",
-				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4623")
-	public void elastic_8_3() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "8.3", "8.3.0",
-				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4623")
-	public void elastic_8_3_0() {
-		testSuccess(
-				ElasticsearchDistributionName.ELASTIC, "8.3.0", "8.3.0",
-				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4623")
-	public void elastic_8_4() {
-		testSuccessWithWarning(
-				ElasticsearchDistributionName.ELASTIC, "8.4", "8.4.0",
-				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4623")
-	public void elastic_8_4_0() {
-		testSuccessWithWarning(
-				ElasticsearchDistributionName.ELASTIC, "8.4.0", "8.4.0",
-				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
-		);
-	}
-
-	@Test
-	public void elastic_9_0_0() {
-		testSuccessWithWarning(
-				ElasticsearchDistributionName.ELASTIC, "9.0.0", "9.0.0",
-				Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4212")
-	public void openSearch_1() {
-		testSuccess(
-				ElasticsearchDistributionName.OPENSEARCH, "1", "1.2.1",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4212")
-	public void openSearch_1_0() {
-		testSuccess(
-				ElasticsearchDistributionName.OPENSEARCH, "1.0", "1.0.0-rc1",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4212")
-	public void openSearch_1_0_0_rc1() {
-		testSuccess(
-				ElasticsearchDistributionName.OPENSEARCH, "1.0.0-rc1", "1.0.0-rc1",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4212")
-	public void openSearch_1_0_0() {
-		testSuccess(
-				ElasticsearchDistributionName.OPENSEARCH, "1.0.0", "1.0.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4212")
-	public void openSearch_1_0_1() {
-		testSuccess(
-				ElasticsearchDistributionName.OPENSEARCH, "1.0.1", "1.0.1",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4412")
-	public void openSearch_1_2() {
-		testSuccess(
-				ElasticsearchDistributionName.OPENSEARCH, "1.2", "1.2.1",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4412")
-	public void openSearch_1_2_0() {
-		testSuccess(
-				ElasticsearchDistributionName.OPENSEARCH, "1.2.0", "1.2.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4412")
-	public void openSearch_1_2_1() {
-		testSuccess(
-				ElasticsearchDistributionName.OPENSEARCH, "1.2.1", "1.2.1",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4561")
-	public void openSearch_1_3() {
-		testSuccess(
-				ElasticsearchDistributionName.OPENSEARCH, "1.3", "1.3.1",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4561")
-	public void openSearch_1_3_0() {
-		testSuccess(
-				ElasticsearchDistributionName.OPENSEARCH, "1.3.0", "1.3.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4561")
-	public void openSearch_1_3_1() {
-		testSuccess(
-				ElasticsearchDistributionName.OPENSEARCH, "1.3.1", "1.3.1",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4561")
-	public void openSearch_1_4() {
-		testSuccessWithWarning(
-				ElasticsearchDistributionName.OPENSEARCH, "1.4", "1.4.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4561")
-	public void openSearch_1_4_0() {
-		testSuccessWithWarning(
-				ElasticsearchDistributionName.OPENSEARCH, "1.4.0", "1.4.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4562")
-	public void openSearch_2() {
-		testSuccess(
-				ElasticsearchDistributionName.OPENSEARCH, "2", "2.0.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4562")
-	public void openSearch_2_0() {
-		testSuccess(
-				ElasticsearchDistributionName.OPENSEARCH, "2.0", "2.0.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4562")
-	public void openSearch_2_0_0() {
-		testSuccess(
-				ElasticsearchDistributionName.OPENSEARCH, "2.0.0", "2.0.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4562")
-	public void openSearch_3() {
-		testSuccessWithWarning(
-				ElasticsearchDistributionName.OPENSEARCH, "3", "3.0.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4562")
-	public void openSearch_3_0() {
-		testSuccessWithWarning(
-				ElasticsearchDistributionName.OPENSEARCH, "3.0", "3.0.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-4562")
-	public void openSearch_3_0_0() {
-		testSuccessWithWarning(
-				ElasticsearchDistributionName.OPENSEARCH, "3.0.0", "3.0.0",
-				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
-		);
-	}
-
-	private void testUnsupported(ElasticsearchDistributionName distributionName,
-			String unsupportedVersionString) {
+	@Parameterized.Parameter
+	public ElasticsearchDistributionName distributionName;
+	@Parameterized.Parameter(1)
+	public String configuredVersionString;
+	@Parameterized.Parameter(2)
+	public String actualVersionString;
+	@Parameterized.Parameter(3)
+	public ExpectedOutcome expectedOutcome;
+	@Parameterized.Parameter(4)
+	public Class<? extends ElasticsearchModelDialect> expectedModelDialectClass;
+	@Parameterized.Parameter(5)
+	public Class<? extends ElasticsearchProtocolDialect> expectedProtocolDialectClass;
+
+	@Test
+	public void test() {
+		switch ( expectedOutcome ) {
+			case UNSUPPORTED:
+				testUnsupported();
+				break;
+			case AMBIGUOUS:
+				testAmbiguous();
+				break;
+			case SUCCESS_WITH_WARNING:
+				testSuccessWithWarning();
+				break;
+			case SUCCESS:
+				testSuccess();
+				break;
+		}
+	}
+
+	private void testUnsupported() {
 		assertThatThrownBy(
 				() -> dialectFactory.createModelDialect(
-						ElasticsearchVersion.of( distributionName, unsupportedVersionString ) ),
-				"Test unsupported version " + unsupportedVersionString
+						ElasticsearchVersion.of( distributionName, configuredVersionString ) ),
+				"Test unsupported version " + configuredVersionString
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageContaining( "HSEARCH400081" )
-				.hasMessageContaining( "'" + distributionName.toString() + ":" + unsupportedVersionString + "'" );
+				.hasMessageContaining( "'" + distributionName.toString() + ":" + configuredVersionString + "'" );
 	}
 
-	private void testAmbiguous(ElasticsearchDistributionName distributionName, String versionString) {
+	private void testAmbiguous() {
 		assertThatThrownBy(
 				() -> {
-					dialectFactory.createModelDialect( ElasticsearchVersion.of( distributionName, versionString ) );
+					dialectFactory.createModelDialect( ElasticsearchVersion.of( distributionName, configuredVersionString ) );
 				},
-				"Test ambiguous version " + versionString
+				"Test ambiguous version " + configuredVersionString
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageContaining( "HSEARCH400561" )
-				.hasMessageContaining( "Ambiguous Elasticsearch version: '" + distributionName + ":" + versionString + "'." )
+				.hasMessageContaining( "Ambiguous Elasticsearch version: '" + distributionName + ":" + configuredVersionString + "'." )
 				.hasMessageContaining( "Please use a more precise version to remove the ambiguity" );
 	}
 
-	private void testSuccessWithWarning(ElasticsearchDistributionName distributionName,
-			String configuredVersionString, String actualVersionString,
-			Class<? extends ElasticsearchModelDialect> expectedModelDialectClass,
-			Class<? extends ElasticsearchProtocolDialect> expectedProtocolDialectClass) {
+	private void testSuccessWithWarning() {
 		ElasticsearchVersion parsedConfiguredVersion = ElasticsearchVersion.of( distributionName, configuredVersionString );
 		ElasticsearchVersion parsedActualVersion = ElasticsearchVersion.of( distributionName, actualVersionString );
 
@@ -898,10 +522,7 @@ public class ElasticsearchDialectFactoryTest {
 		assertThat( protocolDialect ).isInstanceOf( expectedProtocolDialectClass );
 	}
 
-	private void testSuccess(ElasticsearchDistributionName distributionName,
-			String configuredVersionString, String actualVersionString,
-			Class<? extends ElasticsearchModelDialect> expectedModelDialectClass,
-			Class<? extends ElasticsearchProtocolDialect> expectedProtocolDialectClass) {
+	private void testSuccess() {
 		ElasticsearchVersion parsedConfiguredVersion = ElasticsearchVersion.of( distributionName, configuredVersionString );
 		ElasticsearchVersion parsedActualVersion = ElasticsearchVersion.of( distributionName, actualVersionString );
 

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -291,7 +291,7 @@ public class ElasticsearchDialectFactoryTest {
 						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				success(
-						ElasticsearchDistributionName.ELASTIC, "8", "8.2.0",
+						ElasticsearchDistributionName.ELASTIC, "8", "8.4.0",
 						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
 				),
 				success(
@@ -326,12 +326,20 @@ public class ElasticsearchDialectFactoryTest {
 						ElasticsearchDistributionName.ELASTIC, "8.3.0", "8.3.0",
 						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
 				),
-				successWithWarning(
+				success(
 						ElasticsearchDistributionName.ELASTIC, "8.4", "8.4.0",
 						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
 				),
-				successWithWarning(
+				success(
 						ElasticsearchDistributionName.ELASTIC, "8.4.0", "8.4.0",
+						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.ELASTIC, "8.5", "8.5.0",
+						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.ELASTIC, "8.5.0", "8.5.0",
 						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
 				),
 				successWithWarning(

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -631,7 +631,7 @@
             <properties>
                 <test.elasticsearch.run.elastic.skip>${test.elasticsearch.run.skip}</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.distribution>elastic</test.elasticsearch.connection.distribution>
-                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-8.3}</test.elasticsearch.connection.version>
+                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-8.4}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch712TestDialect</test.elasticsearch.testdialect>
             </properties>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.3+ -->
-        <version.org.elasticsearch.client>8.3.3</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>8.4.0</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-8.3) becomes the default. -->

--- a/pom.xml
+++ b/pom.xml
@@ -205,17 +205,18 @@
         <version.org.elasticsearch.client>8.4.0</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
-             to make sure the corresponding profile (e.g. elasticsearch-8.3) becomes the default. -->
-        <version.org.elasticsearch.compatible.main>${version.org.elasticsearch.latest-8.3}</version.org.elasticsearch.compatible.main>
+             to make sure the corresponding profile (e.g. elasticsearch-8.4) becomes the default. -->
+        <version.org.elasticsearch.compatible.main>${version.org.elasticsearch.latest-8.4}</version.org.elasticsearch.compatible.main>
         <documentation.org.elasticsearch.url>https://www.elastic.co/guide/en/elasticsearch/reference/${parsed-version.org.elasticsearch.compatible.main.majorVersion}.${parsed-version.org.elasticsearch.compatible.main.minorVersion}</documentation.org.elasticsearch.url>
 
         <!-- The versions of Elasticsearch advertised as compatible with Hibernate Search -->
         <!-- Make sure to only mention tested versions here -->
         <!-- Make sure that 7.10 stays explicitly mentioned here, because that's the last open-source version -->
-        <version.org.elasticsearch.compatible.regularly-tested.text>5.6, 6.8, 7.10, 7.17 or 8.3</version.org.elasticsearch.compatible.regularly-tested.text>
+        <version.org.elasticsearch.compatible.regularly-tested.text>5.6, 6.8, 7.10, 7.17 or 8.4</version.org.elasticsearch.compatible.regularly-tested.text>
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
         <version.org.elasticsearch.compatible.not-regularly-tested.text>7.0 or 8.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest micro of each Elasticsearch release line -->
+        <version.org.elasticsearch.latest-8.4>8.4.0</version.org.elasticsearch.latest-8.4>
         <version.org.elasticsearch.latest-8.3>8.3.3</version.org.elasticsearch.latest-8.3>
         <version.org.elasticsearch.latest-8.2>8.2.3</version.org.elasticsearch.latest-8.2>
         <version.org.elasticsearch.latest-8.1>8.1.3</version.org.elasticsearch.latest-8.1>


### PR DESCRIPTION
* [HSEARCH-4681](https://hibernate.atlassian.net/browse/HSEARCH-4681): Add compatibility with Elasticsearch 8.4
* [HSEARCH-4680](https://hibernate.atlassian.net/browse/HSEARCH-4680): Upgrade to Elasticsearch client 8.4

