### PR TITLE
HSEARCH-4642 Bump maven-dependency-plugin from 3.3.0 to 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -344,7 +344,7 @@
         <version.clean.plugin>3.2.0</version.clean.plugin>
         <!-- Needing 3.6.2 at least because of MCOMPILER-294 -->
         <version.compiler.plugin>3.10.1</version.compiler.plugin>
-        <version.dependency.plugin>3.3.0</version.dependency.plugin>
+        <version.dependency.plugin>3.4.0</version.dependency.plugin>
         <!-- Check dependencies for security vulnerabilities -->
         <version.dependency-check.plugin>7.2.1</version.dependency-check.plugin>
         <version.deploy.plugin>3.0.0</version.deploy.plugin>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4642

For HSEARCH-4642, folllows up on https://github.com/hibernate/hibernate-search/pull/3313, https://github.com/hibernate/hibernate-search/pull/3294, https://github.com/hibernate/hibernate-search/pull/3146, https://github.com/hibernate/hibernate-search/pull/3148, https://github.com/hibernate/hibernate-search/pull/3157, https://github.com/hibernate/hibernate-search/pull/3176, https://github.com/hibernate/hibernate-search/pull/3189, https://github.com/hibernate/hibernate-search/pull/3194, https://github.com/hibernate/hibernate-search/pull/3208, https://github.com/hibernate/hibernate-search/pull/3219, https://github.com/hibernate/hibernate-search/pull/3234, https://github.com/hibernate/hibernate-search/pull/3239, https://github.com/hibernate/hibernate-search/pull/3249, https://github.com/hibernate/hibernate-search/pull/3255, https://github.com/hibernate/hibernate-search/pull/3262, https://github.com/hibernate/hibernate-search/pull/3281