### PR TITLE
HSEARCH-4294 Expose implicit fields through search DSL

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/impl/ElasticsearchStringImplicitFieldContributor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/impl/ElasticsearchStringImplicitFieldContributor.java
@@ -1,0 +1,48 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.document.model.dsl.impl;
+
+import org.hibernate.search.engine.backend.document.model.dsl.spi.ImplicitFieldCollector;
+import org.hibernate.search.engine.backend.document.model.dsl.spi.ImplicitFieldContributor;
+import org.hibernate.search.engine.backend.types.Aggregable;
+import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.engine.backend.types.Searchable;
+import org.hibernate.search.engine.backend.types.Sortable;
+
+public class ElasticsearchStringImplicitFieldContributor implements ImplicitFieldContributor {
+
+	private final String name;
+	private final Searchable searchable;
+	private final Sortable sortable;
+	private final Projectable projectable;
+	private final Aggregable aggregable;
+
+	public ElasticsearchStringImplicitFieldContributor(String name) {
+		this( name, Searchable.YES, Sortable.YES, Projectable.YES, Aggregable.YES );
+	}
+
+	public ElasticsearchStringImplicitFieldContributor(String name, Searchable searchable, Sortable sortable,
+			Projectable projectable, Aggregable aggregable) {
+		this.name = name;
+		this.searchable = searchable;
+		this.sortable = sortable;
+		this.projectable = projectable;
+		this.aggregable = aggregable;
+	}
+
+	public void contribute(ImplicitFieldCollector collector) {
+		collector.addImplicitField(
+				name,
+				collector.indexFieldTypeFactory().asString()
+						.searchable( searchable )
+						.sortable( sortable )
+						.projectable( projectable )
+						.aggregable( aggregable )
+						.toIndexFieldType()
+		);
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendImpl.java
@@ -255,6 +255,8 @@ class ElasticsearchBackendImpl implements BackendImplementor,
 
 		typeNameMapping.getIndexSchemaRootContributor()
 				.ifPresent( builder::addSchemaRootContributor );
+		typeNameMapping.getImplicitFieldContributor()
+				.ifPresent( builder::addImplicitFieldContributor );
 
 		multiTenancyStrategy.indexSchemaRootContributor()
 				.ifPresent( builder::addSchemaRootContributor );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/mapping/impl/DiscriminatorTypeNameMapping.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/mapping/impl/DiscriminatorTypeNameMapping.java
@@ -10,7 +10,9 @@ import java.lang.invoke.MethodHandles;
 import java.util.Optional;
 
 import org.hibernate.search.backend.elasticsearch.document.impl.DocumentMetadataContributor;
+import org.hibernate.search.engine.backend.document.model.dsl.spi.ImplicitFieldContributor;
 import org.hibernate.search.backend.elasticsearch.document.model.dsl.impl.IndexSchemaRootContributor;
+import org.hibernate.search.backend.elasticsearch.document.model.dsl.impl.ElasticsearchStringImplicitFieldContributor;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.DataTypes;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.PropertyMapping;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.RootTypeMapping;
@@ -49,6 +51,11 @@ public class DiscriminatorTypeNameMapping implements TypeNameMapping {
 	@Override
 	public Optional<DocumentMetadataContributor> getDocumentMetadataContributor(String mappedTypeName) {
 		return Optional.of( new TypeNameDiscriminatorContributor( mappedTypeName ) );
+	}
+
+	@Override
+	public Optional<ImplicitFieldContributor> getImplicitFieldContributor() {
+		return Optional.of( new ElasticsearchStringImplicitFieldContributor( MAPPED_TYPE_FIELD_NAME ) );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/mapping/impl/IndexNameTypeNameMapping.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/mapping/impl/IndexNameTypeNameMapping.java
@@ -12,13 +12,14 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.hibernate.search.backend.elasticsearch.document.impl.DocumentMetadataContributor;
+import org.hibernate.search.engine.backend.document.model.dsl.spi.ImplicitFieldContributor;
 import org.hibernate.search.backend.elasticsearch.document.model.dsl.impl.IndexSchemaRootContributor;
-import org.hibernate.search.backend.elasticsearch.index.layout.impl.IndexNames;
-import org.hibernate.search.backend.elasticsearch.index.layout.IndexLayoutStrategy;
 import org.hibernate.search.backend.elasticsearch.gson.impl.JsonAccessor;
+import org.hibernate.search.backend.elasticsearch.index.layout.IndexLayoutStrategy;
+import org.hibernate.search.backend.elasticsearch.index.layout.impl.IndexNames;
 import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
-import org.hibernate.search.backend.elasticsearch.search.projection.impl.ProjectionExtractionHelper;
 import org.hibernate.search.backend.elasticsearch.search.projection.impl.ProjectionExtractContext;
+import org.hibernate.search.backend.elasticsearch.search.projection.impl.ProjectionExtractionHelper;
 import org.hibernate.search.backend.elasticsearch.search.projection.impl.ProjectionRequestContext;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
@@ -50,6 +51,11 @@ public class IndexNameTypeNameMapping implements TypeNameMapping {
 	@Override
 	public Optional<DocumentMetadataContributor> getDocumentMetadataContributor(String mappedTypeName) {
 		// No need to add anything to documents, Elasticsearch metadata is enough
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<ImplicitFieldContributor> getImplicitFieldContributor() {
 		return Optional.empty();
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/mapping/impl/TypeNameMapping.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/mapping/impl/TypeNameMapping.java
@@ -9,6 +9,7 @@ package org.hibernate.search.backend.elasticsearch.mapping.impl;
 import java.util.Optional;
 
 import org.hibernate.search.backend.elasticsearch.document.impl.DocumentMetadataContributor;
+import org.hibernate.search.engine.backend.document.model.dsl.spi.ImplicitFieldContributor;
 import org.hibernate.search.backend.elasticsearch.document.model.dsl.impl.IndexSchemaRootContributor;
 import org.hibernate.search.backend.elasticsearch.index.layout.impl.IndexNames;
 import org.hibernate.search.backend.elasticsearch.search.projection.impl.ProjectionExtractionHelper;
@@ -30,6 +31,12 @@ public interface TypeNameMapping {
 	 * or an empty optional.
 	 */
 	Optional<DocumentMetadataContributor> getDocumentMetadataContributor(String mappedTypeName);
+
+	/**
+	 * @return A field contributor for the additional implicit properties (_entity_type, ...),
+	 * or an empty optional.
+	 */
+	Optional<ImplicitFieldContributor> getImplicitFieldContributor();
 
 	/**
 	 * Register a new index => type mapping.

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/spi/ImplicitFieldCollector.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/spi/ImplicitFieldCollector.java
@@ -1,0 +1,32 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.backend.document.model.dsl.spi;
+
+import org.hibernate.search.engine.backend.types.IndexFieldType;
+import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactory;
+import org.hibernate.search.util.common.annotation.Incubating;
+
+@Incubating
+public interface ImplicitFieldCollector {
+
+	/**
+	 * Returned factory can be used to easily create a field type for {@link #addImplicitField(String, IndexFieldType)}.
+	 *
+	 * @return A factory for types of index fields.
+	 */
+	IndexFieldTypeFactory indexFieldTypeFactory();
+
+	/**
+	 * Create a new implicit field. It is expected that the field will be present in the created index. Mapping will not
+	 * be modified.
+	 *
+	 * @param fieldName The relative name of the field
+	 * @param indexFieldType The type of the field
+	 * @param <F> The type of values for the field
+	 */
+	<F> void addImplicitField(String fieldName, IndexFieldType<F> indexFieldType);
+}

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/spi/ImplicitFieldContributor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/spi/ImplicitFieldContributor.java
@@ -1,0 +1,17 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.backend.document.model.dsl.spi;
+
+import org.hibernate.search.util.common.annotation.Incubating;
+
+/**
+ * Opens an extension point to accept implicit fields.
+ */
+@Incubating
+public interface ImplicitFieldContributor {
+	void contribute(ImplicitFieldCollector collector);
+}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/metamodel/ElasticsearchIndexDescriptorIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/metamodel/ElasticsearchIndexDescriptorIT.java
@@ -8,9 +8,14 @@ package org.hibernate.search.integrationtest.backend.elasticsearch.metamodel;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collection;
+import java.util.Optional;
+
 import org.hibernate.search.backend.elasticsearch.metamodel.ElasticsearchIndexDescriptor;
 import org.hibernate.search.backend.elasticsearch.index.ElasticsearchIndexManager;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.metamodel.IndexDescriptor;
+import org.hibernate.search.engine.backend.metamodel.IndexFieldDescriptor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingSchemaManagementStrategy;
@@ -41,6 +46,31 @@ public class ElasticsearchIndexDescriptorIT {
 		assertThat( indexDescriptor.readName() ).isEqualTo( "indexname-read" );
 		assertThat( indexDescriptor.writeName() ).isEqualTo( "indexname-write" );
 		assertThat( indexDescriptor.hibernateSearchName() ).isEqualTo( index.name() );
+	}
+
+	@Test
+	public void implicitFields() {
+		IndexDescriptor indexDescriptor = index.toApi().descriptor();
+
+		Optional<IndexFieldDescriptor> valueFieldDescriptorOptional = indexDescriptor.field( "string" );
+		assertThat( valueFieldDescriptorOptional ).isPresent();
+
+		Optional<IndexFieldDescriptor> idDescriptorOptional = indexDescriptor.field( "_id" );
+		assertThat( idDescriptorOptional ).isPresent();
+
+		Optional<IndexFieldDescriptor> indexDescriptorOptional = indexDescriptor.field( "_index" );
+		assertThat( indexDescriptorOptional ).isPresent();
+
+		Optional<IndexFieldDescriptor> entityTypeDescriptorOptional = indexDescriptor.field( "_entity_type" );
+		assertThat( entityTypeDescriptorOptional ).isPresent();
+
+		Collection<IndexFieldDescriptor> staticFields = indexDescriptor.staticFields();
+		assertThat( staticFields ).containsOnly(
+				idDescriptorOptional.get(),
+				indexDescriptorOptional.get(),
+				entityTypeDescriptorOptional.get(),
+				valueFieldDescriptorOptional.get()
+		);
 	}
 
 	private static class IndexBinding {

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/ElasticsearchImplicitFieldsIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/ElasticsearchImplicitFieldsIT.java
@@ -1,0 +1,114 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.elasticsearch.search;
+
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
+
+import java.util.Map;
+
+import org.hibernate.search.engine.backend.common.DocumentReference;
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.engine.search.aggregation.AggregationKey;
+import org.hibernate.search.engine.search.query.SearchQuery;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ElasticsearchImplicitFieldsIT {
+
+	private static final String FIRST_ID = "1";
+	private static final String SECOND_ID = "2";
+	private static final String THIRD_ID = "3";
+	private static final String FOURTH_ID = "4";
+	private static final String FIFTH_ID = "5";
+	private static final String EMPTY_ID = "empty";
+
+	@Rule
+	public final SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private final SimpleMappedIndex<IndexBinding> mainIndex = SimpleMappedIndex.of( IndexBinding::new ).name( "main" );
+
+	@Before
+	public void setup() {
+		setupHelper.start().withIndexes( mainIndex ).setup().integration();
+
+		initData();
+	}
+
+	@Test
+	public void implicit_fields_aggregation_entity_type() {
+		StubMappingScope scope = mainIndex.createScope();
+
+		AggregationKey<Map<String, Long>> countsByEntityKey = AggregationKey.of( "countsByEntity" );
+
+		SearchQuery<DocumentReference> query = scope.query()
+				.where( f -> f.matchAll() )
+				.aggregation( countsByEntityKey, f -> f.terms().field( "_entity_type", String.class ) )
+				.toQuery();
+		assertThatQuery( query ).aggregation( countsByEntityKey )
+				.extracting( "mainType" )
+				.isEqualTo( 6L )
+		;
+	}
+
+	@Test
+	public void implicit_fields_id() {
+		StubMappingScope scope = mainIndex.createScope();
+		SearchQuery<DocumentReference> query = scope.query()
+				.where( f -> f.bool().must( ff -> ff.terms().field( "_id" ).matchingAny( "4" ) ) )
+				.toQuery();
+		assertThatQuery( query )
+				.hasDocRefHitsAnyOrder( "mainType", "4" );
+	}
+
+	@Test
+	public void implicit_fields_index() {
+		StubMappingScope scope = mainIndex.createScope();
+		SearchQuery<DocumentReference> query = scope.query()
+				.where( f -> f.bool().must( ff -> ff.match().field( "_index" ).matching( "main-000001" ) ) )
+				.toQuery();
+		assertThatQuery( query )
+				.hasTotalHitCount( 6 )
+				.hasDocRefHitsAnyOrder( "mainType", "1", "2", "3", "4", "5", "empty" );
+	}
+
+	private void initData() {
+		mainIndex.bulkIndexer()
+				.add( SECOND_ID, document -> {
+					document.addValue( mainIndex.binding().string, "text 2" );
+				} )
+				.add( FIRST_ID, document -> {
+					document.addValue( mainIndex.binding().string, "text 1" );
+				} )
+				.add( THIRD_ID, document -> {
+					document.addValue( mainIndex.binding().string, "text 3" );
+				} )
+				.add( FOURTH_ID, document -> {
+					document.addValue( mainIndex.binding().string, "text 4" );
+				} )
+				.add( FIFTH_ID, document -> {
+					document.addValue( mainIndex.binding().string, "text 5" );
+				} )
+				.add( EMPTY_ID, document -> {
+				} )
+				.join();
+	}
+
+	private static class IndexBinding {
+		final IndexFieldReference<String> string;
+
+		IndexBinding(IndexSchemaElement root) {
+			string = root.field( "string", f -> f.asString().projectable( Projectable.YES ) ).toReference();
+		}
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/metamodel/IndexDescriptorIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/metamodel/IndexDescriptorIT.java
@@ -69,7 +69,7 @@ public class IndexDescriptorIT {
 		assertThat( objectFieldDescriptorOptional ).isPresent();
 
 		Collection<IndexFieldDescriptor> staticFields = indexDescriptor.staticFields();
-		assertThat( staticFields ).containsExactlyInAnyOrder(
+		assertThat( staticFields ).contains(
 				valueFieldDescriptorOptional.get(),
 				objectFieldDescriptorOptional.get()
 		);


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4294

If I understood correctly, we don't want to make any changes to Lucene's backend. But just in case, I've placed the main interfaces under engine SPI, as that's where the other model builder-related interfaces are.
As for the implementation itself - because the fields are already present in the schema in one way or another, it seems that the only thing to do was to let HSEARCH know about their existence and adding them to static fields does the trick.