### PR TITLE
Backport HSEARCH-4707 to branch 6.1 - Upgrade to Hibernate ORM 5.6.12.Final

### DIFF
--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/FilteringOutboxEventFinder.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/FilteringOutboxEventFinder.java
@@ -95,16 +95,8 @@ public class FilteringOutboxEventFinder {
 		allowedIds.clear();
 	}
 
-	public List<OutboxEvent> findOutboxEventsNoFilter(Session session) {
-		checkFiltering();
-		Query<OutboxEvent> query = session.createQuery(
-				"select e from " + ENTITY_NAME + " e order by e.id", OutboxEvent.class );
-		avoidLockingConflicts( query );
-		return query.list();
-	}
-
 	// Orders events by ID, regardless of what order is used when processing them.
-	public List<OutboxEvent> findOutboxEventsNoFilterOrderById(Session session) {
+	public List<OutboxEvent> findOutboxEventsNoFilter(Session session) {
 		checkFiltering();
 		Query<OutboxEvent> query = session.createQuery(
 				"select e from " + ENTITY_NAME + " e order by e.id", OutboxEvent.class );

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/FilteringOutboxEventFinder.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/FilteringOutboxEventFinder.java
@@ -11,10 +11,10 @@ import static org.awaitility.Awaitility.await;
 import static org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl.OutboxPollingOutboxEventAdditionalJaxbMappingProducer.ENTITY_NAME;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.hibernate.LockOptions;
 import org.hibernate.Session;
@@ -29,8 +29,8 @@ import org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl.Out
 
 public class FilteringOutboxEventFinder {
 
-	private boolean filter = true;
-	private final Set<Long> allowedIds = new HashSet<>();
+	private volatile boolean filter = true;
+	private final Set<Long> allowedIds = ConcurrentHashMap.newKeySet();
 
 	public FilteringOutboxEventFinder() {
 	}

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingOutOfOrderIdsIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingOutOfOrderIdsIT.java
@@ -88,7 +88,7 @@ public class OutboxPollingAutomaticIndexingOutOfOrderIdsIT {
 		} );
 
 		OrmUtils.withinSession( sessionFactory, session -> {
-			List<OutboxEvent> events = outboxEventFinder.findOutboxEventsNoFilterOrderById( session );
+			List<OutboxEvent> events = outboxEventFinder.findOutboxEventsNoFilter( session );
 			assertThat( events ).hasSize( 3 );
 			// Correct order when ordered by id (you'll have to trust me on that)
 			// add
@@ -107,7 +107,7 @@ public class OutboxPollingAutomaticIndexingOutOfOrderIdsIT {
 		} );
 
 		OrmUtils.withinSession( sessionFactory, session -> {
-			List<OutboxEvent> events = outboxEventFinder.findOutboxEventsNoFilterOrderById( session );
+			List<OutboxEvent> events = outboxEventFinder.findOutboxEventsNoFilter( session );
 			assertThat( events ).hasSize( 3 );
 			// Out-of-order when ordered by id (you'll have to trust me on that)
 			// delete
@@ -199,7 +199,7 @@ public class OutboxPollingAutomaticIndexingOutOfOrderIdsIT {
 		} );
 
 		OrmUtils.withinSession( sessionFactory, session -> {
-			List<OutboxEvent> events = outboxEventFinder.findOutboxEventsNoFilterOrderById( session );
+			List<OutboxEvent> events = outboxEventFinder.findOutboxEventsNoFilter( session );
 			assertThat( events ).hasSize( 2 );
 			// Correct order when ordered by id (you'll have to trust me on that)
 			// delete
@@ -216,7 +216,7 @@ public class OutboxPollingAutomaticIndexingOutOfOrderIdsIT {
 		} );
 
 		OrmUtils.withinSession( sessionFactory, session -> {
-			List<OutboxEvent> events = outboxEventFinder.findOutboxEventsNoFilterOrderById( session );
+			List<OutboxEvent> events = outboxEventFinder.findOutboxEventsNoFilter( session );
 			assertThat( events ).hasSize( 2 );
 			// Out-of-order when ordered by id (you'll have to trust me on that)
 			// add
@@ -312,7 +312,7 @@ public class OutboxPollingAutomaticIndexingOutOfOrderIdsIT {
 		} );
 
 		OrmUtils.withinSession( sessionFactory, session -> {
-			List<OutboxEvent> events = outboxEventFinder.findOutboxEventsNoFilterOrderById( session );
+			List<OutboxEvent> events = outboxEventFinder.findOutboxEventsNoFilter( session );
 			assertThat( events ).hasSize( 2 );
 			// Correct order when ordered by id
 			OutboxPollingAutomaticIndexingEventSendingIT.verifyOutboxEntry( events.get( 0 ), RoutedIndexedEntity.NAME, "1",
@@ -332,7 +332,7 @@ public class OutboxPollingAutomaticIndexingOutOfOrderIdsIT {
 		} );
 
 		OrmUtils.withinSession( sessionFactory, session -> {
-			List<OutboxEvent> events = outboxEventFinder.findOutboxEventsNoFilterOrderById( session );
+			List<OutboxEvent> events = outboxEventFinder.findOutboxEventsNoFilter( session );
 			assertThat( events ).hasSize( 2 );
 			// Out-of-order when ordered by id
 			OutboxPollingAutomaticIndexingEventSendingIT.verifyOutboxEntry( events.get( 0 ), RoutedIndexedEntity.NAME, "1",

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedEagerOnBothSidesIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedEagerOnBothSidesIT.java
@@ -69,31 +69,31 @@ public class AutomaticIndexingOneToOneOwnedByContainedEagerOnBothSidesIT
 
 	@Override
 	public void directAssociationUpdate_indexedEmbedded() {
-		notTestedBecauseOfHSEARCH4305();
+		notTestedBecauseOfHSEARCH4305AndHSEARCH4708();
 	}
 
 	@Override
 	public void directAssociationUpdate_indexedEmbeddedShallowReindexOnUpdate() {
-		notTestedBecauseOfHSEARCH4305();
+		notTestedBecauseOfHSEARCH4305AndHSEARCH4708();
 	}
 
 	@Override
 	public void indirectAssociationUpdate_indexedEmbedded() {
-		notTestedBecauseOfHSEARCH4305();
+		notTestedBecauseOfHSEARCH4305AndHSEARCH4708();
 	}
 
 	@Override
 	public void indirectAssociationUpdate_indexedEmbeddedShallowReindexOnUpdate() {
-		notTestedBecauseOfHSEARCH4305();
+		notTestedBecauseOfHSEARCH4305AndHSEARCH4708();
 	}
 
 	@Override
 	public void indirectAssociationUpdate_usedInCrossEntityDerivedProperty() {
-		notTestedBecauseOfHSEARCH4305();
+		notTestedBecauseOfHSEARCH4305AndHSEARCH4708();
 	}
 
-	private void notTestedBecauseOfHSEARCH4305() {
-		assumeTrue( "Association update tests fail because of https://hibernate.atlassian.net/browse/HSEARCH-4305",
+	private void notTestedBecauseOfHSEARCH4305AndHSEARCH4708() {
+		assumeTrue( "Association update tests fail because of https://hibernate.atlassian.net/browse/HSEARCH-4305 / https://hibernate.atlassian.net/browse/HSEARCH-4708",
 				false );
 	}
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedLazyOnContainedSideIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedLazyOnContainedSideIT.java
@@ -71,31 +71,31 @@ public class AutomaticIndexingOneToOneOwnedByContainedLazyOnContainedSideIT
 
 	@Override
 	public void directAssociationUpdate_indexedEmbedded() {
-		notTestedBecauseOfHSEARCH4305();
+		notTestedBecauseOfHSEARCH4305AndHSEARCH4708();
 	}
 
 	@Override
 	public void directAssociationUpdate_indexedEmbeddedShallowReindexOnUpdate() {
-		notTestedBecauseOfHSEARCH4305();
+		notTestedBecauseOfHSEARCH4305AndHSEARCH4708();
 	}
 
 	@Override
 	public void indirectAssociationUpdate_indexedEmbedded() {
-		notTestedBecauseOfHSEARCH4305();
+		notTestedBecauseOfHSEARCH4305AndHSEARCH4708();
 	}
 
 	@Override
 	public void indirectAssociationUpdate_indexedEmbeddedShallowReindexOnUpdate() {
-		notTestedBecauseOfHSEARCH4305();
+		notTestedBecauseOfHSEARCH4305AndHSEARCH4708();
 	}
 
 	@Override
 	public void indirectAssociationUpdate_usedInCrossEntityDerivedProperty() {
-		notTestedBecauseOfHSEARCH4305();
+		notTestedBecauseOfHSEARCH4305AndHSEARCH4708();
 	}
 
-	private void notTestedBecauseOfHSEARCH4305() {
-		assumeTrue( "Association update tests fail because of https://hibernate.atlassian.net/browse/HSEARCH-4305",
+	private void notTestedBecauseOfHSEARCH4305AndHSEARCH4708() {
+		assumeTrue( "Association update tests fail because of https://hibernate.atlassian.net/browse/HSEARCH-4305 / https://hibernate.atlassian.net/browse/HSEARCH-4708",
 				false );
 	}
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedLazyOnContainingSideIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedLazyOnContainingSideIT.java
@@ -71,31 +71,31 @@ public class AutomaticIndexingOneToOneOwnedByContainedLazyOnContainingSideIT
 
 	@Override
 	public void directAssociationUpdate_indexedEmbedded() {
-		notTestedBecauseOfHSEARCH4305();
+		notTestedBecauseOfHSEARCH4305AndHSEARCH4708();
 	}
 
 	@Override
 	public void directAssociationUpdate_indexedEmbeddedShallowReindexOnUpdate() {
-		notTestedBecauseOfHSEARCH4305();
+		notTestedBecauseOfHSEARCH4305AndHSEARCH4708();
 	}
 
 	@Override
 	public void indirectAssociationUpdate_indexedEmbedded() {
-		notTestedBecauseOfHSEARCH4305();
+		notTestedBecauseOfHSEARCH4305AndHSEARCH4708();
 	}
 
 	@Override
 	public void indirectAssociationUpdate_indexedEmbeddedShallowReindexOnUpdate() {
-		notTestedBecauseOfHSEARCH4305();
+		notTestedBecauseOfHSEARCH4305AndHSEARCH4708();
 	}
 
 	@Override
 	public void indirectAssociationUpdate_usedInCrossEntityDerivedProperty() {
-		notTestedBecauseOfHSEARCH4305();
+		notTestedBecauseOfHSEARCH4305AndHSEARCH4708();
 	}
 
-	private void notTestedBecauseOfHSEARCH4305() {
-		assumeTrue( "Association update tests fail because of https://hibernate.atlassian.net/browse/HSEARCH-4305",
+	private void notTestedBecauseOfHSEARCH4305AndHSEARCH4708() {
+		assumeTrue( "Association update tests fail because of https://hibernate.atlassian.net/browse/HSEARCH-4305 / https://hibernate.atlassian.net/browse/HSEARCH-4708",
 				false );
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
         <version.org.slf4j>1.7.35</version.org.slf4j>
 
         <!-- >>> ORM -->
-        <version.org.hibernate>5.6.11.Final</version.org.hibernate>
+        <version.org.hibernate>5.6.12.Final</version.org.hibernate>
         <javadoc.org.hibernate.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.majorVersion}.${parsed-version.org.hibernate.minorVersion}/javadocs/</javadoc.org.hibernate.url>
         <documentation.org.hibernate.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.majorVersion}.${parsed-version.org.hibernate.minorVersion}/userguide/html_single/Hibernate_User_Guide.html</documentation.org.hibernate.url>
         <!-- These version must be kept in sync with the version of the dependency in Hibernate ORM.


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4707

Backport of #3256 to branch 6.1.