### PR TITLE
HSEARCH-4669 add more context to constructor pojection exception

### DIFF
--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
@@ -33,6 +33,7 @@ import org.hibernate.search.mapper.pojo.model.spi.PojoConstructorModel;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeModel;
 import org.hibernate.search.mapper.pojo.model.spi.PojoTypeModel;
+import org.hibernate.search.mapper.pojo.search.definition.impl.ConstructorProjectionApplicationException;
 import org.hibernate.search.mapper.pojo.search.definition.impl.PojoConstructorProjectionDefinition;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.common.data.impl.LinkedNode;
@@ -47,6 +48,8 @@ import org.hibernate.search.util.common.reporting.EventContext;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
+
+import static org.hibernate.search.mapper.pojo.search.definition.impl.PojoConstructorProjectionDefinition.ProjectionConstructorPath;
 import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
 import org.jboss.logging.annotations.Cause;
@@ -757,4 +760,11 @@ public interface Log extends BasicLogger {
 	void failedToCreateImplicitReindexingAssociationInverseSideResolverNode(
 			Map<PojoRawTypeModel<?>, PojoModelPathValueNode> inversePathByInverseType, @FormatWith(EventContextFormatter.class) EventContext context,
 			String causeMessage, @Cause Exception cause);
+
+	@Message(id = ID_OFFSET + 123,
+			value = "Could not apply projection constructor: %1$s")
+	ConstructorProjectionApplicationException errorApplyingProjectionConstructor(
+			String causeMessage,
+			@Cause Exception cause,
+			@Param ProjectionConstructorPath path);
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/reporting/impl/PojoConstructorProjectionDefinitionMessages.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/reporting/impl/PojoConstructorProjectionDefinitionMessages.java
@@ -1,0 +1,28 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.reporting.impl;
+
+import org.hibernate.search.util.common.logging.impl.MessageConstants;
+
+import org.jboss.logging.Messages;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageBundle;
+
+/**
+ * Message bundle for constructor projections in the POJO mapper.
+ */
+@MessageBundle(projectCode = MessageConstants.PROJECT_CODE)
+public interface PojoConstructorProjectionDefinitionMessages {
+
+	PojoConstructorProjectionDefinitionMessages INSTANCE = Messages.getBundle(
+			PojoConstructorProjectionDefinitionMessages.class
+	);
+
+	@Message(value = "Executed constructor path:")
+	String executedConstructorPath();
+
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/search/definition/impl/ConstructorProjectionApplicationException.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/search/definition/impl/ConstructorProjectionApplicationException.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.search.definition.impl;
+
+import static org.hibernate.search.mapper.pojo.search.definition.impl.PojoConstructorProjectionDefinition.ProjectionConstructorPath;
+
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.common.annotation.impl.SuppressForbiddenApis;
+
+public class ConstructorProjectionApplicationException extends SearchException {
+
+	private final ProjectionConstructorPath projectionConstructorPath;
+
+	@SuppressForbiddenApis(reason = SEARCH_EXCEPTION_AND_SUBCLASSES_CAN_USE_CONSTRUCTOR)
+	public ConstructorProjectionApplicationException(String message,
+			Throwable cause,
+			ProjectionConstructorPath projectionConstructorPath) {
+		super( message + "\n" + projectionConstructorPath.toPrefixedString(), cause );
+		this.projectionConstructorPath = projectionConstructorPath;
+	}
+
+	public ProjectionConstructorPath projectionConstructorPath() {
+		return projectionConstructorPath;
+	}
+}

--- a/util/common/src/main/java/org/hibernate/search/util/common/logging/impl/CommaSeparatedClassesFormatter.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/logging/impl/CommaSeparatedClassesFormatter.java
@@ -11,12 +11,22 @@ import java.util.Collection;
 public final class CommaSeparatedClassesFormatter {
 
 	public static String format(Class<?>[] classes) {
+		return formatHighlighted( classes, -1 );
+	}
+
+	public static String formatHighlighted(Class<?>[] classes, int position) {
 		StringBuilder builder = new StringBuilder();
 		for ( int i = 0; i < classes.length; i++ ) {
 			if ( i > 0 ) {
 				builder.append( ", " );
 			}
+			if ( position == i ) {
+				builder.append( '*' );
+			}
 			builder.append( classes[i].getName() );
+			if ( position == i ) {
+				builder.append( '*' );
+			}
 		}
 		return builder.toString();
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4669

Needed to bring `PojoConstructorModel` into `PojoConstructorProjectionDefinition` so that we can print a nicely formatted constructor string with `PojoConstructorModelFormatter` 😃 

I wasn't sure if we'd want to have the entire trace of nested constructors or just the only one where the initial problem occurred - so I've added that code in the separate commit so that we can drop it if we want the entire thing.