### PR TITLE
HSEARCH-4484 Bump version.org.springframework.boot from 2.7.0 to 2.7.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,7 +333,7 @@
         <version.org.google.guava>31.1-jre</version.org.google.guava>
 
         <!-- >>> Spring integration tests -->
-        <version.org.springframework.boot>2.7.0</version.org.springframework.boot>
+        <version.org.springframework.boot>2.7.6</version.org.springframework.boot>
 
         <!-- Maven plugins versions -->
 


### PR DESCRIPTION
https://github.com/hibernate/hibernate-search/pull/3318 spring boot cannot be simply upgraded to 3.0 in the main code as Atomikos support, which some of our code relies on, was dropped from the main project and was supposed to be moved to Atmoikos team (I haven't seen a release for 3.0 there). But more important 3.0 moved to Jakarta EE 9 (https://spring.io/blog/2022/05/24/preparing-for-spring-boot-3-0), so it doesn't make sense to update it in the main code. I wonder if we should add this update on top of our ORM 6 patches and keep it there for now...

For HSEARCH-4484, follows up on https://github.com/hibernate/hibernate-search/pull/3134, https://github.com/hibernate/hibernate-search/pull/2895, https://github.com/hibernate/hibernate-search/pull/2902, https://github.com/hibernate/hibernate-search/pull/2904, https://github.com/hibernate/hibernate-search/pull/2913, https://github.com/hibernate/hibernate-search/pull/2931, https://github.com/hibernate/hibernate-search/pull/2941, https://github.com/hibernate/hibernate-search/pull/2954, https://github.com/hibernate/hibernate-search/pull/2293 https://github.com/hibernate/hibernate-search/pull/2983, https://github.com/hibernate/hibernate-search/pull/3021, https://github.com/hibernate/hibernate-search/pull/3028, https://github.com/hibernate/hibernate-search/pull/3041, https://github.com/hibernate/hibernate-search/pull/3052, https://github.com/hibernate/hibernate-search/pull/3066, https://github.com/hibernate/hibernate-search/pull/3083, https://github.com/hibernate/hibernate-search/pull/3092, https://github.com/hibernate/hibernate-search/pull/3100, https://github.com/hibernate/hibernate-search/pull/3110, https://github.com/hibernate/hibernate-search/pull/3118.