### PR TITLE
HSEARCH-4642 + HSEARCH-4697 Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
         <version.com.google.code.gson>2.9.1</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.17.94</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, the AWS SDK and in tests (wiremock, ...) -->
-        <version.com.fasterxml.jackson>2.13.3</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.13.4</version.com.fasterxml.jackson>
         <!--
              In the past, there has been jackson-databind bugfix releases without any jackson-core release,
              so we had to use different versions, e.g. jackson-core 2.9.9 and jackson-databind 2.9.9.3.

--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@
              That's why we have two separate properties for jackson versions,
              even though they may have the same value from time to time.
          -->
-        <version.com.fasterxml.jackson.databind>2.13.3</version.com.fasterxml.jackson.databind>
+        <version.com.fasterxml.jackson.databind>2.13.4</version.com.fasterxml.jackson.databind>
         <!-- Reactive-streams: used by the AWS SDK -->
         <version.org.reactivestreams.reactive-streams>1.0.4</version.org.reactivestreams.reactive-streams>
         <!-- slf4j: used by the AWS SDK -->

--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,7 @@
         <version.install.plugin>3.0.1</version.install.plugin>
         <version.io.takari.maven>0.7.7</version.io.takari.maven>
         <version.jandex.plugin>1.2.3</version.jandex.plugin>
-        <version.japicmp.plugin>0.15.7</version.japicmp.plugin>
+        <version.japicmp.plugin>0.16.0</version.japicmp.plugin>
         <version.jar.plugin>3.2.2</version.jar.plugin>
         <version.javadoc.plugin>3.4.1</version.javadoc.plugin>
         <version.jdeps.plugin>0.5.1</version.jdeps.plugin>


### PR DESCRIPTION
* [HSEARCH-4697](https://hibernate.atlassian.net/browse/HSEARCH-4697): Upgrade to Jackson 2.13.4
* [HSEARCH-4642](https://hibernate.atlassian.net/browse/HSEARCH-4642): Upgrade build dependencies to the latest version

