### PR TITLE
HSEARCH-4642 Upgrade build dependencies to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,7 +352,7 @@
         <version.org.mariadb.jdbc>3.0.7</version.org.mariadb.jdbc>
         <version.mysql.mysql-connector-java>8.0.30</version.mysql.mysql-connector-java>
         <version.com.ibm.db2.jcc>11.5.7.0</version.com.ibm.db2.jcc>
-        <version.com.oracle.database.jdbc>21.6.0.0.1</version.com.oracle.database.jdbc>
+        <version.com.oracle.database.jdbc>21.7.0.0</version.com.oracle.database.jdbc>
         <version.com.microsoft.sqlserver.mssql-jdbc>9.2.1.jre11</version.com.microsoft.sqlserver.mssql-jdbc>
 
         <!-- >>> Performance tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -415,7 +415,7 @@
         <version.scripting.plugin>3.0.0</version.scripting.plugin>
         <version.gpg.plugin>3.0.1</version.gpg.plugin>
         <version.org.codehaus.groovy-jsr223>3.0.12</version.org.codehaus.groovy-jsr223>
-        <version.com.puppycrawl.tools.checkstyle>10.3.2</version.com.puppycrawl.tools.checkstyle>
+        <version.com.puppycrawl.tools.checkstyle>10.3.3</version.com.puppycrawl.tools.checkstyle>
 
         <!-- Asciidoctor -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -374,7 +374,7 @@
 
         <version.assembly.plugin>3.4.2</version.assembly.plugin>
         <version.buildhelper.plugin>3.3.0</version.buildhelper.plugin>
-        <version.checkstyle.plugin>3.1.2</version.checkstyle.plugin>
+        <version.checkstyle.plugin>3.2.0</version.checkstyle.plugin>
         <version.bundle.plugin>5.1.8</version.bundle.plugin>
         <version.clean.plugin>3.2.0</version.clean.plugin>
         <!-- Needing 3.6.2 at least because of MCOMPILER-294 -->

--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,7 @@
         <!-- Sticking to Derby 10.14 for now since later versions require JDK 9+, and we need to test with JDK 8.
              See https://db.apache.org/derby/derby_downloads.html -->
         <version.org.apache.derby>10.14.2.0</version.org.apache.derby>
-        <version.org.postgresql>42.4.2</version.org.postgresql>
+        <version.org.postgresql>42.5.0</version.org.postgresql>
         <version.org.mariadb.jdbc>3.0.7</version.org.mariadb.jdbc>
         <version.mysql.mysql-connector-java>8.0.30</version.mysql.mysql-connector-java>
         <version.com.ibm.db2.jcc>11.5.7.0</version.com.ibm.db2.jcc>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4642

For [HSEARCH-4642](https://hibernate.atlassian.net/browse/HSEARCH-4642), folllows up on #3146, #3148, #3157, #3176, #3189, #3194, #3208