### PR TITLE
Backport HSEARCH-4727 + HSEARCH-4732 to branch 6.1 - OutboxEvent "payload" column created as blob(255) with DB2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -528,7 +528,8 @@ stage('Non-default environments') {
 	// Test ORM integration with multiple databases
 	environments.content.database.enabled.each { DatabaseBuildEnvironment buildEnv ->
 		executions.put(buildEnv.tag, {
-			runBuildOnNode(NODE_PATTERN_BASE) {
+			// Some databases, e.g. DB2 or CockroachDB, can be really slow, so we need to raise the timeout.
+			runBuildOnNode(NODE_PATTERN_BASE, [time: 2, unit: 'HOURS']) {
 				withMavenWorkspace {
 					String mavenBuildAdditionalArgs = ""
 					String mavenDockerArgs = ""

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontained/AutomaticIndexingManyToManyOwnedByContainedCollectionBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontained/AutomaticIndexingManyToManyOwnedByContainedCollectionBaseIT.java
@@ -403,42 +403,42 @@ public class AutomaticIndexingManyToManyOwnedByContainedCollectionBaseIT
 		@JoinTable(name = "i_containedIndexedEmbedded",
 				joinColumns = @JoinColumn(name = "contained"),
 				inverseJoinColumns = @JoinColumn(name = "containing"))
-		@OrderColumn(name = "idx") // Test list associations, not bags
+		@OrderBy("id asc") // Test bag associations, not lists, but still make sure the iteration order is predictable
 		private Collection<ContainingEntity> containingAsIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany
 		@JoinTable(name = "i_containedNonIndexedEmbedded",
 				joinColumns = @JoinColumn(name = "contained"),
 				inverseJoinColumns = @JoinColumn(name = "containing"))
-		@OrderColumn(name = "idx") // Test list associations, not bags
+		@OrderBy("id asc") // Test bag associations, not lists, but still make sure the iteration order is predictable
 		private Collection<ContainingEntity> containingAsNonIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany
 		@JoinTable(name = "i_indexedEmbeddedShallow",
 				joinColumns = @JoinColumn(name = "contained"),
 				inverseJoinColumns = @JoinColumn(name = "containing"))
-		@OrderColumn(name = "idx") // Test list associations, not bags
+		@OrderBy("id asc") // Test bag associations, not lists, but still make sure the iteration order is predictable
 		private Collection<ContainingEntity> containingAsIndexedEmbeddedShallowReindexOnUpdate = new ArrayList<>();
 
 		@ManyToMany
 		@JoinTable(name = "i_indexedEmbeddedNoReindex",
 				joinColumns = @JoinColumn(name = "contained"),
 				inverseJoinColumns = @JoinColumn(name = "containing"))
-		@OrderColumn(name = "idx") // Test list associations, not bags
+		@OrderBy("id asc") // Test bag associations, not lists, but still make sure the iteration order is predictable
 		private Collection<ContainingEntity> containingAsIndexedEmbeddedNoReindexOnUpdate = new ArrayList<>();
 
 		@ManyToMany
 		@JoinTable(name = "i_containedCrossEntityDP",
 				joinColumns = @JoinColumn(name = "contained"),
 				inverseJoinColumns = @JoinColumn(name = "containing"))
-		@OrderColumn(name = "idx") // Test list associations, not bags
+		@OrderBy("id asc") // Test bag associations, not lists, but still make sure the iteration order is predictable
 		private Collection<ContainingEntity> containingAsUsedInCrossEntityDerivedProperty = new ArrayList<>();
 
 		@ManyToMany(targetEntity = ContainingEntity.class)
 		@JoinTable(name = "i_containedIndexedEmbeddedCast",
 				joinColumns = @JoinColumn(name = "contained"),
 				inverseJoinColumns = @JoinColumn(name = "containing"))
-		@OrderColumn(name = "idx") // Test list associations, not bags
+		@OrderBy("id asc") // Test bag associations, not lists, but still make sure the iteration order is predictable
 		private Collection<Object> containingAsIndexedEmbeddedWithCast = new ArrayList<>();
 
 		@Embedded
@@ -449,7 +449,7 @@ public class AutomaticIndexingManyToManyOwnedByContainedCollectionBaseIT
 		private String indexedField;
 
 		@ElementCollection
-		@OrderColumn(name = "idx") // Test list associations, not bags
+		@OrderColumn(name = "idx")
 		@CollectionTable(name = "contained_IElementCF")
 		@GenericField
 		private List<String> indexedElementCollectionField = new ArrayList<>();
@@ -460,7 +460,7 @@ public class AutomaticIndexingManyToManyOwnedByContainedCollectionBaseIT
 		private String nonIndexedField;
 
 		@ElementCollection
-		@OrderColumn(name = "idx") // Test list associations, not bags
+		@OrderColumn(name = "idx")
 		@CollectionTable(name = "nonIndexedECF")
 		@Column(name = "nonIndexed")
 		@GenericField
@@ -704,14 +704,14 @@ public class AutomaticIndexingManyToManyOwnedByContainedCollectionBaseIT
 		@JoinTable(name = "i_emb_containedIdxEmbedded",
 				joinColumns = @JoinColumn(name = "contained"),
 				inverseJoinColumns = @JoinColumn(name = "containing"))
-		@OrderColumn(name = "idx") // Test list associations, not bags
+		@OrderBy("id asc") // Test bag associations, not lists, but still make sure the iteration order is predictable
 		private Collection<ContainingEntity> containingAsIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany
 		@JoinTable(name = "i_emb_containedNonIdxEmbedded",
 				joinColumns = @JoinColumn(name = "contained"),
 				inverseJoinColumns = @JoinColumn(name = "containing"))
-		@OrderColumn(name = "idx") // Test list associations, not bags
+		@OrderBy("id asc") // Test bag associations, not lists, but still make sure the iteration order is predictable
 		private Collection<ContainingEntity> containingAsNonIndexedEmbedded = new ArrayList<>();
 
 		public Collection<ContainingEntity> getContainingAsIndexedEmbedded() {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontained/AutomaticIndexingManyToManyOwnedByContainedListBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontained/AutomaticIndexingManyToManyOwnedByContainedListBaseIT.java
@@ -448,6 +448,7 @@ public class AutomaticIndexingManyToManyOwnedByContainedListBaseIT
 		private String indexedField;
 
 		@ElementCollection
+		@OrderColumn(name = "idx")
 		@CollectionTable(name = "contained_IElementCF")
 		@GenericField
 		private List<String> indexedElementCollectionField = new ArrayList<>();
@@ -458,6 +459,7 @@ public class AutomaticIndexingManyToManyOwnedByContainedListBaseIT
 		private String nonIndexedField;
 
 		@ElementCollection
+		@OrderColumn(name = "idx")
 		@CollectionTable(name = "nonIndexedECF")
 		@Column(name = "nonIndexed")
 		@GenericField

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingCollectionBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingCollectionBaseIT.java
@@ -99,7 +99,7 @@ public class AutomaticIndexingManyToManyOwnedByContainingCollectionBaseIT
 		private ContainingEntity child;
 
 		@ManyToMany
-		@OrderColumn(name = "idx") // Test list associations, not bags
+		@OrderBy("id asc") // Test bag associations, not lists, but still make sure the iteration order is predictable
 		@JoinTable(name = "i_containedIndexedEmbedded",
 				joinColumns = @JoinColumn(name = "containing"),
 				inverseJoinColumns = @JoinColumn(name = "contained"))
@@ -107,14 +107,14 @@ public class AutomaticIndexingManyToManyOwnedByContainingCollectionBaseIT
 		private Collection<ContainedEntity> containedIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany
-		@OrderColumn(name = "idx") // Test list associations, not bags
+		@OrderBy("id asc") // Test bag associations, not lists, but still make sure the iteration order is predictable
 		@JoinTable(name = "i_containedNonIndexedEmbedded",
 				joinColumns = @JoinColumn(name = "containing"),
 				inverseJoinColumns = @JoinColumn(name = "contained"))
 		private Collection<ContainedEntity> containedNonIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany
-		@OrderColumn(name = "idx") // Test list associations, not bags
+		@OrderBy("id asc") // Test bag associations, not lists, but still make sure the iteration order is predictable
 		@JoinTable(name = "i_indexedEmbeddedShallow",
 				joinColumns = @JoinColumn(name = "containing"),
 				inverseJoinColumns = @JoinColumn(name = "contained"))
@@ -123,7 +123,7 @@ public class AutomaticIndexingManyToManyOwnedByContainingCollectionBaseIT
 		private Collection<ContainedEntity> containedIndexedEmbeddedShallowReindexOnUpdate = new ArrayList<>();
 
 		@ManyToMany
-		@OrderColumn(name = "idx") // Test list associations, not bags
+		@OrderBy("id asc") // Test bag associations, not lists, but still make sure the iteration order is predictable
 		@JoinTable(name = "i_indexedEmbeddedNoReindex",
 				joinColumns = @JoinColumn(name = "containing"),
 				inverseJoinColumns = @JoinColumn(name = "contained"))
@@ -132,14 +132,14 @@ public class AutomaticIndexingManyToManyOwnedByContainingCollectionBaseIT
 		private Collection<ContainedEntity> containedIndexedEmbeddedNoReindexOnUpdate = new ArrayList<>();
 
 		@ManyToMany
-		@OrderColumn(name = "idx") // Test list associations, not bags
+		@OrderBy("id asc") // Test bag associations, not lists, but still make sure the iteration order is predictable
 		@JoinTable(name = "i_containedCrossEntityDP",
 				joinColumns = @JoinColumn(name = "containing"),
 				inverseJoinColumns = @JoinColumn(name = "contained"))
 		private Collection<ContainedEntity> containedUsedInCrossEntityDerivedProperty = new ArrayList<>();
 
 		@ManyToMany(targetEntity = ContainedEntity.class)
-		@OrderColumn(name = "idx") // Test list associations, not bags
+		@OrderBy("id asc") // Test bag associations, not lists, but still make sure the iteration order is predictable
 		@JoinTable(name = "i_containedIndexedEmbeddedCast",
 				joinColumns = @JoinColumn(name = "containing"),
 				inverseJoinColumns = @JoinColumn(name = "contained"))
@@ -341,7 +341,7 @@ public class AutomaticIndexingManyToManyOwnedByContainingCollectionBaseIT
 	public static class ContainingEmbeddable {
 
 		@ManyToMany
-		@OrderColumn(name = "idx") // Test list associations, not bags
+		@OrderBy("id asc") // Test bag associations, not lists, but still make sure the iteration order is predictable
 		@JoinTable(name = "i_emb_containedIdxEmbedded",
 				joinColumns = @JoinColumn(name = "containing"),
 				inverseJoinColumns = @JoinColumn(name = "contained"))
@@ -349,7 +349,7 @@ public class AutomaticIndexingManyToManyOwnedByContainingCollectionBaseIT
 		private Collection<ContainedEntity> containedIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany
-		@OrderColumn(name = "idx") // Test list associations, not bags
+		@OrderBy("id asc") // Test bag associations, not lists, but still make sure the iteration order is predictable
 		@JoinTable(name = "i_emb_containedNonIdxEmbedded",
 				joinColumns = @JoinColumn(name = "containing"),
 				inverseJoinColumns = @JoinColumn(name = "contained"))

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingListBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/manytomany/ownedbycontaining/AutomaticIndexingManyToManyOwnedByContainingListBaseIT.java
@@ -98,6 +98,7 @@ public class AutomaticIndexingManyToManyOwnedByContainingListBaseIT
 		private ContainingEntity child;
 
 		@ManyToMany
+		@OrderColumn(name = "idx") // Test list associations, not bags
 		@JoinTable(name = "i_containedIndexedEmbedded",
 				joinColumns = @JoinColumn(name = "containing"),
 				inverseJoinColumns = @JoinColumn(name = "contained"))
@@ -105,12 +106,14 @@ public class AutomaticIndexingManyToManyOwnedByContainingListBaseIT
 		private List<ContainedEntity> containedIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany
+		@OrderColumn(name = "idx") // Test list associations, not bags
 		@JoinTable(name = "i_containedNonIndexedEmbedded",
 				joinColumns = @JoinColumn(name = "containing"),
 				inverseJoinColumns = @JoinColumn(name = "contained"))
 		private List<ContainedEntity> containedNonIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany
+		@OrderColumn(name = "idx") // Test list associations, not bags
 		@JoinTable(name = "i_indexedEmbeddedShallow",
 				joinColumns = @JoinColumn(name = "containing"),
 				inverseJoinColumns = @JoinColumn(name = "contained"))
@@ -119,6 +122,7 @@ public class AutomaticIndexingManyToManyOwnedByContainingListBaseIT
 		private List<ContainedEntity> containedIndexedEmbeddedShallowReindexOnUpdate = new ArrayList<>();
 
 		@ManyToMany
+		@OrderColumn(name = "idx") // Test list associations, not bags
 		@JoinTable(name = "i_indexedEmbeddedNoReindex",
 				joinColumns = @JoinColumn(name = "containing"),
 				inverseJoinColumns = @JoinColumn(name = "contained"))
@@ -127,12 +131,14 @@ public class AutomaticIndexingManyToManyOwnedByContainingListBaseIT
 		private List<ContainedEntity> containedIndexedEmbeddedNoReindexOnUpdate = new ArrayList<>();
 
 		@ManyToMany
+		@OrderColumn(name = "idx") // Test list associations, not bags
 		@JoinTable(name = "i_containedCrossEntityDP",
 				joinColumns = @JoinColumn(name = "containing"),
 				inverseJoinColumns = @JoinColumn(name = "contained"))
 		private List<ContainedEntity> containedUsedInCrossEntityDerivedProperty = new ArrayList<>();
 
 		@ManyToMany(targetEntity = ContainedEntity.class)
+		@OrderColumn(name = "idx") // Test list associations, not bags
 		@JoinTable(name = "i_containedIndexedEmbeddedCast",
 				joinColumns = @JoinColumn(name = "containing"),
 				inverseJoinColumns = @JoinColumn(name = "contained"))

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cluster/impl/OutboxPollingAgentAdditionalJaxbMappingProducer.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cluster/impl/OutboxPollingAgentAdditionalJaxbMappingProducer.java
@@ -74,7 +74,14 @@ public class OutboxPollingAgentAdditionalJaxbMappingProducer
 			"        <property name=\"totalShardCount\" nullable=\"true\" />\n" +
 			"        <property name=\"assignedShardIndex\" nullable=\"true\" />\n" +
 			// Reserved for future use
-			"        <property name=\"payload\" nullable=\"true\" type=\"materialized_blob\" />\n" +
+			"        <property name=\"payload\" nullable=\"true\" type=\"materialized_blob\">\n" +
+			// HSEARCH-4727: this column length will be ignored in most dialects, since the blob type is normally unbounded,
+			// but it will force Hibernate ORM to simulate an unbounded BLOB type with DB2.
+			// Using 2147483647 as it's the documented maximum length of BLOBs in DB2:
+			// https://www.ibm.com/docs/en/db2-for-zos/11?topic=types-large-objects-lobs
+			// TODO HSEARCH-4395/HSEARCH-4532 drop this length definition with ORM 6, because ORM 6 will ignore it.
+			"                <column length=\"2147483647\" />\n" +
+			"        </property>\n" +
 			"    </class>\n" +
 			"</hibernate-mapping>\n";
 

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingOutboxEventAdditionalJaxbMappingProducer.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingOutboxEventAdditionalJaxbMappingProducer.java
@@ -61,7 +61,14 @@ public final class OutboxPollingOutboxEventAdditionalJaxbMappingProducer
 			"        <property name=\"entityName\" type=\"string\" length=\"256\" nullable=\"false\" />\n" +
 			"        <property name=\"entityId\" type=\"string\" length=\"256\" nullable=\"false\" />\n" +
 			"        <property name=\"entityIdHash\" type=\"integer\" index=\"entityIdHash\" nullable=\"false\" />\n" +
-			"        <property name=\"payload\" type=\"materialized_blob\" nullable=\"false\" />\n" +
+			"        <property name=\"payload\" type=\"materialized_blob\" nullable=\"false\">\n" +
+			// HSEARCH-4727: this column length will be ignored in most dialects, since the blob type is normally unbounded,
+			// but it will force Hibernate ORM to simulate an unbounded BLOB type with DB2.
+			// Using 2147483647 as it's the documented maximum length of BLOBs in DB2:
+			// https://www.ibm.com/docs/en/db2-for-zos/11?topic=types-large-objects-lobs
+			// TODO HSEARCH-4395/HSEARCH-4532 drop this length definition with ORM 6, because ORM 6 will ignore it.
+			"                <column length=\"2147483647\" />\n" +
+			"        </property>\n" +
 			"        <property name=\"retries\" type=\"integer\" nullable=\"false\" />\n" +
 			"        <property name=\"processAfter\" type=\"Instant\" index=\"processAfter\" nullable=\"true\" />\n" +
 			"        <property name=\"status\" index=\"status\" nullable=\"false\">\n" +

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -734,7 +734,7 @@
                 <db.dialect>org.hibernate.dialect.DB297Dialect</db.dialect>
                 <jdbc.driver.groupId>com.ibm.db2</jdbc.driver.groupId>
                 <jdbc.driver.artifactId>jcc</jdbc.driver.artifactId>
-                <jdbc.driver.version>11.5.5.0</jdbc.driver.version>
+                <jdbc.driver.version>11.5.8.0</jdbc.driver.version>
                 <jdbc.driver>com.ibm.db2.jcc.DB2Driver</jdbc.driver>
                 <jdbc.url>jdbc:db2://localhost:50005/hreact</jdbc.url>
                 <jdbc.user>hreact</jdbc.user>

--- a/pom.xml
+++ b/pom.xml
@@ -599,7 +599,7 @@
         <!-- DB2 -->
         <test.database.run.db2.skip>true</test.database.run.db2.skip>
         <test.database.run.db2.image.name>ibmcom/db2</test.database.run.db2.image.name>
-        <test.database.run.db2.image.tag>11.5.5.0</test.database.run.db2.image.tag>
+        <test.database.run.db2.image.tag>11.5.8.0</test.database.run.db2.image.tag>
         <!-- Oracle -->
         <test.database.run.oracle.skip>true</test.database.run.oracle.skip>
         <!-- See https://hub.docker.com/r/gvenzl/oracle-xe -->


### PR DESCRIPTION
* [HSEARCH-4727](https://hibernate.atlassian.net/browse/HSEARCH-4727) OutboxEvent "payload" column created as blob(255) with DB2
* [HSEARCH-4732](https://hibernate.atlassian.net/browse/HSEARCH-4732) Run tests against DB2 and DB2 JDBC driver version 11.5.8.0

Backport of  #3282 to branch 6.1.