### PR TITLE
HSEARCH-4642 Upgrade build dependencies to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -406,7 +406,7 @@
         <version.gpg.plugin>3.0.1</version.gpg.plugin>
         <version.org.codehaus.groovy-jsr223>3.0.12</version.org.codehaus.groovy-jsr223>
         <version.com.puppycrawl.tools.checkstyle>10.3.3</version.com.puppycrawl.tools.checkstyle>
-        <version.versions.plugin>2.11.0</version.versions.plugin>
+        <version.versions.plugin>2.12.0</version.versions.plugin>
 
         <!-- Asciidoctor -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,7 @@
         <version.org.osgi.core>6.0.0</version.org.osgi.core>
 
         <version.org.hamcrest>2.2</version.org.hamcrest>
-        <version.org.mockito>4.7.0</version.org.mockito>
+        <version.org.mockito>4.8.0</version.org.mockito>
         <version.org.assertj.assertj-core>3.23.1</version.org.assertj.assertj-core>
         <version.org.awaitily>4.2.0</version.org.awaitily>
         <version.org.skyscreamer.jsonassert>1.5.1</version.org.skyscreamer.jsonassert>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4642

For [HSEARCH-4642](https://hibernate.atlassian.net/browse/HSEARCH-4642), folllows up on #3146, #3148, #3157, #3176, #3189, #3194, #3208, #3219, #3234