### PR TITLE
Backport HSEARCH-4770 to branch 6.1 - Only update dependencies for test modules in dependency-update builds

### DIFF
--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -12,10 +12,8 @@ Map settings() {
 	switch (env.DEPENDENCY_UPDATE_NAME) {
 		case 'orm5.6':
 			return [
-					mavenArgs: """ \
-							-pl mapper/orm,jakarta/mapper/orm -amd \
-					""",
-					updateProperties: ['version.org.hibernate']
+					updateProperties: ['version.org.hibernate'],
+					onlyRunTestDependingOn: ['hibernate-search-mapper-orm', 'hibernate-search-mapper-orm-jakarta']
 			]
 		case 'orm6.0':
 			return [
@@ -26,17 +24,15 @@ Map settings() {
 			]
 		case 'orm6.1':
 			return [
-					mavenArgs: """ \
-							-pl orm6/mapper/orm -amd \
-					""",
-					updateProperties: ['version.org.hibernate.orm']
+					updateProperties: ['version.org.hibernate.orm'],
+					onlyRunTestDependingOn: ['hibernate-search-mapper-orm-orm6']
 			]
 		case 'orm6.2':
 			return [
-					mavenArgs: """ \
-							-pl orm6/mapper/orm -amd \
-					""",
-					updateProperties: ['version.org.hibernate.orm']
+					updateProperties: ['version.org.hibernate.orm'],
+					onlyRunTestDependingOn: ['hibernate-search-mapper-orm-orm6'],
+					// Need to rebuild non-test modules to apply some patches
+					additionalMavenArgs: '-am'
 			]
 		default:
 			return [:]
@@ -45,7 +41,7 @@ Map settings() {
 
 // Perform authenticated pulls of container images, to avoid failure due to download throttling on dockerhub.
 def pullContainerImages() {
-	String containerImageRefsString = ((String) sh(script: "./ci/list-container-images.sh -U -Pdist -Pdependency-update ${settings().mavenArgs}", returnStdout: true))
+	String containerImageRefsString = ((String) sh(script: "./ci/list-container-images.sh -U -Pdist -Pdependency-update ${env.ADDITIONAL_MAVEN_ARGS}", returnStdout: true))
 	String[] containerImageRefs = containerImageRefsString ? containerImageRefsString.split('\\s+') : new String[0]
 	echo 'Container images to be used in tests: ' + Arrays.toString(containerImageRefs)
 	if (containerImageRefs.length == 0) {
@@ -82,6 +78,33 @@ pipeline {
 		rateLimitBuilds(throttle: [count: 2, durationName: 'week', userBoost: true])
 	}
 	stages {
+		// This allows testing the original (unpatched) artifacts,
+		// while patching tests where necessary.
+		// Especially important when testing the compatibility
+		// of published artifacts with different versions of dependencies.
+		stage('Pre-build original code') {
+			agent {
+				label 'Worker&&Containers'
+			}
+			post {
+				cleanup {
+					sh 'ci/docker-cleanup.sh'
+				}
+			}
+			options {
+				timeout(time: 30, unit: 'MINUTES')
+			}
+			steps {
+				withMavenWorkspace {
+					sh """ \
+						mvn clean install -U -Pdist -DskipTests \
+					"""
+					dir(env.WORKSPACE_TMP + '/.m2repository') {
+						stash name: 'original-build-result', includes:"org/hibernate/search/**"
+					}
+				}
+			}
+		}
 		stage('Update dependency and test') {
 			matrix {
 				agent {
@@ -103,6 +126,9 @@ pipeline {
 					stage('Init') {
 						steps {
 							sh 'ci/docker-cleanup.sh'
+							dir(env.WORKSPACE_TMP + '/.m2repository') {
+								unstash name: 'original-build-result'
+							}
 						}
 					}
 					stage('Update dependency') {
@@ -115,24 +141,13 @@ pipeline {
 									error "This job does not seem to update any dependency; perhaps it is misconfigured? The source code has not been updated, neither by merging a WIP branch nor by updating version properties."
 								}
 							}
-						}
-					}
-					// If we're going to execute only a few tests,
-					// make sure all artifacts are built and can be used as dependency in those tests.
-					stage('Pre-build') {
-						when {
-							expression {
-								return !settings().mavenArgs.isBlank()
-							}
-						}
-						options {
-							timeout(time: 30, unit: 'MINUTES')
-						}
-						steps {
 							withMavenWorkspace {
-								sh """ \
-									mvn clean install -U -Pdependency-update -Pdist -DskipTests \
-								"""
+								script {
+									env.ADDITIONAL_MAVEN_ARGS = settings().additionalMavenArgs ?: ''
+									if (settings().onlyRunTestDependingOn) {
+										env.ADDITIONAL_MAVEN_ARGS += ' -pl ' + sh(script: "bash -x ./ci/list-dependent-integration-tests.sh ${settings().onlyRunTestDependingOn.join(' ')}", returnStdout: true).trim()
+									}
+								}
 							}
 						}
 					}
@@ -146,7 +161,7 @@ pipeline {
 								sh """ \
 									mvn clean install -U -Pdependency-update -Pdist -Dsurefire.environment=${env.DEPENDENCY_UPDATE_NAME} \
 									--fail-at-end \
-									${settings().mavenArgs} \
+									${env.ADDITIONAL_MAVEN_ARGS} \
 								"""
 							}
 						}

--- a/ci/list-container-images.sh
+++ b/ci/list-container-images.sh
@@ -4,7 +4,7 @@
 LIST_FILE=$(mktemp)
 trap "rm -f $LIST_FILE" EXIT
 
-# See the configuration of the m
+# See the configuration of the maven-scripting-plugin in the main POM
 ./mvnw scripting:eval@list-container-images -DcontainerImagesListFile="$LIST_FILE" "${@}" 1>&2
 
 sort -u "$LIST_FILE" | { grep -Ev "^\s*$" || true; }

--- a/ci/list-dependent-integration-tests.sh
+++ b/ci/list-dependent-integration-tests.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+# Lists integration test projects that depend on a given project.
+# The output format is the one expected by `mvn -pl`.
+
+if (( $# < 1 ))
+then
+	echo 1>&2 "Usage: $0 <artifactIds that listed IT modules must depend on> [<other artifactIds that listed IT modules must depend on (at least one)> ...]"
+	echo 1>&2 "Aborting."
+	exit 1
+fi
+
+IFS="," COMMA_SEPARATED_TESTED_ARTIFACT_IDS="$*"
+TESTED_ARTIFACT_IDS_REGEXP="(\Q$(echo "$*" | perl -pe 's/,/\\E|\\Q/g')\E)"
+
+{
+	./mvnw -Pdist dependency:list -pl :hibernate-search-parent-integrationtest -am -amd -DincludeArtifactIds="$COMMA_SEPARATED_TESTED_ARTIFACT_IDS"
+	./mvnw -Pdist dependency:list -pl :hibernate-search-parent-integrationtest-orm6 -am -amd -DincludeArtifactIds="$COMMA_SEPARATED_TESTED_ARTIFACT_IDS"
+	./mvnw -Pdist dependency:list -pl :hibernate-search-parent-integrationtest-jakarta -am -amd -DincludeArtifactIds="$COMMA_SEPARATED_TESTED_ARTIFACT_IDS"
+} \
+	| perl -0777 -pe "s/(hibernate-search-.*) ---(\n(?!.*Building).*)*\n.*:$TESTED_ARTIFACT_IDS_REGEXP:jar:/\nMATCH:\$1\n/g" \
+	| perl -ne 'print if s/MATCH:(.*)/:$1/g' \
+	| perl -0777 -pe 's/\n(?!$)/,/g'


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4770

Backport of #3359 to branch 6.1.