### PR TITLE
HSEARCH-4773 Change how agents are stopped in massindexer

### DIFF
--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingBatchCoordinator.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingBatchCoordinator.java
@@ -190,8 +190,12 @@ public class PojoMassIndexingBatchCoordinator extends PojoMassIndexingFailureHan
 		flushAndRefresh();
 		applyToAllContexts(
 				context -> context.agent().preStop()
-						.thenRun( () -> context.agent().stop() )
 		);
+		// NOTE: HSEARCH-4773 this loop was added here on purpose, as composing this stop() operation to the above future
+		// was causing an issue when running against Oracle DB. Doing it like this seems to allow a graceful stopping of the agents.
+		for ( SessionContext context : sessionContexts ) {
+			context.agent().stop();
+		}
 		sessionContexts.clear();
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4773

So this is a place where it starts to cause problems with the Oracle build... I've tried to keep the  `applyToAllContexts(..)` but that becomes ugly pretty fast:
```java
applyToAllContexts(
	context -> {
		try {
			Object result = Futures.unwrappedExceptionGet( context.agent().preStop() );
			context.agent().stop();
			return CompletableFuture.completedFuture( result );
		}
		catch (InterruptedException e) {
			Thread.currentThread().interrupt();
			throw new RuntimeException( e );
		}
	}
);
```

[HSEARCH-4773]: https://hibernate.atlassian.net/browse/HSEARCH-4773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ