### PR TITLE
HSEARCH-4754 Bump Elasticsearch client version to the latest micro 8.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.5+ -->
-        <version.org.elasticsearch.client>8.5.0</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>8.5.1</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-8.4) becomes the default. -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4754

This is just to test if timezone tests will pass on CI with only the client change