### PR TITLE
HSEARCH-4761 Bump Elasticsearch version to test against the latest micro 8.5.3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -246,7 +246,7 @@ stage('Configure') {
 					new EsLocalBuildEnvironment(version: '8.2.3', condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(version: '8.3.3', condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(version: '8.4.3', condition: TestCondition.ON_DEMAND),
-					new EsLocalBuildEnvironment(version: '8.5.2', condition: TestCondition.BEFORE_MERGE, isDefault: true),
+					new EsLocalBuildEnvironment(version: '8.5.3', condition: TestCondition.BEFORE_MERGE, isDefault: true),
 
 					// --------------------------------------------
 					// OpenSearch

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -248,7 +248,7 @@ class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 	@Override
 	public boolean supportsMatchOnScaledNumericLossOfPrecision() {
 		// https://github.com/elastic/elasticsearch/issues/91246
-		// Hopefully this will get fixed in 8.5.3.
-		return !isBetween( actualVersion, "elastic:8.5.0", "elastic:8.5.2" );
+		// Hopefully this will get fixed in 8.5.4.
+		return !isBetween( actualVersion, "elastic:8.5.0", "elastic:8.5.3" );
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.5+ -->
-        <version.org.elasticsearch.client>8.5.2</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>8.5.3</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-8.4) becomes the default. -->
@@ -216,7 +216,7 @@
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
         <version.org.elasticsearch.compatible.not-regularly-tested.text>7.0 or 8.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest version of Elasticsearch tested against by default -->
-        <version.org.elasticsearch.latest>8.5.2</version.org.elasticsearch.latest>
+        <version.org.elasticsearch.latest>8.5.3</version.org.elasticsearch.latest>
         <!-- The versions of OpenSearch advertised as compatible with Hibernate Search -->
         <!-- Make sure to only mention tested versions here -->
         <version.org.opensearch.compatible.regularly-tested.text>1.3 or 2.0</version.org.opensearch.compatible.regularly-tested.text>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4761