### PR TITLE
HSEARCH-4733 + HSEARCH-4735 Test Hibernate Search 6.1 with Hibernate ORM 6.2

### DIFF
--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -31,6 +31,13 @@ Map settings() {
 					""",
 					updateProperties: ['version.org.hibernate.orm']
 			]
+		case 'orm6.2':
+			return [
+					mavenArgs: """ \
+							-pl orm6/mapper/orm -amd \
+					""",
+					updateProperties: ['version.org.hibernate.orm']
+			]
 		default:
 			return [:]
 	}
@@ -89,7 +96,7 @@ pipeline {
 					axis {
 						name 'DEPENDENCY_UPDATE_NAME'
 						// NOTE: Remember to update the settings() method above when changing this.
-						values 'orm5.6', 'orm6.0', 'orm6.1'
+						values 'orm5.6', 'orm6.0', 'orm6.1', 'orm6.2'
 					}
 				}
 				stages {

--- a/ci/dependency-update/rules-orm6.2.xml
+++ b/ci/dependency-update/rules-orm6.2.xml
@@ -1,0 +1,12 @@
+<ruleset comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+  <ignoreVersions>
+    <ignoreVersion type="regex">.*\.Alpha.*</ignoreVersion>
+    <ignoreVersion type="regex">.*\.Beta.*</ignoreVersion>
+    <ignoreVersion type="regex">.*\.CR.*</ignoreVersion>
+    <!-- This is the easiest way to stick to a particular major/minor;
+         forbidding minor/major upgrades in the plugin configuration doesn't always work for some reason. -->
+    <ignoreVersion type="regex">(?!6\.2\.).*</ignoreVersion>
+  </ignoreVersions>
+</ruleset>


### PR DESCRIPTION
* [HSEARCH-4735](https://hibernate.atlassian.net/browse/HSEARCH-4735): Test Hibernate Search 6.1 with Hibernate ORM 6.2
* [HSEARCH-4733](https://hibernate.atlassian.net/browse/HSEARCH-4733): Adapt SyntheticPropertyIT to Hibernate ORM 6.2

Tests already pass, as expected. I checked by triggering a test run on my branch: https://ci.hibernate.org/blue/organizations/jenkins/hibernate-search-dependency-update-personal-yoann/detail/HSEARCH-4735/4/pipeline/247