### PR TITLE
Backport HSEARCH-4687 to branch 6.1 - Fix flaky test org.hibernate.search.integrationtest.mapper.orm.coordination.outboxpolling.automaticindexing.OutboxPollingAutomaticIndexingDynamicShardingRebalancingIT(coord-outbox-default-database-cockroachdb) 

### DIFF
--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendIndexingWorkExpectations.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendIndexingWorkExpectations.java
@@ -63,7 +63,7 @@ public final class BackendIndexingWorkExpectations {
 					// are only about in-memory state (i.e. the CallQueues in BackendMock),
 					// so it's fine to poll aggressively every 5ms.
 					.pollInterval( Duration.ofMillis( 5 ) )
-					.atMost( Duration.ofSeconds( 15 ) )
+					.atMost( Duration.ofSeconds( 30 ) )
 					.untilAsserted( assertions );
 		}
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4687
