### PR TITLE
HSEARCH-4748 follow-up: remove leading "#" from agent references

### DIFF
--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingStaticShardingIncompatibleConfigurationIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingStaticShardingIncompatibleConfigurationIT.java
@@ -73,7 +73,7 @@ public class OutboxPollingAutomaticIndexingStaticShardingIncompatibleConfigurati
 
 		String[] expectedContent = new String[] {
 				"is statically assigned to shard ",
-				"this conflicts with agent '#",
+				"this conflicts with agent '",
 				"' which expects ", " shards.",
 				"This can be a temporary situation caused by some application instances being forcibly stopped and replacements being spun up",
 				"consider adjusting the configuration or switching to dynamic sharding.",
@@ -112,7 +112,7 @@ public class OutboxPollingAutomaticIndexingStaticShardingIncompatibleConfigurati
 
 		String[] expectedContent = new String[] {
 				"is statically assigned to shard ",
-				"this conflicts with agent '#",
+				"this conflicts with agent '",
 				"' which is also assigned to that shard.",
 				"This can be a temporary situation caused by some application instances being forcibly stopped and replacements being spun up",
 				"consider adjusting the configuration or switching to dynamic sharding.",

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cluster/impl/AgentReference.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cluster/impl/AgentReference.java
@@ -23,6 +23,6 @@ public class AgentReference {
 
 	@Override
 	public String toString() {
-		return "#" + id + " - " + name;
+		return id + " - " + name;
 	}
 }

--- a/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/EventProcessorClusterLinkStaticShardingEdgeCasesTest.java
+++ b/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/EventProcessorClusterLinkStaticShardingEdgeCasesTest.java
@@ -116,9 +116,9 @@ public class EventProcessorClusterLinkStaticShardingEdgeCasesTest
 				.hasMessageContainingAll(
 						"Agent '" + SELF_REF + "': failed to infer a target cluster from the list of registered agents.",
 						"The agent will try again in the next pulse.",
-						"Agent '#" + OTHER_2_ID + " - ",
+						"Agent '" + OTHER_2_ID + " - ",
 						"is statically assigned to shard 0 (total " + totalShardCount + ")",
-						"this conflicts with agent '#" + OTHER_1_ID + " - ",
+						"this conflicts with agent '" + OTHER_1_ID + " - ",
 						"' which is also assigned to that shard.",
 						"This can be a temporary situation caused by some application instances being forcibly stopped and replacements being spun up",
 						"consider adjusting the configuration or switching to dynamic sharding.",
@@ -156,7 +156,7 @@ public class EventProcessorClusterLinkStaticShardingEdgeCasesTest
 				.hasMessageContainingAll(
 						"Agent '" + SELF_REF + "': failed to infer a target cluster from the list of registered agents.",
 						"The agent will try again in the next pulse.",
-						"Agent '#" + OTHER_2_ID + " - ",
+						"Agent '" + OTHER_2_ID + " - ",
 						"is statically assigned to shard 2 (total 4)",
 						"this conflicts with agent '" + SELF_REF + "'",
 						"which expects 3 shards.",


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4748

Follows up on #3305 .

Fixes logs like this:

```diff
-... Agent '#5fb45edb-bff4-43f5-b1a3-8dc40986cb81 - Outbox event processor': the persisted shard assignment ...
+... Agent '5fb45edb-bff4-43f5-b1a3-8dc40986cb81 - Outbox event processor': the persisted shard assignment ...
```