### PR TITLE
HSEARCH-4712  Convert synchronized blocks to java.util.concurrent.Locks for better Loom compatibility

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/writer/impl/IndexWriterDelegatorImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/writer/impl/IndexWriterDelegatorImpl.java
@@ -184,7 +184,8 @@ public class IndexWriterDelegatorImpl implements IndexWriterDelegator {
 	private void doCommit() {
 		commitLock.lock();
 		try {
-			// NOTE: underlying Lucene code is using same pattern to sync on object block:
+			// NOTE: underlying Lucene code is using this pattern to sync on object block,
+			// which could be a problem with Loom:
 			// synchronized(commitLock)
 			delegate.commit();
 			updateCommitExpiration();

--- a/build/config/src/main/resources/checkstyle.xml
+++ b/build/config/src/main/resources/checkstyle.xml
@@ -94,6 +94,13 @@
             <property name="ignoreComments" value="true" />
         </module>
 
+        <!-- Do not use sync blocks on objects -->
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="synchronized\s*\(\s*(?!this\b)\w+" />
+            <property name="message" value="Do not use `synchronized (someObject)` blocks. Instead use the `java.util.concurrent.locks.Lock`s. See HSEARCH-4712." />
+            <property name="ignoreComments" value="true" />
+        </module>
+
        <!-- Checks for imports -->
         <module name="AvoidStarImport" />
         <module name="RedundantImport" />

--- a/engine/src/main/java/org/hibernate/search/engine/common/resources/impl/EngineThreads.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/resources/impl/EngineThreads.java
@@ -33,6 +33,9 @@ public class EngineThreads {
 		if ( executor != null ) {
 			return executor;
 		}
+		// this sync block shouldn't be a problem for Loom:
+		// - sync happens only once on init ?
+		// - no I/O and simple in-memory operations
 		synchronized (this) {
 			if ( timingExecutor != null ) {
 				return timingExecutor;

--- a/engine/src/main/java/org/hibernate/search/engine/common/timing/impl/DefaultTimingSource.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/timing/impl/DefaultTimingSource.java
@@ -52,6 +52,9 @@ public final class DefaultTimingSource implements TimingSource {
 		if ( future != null ) {
 			return;
 		}
+		// this sync block shouldn't be a problem for Loom:
+		// - sync happens only once on init ?
+		// - no I/O and simple in-memory operations
 		synchronized ( this ) {
 			if ( future != null ) {
 				return;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingLoggingMonitor.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingLoggingMonitor.java
@@ -53,6 +53,9 @@ public class PojoMassIndexingLoggingMonitor implements MassIndexingMonitor {
 	@Override
 	public void documentsAdded(long increment) {
 		if ( startTime == 0 ) {
+			// this sync block doesn't seem to be a problem for Loom:
+			// - always executed in MassIndexer threads, which are not virtual threads
+			// - no I/O and simple in-memory operations
 			synchronized (this) {
 				if ( startTime == 0 ) {
 					long theStartTime = System.nanoTime();


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4712

There weren't actually that many sync blocks inside of the methods. Ones inside `IndexWriterDelegatorImpl` looked like good candidates for replacement as they are somewhat using sync blocks to do I/O operations. But the underlying Lucene code is using the same pattern, so I suppose it won't help much until that is changed as well:

```java 
  private long commitInternal(MergePolicy mergePolicy) throws IOException {
    // .... 
    synchronized(commitLock) {
      ensureOpen(false);
      // .... 
      finishCommit();
    }
    // .... 
    return seqNo;
  }
```

The other sync blocks were either in test appenders or where sync only happens on the init stage and only performs in-memory operations, so doesn't look like candidates for replacement.