### PR TITLE
HSEARCH-4714 add property path value validation

### DIFF
--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/IncorrectPropertyNameObjectPathIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/IncorrectPropertyNameObjectPathIT.java
@@ -1,0 +1,98 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.mapping;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Collection;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.AssociationInverseSide;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyValue;
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.pojo.standalone.StandalonePojoMappingSetupHelper;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+public class IncorrectPropertyNameObjectPathIT {
+	private static final String BROKEN_PATH_WITH_DOTS = "broken.path.with.dots";
+	@Rule
+	public BackendMock defaultBackendMock = new BackendMock();
+
+	@Rule
+	public StandalonePojoMappingSetupHelper setupHelper = StandalonePojoMappingSetupHelper.withBackendMock(
+			MethodHandles.lookup(),
+			defaultBackendMock
+	);
+
+	@Test
+	public void brokenPathWithDotsThrowsException() {
+		assertThatThrownBy( () -> {
+			setupHelper.start()
+					.withAnnotatedEntityType( Person.class, Person.ENTITY_NAME )
+					.withAnnotatedEntityType( PhoneNumber.class, PhoneNumber.ENTITY_NAME )
+					.setup();
+		} ).isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Property name '" + BROKEN_PATH_WITH_DOTS + "' is invalid." );
+	}
+
+
+	@Indexed(index = Person.INDEX_NAME)
+	private static class Person {
+		public static final String ENTITY_NAME = "PersonEntity";
+		public static final String INDEX_NAME = "Person";
+
+		@DocumentId
+		private Integer id;
+		@GenericField
+		private String name;
+
+		private Collection<PhoneNumber> phoneNumbers;
+
+		public Person() {
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+
+	private static class PhoneNumber {
+		public static final String ENTITY_NAME = "PhoneNumber";
+
+		private Integer id;
+		@GenericField
+		private String number;
+		@AssociationInverseSide(inversePath = @ObjectPath(@PropertyValue(propertyName = BROKEN_PATH_WITH_DOTS)))
+		private Person owner;
+
+		public PhoneNumber() {
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getNumber() {
+			return number;
+		}
+
+		public Person getOwner() {
+			return owner;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/IncorrectPropertyNameObjectPathIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/IncorrectPropertyNameObjectPathIT.java
@@ -43,7 +43,11 @@ public class IncorrectPropertyNameObjectPathIT {
 					.withAnnotatedEntityType( PhoneNumber.class, PhoneNumber.ENTITY_NAME )
 					.setup();
 		} ).isInstanceOf( SearchException.class )
-				.hasMessageContaining( "Property name '" + BROKEN_PATH_WITH_DOTS + "' is invalid." );
+				.hasMessageContainingAll(
+						"propertyName=\"" + BROKEN_PATH_WITH_DOTS + "\"",
+						"Invalid ObjectPath encountered",
+						"Property name '" + BROKEN_PATH_WITH_DOTS + "' cannot contain dots."
+				);
 	}
 
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
@@ -24,6 +24,7 @@ import org.hibernate.search.mapper.pojo.extractor.ContainerExtractor;
 import org.hibernate.search.mapper.pojo.logging.spi.PojoConstructorModelFormatter;
 import org.hibernate.search.mapper.pojo.logging.spi.PojoModelPathFormatter;
 import org.hibernate.search.mapper.pojo.logging.spi.PojoTypeModelFormatter;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
 import org.hibernate.search.mapper.pojo.mapping.impl.PojoContainedTypeManager;
 import org.hibernate.search.mapper.pojo.mapping.impl.PojoIndexedTypeManager;
 import org.hibernate.search.mapper.pojo.model.path.PojoModelPathValueNode;
@@ -738,5 +739,9 @@ public interface Log extends BasicLogger {
 			value = "Both \"dropAndCreateSchemaOnStart()\" and \"purgeAllOnStart()\" are enabled. " +
 					"Consider having just one setting enabled as after the index is recreated there is nothing to purge.")
 	void redundantPurgeAfterDrop();
+
+	@Message(id = ID_OFFSET + 121,
+			value = "Invalid ObjectPath encountered '%1$s': %2$s")
+	SearchException invalidObjectPath(ObjectPath path, String causeMessage, @Cause Exception cause);
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/AbstractMappingAnnotationProcessorContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/AbstractMappingAnnotationProcessorContext.java
@@ -6,19 +6,24 @@
  */
 package org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.impl;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Optional;
 
 import org.hibernate.search.engine.environment.bean.BeanReference;
 import org.hibernate.search.engine.environment.bean.BeanRetrieval;
 import org.hibernate.search.mapper.pojo.extractor.mapping.annotation.ContainerExtraction;
 import org.hibernate.search.mapper.pojo.extractor.mapping.programmatic.ContainerExtractorPath;
+import org.hibernate.search.mapper.pojo.logging.impl.Log;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.MappingAnnotationProcessorContext;
 import org.hibernate.search.mapper.pojo.model.path.PojoModelPathValueNode;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 import org.hibernate.search.util.common.reflect.spi.AnnotationHelper;
 
 public abstract class AbstractMappingAnnotationProcessorContext
 		implements MappingAnnotationProcessorContext {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	protected final AnnotationHelper annotationHelper;
 
@@ -28,7 +33,12 @@ public abstract class AbstractMappingAnnotationProcessorContext
 
 	@Override
 	public Optional<PojoModelPathValueNode> toPojoModelPathValueNode(ObjectPath objectPath) {
-		return MappingAnnotationProcessorUtils.toPojoModelPathValueNode( objectPath );
+		try {
+			return MappingAnnotationProcessorUtils.toPojoModelPathValueNode( objectPath );
+		}
+		catch (IllegalArgumentException e) {
+			throw log.invalidObjectPath( objectPath, e.getMessage(), e );
+		}
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/path/PojoModelPath.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/path/PojoModelPath.java
@@ -30,7 +30,7 @@ public abstract class PojoModelPath {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private static final Pattern DOT_PATTERN = Pattern.compile( "\\." );
+	protected static final Pattern DOT_PATTERN = Pattern.compile( "\\." );
 
 	/**
 	 * @return A builder allowing to create a {@link PojoModelPath}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/path/PojoModelPathPropertyNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/path/PojoModelPathPropertyNode.java
@@ -6,10 +6,13 @@
  */
 package org.hibernate.search.mapper.pojo.model.path;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Objects;
 
 import org.hibernate.search.mapper.pojo.extractor.mapping.programmatic.ContainerExtractorPath;
 import org.hibernate.search.util.common.impl.Contracts;
+import org.hibernate.search.util.common.logging.impl.Log;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 /**
  * A node in a {@link PojoModelPath} representing a property.
@@ -21,12 +24,18 @@ import org.hibernate.search.util.common.impl.Contracts;
  */
 public final class PojoModelPathPropertyNode extends PojoModelPath {
 
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
 	private final PojoModelPathValueNode parent;
 	private final String propertyName;
 
 	PojoModelPathPropertyNode(PojoModelPathValueNode parent, String propertyName) {
-		this.parent = parent;
 		Contracts.assertNotNullNorEmpty( propertyName, "propertyName" );
+		if ( DOT_PATTERN.matcher( propertyName ).find() ) {
+			throw log.propertyNameCannotContainDots( propertyName );
+		}
+
+		this.parent = parent;
 		this.propertyName = propertyName;
 	}
 

--- a/mapper/pojo-base/src/test/java/org/hibernate/search/mapper/pojo/model/path/PojoModelPathTest.java
+++ b/mapper/pojo-base/src/test/java/org/hibernate/search/mapper/pojo/model/path/PojoModelPathTest.java
@@ -36,6 +36,11 @@ public class PojoModelPathTest {
 				() -> PojoModelPath.ofProperty( "" )
 		)
 				.isInstanceOf( IllegalArgumentException.class );
+
+		assertThatThrownBy(
+				() -> PojoModelPath.ofProperty( "foo.bar" )
+		)
+				.isInstanceOf( IllegalArgumentException.class );
 	}
 
 	@Test

--- a/util/common/src/main/java/org/hibernate/search/util/common/impl/Contracts.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/impl/Contracts.java
@@ -60,4 +60,5 @@ public final class Contracts {
 			throw log.collectionMustNotContainNullElement( collectionDescription );
 		}
 	}
+
 }

--- a/util/common/src/main/java/org/hibernate/search/util/common/logging/impl/Log.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/logging/impl/Log.java
@@ -121,4 +121,6 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET + 14, value = "Exception while building Jandex index for '%1$s': %2$s")
 	SearchException errorBuildingJandexIndex(Path jarOrDirectoryPath, String message, @Cause Throwable e);
 
+	@Message(id = ID_OFFSET + 15, value = "Property name '%1$s' cannot contain dots.")
+	IllegalArgumentException propertyNameCannotContainDots(String propertyName);
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4714

this would produce something like the following:
```
3:41:28,715 (main) ERROR RootFailureCollector:231 - HSEARCH000521: Hibernate Search encountered a failure during bootstrap; continuing for now to list all problems, but the process will ultimately be aborted.
Context: Standalone POJO mapping, type 'org.hibernate.search.integrationtest.mapper.pojo.mapping.IncorrectPropertyNameObjectPathIT$PhoneNumber', path '.owner', annotation '@org.hibernate.search.mapper.pojo.mapping.definition.annotation.AssociationInverseSide(extraction=@org.hibernate.search.mapper.pojo.extractor.mapping.annotation.ContainerExtraction(value={}, extract=DEFAULT), inversePath=@org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath({@org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyValue(extraction=@org.hibernate.search.mapper.pojo.extractor.mapping.annotation.ContainerExtraction(value={}, extract=DEFAULT), propertyName="broken.path.with.dots")}))'
Failure:
org.hibernate.search.util.common.SearchException: HSEARCH700121: Invalid ObjectPath encountered '@org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath({@org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyValue(extraction=@org.hibernate.search.mapper.pojo.extractor.mapping.annotation.ContainerExtraction(value={}, extract=DEFAULT), propertyName="broken.path.with.dots")})'. See cause for details.
	at org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.impl.AbstractMappingAnnotationProcessorContext.toPojoModelPathValueNode(AbstractMappingAnnotationProcessorContext.java:40) ~[classes/:?]
.....
Caused by: java.lang.IllegalArgumentException: HSEARCH900015: Property name 'broken.path.with.dots' is invalid. The value must match a property in a corresponding class.
	at org.hibernate.search.util.common.impl.Contracts.assertTrue(Contracts.java:66) ~[classes/:?]
	at org.hibernate.search.mapper.pojo.model.path.PojoModelPathPropertyNode.<init>(PojoModelPathPropertyNode.java:30) ~[classes/:?]
...
```