### PR TITLE
HSEARCH-4642 Bump dependencies / HSEARCH-4764 Bump AWS SDK to 2.19.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -387,7 +387,7 @@
         <version.sonar.plugin>3.9.1.2184</version.sonar.plugin>
         <version.scripting.plugin>3.0.0</version.scripting.plugin>
         <version.gpg.plugin>3.0.1</version.gpg.plugin>
-        <version.org.codehaus.groovy-jsr223>3.0.13</version.org.codehaus.groovy-jsr223>
+        <version.org.codehaus.groovy-jsr223>3.0.14</version.org.codehaus.groovy-jsr223>
         <version.com.puppycrawl.tools.checkstyle>10.3.4</version.com.puppycrawl.tools.checkstyle>
         <version.versions.plugin>2.12.0</version.versions.plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -303,7 +303,7 @@
         <version.org.osgi.core>6.0.0</version.org.osgi.core>
 
         <version.org.hamcrest>2.2</version.org.hamcrest>
-        <version.org.mockito>4.10.0</version.org.mockito>
+        <version.org.mockito>4.11.0</version.org.mockito>
         <version.org.assertj.assertj-core>3.23.1</version.org.assertj.assertj-core>
         <version.org.awaitily>4.2.0</version.org.awaitily>
         <version.org.skyscreamer.jsonassert>1.5.1</version.org.skyscreamer.jsonassert>

--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
         <version.org.opensearch.latest>2.4.1</version.org.opensearch.latest>
 
         <version.com.google.code.gson>2.9.1</version.com.google.code.gson>
-        <version.software.amazon.awssdk>2.18.1</version.software.amazon.awssdk>
+        <version.software.amazon.awssdk>2.19.8</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, the AWS SDK and in tests (wiremock, ...) -->
         <version.com.fasterxml.jackson>2.13.4</version.com.fasterxml.jackson>
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -341,7 +341,7 @@
         <version.org.google.guava>31.1-jre</version.org.google.guava>
 
         <!-- >>> Spring integration tests -->
-        <version.org.springframework.boot>2.7.6</version.org.springframework.boot>
+        <version.org.springframework.boot>2.7.7</version.org.springframework.boot>
 
         <!-- Maven plugins versions -->
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4642
https://hibernate.atlassian.net/browse/HSEARCH-4764

For HSEARCH-4642, folllows up on https://github.com/hibernate/hibernate-search/pull/3339, https://github.com/hibernate/hibernate-search/pull/3322, https://github.com/hibernate/hibernate-search/pull/3313, https://github.com/hibernate/hibernate-search/pull/3294, https://github.com/hibernate/hibernate-search/pull/3146, https://github.com/hibernate/hibernate-search/pull/3148, https://github.com/hibernate/hibernate-search/pull/3157, https://github.com/hibernate/hibernate-search/pull/3176, https://github.com/hibernate/hibernate-search/pull/3189, https://github.com/hibernate/hibernate-search/pull/3194, https://github.com/hibernate/hibernate-search/pull/3208, https://github.com/hibernate/hibernate-search/pull/3219, https://github.com/hibernate/hibernate-search/pull/3234, https://github.com/hibernate/hibernate-search/pull/3239, https://github.com/hibernate/hibernate-search/pull/3249, https://github.com/hibernate/hibernate-search/pull/3255, https://github.com/hibernate/hibernate-search/pull/3262, https://github.com/hibernate/hibernate-search/pull/3281