### PR TITLE
HSEARCH-4690 Change to -faststart Oracle DB container

### DIFF
--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -759,7 +759,7 @@
             <id>ci-oracle</id>
             <properties>
                 <test.database.run.oracle.skip>${test.database.run.skip}</test.database.run.oracle.skip>
-                <db.dialect>org.hibernate.dialect.Oracle10gDialect</db.dialect>
+                <db.dialect>org.hibernate.dialect.Oracle12cDialect</db.dialect>
                 <jdbc.driver.groupId>com.oracle.database.jdbc</jdbc.driver.groupId>
                 <jdbc.driver.artifactId>ojdbc8</jdbc.driver.artifactId>
                 <jdbc.driver>oracle.jdbc.OracleDriver</jdbc.driver>

--- a/pom.xml
+++ b/pom.xml
@@ -650,7 +650,7 @@
         <test.database.run.oracle.skip>true</test.database.run.oracle.skip>
         <!-- See https://hub.docker.com/r/gvenzl/oracle-xe -->
         <test.database.run.oracle.image.name>gvenzl/oracle-xe</test.database.run.oracle.image.name>
-        <test.database.run.oracle.image.tag>11-slim</test.database.run.oracle.image.tag>
+        <test.database.run.oracle.image.tag>21-slim-faststart</test.database.run.oracle.image.tag>
         <!-- MS SQL Server -->
         <test.database.run.mssql.skip>true</test.database.run.mssql.skip>
         <test.database.run.mssql.image.name>mcr.microsoft.com/mssql/server</test.database.run.mssql.image.name>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4690

This seems suspiciously complex 😃. Here's the sample of startups for this container: 

```
old (11-slim) - 30sec:
08:24:36.416 Oracle Database:CONTAINER: starting up...
08:25:06.636 Oracle Database:DATABASE IS READY TO USE!

new (11-slim-faststart) - 29sec:
08:09:22.312 Oracle Database:CONTAINER: starting up...
08:09:51.890 Oracle Database:DATABASE IS READY TO USE!

new 2 (21-slim-faststart)
09:05:58.519 Oracle Database:CONTAINER: starting up...
09:06:57.819 Oracle Database:DATABASE IS READY TO USE!
```
and size:
```
REPOSITORY         TAG                 IMAGE ID       CREATED       SIZE
gvenzl/oracle-xe   21-slim-faststart   d0c4e41a4b77   5 weeks ago   4.94GB
gvenzl/oracle-xe   21-slim             20984e622219   5 weeks ago   2.07GB
gvenzl/oracle-xe   11-slim-faststart   d99bddddf5ff   5 weeks ago   1.66GB
gvenzl/oracle-xe   11-slim             3d46ecb79969   5 weeks ago   605MB
```
Looks like they are pretty close, but maybe there'll be a better difference on CI? 21 is almost double the time 😨 and size.... 21 non -fastsart is 3-4 sec slower.

