### PR TITLE
HSEARCH-4642 + HSEARCH-4726 Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,7 @@
         <version.org.osgi.core>6.0.0</version.org.osgi.core>
 
         <version.org.hamcrest>2.2</version.org.hamcrest>
-        <version.org.mockito>4.8.0</version.org.mockito>
+        <version.org.mockito>4.8.1</version.org.mockito>
         <version.org.assertj.assertj-core>3.23.1</version.org.assertj.assertj-core>
         <version.org.awaitily>4.2.0</version.org.awaitily>
         <version.org.skyscreamer.jsonassert>1.5.1</version.org.skyscreamer.jsonassert>

--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
         <version.org.opensearch.latest-1.0>1.0.0</version.org.opensearch.latest-1.0>
 
         <version.com.google.code.gson>2.9.1</version.com.google.code.gson>
-        <version.software.amazon.awssdk>2.17.94</version.software.amazon.awssdk>
+        <version.software.amazon.awssdk>2.18.1</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, the AWS SDK and in tests (wiremock, ...) -->
         <version.com.fasterxml.jackson>2.13.4</version.com.fasterxml.jackson>
         <!--


### PR DESCRIPTION
* [HSEARCH-4726](https://hibernate.atlassian.net/browse/HSEARCH-4726): Upgrade to AWS SDK 2.18
* [HSEARCH-4642](https://hibernate.atlassian.net/browse/HSEARCH-4642): Upgrade build dependencies to the latest version

For HSEARCH-4642, folllows up on #3146, #3148, #3157, #3176, #3189, #3194, #3208, #3219, #3234, #3239, #3249, #3255, #3262