### PR TITLE
HSEARCH-4645 Syntactic sugar for negating predicates (NOT)

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/AbstractElasticsearchPredicate.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/AbstractElasticsearchPredicate.java
@@ -50,6 +50,10 @@ public abstract class AbstractElasticsearchPredicate implements ElasticsearchSea
 	protected abstract JsonObject doToJsonQuery(PredicateRequestContext context,
 			JsonObject outerObject, JsonObject innerObject);
 
+	protected boolean hasNoModifiers() {
+		return !withConstantScore && boost == null;
+	}
+
 	private JsonObject applyConstantScore(JsonObject filter) {
 		JsonObject constantScore = new JsonObject();
 		constantScore.add( "filter", filter );
@@ -83,5 +87,8 @@ public abstract class AbstractElasticsearchPredicate implements ElasticsearchSea
 			this.withConstantScore = true;
 		}
 
+		protected boolean hasNoModifiers() {
+			return !withConstantScore && boost == null;
+		}
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchBooleanPredicate.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchBooleanPredicate.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.backend.elasticsearch.search.predicate.impl;
 
+import static org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchMatchAllPredicate.MATCH_ALL_ACCESSOR;
+
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -74,6 +76,12 @@ class ElasticsearchBooleanPredicate extends AbstractElasticsearchPredicate {
 		contributeClauses( context, innerObject, MUST_NOT_PROPERTY_NAME, mustNotClauses );
 		contributeClauses( context, innerObject, SHOULD_PROPERTY_NAME, shouldClauses );
 		contributeClauses( context, innerObject, FILTER_PROPERTY_NAME, filterClauses );
+
+		if ( isOnlyMustNot() && !super.hasNoModifiers() ) {
+			JsonObject matchAllClause = new JsonObject();
+			MATCH_ALL_ACCESSOR.set( matchAllClause, new JsonObject() );
+			GsonUtils.setOrAppendToArray( innerObject, MUST_PROPERTY_NAME, matchAllClause );
+		}
 
 		if ( minimumShouldMatchConstraints != null ) {
 			MINIMUM_SHOULD_MATCH_ACCESSOR.set(

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchMatchAllPredicate.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchMatchAllPredicate.java
@@ -17,7 +17,7 @@ import com.google.gson.JsonObject;
 
 class ElasticsearchMatchAllPredicate extends AbstractElasticsearchPredicate {
 
-	private static final JsonObjectAccessor MATCH_ALL_ACCESSOR = JsonAccessor.root().property( "match_all" ).asObject();
+	static final JsonObjectAccessor MATCH_ALL_ACCESSOR = JsonAccessor.root().property( "match_all" ).asObject();
 
 	private ElasticsearchMatchAllPredicate(Builder builder) {
 		super( builder );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/AbstractLuceneSearchPredicate.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/AbstractLuceneSearchPredicate.java
@@ -51,6 +51,10 @@ public abstract class AbstractLuceneSearchPredicate implements LuceneSearchPredi
 
 	protected abstract Query doToQuery(PredicateRequestContext context);
 
+	protected boolean hasNoModifiers() {
+		return !constantScore && boost == null;
+	}
+
 	public abstract static class AbstractBuilder implements SearchPredicateBuilder {
 		protected final LuceneSearchIndexScope<?> scope;
 
@@ -69,6 +73,10 @@ public abstract class AbstractLuceneSearchPredicate implements LuceneSearchPredi
 		@Override
 		public void constantScore() {
 			this.constantScore = true;
+		}
+
+		protected boolean hasNoModifiers() {
+			return !constantScore && boost == null;
 		}
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneBooleanPredicate.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneBooleanPredicate.java
@@ -71,7 +71,7 @@ class LuceneBooleanPredicate extends AbstractLuceneSearchPredicate {
 		contributeQueries( context, booleanQueryBuilder, filterClauses, Occur.FILTER );
 
 		if ( isOnlyMustNot() ) {
-			booleanQueryBuilder.add( new MatchAllDocsQuery(), Occur.FILTER );
+			booleanQueryBuilder.add( new MatchAllDocsQuery(), super.hasNoModifiers() ? Occur.FILTER : Occur.MUST );
 		}
 
 		if ( minimumShouldMatchConstraints != null && shouldClauses != null ) {

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/NotPredicateFinalStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/NotPredicateFinalStep.java
@@ -1,0 +1,13 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.predicate.dsl;
+
+/**
+ * The initial and final step in "not" predicate definition.
+ */
+public interface NotPredicateFinalStep extends PredicateFinalStep, PredicateScoreStep<NotPredicateFinalStep> {
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/SearchPredicateFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/SearchPredicateFactory.java
@@ -133,6 +133,26 @@ public interface SearchPredicateFactory {
 			PredicateFinalStep... otherSearchPredicates);
 
 	/**
+	 * Match documents that do not satisfy the passed in previously-built {@link SearchPredicate}.
+	 * <p>
+	 * Can be used to negate a predicate.
+	 *
+	 * @return The initial and final step of a DSL where the "not" predicate can be defined.
+	 * @see NotPredicateFinalStep
+	 */
+	NotPredicateFinalStep not(SearchPredicate searchPredicate);
+
+	/**
+	 * Match documents that do not satisfy the passed in predicate.
+	 * <p>
+	 * Can be used to negate a predicate.
+	 *
+	 * @return The initial and final step of a DSL where the "not" predicate can be defined.
+	 * @see NotPredicateFinalStep
+	 */
+	NotPredicateFinalStep not(PredicateFinalStep searchPredicate);
+
+	/**
 	 * Match documents where targeted fields have a value that "matches" a given single value.
 	 * <p>
 	 * Note that "value matching" may be exact or approximate depending on the type of the targeted fields:

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/impl/NotPredicateFinalStepImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/impl/NotPredicateFinalStepImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.predicate.dsl.impl;
+
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.engine.search.predicate.dsl.NotPredicateFinalStep;
+import org.hibernate.search.engine.search.predicate.dsl.PredicateFinalStep;
+import org.hibernate.search.engine.search.predicate.dsl.spi.AbstractPredicateFinalStep;
+import org.hibernate.search.engine.search.predicate.dsl.spi.SearchPredicateDslContext;
+import org.hibernate.search.engine.search.predicate.spi.BooleanPredicateBuilder;
+
+
+public final class NotPredicateFinalStepImpl extends AbstractPredicateFinalStep
+		implements NotPredicateFinalStep {
+
+	private final BooleanPredicateBuilder builder;
+
+	public NotPredicateFinalStepImpl(SearchPredicateDslContext<?> dslContext, SearchPredicate searchPredicate) {
+		super( dslContext );
+		this.builder = dslContext.scope().predicateBuilders().bool();
+		this.builder.mustNot( searchPredicate );
+	}
+
+	public NotPredicateFinalStepImpl(SearchPredicateDslContext<?> dslContext, PredicateFinalStep searchPredicate) {
+		this( dslContext, searchPredicate.toPredicate() );
+	}
+
+	@Override
+	protected SearchPredicate build() {
+		return builder.build();
+	}
+
+	@Override
+	public NotPredicateFinalStep boost(float boost) {
+		builder.boost( boost );
+		return this;
+	}
+
+	@Override
+	public NotPredicateFinalStep constantScore() {
+		builder.constantScore();
+		return this;
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/spi/AbstractSearchPredicateFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/spi/AbstractSearchPredicateFactory.java
@@ -23,6 +23,7 @@ import org.hibernate.search.engine.search.predicate.dsl.MatchNonePredicateFinalS
 import org.hibernate.search.engine.search.predicate.dsl.MatchPredicateFieldStep;
 import org.hibernate.search.engine.search.predicate.dsl.NamedPredicateOptionsStep;
 import org.hibernate.search.engine.search.predicate.dsl.NestedPredicateClausesStep;
+import org.hibernate.search.engine.search.predicate.dsl.NotPredicateFinalStep;
 import org.hibernate.search.engine.search.predicate.dsl.PhrasePredicateFieldStep;
 import org.hibernate.search.engine.search.predicate.dsl.PredicateFinalStep;
 import org.hibernate.search.engine.search.predicate.dsl.RangePredicateFieldStep;
@@ -43,6 +44,7 @@ import org.hibernate.search.engine.search.predicate.dsl.impl.MatchNonePredicateF
 import org.hibernate.search.engine.search.predicate.dsl.impl.MatchPredicateFieldStepImpl;
 import org.hibernate.search.engine.search.predicate.dsl.impl.NamedPredicateOptionsStepImpl;
 import org.hibernate.search.engine.search.predicate.dsl.impl.NestedPredicateClausesStepImpl;
+import org.hibernate.search.engine.search.predicate.dsl.impl.NotPredicateFinalStepImpl;
 import org.hibernate.search.engine.search.predicate.dsl.impl.PhrasePredicateFieldStepImpl;
 import org.hibernate.search.engine.search.predicate.dsl.impl.RangePredicateFieldStepImpl;
 import org.hibernate.search.engine.search.predicate.dsl.impl.RegexpPredicateFieldStepImpl;
@@ -121,6 +123,16 @@ public abstract class AbstractSearchPredicateFactory<
 	public SimpleBooleanPredicateOptionsStep<?> or(PredicateFinalStep firstSearchPredicate,
 			PredicateFinalStep... otherSearchPredicate) {
 		return new SimpleBooleanPredicateClausesStepImpl( OR, dslContext, this, firstSearchPredicate, otherSearchPredicate );
+	}
+
+	@Override
+	public NotPredicateFinalStep not(SearchPredicate searchPredicate) {
+		return new NotPredicateFinalStepImpl( dslContext, searchPredicate );
+	}
+
+	@Override
+	public NotPredicateFinalStep not(PredicateFinalStep searchPredicate) {
+		return new NotPredicateFinalStepImpl( dslContext, searchPredicate );
 	}
 
 	@Override

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/query/ElasticsearchBoolSearchPredicateIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/query/ElasticsearchBoolSearchPredicateIT.java
@@ -1,0 +1,153 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.elasticsearch.search.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.search.predicate.dsl.BooleanPredicateClausesStep;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+public class ElasticsearchBoolSearchPredicateIT {
+
+	@Rule
+	public final SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private final SimpleMappedIndex<IndexBinding> index = SimpleMappedIndex.of( IndexBinding::new );
+
+	@Before
+	public void setup() {
+		setupHelper.start().withIndex( index ).setup();
+	}
+
+	@Test
+	public void resultingQueryOptimization() {
+		SearchPredicateFactory f = index.createScope().predicate();
+		BooleanPredicateClausesStep<?> step = f.bool().must( f.not( f.not(
+				f.not( f.not( f.not( f.not( f.not( f.match().field( "fieldName" ).matching( "test" ) ) ) ) ) ) ) ) );
+
+		assertThat(
+				new Gson().fromJson(
+						index.query()
+								.where( ( step ).toPredicate() )
+								.toQuery()
+								.queryString(),
+						JsonObject.class
+				)
+		).isEqualTo( new Gson().fromJson(
+				"{" +
+						"  \"query\": {" +
+						"    \"bool\": {" +
+						"      \"must_not\": {" +
+						"        \"match\": {" +
+						"          \"fieldName\": {" +
+						"            \"query\": \"test\"" +
+						"          }" +
+						"        }" +
+						"      }" +
+						"    }" +
+						"  }," +
+						"  \"_source\": false" +
+						"}",
+				JsonObject.class
+		) );
+
+		assertThat(
+				new Gson().fromJson(
+						index.query()
+								.where( f.not( ( step ) ).toPredicate() )
+								.toQuery()
+								.queryString(),
+						JsonObject.class
+				)
+		).isEqualTo( new Gson().fromJson(
+				"{" +
+						"  \"query\": {" +
+						"    \"match\": {" +
+						"      \"fieldName\": {" +
+						"        \"query\": \"test\"" +
+						"      }" +
+						"    }" +
+						"  }," +
+						"  \"_source\": false" +
+						"}",
+				JsonObject.class
+		) );
+
+		assertThat(
+				new Gson().fromJson(
+						index.query()
+								.where( f.bool()
+										.must( f.match().field( "fieldName" ).matching( "test1" ) )
+										.must( f.not( f.match().field( "fieldName" ).matching( "test2" ) ) )
+										.mustNot( f.not( f.match().field( "fieldName" ).matching( "test3" ) ) )
+										.mustNot( f.matchNone() )
+										.toPredicate()
+								)
+								.toQuery()
+								.queryString(),
+						JsonObject.class
+				)
+		).isEqualTo( new Gson().fromJson(
+				"{" +
+						"  \"query\": {" +
+						"    \"bool\": {" +
+						"      \"must\": [" +
+						"        {" +
+						"          \"match\": {" +
+						"            \"fieldName\": {" +
+						"              \"query\": \"test1\"" +
+						"            }" +
+						"          }" +
+						"        }," +
+						"        {" +
+						"          \"match\": {" +
+						"            \"fieldName\": {" +
+						"              \"query\": \"test3\"" +
+						"            }" +
+						"          }" +
+						"        }" +
+						"      ]," +
+						"      \"must_not\": [" +
+						"        {" +
+						"          \"match_none\": {}" +
+						"        }," +
+						"        {" +
+						"          \"match\": {" +
+						"            \"fieldName\": {" +
+						"              \"query\": \"test2\"" +
+						"            }" +
+						"          }" +
+						"        }" +
+						"      ]," +
+						"      \"minimum_should_match\": \"0\"" +
+						"    }" +
+						"  }," +
+						"  \"_source\": false" +
+						"}",
+				JsonObject.class
+		) );
+	}
+
+	private static class IndexBinding {
+		final IndexFieldReference<String> field;
+
+		IndexBinding(IndexSchemaElement root) {
+			field = root.field( "fieldName", c -> c.asString() ).toReference();
+		}
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NotPredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NotPredicateBaseIT.java
@@ -1,0 +1,116 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.search.predicate;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.hibernate.search.engine.search.predicate.dsl.PredicateFinalStep;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappedIndex;
+import org.hibernate.search.util.impl.test.runner.nested.Nested;
+import org.hibernate.search.util.impl.test.runner.nested.NestedRunner;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(NestedRunner.class)
+public class NotPredicateBaseIT {
+
+	@ClassRule
+	public static SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	@BeforeClass
+	public static void setup() {
+		setupHelper.start()
+				.withIndexes(
+						ScoreIT.index
+				)
+				.setup();
+
+		final BulkIndexer scoreIndexer = ScoreIT.index.bulkIndexer();
+		ScoreIT.dataSet.contribute( scoreIndexer );
+
+		scoreIndexer.join();
+	}
+
+	@Test
+	public void takariCpSuiteWorkaround() {
+		// Workaround to get Takari-CPSuite to run this test.
+	}
+
+	@Nested
+	public static class ScoreIT extends AbstractPredicateScoreIT {
+		private static final DataSet dataSet = new DataSet();
+
+		private static final StubMappedIndex index = StubMappedIndex.withoutFields().name( "score" );
+
+		public ScoreIT() {
+			super( index, dataSet );
+		}
+
+
+		@Override
+		public void predicateLevelBoost() {
+			// ignore
+		}
+
+		@Override
+		protected PredicateFinalStep predicate(SearchPredicateFactory f, int matchingDocOrdinal) {
+			return f.not( f.id().matchingAny( dataSet.docsExcept( matchingDocOrdinal ) ) );
+		}
+
+		@Override
+		protected PredicateFinalStep predicateWithBoost(SearchPredicateFactory f, int matchingDocOrdinal,
+				float boost) {
+			return f.not( f.id().matchingAny( dataSet.docsExcept( matchingDocOrdinal ) ) )
+					.boost( boost );
+		}
+
+		@Override
+		protected PredicateFinalStep predicateWithConstantScore(SearchPredicateFactory f, int matchingDocOrdinal) {
+			return f.not( f.id().matchingAny( dataSet.docsExcept( matchingDocOrdinal ) ) )
+					.constantScore();
+		}
+
+		@Override
+		protected PredicateFinalStep predicateWithConstantScoreAndBoost(SearchPredicateFactory f,
+				int matchingDocOrdinal, float boost) {
+			return f.not( f.id().matchingAny( dataSet.docsExcept( matchingDocOrdinal ) ) )
+					.constantScore()
+					.boost( boost );
+		}
+
+		private static class DataSet extends AbstractPredicateDataSet {
+
+			private final List<Integer> ordinals = Arrays.asList( 0, 1, 2 );
+
+			protected DataSet() {
+				super( "singleRoutingKey" );
+			}
+
+			public void contribute(BulkIndexer scoreIndexer) {
+				for ( Integer ordinal : ordinals ) {
+					scoreIndexer.add( docId( ordinal ), routingKey, document -> { } );
+				}
+			}
+
+			Collection<String> docsExcept(int docOrdinal) {
+				return ordinals.stream()
+						.filter( i -> !i.equals( docOrdinal ) )
+						.map( this::docId )
+						.collect( Collectors.toList() );
+			}
+		}
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NotPredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NotPredicateBaseIT.java
@@ -59,12 +59,6 @@ public class NotPredicateBaseIT {
 			super( index, dataSet );
 		}
 
-
-		@Override
-		public void predicateLevelBoost() {
-			// ignore
-		}
-
 		@Override
 		protected PredicateFinalStep predicate(SearchPredicateFactory f, int matchingDocOrdinal) {
 			return f.not( f.id().matchingAny( dataSet.docsExcept( matchingDocOrdinal ) ) );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NotPredicateSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NotPredicateSpecificsIT.java
@@ -6,21 +6,14 @@
  */
 package org.hibernate.search.integrationtest.backend.tck.search.predicate;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
 
-import java.util.Arrays;
-
-import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.engine.search.predicate.dsl.BooleanPredicateClausesStep;
 import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
-import org.hibernate.search.engine.search.query.dsl.SearchQueryOptionsStep;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
-import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubLoadingOptionsStep;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -102,15 +95,14 @@ public class NotPredicateSpecificsIT {
 	@Test
 	public void manyNestedNot() {
 		SearchPredicateFactory f = index.createScope().predicate();
-		BooleanPredicateClausesStep<?> step = f.bool().must( f.not( f.not( f.not( f.not( f.not( f.not( f.not( f.match().field( "field2" ).matching( FIELD2_VALUE1 ) ) ) ) ) ) ) ) );
 
 		assertThatQuery( index.query()
-				.where( ( step ).toPredicate() ) )
+				.where( f.bool().must( f.not( f.not( f.not( f.not( f.not( f.not( f.not( f.match().field( "field2" ).matching( FIELD2_VALUE1 ) ) ) ) ) ) ) ) ).toPredicate() ) )
 				.hasTotalHitCount( 2 )
 				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_2, DOCUMENT_3 );
 
 		assertThatQuery( index.query()
-				.where( f.not( ( step ) ).toPredicate() ) )
+				.where( f.not( f.bool().must( f.not( f.not( f.not( f.not( f.not( f.not( f.not( f.match().field( "field2" ).matching( FIELD2_VALUE1 ) ) ) ) ) ) ) ) ) ).toPredicate() ) )
 				.hasTotalHitCount( 1 )
 				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NotPredicateSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NotPredicateSpecificsIT.java
@@ -1,0 +1,135 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.search.predicate;
+
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
+
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class NotPredicateSpecificsIT {
+
+	private static final String DOCUMENT_1 = "1";
+	private static final String DOCUMENT_2 = "2";
+	private static final String DOCUMENT_3 = "3";
+
+	// Document 1
+
+	private static final String FIELD1_VALUE1 = "Irving";
+	private static final Integer FIELD2_VALUE1 = 3;
+	private static final Integer FIELD3_VALUE1 = 4;
+	private static final Integer FIELD4_VALUE1AND2 = 1_000;
+	private static final Integer FIELD5_VALUE1AND2 = 2_000;
+
+	// Document 2
+
+	private static final String FIELD1_VALUE2 = "Auster";
+	private static final Integer FIELD2_VALUE2 = 13;
+	private static final Integer FIELD3_VALUE2 = 14;
+	// Field 4: Same as document 1
+	// Field 5: Same as document 1
+
+	// Document 3
+
+	private static final String FIELD1_VALUE3 = "Coe";
+	private static final Integer FIELD2_VALUE3 = 25;
+	private static final Integer FIELD3_VALUE3 = 42;
+	private static final Integer FIELD4_VALUE3 = 42_000; // Different from document 1
+	private static final Integer FIELD5_VALUE3 = 142_000; // Different from document 1
+
+	@ClassRule
+	public static final SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private static final SimpleMappedIndex<IndexBinding> index = SimpleMappedIndex.of( IndexBinding::new );
+
+	@BeforeClass
+	public static void setup() {
+		setupHelper.start().withIndex( index ).setup();
+
+		initData();
+	}
+
+	@Test
+	public void notMatchAll() {
+		assertThatQuery( index.query()
+				.where( f -> f.not( f.matchAll() ) ) )
+				.hasNoHits();
+	}
+
+	@Test
+	public void notMatchNone() {
+		assertThatQuery( index.query()
+				.where( f -> f.not( f.matchNone() ) ) )
+				.hasTotalHitCount( 3 )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
+	}
+
+	@Test
+	public void notMatchSpecificValue() {
+		assertThatQuery( index.query()
+				.where( f -> f.not( f.match().field( "field2" ).matching( FIELD2_VALUE1 ) ) ) )
+				.hasTotalHitCount( 2 )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_2, DOCUMENT_3 );
+	}
+
+	@Test
+	public void mustWithNotInside() {
+		assertThatQuery( index.query()
+				.where( f -> f.bool().must( f.not( f.match().field( "field2" ).matching( FIELD2_VALUE1 ) ) ) ) )
+				.hasTotalHitCount( 2 )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_2, DOCUMENT_3 );
+	}
+
+	private static void initData() {
+		BulkIndexer indexer = index.bulkIndexer();
+		indexer.add( DOCUMENT_1, document -> {
+			document.addValue( index.binding().field1, FIELD1_VALUE1 );
+			document.addValue( index.binding().field2, FIELD2_VALUE1 );
+			document.addValue( index.binding().field3, FIELD3_VALUE1 );
+			document.addValue( index.binding().field4, FIELD4_VALUE1AND2 );
+			document.addValue( index.binding().field5, FIELD5_VALUE1AND2 );
+		} );
+		indexer.add( DOCUMENT_2, document -> {
+			document.addValue( index.binding().field1, FIELD1_VALUE2 );
+			document.addValue( index.binding().field2, FIELD2_VALUE2 );
+			document.addValue( index.binding().field3, FIELD3_VALUE2 );
+			document.addValue( index.binding().field4, FIELD4_VALUE1AND2 );
+			document.addValue( index.binding().field5, FIELD5_VALUE1AND2 );
+		} );
+		indexer.add( DOCUMENT_3, document -> {
+			document.addValue( index.binding().field1, FIELD1_VALUE3 );
+			document.addValue( index.binding().field2, FIELD2_VALUE3 );
+			document.addValue( index.binding().field3, FIELD3_VALUE3 );
+			document.addValue( index.binding().field4, FIELD4_VALUE3 );
+			document.addValue( index.binding().field5, FIELD5_VALUE3 );
+		} );
+		indexer.join();
+	}
+
+	private static class IndexBinding {
+		final IndexFieldReference<String> field1;
+		final IndexFieldReference<Integer> field2;
+		final IndexFieldReference<Integer> field3;
+		final IndexFieldReference<Integer> field4;
+		final IndexFieldReference<Integer> field5;
+
+		IndexBinding(IndexSchemaElement root) {
+			field1 = root.field( "field1", f -> f.asString() ).toReference();
+			field2 = root.field( "field2", f -> f.asInteger() ).toReference();
+			field3 = root.field( "field3", f -> f.asInteger() ).toReference();
+			field4 = root.field( "field4", f -> f.asInteger() ).toReference();
+			field5 = root.field( "field5", f -> f.asInteger() ).toReference();
+		}
+	}
+}

--- a/integrationtest/v5migrationhelper/engine/src/test/java/org/hibernate/search/test/dsl/DSLTest.java
+++ b/integrationtest/v5migrationhelper/engine/src/test/java/org/hibernate/search/test/dsl/DSLTest.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.test.dsl;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -36,6 +35,7 @@ import org.junit.rules.ExpectedException;
 
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.Query;
 import org.hamcrest.CoreMatchers;
 
@@ -355,8 +355,7 @@ public class DSLTest {
 				.should( null )
 				.createQuery();
 
-		assertThat( query, CoreMatchers.instanceOf( BooleanQuery.class ) );
-		assertEquals( 1, ( (BooleanQuery) query ).clauses().size() );
+		assertThat( query, CoreMatchers.instanceOf( BoostQuery.class ) );
 
 		helper.assertThatQuery( query ).from( Month.class ).matchesExactlyIds( 1 );
 
@@ -368,8 +367,7 @@ public class DSLTest {
 					.must( monthQb.keyword().onField( "mythology" ).matching( "colder" ).createQuery() )
 					.createQuery();
 
-		assertThat( query, CoreMatchers.instanceOf( BooleanQuery.class ) );
-		assertEquals( 1, ( (BooleanQuery) query ).clauses().size() );
+		assertThat( query, CoreMatchers.instanceOf( BoostQuery.class ) );
 
 		helper.assertThatQuery( query ).from( Month.class ).matchesExactlyIds( 1 );
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4645

I wasn't sure about the "simplification" part:
> optimize things such as f.bool().must(f.not(something)).must(somethingElse) into f.bool().mustNot(something).must(somethingElse), if possible. Or maybe we could do it ourselves.

so I've pushed it as a separate commit. It does reduce the nested predicates, but it looks so-so 😄 

[HSEARCH-4645]: https://hibernate.atlassian.net/browse/HSEARCH-4645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ