### PR TITLE
HSEARCH-4768 + HSEARCH-4775 Fix ORM 6.2 dependency update tests

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -87,7 +87,7 @@ BRANCH_NAME=main ci/dependency-update/perform-update.sh orm6.2 version.org.hiber
 After applying the update, you can easily run all tests that rely on a particular module with this command:
 
 ```shell
-./mvnw clean verify -Pdist -pl $(./ci/list-dependent-integration-tests.sh hibernate-search-mapper-orm)
+./mvnw clean verify -Pdependency-update -Pdist -pl $(./ci/list-dependent-integration-tests.sh hibernate-search-mapper-orm)
 ```
 
 ### Performance pipeline

--- a/integrationtest/java/modules/pojo-standalone-elasticsearch/src/main/java/module-info.java
+++ b/integrationtest/java/modules/pojo-standalone-elasticsearch/src/main/java/module-info.java
@@ -5,7 +5,6 @@ module org.hibernate.search.integrationtest.java.modules.pojo.standalone.elastic
 	opens org.hibernate.search.integrationtest.java.modules.pojo.standalone.elasticsearch.config to
 			org.hibernate.search.engine; // For reflective instantiation of the analysis configurer
 
-	requires org.hibernate.search.engine;
 	requires org.hibernate.search.backend.elasticsearch;
 	requires org.hibernate.search.mapper.pojo.standalone;
 

--- a/integrationtest/java/modules/pojo-standalone-lucene/src/main/java/module-info.java
+++ b/integrationtest/java/modules/pojo-standalone-lucene/src/main/java/module-info.java
@@ -5,7 +5,6 @@ module org.hibernate.search.integrationtest.java.modules.pojo.standalone.lucene 
 	opens org.hibernate.search.integrationtest.java.modules.pojo.standalone.lucene.config to
 			org.hibernate.search.engine; // For reflective instantiation of the analysis configurer
 
-	requires org.hibernate.search.engine;
 	requires org.hibernate.search.backend.lucene;
 	requires org.hibernate.search.mapper.pojo.standalone;
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java
@@ -284,11 +284,14 @@ public class BytecodeEnhancementIT {
 			extends IndexedEntitySuperClass {
 		public static final String INDEX = "IndexedEntity";
 
+		// "containedEntityList" is not listed here,
+		// because collection properties are initialized eagerly on ORM 6.2+
+		// (even if the collection themselves are initialized lazily).
+		// See HHH-15473 / https://github.com/hibernate/hibernate-orm/pull/5252
 		private static final String[] LAZY_PROPERTY_NAMES = new String[] {
 				"mappedSuperClassText",
 				"entitySuperClassText",
 				"notIndexedText",
-				"containedEntityList",
 				"text1",
 				"text2",
 				"primitiveInteger",

--- a/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/massindexing/util/impl/PersistenceUtil.java
+++ b/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/massindexing/util/impl/PersistenceUtil.java
@@ -46,7 +46,8 @@ public final class PersistenceUtil {
 	 */
 	public static Session openSession(EntityManagerFactory entityManagerFactory, String tenantId) {
 		SessionFactory sessionFactory = entityManagerFactory.unwrap( SessionFactory.class );
-		SessionBuilder<?> builder = sessionFactory.withOptions();
+		@SuppressWarnings("rawtypes")
+		SessionBuilder builder = sessionFactory.withOptions();
 		if ( StringHelper.isNotEmpty( tenantId ) ) {
 			builder.tenantIdentifier( tenantId );
 		}
@@ -69,7 +70,8 @@ public final class PersistenceUtil {
 	 */
 	public static StatelessSession openStatelessSession(EntityManagerFactory entityManagerFactory, String tenantId) {
 		SessionFactory sessionFactory = entityManagerFactory.unwrap( SessionFactory.class );
-		StatelessSessionBuilder<?> builder = sessionFactory.withStatelessOptions();
+		@SuppressWarnings("rawtypes")
+		StatelessSessionBuilder builder = sessionFactory.withStatelessOptions();
 		if ( StringHelper.isNotEmpty( tenantId ) ) {
 			builder.tenantIdentifier( tenantId );
 		}

--- a/mapper/orm-coordination-outbox-polling/pom.xml
+++ b/mapper/orm-coordination-outbox-polling/pom.xml
@@ -97,11 +97,11 @@
                         <configuration>
                             <module>
                                 <moduleInfo>
-                                    <!-- cluster and event packages to expose Agent and OutboxEvent entities to ORM -->
+                                    <!-- cluster and event packages to expose Agent and OutboxEvent entities to ORM and ByteBuddy -->
                                     <opens>
                                         org.hibernate.search.mapper.orm.coordination.outboxpolling.avro.generated.impl to org.apache.avro;
-                                        org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl to org.hibernate.orm.core;
-                                        org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl to org.hibernate.orm.core;
+                                        org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl to org.hibernate.orm.core, net.bytebuddy;
+                                        org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl to org.hibernate.orm.core, net.bytebuddy;
                                     </opens>
                                 </moduleInfo>
                             </module>

--- a/orm6/README.md
+++ b/orm6/README.md
@@ -28,6 +28,8 @@ Then:
 * Rebase on `main` and fix conflicts as necessary.
 * If the last few commits are there to upgrade to the latest snapshot of ORM 6, revert them.
 * Try to build that branch as you would usually build Hibernate Search.
+  WARNING: Do not forget to also enable the dependency-update profile (`-Pdependency-update`)
+  to disable unwanted checks (deprecations, ...).
 * Fix compilation/test errors by updating the code as necessary.
 * Commit your changes, rebase and squash them with the relevant commit
   (probably the one that upgrades to ORM 6.0.0.Beta3 or something similar).

--- a/orm6/README.md
+++ b/orm6/README.md
@@ -33,10 +33,20 @@ Then:
 * Fix compilation/test errors by updating the code as necessary.
 * Commit your changes, rebase and squash them with the relevant commit
   (probably the one that upgrades to ORM 6.0.0.Beta3 or something similar).
-* Rebase again to remove the "revert" commits that you added earlier.
+* Rebase again to remove the "revert" commits that you added earlier (if any).
 * Identify the first and last commit that are necessary to upgrade from ORM 5
   to the version of ORM 6 that you want to target.
   Copy their SHA somewhere.
 * Checkout the branch where you originally witnessed the compilation failures.
 * Execute `./orm6/extract-patches <first commit SHA>~1..<last commit SHA>` from the root of your local git repository.
 * Commit the resulting changes.
+
+Alternatively, if you know of some words that can uniquely identify
+the first commit to include and first commit to exclude,
+you can try something like this:
+
+```shell
+COMMIT_RANGE="wip/main/dependency-update/orm6-in-main-code^{/6.0.0.Beta3}^1..wip/main/dependency-update/orm6-in-main-code^{/6.2.0-SNAPSHOT}^1"
+tig $COMMIT_RANGE # To check the range
+./orm6/extract-patches.sh $COMMIT_RANGE
+```

--- a/orm6/integrationtest/java/modules/orm-coordination-outbox-polling-elasticsearch/ant-src-changes.patch
+++ b/orm6/integrationtest/java/modules/orm-coordination-outbox-polling-elasticsearch/ant-src-changes.patch
@@ -1,0 +1,27 @@
+diff --git a/main/java/module-info.java b/main/java/module-info.java
+index de9b64d55f..56efa76484 100644
+--- a/main/java/module-info.java
++++ b/main/java/module-info.java
+@@ -17,16 +17,16 @@
+ 	requires org.hibernate.search.backend.elasticsearch;
+ 	requires org.hibernate.search.mapper.orm.coordination.outboxpolling;
+ 
+-	// This should be re-exported transitively by org.hibernate.search.mapper.orm
+-	// but currently isn't, because org.hibernate.search.mapper.orm
+-	// is still an automatic module
+-	requires org.hibernate.search.engine;
+-	requires org.hibernate.search.mapper.pojo;
+-
+ 	/*
+ 	 * This is necessary in order to use SessionFactory,
+ 	 * which extends "javax.naming.Referenceable".
+ 	 * Without this, compilation as a Java module fails.
+ 	 */
+ 	requires java.naming;
++
++	/*
++	 * This is necessary in order to put ByteBuddy in the modulepath and make module exports effective.
++	 * I do not know why ByteBuddy doesn't end up in the modulepath without this.
++	 */
++	requires net.bytebuddy;
+ }

--- a/orm6/integrationtest/java/modules/orm-coordination-outbox-polling-elasticsearch/pom.xml
+++ b/orm6/integrationtest/java/modules/orm-coordination-outbox-polling-elasticsearch/pom.xml
@@ -46,6 +46,14 @@
             <artifactId>hibernate-search-mapper-orm-coordination-outbox-polling-orm6</artifactId>
         </dependency>
 
+        <!-- Adding this dependency to be able to refer to ByteBuddy in module-info.java -->
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <!-- DO NOT REMOVE and DO NOT MANAGE the version of this dependency. See the version property declaration. -->
+            <version>${version.net.bytebuddy}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-util-internal-test-orm-orm6</artifactId>

--- a/orm6/integrationtest/java/modules/orm-elasticsearch/ant-src-changes.patch
+++ b/orm6/integrationtest/java/modules/orm-elasticsearch/ant-src-changes.patch
@@ -1,0 +1,17 @@
+diff --git a/main/java/module-info.java b/main/java/module-info.java
+index 3bd5c117f3..28074f5739 100644
+--- a/main/java/module-info.java
++++ b/main/java/module-info.java
+@@ -16,12 +16,6 @@
+ 	requires org.hibernate.search.mapper.orm;
+ 	requires org.hibernate.search.backend.elasticsearch;
+ 
+-	// This should be re-exported transitively by org.hibernate.search.mapper.orm
+-	// but currently isn't, because org.hibernate.search.mapper.orm
+-	// is still an automatic module
+-	requires org.hibernate.search.engine;
+-	requires org.hibernate.search.mapper.pojo;
+-
+ 	/*
+ 	 * This is necessary in order to use SessionFactory,
+ 	 * which extends "javax.naming.Referenceable".

--- a/orm6/integrationtest/java/modules/orm-lucene/ant-src-changes.patch
+++ b/orm6/integrationtest/java/modules/orm-lucene/ant-src-changes.patch
@@ -1,0 +1,17 @@
+diff --git a/main/java/module-info.java b/main/java/module-info.java
+index 237df74c7f..8921d66f18 100644
+--- a/main/java/module-info.java
++++ b/main/java/module-info.java
+@@ -16,12 +16,6 @@
+ 	requires org.hibernate.search.mapper.orm;
+ 	requires org.hibernate.search.backend.lucene;
+ 
+-	// This should be re-exported transitively by org.hibernate.search.mapper.orm
+-	// but currently isn't, because org.hibernate.search.mapper.orm
+-	// is still an automatic module
+-	requires org.hibernate.search.engine;
+-	requires org.hibernate.search.mapper.pojo;
+-
+ 	/*
+ 	 * This is necessary in order to use SessionFactory,
+ 	 * which extends "javax.naming.Referenceable".

--- a/orm6/mapper/orm-coordination-outbox-polling/pom.xml
+++ b/orm6/mapper/orm-coordination-outbox-polling/pom.xml
@@ -112,11 +112,11 @@
                         <configuration>
                             <module>
                                 <moduleInfo>
-                                    <!-- cluster and event packages to expose Agent and OutboxEvent entities to ORM -->
+                                    <!-- cluster and event packages to expose Agent and OutboxEvent entities to ORM and ByteBuddy -->
                                     <opens>
                                         org.hibernate.search.mapper.orm.coordination.outboxpolling.avro.generated.impl to org.apache.avro;
-                                        org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl to org.hibernate.orm.core;
-                                        org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl to org.hibernate.orm.core;
+                                        org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl to org.hibernate.orm.core, net.bytebuddy;
+                                        org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl to org.hibernate.orm.core, net.bytebuddy;
                                     </opens>
                                 </moduleInfo>
                             </module>

--- a/orm6/mapper/orm/ant-src-changes.patch
+++ b/orm6/mapper/orm/ant-src-changes.patch
@@ -591,10 +591,10 @@ index 1e581dd9de..189f713827 100644
  					|| isWholePath && isAssociation( containedValueClass ) ) {
  				String stringRepresentationAsProperty = propertyNode.toPropertyString();
 diff --git a/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java b/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java
-index c8ca89a1e0..f7140b4d52 100644
+index c8ca89a1e0..995f314a33 100644
 --- a/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java
 +++ b/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java
-@@ -7,52 +7,48 @@
+@@ -7,52 +7,50 @@
  package org.hibernate.search.mapper.orm.search.query.impl;
  
  import java.lang.invoke.MethodHandles;
@@ -602,7 +602,6 @@ index c8ca89a1e0..f7140b4d52 100644
 -import java.util.Collections;
 -import java.util.Date;
 -import java.util.Iterator;
-+import java.util.Collection;
  import java.util.List;
  import java.util.Map;
 -import java.util.Set;
@@ -634,7 +633,9 @@ index c8ca89a1e0..f7140b4d52 100644
 +import org.hibernate.query.spi.AbstractQuery;
 +import org.hibernate.query.spi.ParameterMetadataImplementor;
 +import org.hibernate.query.spi.QueryImplementor;
++import org.hibernate.query.spi.QueryParameterBinding;
  import org.hibernate.query.spi.QueryParameterBindings;
++import org.hibernate.query.spi.QueryParameterImplementor;
  import org.hibernate.query.spi.ScrollableResultsImplementor;
  import org.hibernate.search.engine.search.query.SearchQuery;
  import org.hibernate.search.engine.search.query.spi.SearchQueryImplementor;
@@ -653,6 +654,7 @@ index c8ca89a1e0..f7140b4d52 100644
  
 -@SuppressForbiddenApis(reason = "We need to extend the internal AbstractProducedQuery"
 +import jakarta.persistence.LockModeType;
++import jakarta.persistence.Parameter;
 +import jakarta.persistence.PersistenceException;
 +import jakarta.persistence.QueryTimeoutException;
 +
@@ -664,7 +666,7 @@ index c8ca89a1e0..f7140b4d52 100644
  
  	public static <R> HibernateOrmSearchQueryAdapter<R> create(SearchQuery<R> query) {
  		return query.extension( HibernateOrmSearchQueryAdapterExtension.get() );
-@@ -61,15 +57,16 @@ public static <R> HibernateOrmSearchQueryAdapter<R> create(SearchQuery<R> query)
+@@ -61,15 +59,16 @@ public static <R> HibernateOrmSearchQueryAdapter<R> create(SearchQuery<R> query)
  	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
  
  	private final SearchQueryImplementor<R> delegate;
@@ -685,7 +687,7 @@ index c8ca89a1e0..f7140b4d52 100644
  		this.loadingOptions = loadingOptions;
  	}
  
-@@ -84,83 +81,26 @@ public String toString() {
+@@ -84,83 +83,26 @@ public String toString() {
  
  	@Override
  	@SuppressWarnings("unchecked")
@@ -776,7 +778,7 @@ index c8ca89a1e0..f7140b4d52 100644
  	}
  
  	@Override
-@@ -168,6 +108,11 @@ public String getQueryString() {
+@@ -168,6 +110,11 @@ public String getQueryString() {
  		return delegate.queryString();
  	}
  
@@ -788,7 +790,7 @@ index c8ca89a1e0..f7140b4d52 100644
  	@Override
  	public HibernateOrmSearchQueryAdapter<R> setHint(String hintName, Object value) {
  		switch ( hintName ) {
-@@ -180,14 +125,12 @@ public HibernateOrmSearchQueryAdapter<R> setHint(String hintName, Object value)
+@@ -180,14 +127,12 @@ public HibernateOrmSearchQueryAdapter<R> setHint(String hintName, Object value)
  				break;
  			case HibernateOrmSearchQueryHints.JAVAX_FETCHGRAPH:
  			case HibernateOrmSearchQueryHints.JAKARTA_FETCHGRAPH:
@@ -805,7 +807,7 @@ index c8ca89a1e0..f7140b4d52 100644
  				break;
  		}
  		return this;
-@@ -200,148 +143,104 @@ public HibernateOrmSearchQueryAdapter<R> setTimeout(int timeout) {
+@@ -200,148 +145,109 @@ public HibernateOrmSearchQueryAdapter<R> setTimeout(int timeout) {
  	}
  
  	@Override
@@ -915,22 +917,23 @@ index c8ca89a1e0..f7140b4d52 100644
 +	}
 +
 +	@Override
-+	public HibernateOrmSearchQueryAdapter<R> setParameterList(String name, Object[] values) {
++	protected <P> QueryParameterBinding<P> locateBinding(String name) {
  		throw parametersNoSupported();
  	}
  
  	@Override
 -	public HibernateOrmSearchQueryAdapter<R> setParameter(Parameter<Date> dateParameter, Date date, TemporalType temporalType) {
-+	public QueryImplementor<R> setParameterList(String s, Collection collection, Class aClass) {
++	protected <P> QueryParameterBinding<P> locateBinding(int position) {
  		throw parametersNoSupported();
  	}
  
  	@Override
 -	public HibernateOrmSearchQueryAdapter<R> setParameter(String name, Object value) {
--		throw parametersNoSupported();
--	}
--
--	@Override
++	protected <P> QueryParameterBinding<P> locateBinding(Parameter<P> parameter) {
+ 		throw parametersNoSupported();
+ 	}
+ 
+ 	@Override
 -	public HibernateOrmSearchQueryAdapter<R> setParameter(String name, Date value, TemporalType temporalType) {
 -		throw parametersNoSupported();
 -	}
@@ -1002,11 +1005,11 @@ index c8ca89a1e0..f7140b4d52 100644
 -
 -	@Override
 -	public Object getParameterValue(int position) {
-+	public QueryImplementor<R> setParameterList(int i, Collection collection, Class aClass) {
++	protected <P> QueryParameterBinding<P> locateBinding(QueryParameterImplementor<P> parameter) {
  		throw parametersNoSupported();
  	}
  
-@@ -350,18 +249,16 @@ private UnsupportedOperationException parametersNoSupported() {
+@@ -350,18 +256,16 @@ private UnsupportedOperationException parametersNoSupported() {
  	}
  
  	@Override
@@ -1030,7 +1033,7 @@ index c8ca89a1e0..f7140b4d52 100644
  		return new UnsupportedOperationException( "Result transformers are not supported in Hibernate Search queries" );
  	}
  
-@@ -391,7 +288,12 @@ private UnsupportedOperationException lockOptionsNotSupported() {
+@@ -391,7 +295,12 @@ private UnsupportedOperationException lockOptionsNotSupported() {
  	}
  
  	@Override
@@ -1044,7 +1047,7 @@ index c8ca89a1e0..f7140b4d52 100644
  		throw new UnsupportedOperationException( "executeUpdate is not supported in Hibernate Search queries" );
  	}
  
-@@ -400,30 +302,6 @@ public HibernateOrmSearchQueryAdapter<R> setLockMode(String alias, LockMode lock
+@@ -400,30 +309,6 @@ public HibernateOrmSearchQueryAdapter<R> setLockMode(String alias, LockMode lock
  		throw lockOptionsNotSupported();
  	}
  
@@ -1075,7 +1078,7 @@ index c8ca89a1e0..f7140b4d52 100644
  	private static long hintValueToLong(Object value) {
  		if ( value instanceof Number ) {
  			return ( (Number) value ).longValue();
-@@ -442,8 +320,4 @@ private static int hintValueToInteger(Object value) {
+@@ -442,8 +327,4 @@ private static int hintValueToInteger(Object value) {
  		}
  	}
  

--- a/orm6/v5migrationhelper/orm/ant-src-changes.patch
+++ b/orm6/v5migrationhelper/orm/ant-src-changes.patch
@@ -109,7 +109,7 @@ index 9f6bfae665..6c5728910f 100644
  	public FullTextSession openSession() {
  		return Search.getFullTextSession( builder.openSession() );
 diff --git a/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java b/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
-index c6481cc62e..f46722f7b2 100644
+index c6481cc62e..6ea158d8ae 100644
 --- a/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
 +++ b/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
 @@ -7,21 +7,13 @@
@@ -119,7 +119,6 @@ index c6481cc62e..f46722f7b2 100644
 -import java.util.Calendar;
 -import java.util.Collections;
 -import java.util.Date;
-+import java.util.Collection;
  import java.util.HashMap;
 -import java.util.Iterator;
  import java.util.List;
@@ -129,14 +128,14 @@ index c6481cc62e..f46722f7b2 100644
  import java.util.function.Consumer;
 -import jakarta.persistence.FlushModeType;
 -import jakarta.persistence.LockModeType;
--import jakarta.persistence.Parameter;
++import java.util.function.Function;
+ import jakarta.persistence.Parameter;
 -import jakarta.persistence.QueryTimeoutException;
 -import jakarta.persistence.TemporalType;
-+import java.util.function.Function;
  
  import org.hibernate.HibernateException;
  import org.hibernate.LockMode;
-@@ -29,12 +21,14 @@
+@@ -29,14 +21,18 @@
  import org.hibernate.ScrollMode;
  import org.hibernate.TypeMismatchException;
  import org.hibernate.engine.spi.SessionImplementor;
@@ -153,9 +152,13 @@ index c6481cc62e..f46722f7b2 100644
 +import org.hibernate.query.spi.AbstractQuery;
 +import org.hibernate.query.spi.ParameterMetadataImplementor;
  import org.hibernate.query.spi.QueryImplementor;
++import org.hibernate.query.spi.QueryParameterBinding;
  import org.hibernate.query.spi.QueryParameterBindings;
++import org.hibernate.query.spi.QueryParameterImplementor;
  import org.hibernate.query.spi.ScrollableResultsImplementor;
-@@ -45,7 +39,6 @@
+ import org.hibernate.search.FullTextQuery;
+ import org.hibernate.search.engine.search.query.SearchScroll;
+@@ -45,7 +41,6 @@
  import org.hibernate.search.mapper.orm.search.loading.dsl.SearchLoadingOptionsStep;
  import org.hibernate.search.mapper.orm.search.query.spi.HibernateOrmSearchQueryHints;
  import org.hibernate.search.mapper.orm.search.query.spi.HibernateOrmSearchScrollableResultsAdapter;
@@ -163,7 +166,7 @@ index c6481cc62e..f46722f7b2 100644
  import org.hibernate.search.query.DatabaseRetrievalMethod;
  import org.hibernate.search.query.ObjectLookupMethod;
  import org.hibernate.search.query.engine.spi.FacetManager;
-@@ -55,8 +48,11 @@
+@@ -55,8 +50,11 @@
  import org.hibernate.search.spatial.impl.Point;
  import org.hibernate.search.util.common.SearchTimeoutException;
  import org.hibernate.transform.ResultTransformer;
@@ -176,7 +179,7 @@ index c6481cc62e..f46722f7b2 100644
  import org.apache.lucene.search.Explanation;
  import org.apache.lucene.search.Query;
  import org.apache.lucene.search.Sort;
-@@ -68,14 +64,14 @@
+@@ -68,14 +66,14 @@
   * @author Hardy Ferentschik
   */
  @SuppressWarnings("rawtypes") // We extend the raw version of AbstractProducedQuery on purpose, see HSEARCH-2564
@@ -194,7 +197,7 @@ index c6481cc62e..f46722f7b2 100644
  	//initialized at 0 since we don't expect to use hints at this stage
  	private final Map<String, Object> hints = new HashMap<String, Object>( 0 );
  
-@@ -96,11 +92,12 @@ public class FullTextQueryImpl extends AbstractProducedQuery implements FullText
+@@ -96,11 +94,12 @@ public class FullTextQueryImpl extends AbstractProducedQuery implements FullText
  
  	private ResultTransformer resultTransformer;
  
@@ -209,7 +212,7 @@ index c6481cc62e..f46722f7b2 100644
  		this.searchSession = searchSession;
  		this.hSearchQuery = searchIntegrator.createHSQuery( luceneQuery, searchSession,
  				loadingOptionsContributor, entities );
-@@ -118,54 +115,61 @@ public List getResultList() {
+@@ -118,54 +117,61 @@ public List getResultList() {
  	}
  
  	@Override
@@ -295,7 +298,7 @@ index c6481cc62e..f46722f7b2 100644
  	@Override
  	public Explanation explain(Object entityId) {
  		return hSearchQuery.explain( entityId );
-@@ -179,8 +183,14 @@ public int getResultSize() {
+@@ -179,8 +185,14 @@ public int getResultSize() {
  		catch (SearchTimeoutException e) {
  			throw new QueryTimeoutException( e );
  		}
@@ -311,7 +314,7 @@ index c6481cc62e..f46722f7b2 100644
  		}
  	}
  
-@@ -189,11 +199,16 @@ public int doGetResultSize() {
+@@ -189,11 +201,16 @@ public int doGetResultSize() {
  	}
  
  	@Override
@@ -330,7 +333,7 @@ index c6481cc62e..f46722f7b2 100644
  	@Override
  	public FullTextQueryImpl setProjection(String... fields) {
  		hSearchQuery.projection( fields );
-@@ -214,44 +229,16 @@ public FullTextQueryImpl setSpatialParameters(double latitude, double longitude,
+@@ -214,44 +231,16 @@ public FullTextQueryImpl setSpatialParameters(double latitude, double longitude,
  
  	@Override
  	public FullTextQuery setMaxResults(int maxResults) {
@@ -377,7 +380,7 @@ index c6481cc62e..f46722f7b2 100644
  	@Override
  	@SuppressWarnings("deprecation")
  	public FullTextQuery setHint(String hintName, Object value) {
-@@ -266,14 +253,11 @@ public FullTextQuery setHint(String hintName, Object value) {
+@@ -266,14 +255,11 @@ public FullTextQuery setHint(String hintName, Object value) {
  				break;
  			case HibernateOrmSearchQueryHints.JAVAX_FETCHGRAPH:
  			case HibernateOrmSearchQueryHints.JAKARTA_FETCHGRAPH:
@@ -393,7 +396,7 @@ index c6481cc62e..f46722f7b2 100644
  				break;
  		}
  		return this;
-@@ -284,99 +268,35 @@ public Map<String, Object> getHints() {
+@@ -284,99 +270,40 @@ public Map<String, Object> getHints() {
  		return hints;
  	}
  
@@ -428,22 +431,23 @@ index c6481cc62e..f46722f7b2 100644
 +	}
 +
 +	@Override
-+	public QueryImplementor<?> setParameterList(String name, Object[] values) {
++	protected QueryParameterBinding locateBinding(String name) {
  		throw parametersNoSupported();
  	}
  
  	@Override
 -	public FullTextQueryImpl setParameter(String name, Date value, TemporalType temporalType) {
-+	public QueryImplementor<?> setParameterList(String s, Collection collection, Class aClass) {
++	protected QueryParameterBinding locateBinding(int position) {
  		throw parametersNoSupported();
  	}
  
  	@Override
 -	public FullTextQueryImpl setParameter(String name, Calendar value, TemporalType temporalType) {
--		throw parametersNoSupported();
--	}
--
--	@Override
++	protected QueryParameterBinding locateBinding(Parameter parameter) {
+ 		throw parametersNoSupported();
+ 	}
+ 
+ 	@Override
 -	public FullTextQueryImpl setParameter(int position, Object value) {
 -		throw parametersNoSupported();
 -	}
@@ -506,11 +510,11 @@ index c6481cc62e..f46722f7b2 100644
 -
 -	@Override
 -	public Object getParameterValue(int position) {
-+	public QueryImplementor<?> setParameterList(int i, Collection collection, Class aClass) {
++	protected QueryParameterBinding locateBinding(QueryParameterImplementor parameter) {
  		throw parametersNoSupported();
  	}
  
-@@ -391,12 +311,7 @@ public FullTextQueryImpl setFlushMode(FlushModeType flushModeType) {
+@@ -391,12 +318,7 @@ public FullTextQueryImpl setFlushMode(FlushModeType flushModeType) {
  
  	@Override
  	public FullTextQueryImpl setFetchSize(int fetchSize) {
@@ -524,7 +528,7 @@ index c6481cc62e..f46722f7b2 100644
  	}
  
  	@Override
-@@ -434,7 +349,12 @@ public Object unwrap(Class type) {
+@@ -434,7 +356,12 @@ public Object unwrap(Class type) {
  		if ( type == org.apache.lucene.search.Query.class ) {
  			return hSearchQuery.getLuceneQuery();
  		}
@@ -538,7 +542,7 @@ index c6481cc62e..f46722f7b2 100644
  	}
  
  	@Override
-@@ -457,7 +377,12 @@ private UnsupportedOperationException lockOptionsNotSupported() {
+@@ -457,7 +384,12 @@ private UnsupportedOperationException lockOptionsNotSupported() {
  	}
  
  	@Override
@@ -552,7 +556,7 @@ index c6481cc62e..f46722f7b2 100644
  		throw new UnsupportedOperationException( "executeUpdate is not supported in Hibernate Search queries" );
  	}
  
-@@ -515,32 +440,13 @@ public String getQueryString() {
+@@ -515,32 +447,13 @@ public String getQueryString() {
  	}
  
  	@Override
@@ -589,7 +593,7 @@ index c6481cc62e..f46722f7b2 100644
  	}
  
  	@Override
-@@ -549,12 +455,12 @@ public String toString() {
+@@ -549,12 +462,12 @@ public String toString() {
  	}
  
  	private static final class Search5ScrollHitExtractor
@@ -604,7 +608,7 @@ index c6481cc62e..f46722f7b2 100644
  			if ( hit instanceof Object[] ) {
  				return (Object[]) hit;
  			}
-@@ -562,19 +468,6 @@ public Object[] toArray(Object hit) {
+@@ -562,19 +475,6 @@ public Object[] toArray(Object hit) {
  				return new Object[] { hit };
  			}
  		}
@@ -624,7 +628,7 @@ index c6481cc62e..f46722f7b2 100644
  	}
  
  	private static int hintValueToInteger(Object value) {
-@@ -586,7 +479,7 @@ private static int hintValueToInteger(Object value) {
+@@ -586,7 +486,7 @@ private static int hintValueToInteger(Object value) {
  		}
  	}
  


### PR DESCRIPTION
* [HSEARCH-4775](https://hibernate.atlassian.net/browse/HSEARCH-4775): Improve source code compatibility of Hibernate Search with Hibernate ORM 6.2
* [HSEARCH-4768](https://hibernate.atlassian.net/browse/HSEARCH-4768): Fix JavaModulePathTest with ORM 6.2



[HSEARCH-4775]: https://hibernate.atlassian.net/browse/HSEARCH-4775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HSEARCH-4768]: https://hibernate.atlassian.net/browse/HSEARCH-4768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ