### PR TITLE
Backport HSEARCH-4697 + HSEARCH-4739 to branch 6.1 - Upgrade to Jackson 2.13.4/2.13.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,14 +239,14 @@
         <version.com.google.code.gson>2.8.9</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.17.94</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, the AWS SDK and in tests (wiremock, ...) -->
-        <version.com.fasterxml.jackson>2.13.1</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.13.4</version.com.fasterxml.jackson>
         <!--
              In the past, there has been jackson-databind bugfix releases without any jackson-core release,
              so we had to use different versions, e.g. jackson-core 2.9.9 and jackson-databind 2.9.9.3.
              That's why we have two separate properties for jackson versions,
              even though they may have the same value from time to time.
          -->
-        <version.com.fasterxml.jackson.databind>2.13.1</version.com.fasterxml.jackson.databind>
+        <version.com.fasterxml.jackson.databind>2.13.4</version.com.fasterxml.jackson.databind>
         <!-- Reactive-streams: used by the AWS SDK -->
         <version.org.reactivestreams.reactive-streams>1.0.3</version.org.reactivestreams.reactive-streams>
         <!-- slf4j: used by the AWS SDK -->

--- a/pom.xml
+++ b/pom.xml
@@ -242,11 +242,11 @@
         <version.com.fasterxml.jackson>2.13.4</version.com.fasterxml.jackson>
         <!--
              In the past, there has been jackson-databind bugfix releases without any jackson-core release,
-             so we had to use different versions, e.g. jackson-core 2.9.9 and jackson-databind 2.9.9.3.
+             so we had to use different versions, e.g. jackson-core 2.13.4 and jackson-databind 2.13.4.2.
              That's why we have two separate properties for jackson versions,
              even though they may have the same value from time to time.
          -->
-        <version.com.fasterxml.jackson.databind>2.13.4</version.com.fasterxml.jackson.databind>
+        <version.com.fasterxml.jackson.databind>2.13.4.2</version.com.fasterxml.jackson.databind>
         <!-- Reactive-streams: used by the AWS SDK -->
         <version.org.reactivestreams.reactive-streams>1.0.3</version.org.reactivestreams.reactive-streams>
         <!-- slf4j: used by the AWS SDK -->


### PR DESCRIPTION
* [HSEARCH-4739](https://hibernate.atlassian.net/browse/HSEARCH-4739): Upgrade to jackson-databind 2.13.4.1
* [HSEARCH-4697](https://hibernate.atlassian.net/browse/HSEARCH-4697): Upgrade to Jackson 2.13.4

Backport of #3297 in particular