### PR TITLE
HSEARCH-4541 Catch load exception and pass to failure handler

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureCustomBackgroundFailureHandlerIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureCustomBackgroundFailureHandlerIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.massindexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -151,6 +152,29 @@ public class MassIndexingFailureCustomBackgroundFailureHandlerIT extends Abstrac
 				.hasMessageContaining( exceptionMessage );
 		assertThat( context.failingOperation() ).asString()
 				.isEqualTo( failingOperationAsString );
+	}
+
+	@Override
+	protected void expectMassIndexerLoadingOperationFailureHandling(Class<? extends Throwable> exceptionType,
+			String exceptionMessage, String failingOperationAsString, int count) {
+		// We'll check in the assert*() method, see below.
+	}
+
+	@Override
+	protected void assertMassIndexerLoadingOperationFailureHandling(Class<? extends Throwable> exceptionType,
+			String exceptionMessage, String failingOperationAsString, int count) {
+		verify( failureHandler, times( count ) ).handle( entityFailureContextCapture.capture() );
+
+		EntityIndexingFailureContext context = entityFailureContextCapture.getValue();
+		assertThat( context.throwable() )
+				.isInstanceOf( SimulatedFailure.class )
+				.hasMessageContainingAll( exceptionMessage );
+		assertThat( context.failingOperation() ).asString()
+				.isEqualTo( failingOperationAsString );
+		assertThat( context.entityReferences() )
+				.hasSize( 1 );
+
+		verifyNoMoreInteractions( failureHandler );
 	}
 
 	@Override

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureDefaultBackgroundFailureHandlerIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureDefaultBackgroundFailureHandlerIT.java
@@ -121,6 +121,25 @@ public class MassIndexingFailureDefaultBackgroundFailureHandlerIT extends Abstra
 	}
 
 	@Override
+	protected void expectMassIndexerLoadingOperationFailureHandling(Class<? extends Throwable> exceptionType,
+			String exceptionMessage, String failingOperationAsString, int count) {
+		logged.expectEvent(
+						Level.ERROR,
+						ExceptionMatcherBuilder.isException( exceptionType )
+								.withMessage( exceptionMessage )
+								.build(),
+						failingOperationAsString
+				)
+				.times( count );
+	}
+
+	@Override
+	protected void assertMassIndexerLoadingOperationFailureHandling(Class<? extends Throwable> exceptionType,
+			String exceptionMessage, String failingOperationAsString, int count) {
+		// If we get there, everything works fine.
+	}
+
+	@Override
 	protected void expectEntityIndexingAndMassIndexerOperationFailureHandling(String entityName,
 			String entityReferenceAsString,
 			String failingEntityIndexingExceptionMessage, String failingEntityIndexingOperationAsString,

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingFailureCustomBackgroundFailureHandlerIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingFailureCustomBackgroundFailureHandlerIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.pojo.massindexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -151,6 +152,29 @@ public class MassIndexingFailureCustomBackgroundFailureHandlerIT extends Abstrac
 				.hasMessageContaining( exceptionMessage );
 		assertThat( context.failingOperation() ).asString()
 				.isEqualTo( failingOperationAsString );
+	}
+
+	@Override
+	protected void expectMassIndexerLoadingOperationFailureHandling(Class<? extends Throwable> exceptionType,
+			String exceptionMessage, String failingOperationAsString, int count) {
+		// We'll check in the assert*() method, see below.
+	}
+
+	@Override
+	protected void assertMassIndexerLoadingOperationFailureHandling(Class<? extends Throwable> exceptionType,
+			String exceptionMessage, String failingOperationAsString, int count) {
+		verify( failureHandler, times( count ) ).handle( entityFailureContextCapture.capture() );
+
+		EntityIndexingFailureContext context = entityFailureContextCapture.getValue();
+		assertThat( context.throwable() )
+				.isInstanceOf( SimulatedFailure.class )
+				.hasMessageContainingAll( exceptionMessage );
+		assertThat( context.failingOperation() ).asString()
+				.isEqualTo( failingOperationAsString );
+		assertThat( context.entityReferences() )
+				.hasSize( 1 );
+
+		verifyNoMoreInteractions( failureHandler );
 	}
 
 	@Override

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingFailureCustomMassIndexingFailureHandlerIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingFailureCustomMassIndexingFailureHandlerIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.pojo.massindexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -151,6 +152,29 @@ public class MassIndexingFailureCustomMassIndexingFailureHandlerIT extends Abstr
 				.hasMessageContaining( exceptionMessage );
 		assertThat( context.failingOperation() ).asString()
 				.isEqualTo( failingOperationAsString );
+	}
+
+	@Override
+	protected void expectMassIndexerLoadingOperationFailureHandling(Class<? extends Throwable> exceptionType,
+			String exceptionMessage, String failingOperationAsString, int count) {
+		// We'll check in the assert*() method, see below.
+	}
+
+	@Override
+	protected void assertMassIndexerLoadingOperationFailureHandling(Class<? extends Throwable> exceptionType,
+			String exceptionMessage, String failingOperationAsString, int count) {
+		verify( failureHandler, times( count ) ).handle( entityFailureContextCapture.capture() );
+
+		MassIndexingEntityFailureContext context = entityFailureContextCapture.getValue();
+		assertThat( context.throwable() )
+				.isInstanceOf( SimulatedFailure.class )
+				.hasMessageContainingAll( exceptionMessage );
+		assertThat( context.failingOperation() ).asString()
+				.isEqualTo( failingOperationAsString );
+		assertThat( context.entityReferences() )
+				.hasSize( 1 );
+
+		verifyNoMoreInteractions( failureHandler );
 	}
 
 	@Override

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingFailureDefaultBackgroundFailureHandlerIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingFailureDefaultBackgroundFailureHandlerIT.java
@@ -121,6 +121,25 @@ public class MassIndexingFailureDefaultBackgroundFailureHandlerIT extends Abstra
 	}
 
 	@Override
+	protected void expectMassIndexerLoadingOperationFailureHandling(Class<? extends Throwable> exceptionType,
+			String exceptionMessage, String failingOperationAsString, int count) {
+		logged.expectEvent(
+						Level.ERROR,
+						ExceptionMatcherBuilder.isException( exceptionType )
+								.withMessage( exceptionMessage )
+								.build(),
+						failingOperationAsString
+				)
+				.times( count );
+	}
+
+	@Override
+	protected void assertMassIndexerLoadingOperationFailureHandling(Class<? extends Throwable> exceptionType,
+			String exceptionMessage, String failingOperationAsString, int count) {
+		// If we get there, everything works fine.
+	}
+
+	@Override
 	protected void expectEntityIndexingAndMassIndexerOperationFailureHandling(String entityName,
 			String entityReferenceAsString,
 			String failingEntityIndexingExceptionMessage, String failingEntityIndexingOperationAsString,

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingEntityLoadingRunnable.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingEntityLoadingRunnable.java
@@ -61,7 +61,12 @@ public class PojoMassIndexingEntityLoadingRunnable<E, I>
 				if ( idList != null ) {
 					log.tracef( "received list of ids %s", idList );
 					// This will pass the loaded entities to the sink, which will trigger indexing for those entities.
-					entityLoader.load( idList );
+					try {
+						entityLoader.load( idList );
+					}
+					catch (RuntimeException e) {
+						getNotifier().reportEntitiesLoadingFailure( typeGroup, idList, e );
+					}
 				}
 			}
 			while ( idList != null );

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingIndexedTypeGroup.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingIndexedTypeGroup.java
@@ -118,7 +118,13 @@ public class PojoMassIndexingIndexedTypeGroup<E> {
 		String entityName = typeContext.entityName();
 		Object identifier = extractIdentifier( typeContext, sessionContext, entity );
 		return mappingContext.entityReferenceFactory().createEntityReference( entityName, identifier );
+	}
 
+	public Object makeSuperTypeReference(Object identifier) {
+		return mappingContext.entityReferenceFactory().createEntityReference(
+				commonSuperType.entityName(),
+				identifier
+		);
 	}
 
 	public <E2> Object extractIdentifier(PojoMassIndexingIndexedTypeContext<E2> typeContext,


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4541

I'm not sure if that's what you expected, but while I was trying to create some reproducer of the problem, here are the changes I've made 😄 
The test fails two batches, but the remaining ones are still completed, and in the end, an exception is thrown by `indexer.startAndWait();`
As for the logging of failed IDs, there's already a trace log in place, so I assume that covers it.

[HSEARCH-4541]: https://hibernate.atlassian.net/browse/HSEARCH-4541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ