### PR TITLE
HSEARCH-4752 Bump Elasticsearch version to test against the latest micro 8.5.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -246,7 +246,7 @@ stage('Configure') {
 					new EsLocalBuildEnvironment(version: '8.2.3', condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(version: '8.3.3', condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(version: '8.4.3', condition: TestCondition.ON_DEMAND),
-					new EsLocalBuildEnvironment(version: '8.5.0', condition: TestCondition.BEFORE_MERGE, isDefault: true),
+					new EsLocalBuildEnvironment(version: '8.5.2', condition: TestCondition.BEFORE_MERGE, isDefault: true),
 
 					// --------------------------------------------
 					// OpenSearch

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -248,7 +248,7 @@ class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 	@Override
 	public boolean supportsMatchOnScaledNumericLossOfPrecision() {
 		// https://github.com/elastic/elasticsearch/issues/91246
-		// Hopefully this will get fixed in 8.5.1.
-		return !isBetween( actualVersion, "elastic:8.5.0", "elastic:8.5.0" );
+		// Hopefully this will get fixed in 8.5.3.
+		return !isBetween( actualVersion, "elastic:8.5.0", "elastic:8.5.2" );
 	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ZonedDateTimeFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ZonedDateTimeFieldTypeDescriptor.java
@@ -148,7 +148,8 @@ public class ZonedDateTimeFieldTypeDescriptor extends FieldTypeDescriptor<ZonedD
 		return Arrays.asList(
 				ZoneId.of( "UTC" ),
 				ZoneId.of( "Europe/Paris" ),
-				ZoneId.of( "Europe/Amsterdam" ),
+				ZoneId.of( "Europe/London" ),
+				ZoneId.of( "Europe/Warsaw" ),
 				ZoneId.of( "America/Los_Angeles" ),
 				// HSEARCH-3548: also test ZoneOffsets used as ZoneIds
 				ZoneOffset.UTC, // Strangely, this is not the same as ZoneId.of( "UTC" )

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.5+ -->
-        <version.org.elasticsearch.client>8.5.0</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>8.5.2</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-8.4) becomes the default. -->

--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
         <version.org.elasticsearch.compatible.not-regularly-tested.text>7.0 or 8.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest version of Elasticsearch tested against by default -->
-        <version.org.elasticsearch.latest>8.5.0</version.org.elasticsearch.latest>
+        <version.org.elasticsearch.latest>8.5.2</version.org.elasticsearch.latest>
         <!-- The versions of OpenSearch advertised as compatible with Hibernate Search -->
         <!-- Make sure to only mention tested versions here -->
         <version.org.opensearch.compatible.regularly-tested.text>1.3 or 2.0</version.org.opensearch.compatible.regularly-tested.text>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4752
https://hibernate.atlassian.net/browse/HSEARCH-4754

The bug with the scaled_float property hasn't been fixed yet, so I've updated `supportsMatchOnScaledNumericLossOfPrecision` to include this new version.