### PR TITLE
HSEARCH-4642 Upgrade build dependencies to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,7 +353,7 @@
         <version.exec.plugin>3.1.0</version.exec.plugin>
         <version.forbiddenapis.plugin>3.4</version.forbiddenapis.plugin>
         <version.help.plugin>3.3.0</version.help.plugin>
-        <version.install.plugin>3.0.1</version.install.plugin>
+        <version.install.plugin>3.1.0</version.install.plugin>
         <version.io.takari.maven>0.7.7</version.io.takari.maven>
         <version.jandex.plugin>1.2.3</version.jandex.plugin>
         <version.japicmp.plugin>0.16.0</version.japicmp.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -321,7 +321,7 @@
         <version.com.microsoft.sqlserver.mssql-jdbc>9.2.1.jre11</version.com.microsoft.sqlserver.mssql-jdbc>
 
         <!-- >>> Performance tests -->
-        <version.org.openjdk.jmh>1.35</version.org.openjdk.jmh>
+        <version.org.openjdk.jmh>1.36</version.org.openjdk.jmh>
 
         <!-- >>> JSR 352: JBatch runtime -->
         <version.com.ibm.jbatch>1.0</version.com.ibm.jbatch>

--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,7 @@
         <version.org.osgi.core>6.0.0</version.org.osgi.core>
 
         <version.org.hamcrest>2.2</version.org.hamcrest>
-        <version.org.mockito>4.8.1</version.org.mockito>
+        <version.org.mockito>4.9.0</version.org.mockito>
         <version.org.assertj.assertj-core>3.23.1</version.org.assertj.assertj-core>
         <version.org.awaitily>4.2.0</version.org.awaitily>
         <version.org.skyscreamer.jsonassert>1.5.1</version.org.skyscreamer.jsonassert>

--- a/pom.xml
+++ b/pom.xml
@@ -356,7 +356,7 @@
         <version.install.plugin>3.1.0</version.install.plugin>
         <version.io.takari.maven>0.7.7</version.io.takari.maven>
         <version.jandex.plugin>1.2.3</version.jandex.plugin>
-        <version.japicmp.plugin>0.16.0</version.japicmp.plugin>
+        <version.japicmp.plugin>0.17.1</version.japicmp.plugin>
         <version.jar.plugin>3.3.0</version.jar.plugin>
         <version.javadoc.plugin>3.4.1</version.javadoc.plugin>
         <version.jdeps.plugin>0.5.1</version.jdeps.plugin>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4642

For HSEARCH-4642, folllows up on https://github.com/hibernate/hibernate-search/pull/3294, https://github.com/hibernate/hibernate-search/pull/3146, https://github.com/hibernate/hibernate-search/pull/3148, https://github.com/hibernate/hibernate-search/pull/3157, https://github.com/hibernate/hibernate-search/pull/3176, https://github.com/hibernate/hibernate-search/pull/3189, https://github.com/hibernate/hibernate-search/pull/3194, https://github.com/hibernate/hibernate-search/pull/3208, https://github.com/hibernate/hibernate-search/pull/3219, https://github.com/hibernate/hibernate-search/pull/3234, https://github.com/hibernate/hibernate-search/pull/3239, https://github.com/hibernate/hibernate-search/pull/3249, https://github.com/hibernate/hibernate-search/pull/3255, https://github.com/hibernate/hibernate-search/pull/3262, https://github.com/hibernate/hibernate-search/pull/3281