### PR TITLE
HSEARCH-4737 + HSEARCH-4738 Upgrade to Elasticsearch client 8.5.0 and add compatibility with Elasticsearch 8.5

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -241,11 +241,12 @@ stage('Configure') {
 					new EsLocalBuildEnvironment(version: '7.16.3', condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(version: '7.17.0', condition: TestCondition.AFTER_MERGE),
 					// Not testing 8.0 because we know there are problems in 8.0.1 (see https://hibernate.atlassian.net/browse/HSEARCH-4497)
-					// Not testing 8.1 to make the build quicker.
+					// Not testing 8.1-8.4 to make the build quicker.
 					new EsLocalBuildEnvironment(version: '8.1.3', condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(version: '8.2.3', condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(version: '8.3.3', condition: TestCondition.ON_DEMAND),
-					new EsLocalBuildEnvironment(version: '8.4.3', condition: TestCondition.BEFORE_MERGE, isDefault: true),
+					new EsLocalBuildEnvironment(version: '8.4.3', condition: TestCondition.ON_DEMAND),
+					new EsLocalBuildEnvironment(version: '8.5.0', condition: TestCondition.BEFORE_MERGE, isDefault: true),
 
 					// --------------------------------------------
 					// OpenSearch

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
@@ -166,7 +166,7 @@ public class ElasticsearchDialectFactory {
 	}
 
 	private ElasticsearchProtocolDialect createProtocolDialectElasticV8(ElasticsearchVersion version, int minor) {
-		if ( minor > 4 ) {
+		if ( minor > 5 ) {
 			log.unknownElasticsearchVersion( version );
 		}
 		else if ( minor == 0 ) {

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -291,7 +291,7 @@ public class ElasticsearchDialectFactoryTest {
 						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				success(
-						ElasticsearchDistributionName.ELASTIC, "8", "8.4.0",
+						ElasticsearchDistributionName.ELASTIC, "8", "8.5.0",
 						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
 				),
 				success(
@@ -334,12 +334,20 @@ public class ElasticsearchDialectFactoryTest {
 						ElasticsearchDistributionName.ELASTIC, "8.4.0", "8.4.0",
 						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
 				),
-				successWithWarning(
+				success(
 						ElasticsearchDistributionName.ELASTIC, "8.5", "8.5.0",
 						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
 				),
-				successWithWarning(
+				success(
 						ElasticsearchDistributionName.ELASTIC, "8.5.0", "8.5.0",
+						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.ELASTIC, "8.6", "8.6.0",
+						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.ELASTIC, "8.6.0", "8.6.0",
 						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
 				),
 				successWithWarning(

--- a/build/parents/integrationtest/pom.xml
+++ b/build/parents/integrationtest/pom.xml
@@ -111,6 +111,12 @@
                                              leaving too little for filesystem caches and resulting in freezes.
                                          -->
                                         <ES_JAVA_OPTS>-Xms1g -Xmx1g</ES_JAVA_OPTS>
+                                        <!-- Disable disk-based shard allocation thresholds: on large, relatively full disks (>90% used),
+                                             it will lead to index creation to get stuck waiting for other nodes to join the cluster,
+                                             which will never happen since we only have one node.
+                                             See https://www.elastic.co/guide/en/elasticsearch/reference/7.17/modules-cluster.html#disk-based-shard-allocation
+                                         -->
+                                        <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                     </env>
                                     <ports>
                                         <port>9200:9200</port>
@@ -148,6 +154,13 @@
                                              See https://docs-beta.opensearch.org/im-plugin/ism/settings/
                                          -->
                                         <plugins.index_state_management.enabled>false</plugins.index_state_management.enabled>
+                                        <!-- Disable disk-based shard allocation thresholds: on large, relatively full disks (>90% used),
+                                             it will lead to index creation to get stuck waiting for other nodes to join the cluster,
+                                             which will never happen since we only have one node.
+                                             See https://www.elastic.co/guide/en/elasticsearch/reference/7.17/modules-cluster.html#disk-based-shard-allocation
+                                             See https://opensearch.org/docs/latest/opensearch/popular-api/#change-disk-watermarks-or-other-cluster-settings
+                                         -->
+                                        <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                     </env>
                                     <ports>
                                         <port>9200:9200</port>

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -244,4 +244,11 @@ class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 		// https://github.com/elastic/elasticsearch/pull/90458
 		return !isBetween( actualVersion, "elastic:8.4.2", "elastic:8.5.0" );
 	}
+
+	@Override
+	public boolean supportsMatchOnScaledNumericLossOfPrecision() {
+		// https://github.com/elastic/elasticsearch/issues/91246
+		// Hopefully this will get fixed in 8.5.1.
+		return !isBetween( actualVersion, "elastic:8.5.0", "elastic:8.5.0" );
+	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/BigDecimalFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/BigDecimalFieldTypeDescriptor.java
@@ -8,7 +8,9 @@ package org.hibernate.search.integrationtest.backend.tck.testsupport.types;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,6 +19,7 @@ import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptio
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexNullAsMatchPredicateExpectactions;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values.AscendingUniqueTermValues;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values.IndexableValues;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 
 public class BigDecimalFieldTypeDescriptor extends FieldTypeDescriptor<BigDecimal> {
 
@@ -87,17 +90,23 @@ public class BigDecimalFieldTypeDescriptor extends FieldTypeDescriptor<BigDecima
 
 	@Override
 	protected List<BigDecimal> createUniquelyMatchableValues() {
-		return Arrays.asList(
+		List<BigDecimal> list = new ArrayList<>( Arrays.asList(
 				BigDecimal.ZERO,
 				BigDecimal.ONE,
 				BigDecimal.TEN,
 				nextUp( BigDecimal.ONE ),
 				nextDown( BigDecimal.ONE ),
 				BigDecimal.valueOf( 42.42 ),
-				BigDecimal.valueOf( 1584514514.000000184 ),
-				scaled( Long.MAX_VALUE ),
-				scaled( Long.MIN_VALUE )
-		);
+				BigDecimal.valueOf( 1584514514.000000184 )
+		) );
+		if ( TckConfiguration.get().getBackendFeatures().supportsMatchOnScaledNumericLossOfPrecision() ) {
+			Collections.addAll(
+					list,
+					scaled( Long.MAX_VALUE ),
+					scaled( Long.MIN_VALUE )
+			);
+		}
+		return list;
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
@@ -120,4 +120,8 @@ public abstract class TckBackendFeatures {
 		return true;
 	}
 
+	public boolean supportsMatchOnScaledNumericLossOfPrecision() {
+		return true;
+	}
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -201,8 +201,8 @@
 
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
-        <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.4+ -->
-        <version.org.elasticsearch.client>8.4.3</version.org.elasticsearch.client>
+        <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.5+ -->
+        <version.org.elasticsearch.client>8.5.0</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-8.4) becomes the default. -->

--- a/pom.xml
+++ b/pom.xml
@@ -212,11 +212,11 @@
         <!-- The versions of Elasticsearch advertised as compatible with Hibernate Search -->
         <!-- Make sure to only mention tested versions here -->
         <!-- Make sure that 7.10 stays explicitly mentioned here, because that's the last open-source version -->
-        <version.org.elasticsearch.compatible.regularly-tested.text>5.6, 6.8, 7.10, 7.17 or 8.4</version.org.elasticsearch.compatible.regularly-tested.text>
+        <version.org.elasticsearch.compatible.regularly-tested.text>5.6, 6.8, 7.10, 7.17 or 8.5</version.org.elasticsearch.compatible.regularly-tested.text>
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
         <version.org.elasticsearch.compatible.not-regularly-tested.text>7.0 or 8.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest version of Elasticsearch tested against by default -->
-        <version.org.elasticsearch.latest>8.4.3</version.org.elasticsearch.latest>
+        <version.org.elasticsearch.latest>8.5.0</version.org.elasticsearch.latest>
         <!-- The versions of OpenSearch advertised as compatible with Hibernate Search -->
         <!-- Make sure to only mention tested versions here -->
         <version.org.opensearch.compatible.regularly-tested.text>1.3 or 2.0</version.org.opensearch.compatible.regularly-tested.text>


### PR DESCRIPTION
* [HSEARCH-4738](https://hibernate.atlassian.net/browse/HSEARCH-4738): Add compatibility with Elasticsearch 8.5
* [HSEARCH-4737](https://hibernate.atlassian.net/browse/HSEARCH-4737): Upgrade to Elasticsearch client 8.5.0

