### PR TITLE
HSEARCH-4642 Upgrade build dependencies to the latest version

### DIFF
--- a/build/parents/integrationtest/pom.xml
+++ b/build/parents/integrationtest/pom.xml
@@ -639,7 +639,7 @@
                 <jdbc.driver.groupId>com.microsoft.sqlserver</jdbc.driver.groupId>
                 <jdbc.driver.artifactId>mssql-jdbc</jdbc.driver.artifactId>
                 <jdbc.driver>com.microsoft.sqlserver.jdbc.SQLServerDriver</jdbc.driver>
-                <jdbc.url>jdbc:sqlserver://localhost:1433;databaseName=tempdb</jdbc.url>
+                <jdbc.url>jdbc:sqlserver://localhost:1433;databaseName=tempdb;encrypt=false</jdbc.url>
                 <jdbc.user>sa</jdbc.user>
                 <jdbc.pass>ActuallyRequired11Complexity</jdbc.pass>
             </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -321,12 +321,12 @@
         <!-- Sticking to Derby 10.14 for now since later versions require JDK 9+, and we need to test with JDK 8.
              See https://db.apache.org/derby/derby_downloads.html -->
         <version.org.apache.derby>10.14.2.0</version.org.apache.derby>
-        <version.org.postgresql>42.5.0</version.org.postgresql>
-        <version.org.mariadb.jdbc>3.0.8</version.org.mariadb.jdbc>
-        <version.mysql.mysql-connector-java>8.0.30</version.mysql.mysql-connector-java>
+        <version.org.postgresql>42.5.1</version.org.postgresql>
+        <version.org.mariadb.jdbc>3.1.0</version.org.mariadb.jdbc>
+        <version.mysql.mysql-connector-java>8.0.31</version.mysql.mysql-connector-java>
         <version.com.ibm.db2.jcc>11.5.8.0</version.com.ibm.db2.jcc>
         <version.com.oracle.database.jdbc>21.8.0.0</version.com.oracle.database.jdbc>
-        <version.com.microsoft.sqlserver.mssql-jdbc>9.2.1.jre11</version.com.microsoft.sqlserver.mssql-jdbc>
+        <version.com.microsoft.sqlserver.mssql-jdbc>11.2.2.jre11</version.com.microsoft.sqlserver.mssql-jdbc>
 
         <!-- >>> Performance tests -->
         <version.org.openjdk.jmh>1.36</version.org.openjdk.jmh>

--- a/pom.xml
+++ b/pom.xml
@@ -618,34 +618,40 @@
         <!-- Run containers for additional ORM databases -->
         <test.database.run.skip>true</test.database.run.skip>
         <!-- PostgreSQL -->
+        <!-- See https://hub.docker.com/_/postgres -->
         <test.database.run.postgres.skip>true</test.database.run.postgres.skip>
         <test.database.run.postgres.image.name>postgres</test.database.run.postgres.image.name>
-        <test.database.run.postgres.image.tag>13.1</test.database.run.postgres.image.tag>
+        <test.database.run.postgres.image.tag>15.1</test.database.run.postgres.image.tag>
         <!-- MariaDB -->
+        <!-- See https://hub.docker.com/_/mariadb -->
         <test.database.run.mariadb.skip>true</test.database.run.mariadb.skip>
         <test.database.run.mariadb.image.name>mariadb</test.database.run.mariadb.image.name>
-        <test.database.run.mariadb.image.tag>10.5.8</test.database.run.mariadb.image.tag>
+        <test.database.run.mariadb.image.tag>10.10.2</test.database.run.mariadb.image.tag>
         <!-- MySQL -->
+        <!-- See https://hub.docker.com/_/mysql -->
         <test.database.run.mysql.skip>true</test.database.run.mysql.skip>
         <test.database.run.mysql.image.name>mysql</test.database.run.mysql.image.name>
-        <test.database.run.mysql.image.tag>8.0.22</test.database.run.mysql.image.tag>
+        <test.database.run.mysql.image.tag>8.0.31</test.database.run.mysql.image.tag>
         <!-- DB2 -->
+        <!-- See https://hub.docker.com/r/ibmcom/db2 -->
         <test.database.run.db2.skip>true</test.database.run.db2.skip>
         <test.database.run.db2.image.name>ibmcom/db2</test.database.run.db2.image.name>
         <test.database.run.db2.image.tag>11.5.8.0</test.database.run.db2.image.tag>
         <!-- Oracle -->
-        <test.database.run.oracle.skip>true</test.database.run.oracle.skip>
         <!-- See https://hub.docker.com/r/gvenzl/oracle-xe -->
+        <test.database.run.oracle.skip>true</test.database.run.oracle.skip>
         <test.database.run.oracle.image.name>gvenzl/oracle-xe</test.database.run.oracle.image.name>
-        <test.database.run.oracle.image.tag>21-slim-faststart</test.database.run.oracle.image.tag>
+        <test.database.run.oracle.image.tag>21.3.0-slim-faststart</test.database.run.oracle.image.tag>
         <!-- MS SQL Server -->
+        <!-- See https://hub.docker.com/_/microsoft-mssql-server -->
         <test.database.run.mssql.skip>true</test.database.run.mssql.skip>
         <test.database.run.mssql.image.name>mcr.microsoft.com/mssql/server</test.database.run.mssql.image.name>
-        <test.database.run.mssql.image.tag>2019-CU8-ubuntu-16.04</test.database.run.mssql.image.tag>
+        <test.database.run.mssql.image.tag>2019-CU18-ubuntu-20.04</test.database.run.mssql.image.tag>
         <!-- CockroachDB -->
+        <!-- See https://hub.docker.com/r/cockroachdb/cockroach/tags -->
         <test.database.run.cockroachdb.skip>true</test.database.run.cockroachdb.skip>
         <test.database.run.cockroachdb.image.name>cockroachdb/cockroach</test.database.run.cockroachdb.image.name>
-        <test.database.run.cockroachdb.image.tag>v22.1.4</test.database.run.cockroachdb.image.tag>
+        <test.database.run.cockroachdb.image.tag>v22.1.12</test.database.run.cockroachdb.image.tag>
 
         <!-- Property whose sole purpose is to be referenced in the definition of surefire.jvm.args.module
              when Weld is used. -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4642

For HSEARCH-4642, folllows up on https://github.com/hibernate/hibernate-search/pull/3313, https://github.com/hibernate/hibernate-search/pull/3294, https://github.com/hibernate/hibernate-search/pull/3146, https://github.com/hibernate/hibernate-search/pull/3148, https://github.com/hibernate/hibernate-search/pull/3157, https://github.com/hibernate/hibernate-search/pull/3176, https://github.com/hibernate/hibernate-search/pull/3189, https://github.com/hibernate/hibernate-search/pull/3194, https://github.com/hibernate/hibernate-search/pull/3208, https://github.com/hibernate/hibernate-search/pull/3219, https://github.com/hibernate/hibernate-search/pull/3234, https://github.com/hibernate/hibernate-search/pull/3239, https://github.com/hibernate/hibernate-search/pull/3249, https://github.com/hibernate/hibernate-search/pull/3255, https://github.com/hibernate/hibernate-search/pull/3262, https://github.com/hibernate/hibernate-search/pull/3281, #3331