### PR TITLE
HSEARCH-4645 Document `not` predicate

### DIFF
--- a/documentation/src/main/asciidoc/migration/index.asciidoc
+++ b/documentation/src/main/asciidoc/migration/index.asciidoc
@@ -396,3 +396,10 @@ if internal queues of operations are full, but will throw `RejectedOperationExce
 Due to switching from `new URL(..)` to `new URI(..)` in the Hibernate Search internals indexing
 behaviour of `URL` properties might change. In particular malformed URLs won't be accepted anymore and would result in
 a runtime exception.
+
+Due to some optimizations applied to bool queries, the resulting query might get replaced with a more straightforward
+query that returns the same results.
+Possible changes can include: some clauses can be rearranged, nested bool queries might be flattened, a bool query might be
+replaced with its clause.
+
+A bool query with a single `mustNot` clause and applied boost would implicitly add a `must` with `match_all` clause.

--- a/documentation/src/main/asciidoc/reference/search-dsl-predicate.asciidoc
+++ b/documentation/src/main/asciidoc/reference/search-dsl-predicate.asciidoc
@@ -912,6 +912,28 @@ but can be <<search-dsl-predicate-common-constantScore,made constant with `.cons
 * The score of an `or` predicate can be <<search-dsl-predicate-common-boost,boosted>>
 with a call to `.boost(...)`.
 
+
+[[search-dsl-predicate-not]]
+== `not`: negating another predicate
+
+The `not` predicate matches documents that are not matched by a given predicate.
+
+.Negating a `match` predicate
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java[tags=not]
+----
+====
+
+[[search-dsl-predicate-not-other]]
+=== Other options
+
+* The score of a `not` predicate is constant and equal to 0 by default,
+but if <<search-dsl-predicate-common-boost,boosted with `.boost(...)`>> the default would be changed to 1
+and corresponding boost will be applied.
+
+
 [[search-dsl-predicate-boolean]]
 == [[_combining_queries]] `bool`: advanced combinations of predicates (or/and/...)
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
@@ -1068,6 +1068,25 @@ public class PredicateDslIT {
 		} );
 	}
 
+	@Test
+	public void not() {
+		withinSearchSession( searchSession -> {
+			// tag::not[]
+			List<Book> hits = searchSession.search( Book.class )
+					.where( f -> f.not(
+							f.match()
+									.field( "genre" )
+									.matching( Genre.SCIENCE_FICTION )
+					) )
+					.fetchHits( 20 );
+			// end::not[]
+			assertThat( hits )
+					.extracting( Book::getGenre )
+					.isNotEmpty()
+					.doesNotContain( Genre.SCIENCE_FICTION );
+		} );
+	}
+
 	private MySearchParameters getSearchParameters() {
 		return new MySearchParameters() {
 			@Override


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4645

Add docs + note to migration guide on change behaviour of bool queries.