### PR TITLE
HSEARCH-4713 Upgrade to Elasticsearch client 8.4.3 and test against Elasticsearch 8.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
         <version.org.elasticsearch.compatible.not-regularly-tested.text>7.0 or 8.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest micro of each Elasticsearch release line -->
-        <version.org.elasticsearch.latest-8.4>8.4.2</version.org.elasticsearch.latest-8.4>
+        <version.org.elasticsearch.latest-8.4>8.4.3</version.org.elasticsearch.latest-8.4>
         <version.org.elasticsearch.latest-8.3>8.3.3</version.org.elasticsearch.latest-8.3>
         <version.org.elasticsearch.latest-8.2>8.2.3</version.org.elasticsearch.latest-8.2>
         <version.org.elasticsearch.latest-8.1>8.1.3</version.org.elasticsearch.latest-8.1>

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.4+ -->
-        <version.org.elasticsearch.client>8.4.2</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>8.4.3</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-8.4) becomes the default. -->

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/Elasticsearch712TestDialect.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/Elasticsearch712TestDialect.java
@@ -188,6 +188,9 @@ public class Elasticsearch712TestDialect implements ElasticsearchTestDialect {
 	@Override
 	public boolean hasBugForDateFormattedAsYear() {
 		// https://github.com/elastic/elasticsearch/issues/90187
-		return ElasticsearchVersion.of( "elastic:8.4.2" ).matches( ElasticsearchTestDialect.getActualVersion() );
+		// Seems like this was fixed in 8.5.1 and they won't backport to 8.4:
+		// https://github.com/elastic/elasticsearch/pull/90458
+		return ElasticsearchVersion.of( "elastic:8.4.2" ).matches( ElasticsearchTestDialect.getActualVersion() )
+				|| ElasticsearchVersion.of( "elastic:8.4.3" ).matches( ElasticsearchTestDialect.getActualVersion() );
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4713
