### PR TITLE
HSEARCH-4642 Upgrade build dependencies to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -405,7 +405,7 @@
         <version.scripting.plugin>3.0.0</version.scripting.plugin>
         <version.gpg.plugin>3.0.1</version.gpg.plugin>
         <version.org.codehaus.groovy-jsr223>3.0.13</version.org.codehaus.groovy-jsr223>
-        <version.com.puppycrawl.tools.checkstyle>10.3.3</version.com.puppycrawl.tools.checkstyle>
+        <version.com.puppycrawl.tools.checkstyle>10.3.4</version.com.puppycrawl.tools.checkstyle>
         <version.versions.plugin>2.12.0</version.versions.plugin>
 
         <!-- Asciidoctor -->

--- a/pom.xml
+++ b/pom.xml
@@ -339,7 +339,7 @@
              See https://db.apache.org/derby/derby_downloads.html -->
         <version.org.apache.derby>10.14.2.0</version.org.apache.derby>
         <version.org.postgresql>42.5.0</version.org.postgresql>
-        <version.org.mariadb.jdbc>3.0.7</version.org.mariadb.jdbc>
+        <version.org.mariadb.jdbc>3.0.8</version.org.mariadb.jdbc>
         <version.mysql.mysql-connector-java>8.0.30</version.mysql.mysql-connector-java>
         <version.com.ibm.db2.jcc>11.5.7.0</version.com.ibm.db2.jcc>
         <version.com.oracle.database.jdbc>21.7.0.0</version.com.oracle.database.jdbc>

--- a/pom.xml
+++ b/pom.xml
@@ -371,7 +371,7 @@
         <version.compiler.plugin>3.10.1</version.compiler.plugin>
         <version.dependency.plugin>3.3.0</version.dependency.plugin>
         <!-- Check dependencies for security vulnerabilities -->
-        <version.dependency-check.plugin>7.2.0</version.dependency-check.plugin>
+        <version.dependency-check.plugin>7.2.1</version.dependency-check.plugin>
         <version.deploy.plugin>3.0.0</version.deploy.plugin>
         <version.org.eclipse.m2e.lifecycle-mapping>1.0.0</version.org.eclipse.m2e.lifecycle-mapping>
         <version.enforcer.plugin>3.1.0</version.enforcer.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -413,7 +413,7 @@
         <version.asciidoctor.plugin>2.2.2</version.asciidoctor.plugin>
         <version.org.hibernate.infra.hibernate-asciidoctor-theme>1.0.4.Final</version.org.hibernate.infra.hibernate-asciidoctor-theme>
         <version.org.jruby>9.3.2.0</version.org.jruby>
-        <version.org.asciidoctor.asciidoctorj>2.5.5</version.org.asciidoctor.asciidoctorj>
+        <version.org.asciidoctor.asciidoctorj>2.5.6</version.org.asciidoctor.asciidoctorj>
         <version.org.asciidoctor.asciidoctorj-pdf>1.5.0-alpha.18</version.org.asciidoctor.asciidoctorj-pdf>
 
         <!-- Maven Central repository -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4642

For [HSEARCH-4642](https://hibernate.atlassian.net/browse/HSEARCH-4642), folllows up on #3146, #3148, #3157, #3176, #3189, #3194, #3208, #3219, #3234, #3239, #3249