### PR TITLE
Backport HSEARCH-4757 + HSEARCH-4768 + HSEARCH-4775 to branch 6.1 - Fix ORM 6.2 dependency update tests

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingEmbeddableIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingEmbeddableIT.java
@@ -960,6 +960,24 @@ public class AutomaticIndexingEmbeddableIT {
 			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
 			containingEntity1.getContainedSingleWithInverseSideEmbedded()
 					.getContainingAsSingleWithInverseSideEmbedded().setContainingAsSingle( null );
+			// Clear the one-to-one association and flush it first, to avoid problems with unique key constraints. See details in HHH-15767
+			containingEntity1.setContainedSingleWithInverseSideEmbedded( null );
+
+			if ( setupHolder.areEntitiesProcessedInSession() ) {
+				backendMock.expectWorks( IndexedEntity.INDEX )
+						.addOrUpdate( "1", b -> b
+								.objectField( "child", b2 -> b2
+										.objectField( "containedEmbeddedSingle", b3 -> {
+										} )
+										.objectField( "containedEmbeddedList", b3 -> {
+										} )
+										.objectField( "containedBidirectionalEmbedded", b3 -> {
+										} )
+								)
+						);
+			}
+			session.flush();
+
 			containingEntity1.setContainedSingleWithInverseSideEmbedded( containedEntity );
 			containedEntity.setContainingAsSingleWithInverseSideEmbedded( new InverseSideEmbeddable( containingEntity1 ) );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/AbstractAutomaticIndexingAssociationBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/AbstractAutomaticIndexingAssociationBaseIT.java
@@ -207,6 +207,10 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 
 	protected abstract boolean isAssociationLazyOnContainingSide();
 
+	protected boolean isEmbeddedAssociationChangeCausingWork() {
+		return !isAssociationOwnedByContainedSide() && !isAssociationMultiValuedOnContainingSide();
+	}
+
 	private boolean isElementCollectionAssociationsOnContainingSide() {
 		return !isAssociationOwnedByContainedSide() && !isAssociationMultiValuedOnContainingSide();
 	}
@@ -450,6 +454,18 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 
 			TContained oldContained = containingAssociation.get( entity1 );
 			containedAssociation.clear( oldContained );
+			// Clear the one-to-one association and flush it first, to avoid problems with unique key constraints. See details in HHH-15767
+			if ( !isAssociationMultiValuedOnContainingSide() ) {
+				containingAssociation.clear( entity1 );
+
+				if ( setupHolder.areEntitiesProcessedInSession() ) {
+					backendMock.expectWorks( _indexed().indexName() )
+							.addOrUpdate( "1", b -> {
+							} );
+				}
+				session.flush();
+			}
+
 			containingAssociation.set( entity1, containedEntity );
 			containedAssociation.set( containedEntity, entity1 );
 
@@ -525,6 +541,12 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 
 			TContained oldContained = containingAssociation.get( entity1 );
 			containedAssociation.clear( oldContained );
+			// Clear the one-to-one association and flush it first, to avoid problems with unique key constraints. See details in HHH-15767
+			if ( !isAssociationMultiValuedOnContainingSide() ) {
+				containingAssociation.clear( entity1 );
+				session.flush();
+			}
+
 			containingAssociation.set( entity1, containedEntity );
 			containedAssociation.set( containedEntity, entity1 );
 
@@ -599,6 +621,18 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 
 			TContained oldContained = containingAssociation.get( entity1 );
 			containedAssociation.clear( oldContained );
+			// Clear the one-to-one association and flush it first, to avoid problems with unique key constraints. See details in HHH-15767
+			if ( !isAssociationMultiValuedOnContainingSide() ) {
+				containingAssociation.clear( entity1 );
+
+				if ( setupHolder.areEntitiesProcessedInSession() ) {
+					backendMock.expectWorks( _indexed().indexName() )
+							.addOrUpdate( "1", b -> {
+							} );
+				}
+				session.flush();
+			}
+
 			containingAssociation.set( entity1, containedEntity );
 			containedAssociation.set( containedEntity, entity1 );
 
@@ -674,6 +708,12 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 
 			TContained oldContained = containingAssociation.get( entity1 );
 			containedAssociation.clear( oldContained );
+			// Clear the one-to-one association and flush it first, to avoid problems with unique key constraints. See details in HHH-15767
+			if ( !isAssociationMultiValuedOnContainingSide() ) {
+				containingAssociation.clear( entity1 );
+				session.flush();
+			}
+
 			containingAssociation.set( entity1, containedEntity );
 			containedAssociation.set( containedEntity, entity1 );
 
@@ -747,6 +787,18 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 
 			TContained oldContained = containingAssociation.get( entity1 );
 			containedAssociation.clear( oldContained );
+			// Clear the one-to-one association and flush it first, to avoid problems with unique key constraints. See details in HHH-15767
+			if ( !isAssociationMultiValuedOnContainingSide() ) {
+				containingAssociation.clear( entity1 );
+
+				if ( setupHolder.areEntitiesProcessedInSession() ) {
+					backendMock.expectWorks( _indexed().indexName() )
+							.addOrUpdate( "1", b -> {
+							} );
+				}
+				session.flush();
+			}
+
 			containingAssociation.set( entity1, containedEntity );
 			containedAssociation.set( containedEntity, entity1 );
 
@@ -829,6 +881,17 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 
 			TContained oldContained = containingAssociation.get( entity1 );
 			containedAssociation.clear( oldContained );
+			// Clear the one-to-one association and flush it first, to avoid problems with unique key constraints. See details in HHH-15767
+			if ( !isAssociationMultiValuedOnContainingSide() ) {
+				containingAssociation.clear( entity1 );
+				if ( isEmbeddedAssociationChangeCausingWork() && setupHolder.areEntitiesProcessedInSession() ) {
+					backendMock.expectWorks( _indexed().indexName() )
+							.addOrUpdate( "1", b ->
+									b.objectField( "embeddedAssociations", b2 -> { } ) );
+				}
+				session.flush();
+			}
+
 			containingAssociation.set( entity1, containedEntity );
 			containedAssociation.set( containedEntity, entity1 );
 
@@ -1087,6 +1150,17 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 
 			TContained oldContained = containingAssociation.get( entity1 );
 			containedAssociation.clear( oldContained );
+			// Clear the one-to-one association and flush it first, to avoid problems with unique key constraints. See details in HHH-15767
+			if ( !isAssociationMultiValuedOnContainingSide() ) {
+				containingAssociation.clear( entity1 );
+
+				if ( setupHolder.areEntitiesProcessedInSession() ) {
+					backendMock.expectWorks( _indexed().indexName() )
+							.addOrUpdate( "1", b -> { } );
+				}
+				session.flush();
+			}
+
 			_containing().embeddedAssociations().set( entity1, _containingEmbeddable().newInstance() );
 			containingAssociation.set( entity1, contained );
 			containedAssociation.set( contained, entity1 );
@@ -1139,6 +1213,17 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 
 			TContained oldContained = containingAssociation.get( entity1 );
 			containedAssociation.clear( oldContained );
+			// Clear the one-to-one association and flush it first, to avoid problems with unique key constraints. See details in HHH-15767
+			if ( !isAssociationMultiValuedOnContainingSide() ) {
+				containingAssociation.clear( entity1 );
+				if ( isEmbeddedAssociationChangeCausingWork() && setupHolder.areEntitiesProcessedInSession() ) {
+					backendMock.expectWorks( _indexed().indexName() )
+							.addOrUpdate( "1", b ->
+									b.objectField( "embeddedAssociations", b2 -> { } ) );
+				}
+				session.flush();
+			}
+
 			_containing().embeddedAssociations().set( entity1, _containingEmbeddable().newInstance() );
 			containingAssociation.set( entity1, contained );
 			containedAssociation.set( contained, entity1 );
@@ -1844,6 +1929,20 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 
 			TContained oldContained = containingAssociation.get( containingEntity1 );
 			containedAssociation.clear( oldContained );
+			// Clear the one-to-one association and flush it first, to avoid problems with unique key constraints. See details in HHH-15767
+			if ( !isAssociationMultiValuedOnContainingSide() ) {
+				containingAssociation.clear( containingEntity1 );
+
+				if ( setupHolder.areEntitiesProcessedInSession() ) {
+					backendMock.expectWorks( _indexed().indexName() )
+							.addOrUpdate( "1", b -> b
+									.objectField( "child", b2 -> {
+									} )
+							);
+				}
+				session.flush();
+			}
+
 			containingAssociation.set( containingEntity1, containedEntity );
 			containedAssociation.set( containedEntity, containingEntity1 );
 
@@ -1946,6 +2045,12 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 
 			TContained oldContained = containingAssociation.get( containingEntity1 );
 			containedAssociation.clear( oldContained );
+			// Clear the one-to-one association and flush it first, to avoid problems with unique key constraints. See details in HHH-15767
+			if ( !isAssociationMultiValuedOnContainingSide() ) {
+				containingAssociation.clear( containingEntity1 );
+				session.flush();
+			}
+
 			containingAssociation.set( containingEntity1, containedEntity );
 			containedAssociation.set( containedEntity, containingEntity1 );
 
@@ -2030,6 +2135,19 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 
 			TContained oldContained = containingAssociation.get( containingEntity1 );
 			containedAssociation.clear( oldContained );
+			// Clear the one-to-one association and flush it first, to avoid problems with unique key constraints. See details in HHH-15767
+			if ( !isAssociationMultiValuedOnContainingSide() ) {
+				containingAssociation.clear( containingEntity1 );
+
+				if ( setupHolder.areEntitiesProcessedInSession() ) {
+					backendMock.expectWorks( _indexed().indexName() )
+							.addOrUpdate( "1", b -> b
+									.objectField( "child", b2 -> { } )
+							);
+				}
+				session.flush();
+			}
+
 			containingAssociation.set( containingEntity1, containedEntity );
 			containedAssociation.set( containedEntity, containingEntity1 );
 
@@ -2117,6 +2235,12 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 
 			TContained oldContained = containingAssociation.get( containingEntity1 );
 			containedAssociation.clear( oldContained );
+			// Clear the one-to-one association and flush it first, to avoid problems with unique key constraints. See details in HHH-15767
+			if ( !isAssociationMultiValuedOnContainingSide() ) {
+				containingAssociation.clear( containingEntity1 );
+				session.flush();
+			}
+
 			containingAssociation.set( containingEntity1, containedEntity );
 			containedAssociation.set( containedEntity, containingEntity1 );
 
@@ -2209,6 +2333,19 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 
 			TContained oldContained = containingAssociation.get( containingEntity1 );
 			containedAssociation.clear( oldContained );
+			// Clear the one-to-one association and flush it first, to avoid problems with unique key constraints. See details in HHH-15767
+			if ( !isAssociationMultiValuedOnContainingSide() ) {
+				containingAssociation.clear( containingEntity1 );
+
+				if ( setupHolder.areEntitiesProcessedInSession() ) {
+					backendMock.expectWorks( _indexed().indexName() )
+							.addOrUpdate( "1", b -> b
+									.objectField( "child", b2 -> { } )
+							);
+				}
+				session.flush();
+			}
+
 			containingAssociation.set( containingEntity1, containedEntity );
 			containedAssociation.set( containedEntity, containingEntity1 );
 
@@ -2324,6 +2461,19 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 
 			TContained oldContained = containingAssociation.get( containingEntity1 );
 			containedAssociation.clear( oldContained );
+			// Clear the one-to-one association and flush it first, to avoid problems with unique key constraints. See details in HHH-15767
+			if ( !isAssociationMultiValuedOnContainingSide() ) {
+				containingAssociation.clear( containingEntity1 );
+
+				if ( setupHolder.areEntitiesProcessedInSession() ) {
+					backendMock.expectWorks( _indexed().indexName() )
+							.addOrUpdate( "1", b -> b
+									.objectField( "child", b2 -> { } )
+							);
+				}
+				session.flush();
+			}
+
 			containingAssociation.set( containingEntity1, containedEntity );
 			containedAssociation.set( containedEntity, containingEntity1 );
 
@@ -2435,6 +2585,17 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 
 			TContained oldContained = containingAssociation.get( containingEntity1 );
 			containedAssociation.clear( oldContained );
+			// Clear the one-to-one association and flush it first, to avoid problems with unique key constraints. See details in HHH-15767
+			if ( !isAssociationMultiValuedOnContainingSide() ) {
+				containingAssociation.clear( containingEntity1 );
+				if ( isEmbeddedAssociationChangeCausingWork() && setupHolder.areEntitiesProcessedInSession() ) {
+					backendMock.expectWorks( _indexed().indexName() )
+							.addOrUpdate( "1", b ->
+									b.objectField( "child", b2 -> { } ) );
+				}
+				session.flush();
+			}
+
 			containingAssociation.set( containingEntity1, containedEntity );
 			containedAssociation.set( containedEntity, containingEntity1 );
 
@@ -2523,6 +2684,19 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 
 			TContained oldContained = containingAssociation.get( containing );
 			containedAssociation.clear( oldContained );
+			// Clear the one-to-one association and flush it first, to avoid problems with unique key constraints. See details in HHH-15767
+			if ( !isAssociationMultiValuedOnContainingSide() ) {
+				containingAssociation.clear( containing );
+
+				if ( setupHolder.areEntitiesProcessedInSession() ) {
+					backendMock.expectWorks( _indexed().indexName() )
+							.addOrUpdate( "1", b -> b
+									.objectField( "child", b2 -> { } )
+							);
+				}
+				session.flush();
+			}
+
 			_containing().embeddedAssociations().set( containing, _containingEmbeddable().newInstance() );
 			containingAssociation.set( containing, contained );
 			containedAssociation.set( contained, containing );
@@ -2605,6 +2779,19 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 
 			TContained oldContained = containingAssociation.get( containing );
 			containedAssociation.clear( oldContained );
+			// Clear the one-to-one association and flush it first, to avoid problems with unique key constraints. See details in HHH-15767
+			if ( !isAssociationMultiValuedOnContainingSide() ) {
+				containingAssociation.clear( containing );
+				if ( isEmbeddedAssociationChangeCausingWork() && setupHolder.areEntitiesProcessedInSession() ) {
+					backendMock.expectWorks( _indexed().indexName() )
+							.addOrUpdate( "1", b -> b
+									.objectField( "child", b2 ->
+											b2.objectField( "embeddedAssociations", b3 -> { } ) )
+							);
+				}
+				session.flush();
+			}
+
 			_containing().embeddedAssociations().set( containing, _containingEmbeddable().newInstance() );
 			containingAssociation.set( containing, contained );
 			containedAssociation.set( contained, containing );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontaining/AutomaticIndexingOneToOneOwnedByContainingEagerOnBothSidesIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontaining/AutomaticIndexingOneToOneOwnedByContainingEagerOnBothSidesIT.java
@@ -18,6 +18,7 @@ import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 import javax.persistence.OrderColumn;
 import javax.persistence.Transient;
@@ -466,7 +467,7 @@ public class AutomaticIndexingOneToOneOwnedByContainingEagerOnBothSidesIT
 		 * and in this case it is a List.
 		 * TODO use mappedBy when the above gets fixed in Hibernate ORM
 		 */
-		@OneToOne
+		@ManyToOne
 		@JoinColumn(name = "CECAssocIdxEmb")
 		@AssociationInverseSide(inversePath = @ObjectPath({
 				@PropertyValue(propertyName = "elementCollectionAssociations"),
@@ -478,7 +479,7 @@ public class AutomaticIndexingOneToOneOwnedByContainingEagerOnBothSidesIT
 		 * No mappedBy here. Same reason as just above.
 		 * TODO use mappedBy when the above gets fixed in Hibernate ORM
 		 */
-		@OneToOne
+		@ManyToOne
 		@JoinColumn(name = "CECAssocNonIdxEmb")
 		@AssociationInverseSide(inversePath = @ObjectPath({
 				@PropertyValue(propertyName = "elementCollectionAssociations"),

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontaining/AutomaticIndexingOneToOneOwnedByContainingLazyOnContainedSideIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontaining/AutomaticIndexingOneToOneOwnedByContainingLazyOnContainedSideIT.java
@@ -19,6 +19,7 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 import javax.persistence.OrderColumn;
 import javax.persistence.Transient;
@@ -471,7 +472,7 @@ public class AutomaticIndexingOneToOneOwnedByContainingLazyOnContainedSideIT
 		 * and in this case it is a List.
 		 * TODO use mappedBy when the above gets fixed in Hibernate ORM
 		 */
-		@OneToOne(fetch = FetchType.LAZY)
+		@ManyToOne(fetch = FetchType.LAZY)
 		@JoinColumn(name = "CECAssocIdxEmb")
 		@AssociationInverseSide(inversePath = @ObjectPath({
 				@PropertyValue(propertyName = "elementCollectionAssociations"),
@@ -483,7 +484,7 @@ public class AutomaticIndexingOneToOneOwnedByContainingLazyOnContainedSideIT
 		 * No mappedBy here. Same reason as just above.
 		 * TODO use mappedBy when the above gets fixed in Hibernate ORM
 		 */
-		@OneToOne(fetch = FetchType.LAZY)
+		@ManyToOne(fetch = FetchType.LAZY)
 		@JoinColumn(name = "CECAssocNonIdxEmb")
 		@AssociationInverseSide(inversePath = @ObjectPath({
 				@PropertyValue(propertyName = "elementCollectionAssociations"),

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontaining/AutomaticIndexingOneToOneOwnedByContainingLazyOnContainingSideIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontaining/AutomaticIndexingOneToOneOwnedByContainingLazyOnContainingSideIT.java
@@ -19,6 +19,7 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 import javax.persistence.OrderColumn;
 import javax.persistence.Transient;
@@ -471,7 +472,7 @@ public class AutomaticIndexingOneToOneOwnedByContainingLazyOnContainingSideIT
 		 * and in this case it is a List.
 		 * TODO use mappedBy when the above gets fixed in Hibernate ORM
 		 */
-		@OneToOne
+		@ManyToOne
 		@JoinColumn(name = "CECAssocIdxEmb")
 		@AssociationInverseSide(inversePath = @ObjectPath({
 				@PropertyValue(propertyName = "elementCollectionAssociations"),
@@ -483,7 +484,7 @@ public class AutomaticIndexingOneToOneOwnedByContainingLazyOnContainingSideIT
 		 * No mappedBy here. Same reason as just above.
 		 * TODO use mappedBy when the above gets fixed in Hibernate ORM
 		 */
-		@OneToOne
+		@ManyToOne
 		@JoinColumn(name = "CECAssocNonIdxEmb")
 		@AssociationInverseSide(inversePath = @ObjectPath({
 				@PropertyValue(propertyName = "elementCollectionAssociations"),

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java
@@ -275,11 +275,14 @@ public class BytecodeEnhancementIT {
 			extends IndexedEntitySuperClass {
 		public static final String INDEX = "IndexedEntity";
 
+		// "containedEntityList" is not listed here,
+		// because collection properties are initialized eagerly on ORM 6.2+
+		// (even if the collection themselves are initialized lazily).
+		// See HHH-15473 / https://github.com/hibernate/hibernate-orm/pull/5252
 		private static final String[] LAZY_PROPERTY_NAMES = new String[] {
 				"mappedSuperClassText",
 				"entitySuperClassText",
 				"notIndexedText",
-				"containedEntityList",
 				"text1",
 				"text2",
 				"primitiveInteger",

--- a/jakarta/integrationtest/jdk/java-modules/orm-lucene/ant-src-changes.patch
+++ b/jakarta/integrationtest/jdk/java-modules/orm-lucene/ant-src-changes.patch
@@ -1,0 +1,17 @@
+diff --git a/main/java/module-info.java b/main/java/module-info.java
+index 3bd5c117f3..28074f5739 100644
+--- a/main/java/module-info.java
++++ b/main/java/module-info.java
+@@ -16,12 +16,6 @@
+ 	requires org.hibernate.search.mapper.orm;
+ 	requires org.hibernate.search.backend.elasticsearch;
+ 
+-	// This should be re-exported transitively by org.hibernate.search.mapper.orm
+-	// but currently isn't, because org.hibernate.search.mapper.orm
+-	// is still an automatic module
+-	requires org.hibernate.search.engine;
+-	requires org.hibernate.search.mapper.pojo;
+-
+ 	/*
+ 	 * This is necessary in order to use SessionFactory,
+ 	 * which extends "javax.naming.Referenceable".

--- a/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/massindexing/util/impl/PersistenceUtil.java
+++ b/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/massindexing/util/impl/PersistenceUtil.java
@@ -46,7 +46,8 @@ public final class PersistenceUtil {
 	 */
 	public static Session openSession(EntityManagerFactory entityManagerFactory, String tenantId) {
 		SessionFactory sessionFactory = entityManagerFactory.unwrap( SessionFactory.class );
-		SessionBuilder<?> builder = sessionFactory.withOptions();
+		@SuppressWarnings("rawtypes")
+		SessionBuilder builder = sessionFactory.withOptions();
 		if ( StringHelper.isNotEmpty( tenantId ) ) {
 			builder.tenantIdentifier( tenantId );
 		}
@@ -69,7 +70,8 @@ public final class PersistenceUtil {
 	 */
 	public static StatelessSession openStatelessSession(EntityManagerFactory entityManagerFactory, String tenantId) {
 		SessionFactory sessionFactory = entityManagerFactory.unwrap( SessionFactory.class );
-		StatelessSessionBuilder<?> builder = sessionFactory.withStatelessOptions();
+		@SuppressWarnings("rawtypes")
+		StatelessSessionBuilder builder = sessionFactory.withStatelessOptions();
 		if ( StringHelper.isNotEmpty( tenantId ) ) {
 			builder.tenantIdentifier( tenantId );
 		}

--- a/mapper/orm-coordination-outbox-polling/pom.xml
+++ b/mapper/orm-coordination-outbox-polling/pom.xml
@@ -93,11 +93,11 @@
                         <configuration>
                             <module>
                                 <moduleInfo>
-                                    <!-- cluster and event packages to expose Agent and OutboxEvent entities to ORM -->
+                                    <!-- cluster and event packages to expose Agent and OutboxEvent entities to ORM and ByteBuddy -->
                                     <opens>
                                         org.hibernate.search.mapper.orm.coordination.outboxpolling.avro.generated.impl to org.apache.avro;
-                                        org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl to org.hibernate.orm.core;
-                                        org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl to org.hibernate.orm.core;
+                                        org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl to org.hibernate.orm.core, net.bytebuddy;
+                                        org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl to org.hibernate.orm.core, net.bytebuddy;
                                     </opens>
                                 </moduleInfo>
                             </module>

--- a/orm6/integrationtest/jdk/java-modules/orm-coordination-outbox-polling-elasticsearch/ant-src-changes.patch
+++ b/orm6/integrationtest/jdk/java-modules/orm-coordination-outbox-polling-elasticsearch/ant-src-changes.patch
@@ -1,0 +1,27 @@
+diff --git a/main/java/module-info.java b/main/java/module-info.java
+index de9b64d55f..56efa76484 100644
+--- a/main/java/module-info.java
++++ b/main/java/module-info.java
+@@ -17,16 +17,16 @@
+ 	requires org.hibernate.search.backend.elasticsearch;
+ 	requires org.hibernate.search.mapper.orm.coordination.outboxpolling;
+ 
+-	// This should be re-exported transitively by org.hibernate.search.mapper.orm
+-	// but currently isn't, because org.hibernate.search.mapper.orm
+-	// is still an automatic module
+-	requires org.hibernate.search.engine;
+-	requires org.hibernate.search.mapper.pojo;
+-
+ 	/*
+ 	 * This is necessary in order to use SessionFactory,
+ 	 * which extends "javax.naming.Referenceable".
+ 	 * Without this, compilation as a Java module fails.
+ 	 */
+ 	requires java.naming;
++
++	/*
++	 * This is necessary in order to put ByteBuddy in the modulepath and make module exports effective.
++	 * I do not know why ByteBuddy doesn't end up in the modulepath without this.
++	 */
++	requires net.bytebuddy;
+ }

--- a/orm6/integrationtest/jdk/java-modules/orm-coordination-outbox-polling-elasticsearch/pom.xml
+++ b/orm6/integrationtest/jdk/java-modules/orm-coordination-outbox-polling-elasticsearch/pom.xml
@@ -53,6 +53,14 @@
             <artifactId>hibernate-search-mapper-orm-coordination-outbox-polling-orm6</artifactId>
         </dependency>
 
+        <!-- Adding this dependency to be able to refer to ByteBuddy in module-info.java -->
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <!-- DO NOT REMOVE and DO NOT MANAGE the version of this dependency. See the version property declaration. -->
+            <version>${version.net.bytebuddy}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-util-internal-test-orm-orm6</artifactId>

--- a/orm6/integrationtest/jdk/java-modules/orm-lucene/ant-src-changes.patch
+++ b/orm6/integrationtest/jdk/java-modules/orm-lucene/ant-src-changes.patch
@@ -1,0 +1,17 @@
+diff --git a/main/java/module-info.java b/main/java/module-info.java
+index 237df74c7f..8921d66f18 100644
+--- a/main/java/module-info.java
++++ b/main/java/module-info.java
+@@ -16,12 +16,6 @@
+ 	requires org.hibernate.search.mapper.orm;
+ 	requires org.hibernate.search.backend.lucene;
+ 
+-	// This should be re-exported transitively by org.hibernate.search.mapper.orm
+-	// but currently isn't, because org.hibernate.search.mapper.orm
+-	// is still an automatic module
+-	requires org.hibernate.search.engine;
+-	requires org.hibernate.search.mapper.pojo;
+-
+ 	/*
+ 	 * This is necessary in order to use SessionFactory,
+ 	 * which extends "javax.naming.Referenceable".

--- a/orm6/integrationtest/mapper/orm/ant-src-changes.patch
+++ b/orm6/integrationtest/mapper/orm/ant-src-changes.patch
@@ -1271,26 +1271,6 @@ index 798418f3a9..bbfc99e232 100644
  				.contains( "_containing_fk_containingidBackref" )
  				.contains( "_containingIndexBackref" );
  
-diff --git a/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java b/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java
-index 0d83f15961..7a71fb282b 100644
---- a/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java
-+++ b/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java
-@@ -275,11 +275,14 @@ public static class IndexedEntitySuperClass extends IndexedMappedSuperClass {
- 			extends IndexedEntitySuperClass {
- 		public static final String INDEX = "IndexedEntity";
-
-+		// "containedEntityList" is not listed here,
-+		// because collection properties are initialized eagerly
-+		// (even if the collection themselves are initialized lazily).
-+		// See HHH-15473 / https://github.com/hibernate/hibernate-orm/pull/5252
- 		private static final String[] LAZY_PROPERTY_NAMES = new String[] {
- 				"mappedSuperClassText",
- 				"entitySuperClassText",
- 				"notIndexedText",
--				"containedEntityList",
- 				"text1",
- 				"text2",
- 				"primitiveInteger",
 diff --git a/test/java/org/hibernate/search/integrationtest/mapper/orm/model/GenericPropertyIT.java b/test/java/org/hibernate/search/integrationtest/mapper/orm/model/GenericPropertyIT.java
 index d110dbb171..0796b95350 100644
 --- a/test/java/org/hibernate/search/integrationtest/mapper/orm/model/GenericPropertyIT.java

--- a/orm6/mapper/orm-coordination-outbox-polling/pom.xml
+++ b/orm6/mapper/orm-coordination-outbox-polling/pom.xml
@@ -112,11 +112,11 @@
                         <configuration>
                             <module>
                                 <moduleInfo>
-                                    <!-- cluster and event packages to expose Agent and OutboxEvent entities to ORM -->
+                                    <!-- cluster and event packages to expose Agent and OutboxEvent entities to ORM and ByteBuddy -->
                                     <opens>
                                         org.hibernate.search.mapper.orm.coordination.outboxpolling.avro.generated.impl to org.apache.avro;
-                                        org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl to org.hibernate.orm.core;
-                                        org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl to org.hibernate.orm.core;
+                                        org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl to org.hibernate.orm.core, net.bytebuddy;
+                                        org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl to org.hibernate.orm.core, net.bytebuddy;
                                     </opens>
                                 </moduleInfo>
                             </module>

--- a/orm6/mapper/orm/ant-src-changes.patch
+++ b/orm6/mapper/orm/ant-src-changes.patch
@@ -590,10 +590,10 @@ index 434c1e7bc3..099cee2604 100644
  					|| isWholePath && isAssociation( containedValueClass ) ) {
  				String stringRepresentationAsProperty = propertyNode.toPropertyString();
 diff --git a/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java b/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java
-index c8ca89a1e0..f7140b4d52 100644
+index c8ca89a1e0..995f314a33 100644
 --- a/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java
 +++ b/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java
-@@ -7,52 +7,48 @@
+@@ -7,52 +7,50 @@
  package org.hibernate.search.mapper.orm.search.query.impl;
  
  import java.lang.invoke.MethodHandles;
@@ -601,7 +601,6 @@ index c8ca89a1e0..f7140b4d52 100644
 -import java.util.Collections;
 -import java.util.Date;
 -import java.util.Iterator;
-+import java.util.Collection;
  import java.util.List;
  import java.util.Map;
 -import java.util.Set;
@@ -633,7 +632,9 @@ index c8ca89a1e0..f7140b4d52 100644
 +import org.hibernate.query.spi.AbstractQuery;
 +import org.hibernate.query.spi.ParameterMetadataImplementor;
 +import org.hibernate.query.spi.QueryImplementor;
++import org.hibernate.query.spi.QueryParameterBinding;
  import org.hibernate.query.spi.QueryParameterBindings;
++import org.hibernate.query.spi.QueryParameterImplementor;
  import org.hibernate.query.spi.ScrollableResultsImplementor;
  import org.hibernate.search.engine.search.query.SearchQuery;
  import org.hibernate.search.engine.search.query.spi.SearchQueryImplementor;
@@ -652,6 +653,7 @@ index c8ca89a1e0..f7140b4d52 100644
  
 -@SuppressForbiddenApis(reason = "We need to extend the internal AbstractProducedQuery"
 +import jakarta.persistence.LockModeType;
++import jakarta.persistence.Parameter;
 +import jakarta.persistence.PersistenceException;
 +import jakarta.persistence.QueryTimeoutException;
 +
@@ -663,7 +665,7 @@ index c8ca89a1e0..f7140b4d52 100644
  
  	public static <R> HibernateOrmSearchQueryAdapter<R> create(SearchQuery<R> query) {
  		return query.extension( HibernateOrmSearchQueryAdapterExtension.get() );
-@@ -61,15 +57,16 @@ public static <R> HibernateOrmSearchQueryAdapter<R> create(SearchQuery<R> query)
+@@ -61,15 +59,16 @@ public static <R> HibernateOrmSearchQueryAdapter<R> create(SearchQuery<R> query)
  	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
  
  	private final SearchQueryImplementor<R> delegate;
@@ -684,7 +686,7 @@ index c8ca89a1e0..f7140b4d52 100644
  		this.loadingOptions = loadingOptions;
  	}
  
-@@ -84,83 +81,26 @@ public String toString() {
+@@ -84,83 +83,26 @@ public String toString() {
  
  	@Override
  	@SuppressWarnings("unchecked")
@@ -775,7 +777,7 @@ index c8ca89a1e0..f7140b4d52 100644
  	}
  
  	@Override
-@@ -168,6 +108,11 @@ public String getQueryString() {
+@@ -168,6 +110,11 @@ public String getQueryString() {
  		return delegate.queryString();
  	}
  
@@ -787,7 +789,7 @@ index c8ca89a1e0..f7140b4d52 100644
  	@Override
  	public HibernateOrmSearchQueryAdapter<R> setHint(String hintName, Object value) {
  		switch ( hintName ) {
-@@ -180,14 +125,12 @@ public HibernateOrmSearchQueryAdapter<R> setHint(String hintName, Object value)
+@@ -180,14 +127,12 @@ public HibernateOrmSearchQueryAdapter<R> setHint(String hintName, Object value)
  				break;
  			case HibernateOrmSearchQueryHints.JAVAX_FETCHGRAPH:
  			case HibernateOrmSearchQueryHints.JAKARTA_FETCHGRAPH:
@@ -804,7 +806,7 @@ index c8ca89a1e0..f7140b4d52 100644
  				break;
  		}
  		return this;
-@@ -200,148 +143,104 @@ public HibernateOrmSearchQueryAdapter<R> setTimeout(int timeout) {
+@@ -200,148 +145,109 @@ public HibernateOrmSearchQueryAdapter<R> setTimeout(int timeout) {
  	}
  
  	@Override
@@ -914,22 +916,23 @@ index c8ca89a1e0..f7140b4d52 100644
 +	}
 +
 +	@Override
-+	public HibernateOrmSearchQueryAdapter<R> setParameterList(String name, Object[] values) {
++	protected <P> QueryParameterBinding<P> locateBinding(String name) {
  		throw parametersNoSupported();
  	}
  
  	@Override
 -	public HibernateOrmSearchQueryAdapter<R> setParameter(Parameter<Date> dateParameter, Date date, TemporalType temporalType) {
-+	public QueryImplementor<R> setParameterList(String s, Collection collection, Class aClass) {
++	protected <P> QueryParameterBinding<P> locateBinding(int position) {
  		throw parametersNoSupported();
  	}
  
  	@Override
 -	public HibernateOrmSearchQueryAdapter<R> setParameter(String name, Object value) {
--		throw parametersNoSupported();
--	}
--
--	@Override
++	protected <P> QueryParameterBinding<P> locateBinding(Parameter<P> parameter) {
+ 		throw parametersNoSupported();
+ 	}
+ 
+ 	@Override
 -	public HibernateOrmSearchQueryAdapter<R> setParameter(String name, Date value, TemporalType temporalType) {
 -		throw parametersNoSupported();
 -	}
@@ -1001,11 +1004,11 @@ index c8ca89a1e0..f7140b4d52 100644
 -
 -	@Override
 -	public Object getParameterValue(int position) {
-+	public QueryImplementor<R> setParameterList(int i, Collection collection, Class aClass) {
++	protected <P> QueryParameterBinding<P> locateBinding(QueryParameterImplementor<P> parameter) {
  		throw parametersNoSupported();
  	}
  
-@@ -350,18 +249,16 @@ private UnsupportedOperationException parametersNoSupported() {
+@@ -350,18 +256,16 @@ private UnsupportedOperationException parametersNoSupported() {
  	}
  
  	@Override
@@ -1029,7 +1032,7 @@ index c8ca89a1e0..f7140b4d52 100644
  		return new UnsupportedOperationException( "Result transformers are not supported in Hibernate Search queries" );
  	}
  
-@@ -391,7 +288,12 @@ private UnsupportedOperationException lockOptionsNotSupported() {
+@@ -391,7 +295,12 @@ private UnsupportedOperationException lockOptionsNotSupported() {
  	}
  
  	@Override
@@ -1043,7 +1046,7 @@ index c8ca89a1e0..f7140b4d52 100644
  		throw new UnsupportedOperationException( "executeUpdate is not supported in Hibernate Search queries" );
  	}
  
-@@ -400,30 +302,6 @@ public HibernateOrmSearchQueryAdapter<R> setLockMode(String alias, LockMode lock
+@@ -400,30 +309,6 @@ public HibernateOrmSearchQueryAdapter<R> setLockMode(String alias, LockMode lock
  		throw lockOptionsNotSupported();
  	}
  
@@ -1074,7 +1077,7 @@ index c8ca89a1e0..f7140b4d52 100644
  	private static long hintValueToLong(Object value) {
  		if ( value instanceof Number ) {
  			return ( (Number) value ).longValue();
-@@ -442,8 +320,4 @@ private static int hintValueToInteger(Object value) {
+@@ -442,8 +327,4 @@ private static int hintValueToInteger(Object value) {
  		}
  	}
  

--- a/orm6/v5migrationhelper/orm/ant-src-changes.patch
+++ b/orm6/v5migrationhelper/orm/ant-src-changes.patch
@@ -109,7 +109,7 @@ index 9f6bfae665..6c5728910f 100644
  	public FullTextSession openSession() {
  		return Search.getFullTextSession( builder.openSession() );
 diff --git a/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java b/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
-index c6481cc62e..f46722f7b2 100644
+index c6481cc62e..6ea158d8ae 100644
 --- a/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
 +++ b/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
 @@ -7,21 +7,13 @@
@@ -119,7 +119,6 @@ index c6481cc62e..f46722f7b2 100644
 -import java.util.Calendar;
 -import java.util.Collections;
 -import java.util.Date;
-+import java.util.Collection;
  import java.util.HashMap;
 -import java.util.Iterator;
  import java.util.List;
@@ -129,14 +128,14 @@ index c6481cc62e..f46722f7b2 100644
  import java.util.function.Consumer;
 -import jakarta.persistence.FlushModeType;
 -import jakarta.persistence.LockModeType;
--import jakarta.persistence.Parameter;
++import java.util.function.Function;
+ import jakarta.persistence.Parameter;
 -import jakarta.persistence.QueryTimeoutException;
 -import jakarta.persistence.TemporalType;
-+import java.util.function.Function;
  
  import org.hibernate.HibernateException;
  import org.hibernate.LockMode;
-@@ -29,12 +21,14 @@
+@@ -29,14 +21,18 @@
  import org.hibernate.ScrollMode;
  import org.hibernate.TypeMismatchException;
  import org.hibernate.engine.spi.SessionImplementor;
@@ -153,9 +152,13 @@ index c6481cc62e..f46722f7b2 100644
 +import org.hibernate.query.spi.AbstractQuery;
 +import org.hibernate.query.spi.ParameterMetadataImplementor;
  import org.hibernate.query.spi.QueryImplementor;
++import org.hibernate.query.spi.QueryParameterBinding;
  import org.hibernate.query.spi.QueryParameterBindings;
++import org.hibernate.query.spi.QueryParameterImplementor;
  import org.hibernate.query.spi.ScrollableResultsImplementor;
-@@ -45,7 +39,6 @@
+ import org.hibernate.search.FullTextQuery;
+ import org.hibernate.search.engine.search.query.SearchScroll;
+@@ -45,7 +41,6 @@
  import org.hibernate.search.mapper.orm.search.loading.dsl.SearchLoadingOptionsStep;
  import org.hibernate.search.mapper.orm.search.query.spi.HibernateOrmSearchQueryHints;
  import org.hibernate.search.mapper.orm.search.query.spi.HibernateOrmSearchScrollableResultsAdapter;
@@ -163,7 +166,7 @@ index c6481cc62e..f46722f7b2 100644
  import org.hibernate.search.query.DatabaseRetrievalMethod;
  import org.hibernate.search.query.ObjectLookupMethod;
  import org.hibernate.search.query.engine.spi.FacetManager;
-@@ -55,8 +48,11 @@
+@@ -55,8 +50,11 @@
  import org.hibernate.search.spatial.impl.Point;
  import org.hibernate.search.util.common.SearchTimeoutException;
  import org.hibernate.transform.ResultTransformer;
@@ -176,7 +179,7 @@ index c6481cc62e..f46722f7b2 100644
  import org.apache.lucene.search.Explanation;
  import org.apache.lucene.search.Query;
  import org.apache.lucene.search.Sort;
-@@ -68,14 +64,14 @@
+@@ -68,14 +66,14 @@
   * @author Hardy Ferentschik
   */
  @SuppressWarnings("rawtypes") // We extend the raw version of AbstractProducedQuery on purpose, see HSEARCH-2564
@@ -194,7 +197,7 @@ index c6481cc62e..f46722f7b2 100644
  	//initialized at 0 since we don't expect to use hints at this stage
  	private final Map<String, Object> hints = new HashMap<String, Object>( 0 );
  
-@@ -96,11 +92,12 @@ public class FullTextQueryImpl extends AbstractProducedQuery implements FullText
+@@ -96,11 +94,12 @@ public class FullTextQueryImpl extends AbstractProducedQuery implements FullText
  
  	private ResultTransformer resultTransformer;
  
@@ -209,7 +212,7 @@ index c6481cc62e..f46722f7b2 100644
  		this.searchSession = searchSession;
  		this.hSearchQuery = searchIntegrator.createHSQuery( luceneQuery, searchSession,
  				loadingOptionsContributor, entities );
-@@ -118,54 +115,61 @@ public List getResultList() {
+@@ -118,54 +117,61 @@ public List getResultList() {
  	}
  
  	@Override
@@ -295,7 +298,7 @@ index c6481cc62e..f46722f7b2 100644
  	@Override
  	public Explanation explain(Object entityId) {
  		return hSearchQuery.explain( entityId );
-@@ -179,8 +183,14 @@ public int getResultSize() {
+@@ -179,8 +185,14 @@ public int getResultSize() {
  		catch (SearchTimeoutException e) {
  			throw new QueryTimeoutException( e );
  		}
@@ -311,7 +314,7 @@ index c6481cc62e..f46722f7b2 100644
  		}
  	}
  
-@@ -189,11 +199,16 @@ public int doGetResultSize() {
+@@ -189,11 +201,16 @@ public int doGetResultSize() {
  	}
  
  	@Override
@@ -330,7 +333,7 @@ index c6481cc62e..f46722f7b2 100644
  	@Override
  	public FullTextQueryImpl setProjection(String... fields) {
  		hSearchQuery.projection( fields );
-@@ -214,44 +229,16 @@ public FullTextQueryImpl setSpatialParameters(double latitude, double longitude,
+@@ -214,44 +231,16 @@ public FullTextQueryImpl setSpatialParameters(double latitude, double longitude,
  
  	@Override
  	public FullTextQuery setMaxResults(int maxResults) {
@@ -377,7 +380,7 @@ index c6481cc62e..f46722f7b2 100644
  	@Override
  	@SuppressWarnings("deprecation")
  	public FullTextQuery setHint(String hintName, Object value) {
-@@ -266,14 +253,11 @@ public FullTextQuery setHint(String hintName, Object value) {
+@@ -266,14 +255,11 @@ public FullTextQuery setHint(String hintName, Object value) {
  				break;
  			case HibernateOrmSearchQueryHints.JAVAX_FETCHGRAPH:
  			case HibernateOrmSearchQueryHints.JAKARTA_FETCHGRAPH:
@@ -393,7 +396,7 @@ index c6481cc62e..f46722f7b2 100644
  				break;
  		}
  		return this;
-@@ -284,99 +268,35 @@ public Map<String, Object> getHints() {
+@@ -284,99 +270,40 @@ public Map<String, Object> getHints() {
  		return hints;
  	}
  
@@ -428,22 +431,23 @@ index c6481cc62e..f46722f7b2 100644
 +	}
 +
 +	@Override
-+	public QueryImplementor<?> setParameterList(String name, Object[] values) {
++	protected QueryParameterBinding locateBinding(String name) {
  		throw parametersNoSupported();
  	}
  
  	@Override
 -	public FullTextQueryImpl setParameter(String name, Date value, TemporalType temporalType) {
-+	public QueryImplementor<?> setParameterList(String s, Collection collection, Class aClass) {
++	protected QueryParameterBinding locateBinding(int position) {
  		throw parametersNoSupported();
  	}
  
  	@Override
 -	public FullTextQueryImpl setParameter(String name, Calendar value, TemporalType temporalType) {
--		throw parametersNoSupported();
--	}
--
--	@Override
++	protected QueryParameterBinding locateBinding(Parameter parameter) {
+ 		throw parametersNoSupported();
+ 	}
+ 
+ 	@Override
 -	public FullTextQueryImpl setParameter(int position, Object value) {
 -		throw parametersNoSupported();
 -	}
@@ -506,11 +510,11 @@ index c6481cc62e..f46722f7b2 100644
 -
 -	@Override
 -	public Object getParameterValue(int position) {
-+	public QueryImplementor<?> setParameterList(int i, Collection collection, Class aClass) {
++	protected QueryParameterBinding locateBinding(QueryParameterImplementor parameter) {
  		throw parametersNoSupported();
  	}
  
-@@ -391,12 +311,7 @@ public FullTextQueryImpl setFlushMode(FlushModeType flushModeType) {
+@@ -391,12 +318,7 @@ public FullTextQueryImpl setFlushMode(FlushModeType flushModeType) {
  
  	@Override
  	public FullTextQueryImpl setFetchSize(int fetchSize) {
@@ -524,7 +528,7 @@ index c6481cc62e..f46722f7b2 100644
  	}
  
  	@Override
-@@ -434,7 +349,12 @@ public Object unwrap(Class type) {
+@@ -434,7 +356,12 @@ public Object unwrap(Class type) {
  		if ( type == org.apache.lucene.search.Query.class ) {
  			return hSearchQuery.getLuceneQuery();
  		}
@@ -538,7 +542,7 @@ index c6481cc62e..f46722f7b2 100644
  	}
  
  	@Override
-@@ -457,7 +377,12 @@ private UnsupportedOperationException lockOptionsNotSupported() {
+@@ -457,7 +384,12 @@ private UnsupportedOperationException lockOptionsNotSupported() {
  	}
  
  	@Override
@@ -552,7 +556,7 @@ index c6481cc62e..f46722f7b2 100644
  		throw new UnsupportedOperationException( "executeUpdate is not supported in Hibernate Search queries" );
  	}
  
-@@ -515,32 +440,13 @@ public String getQueryString() {
+@@ -515,32 +447,13 @@ public String getQueryString() {
  	}
  
  	@Override
@@ -589,7 +593,7 @@ index c6481cc62e..f46722f7b2 100644
  	}
  
  	@Override
-@@ -549,12 +455,12 @@ public String toString() {
+@@ -549,12 +462,12 @@ public String toString() {
  	}
  
  	private static final class Search5ScrollHitExtractor
@@ -604,7 +608,7 @@ index c6481cc62e..f46722f7b2 100644
  			if ( hit instanceof Object[] ) {
  				return (Object[]) hit;
  			}
-@@ -562,19 +468,6 @@ public Object[] toArray(Object hit) {
+@@ -562,19 +475,6 @@ public Object[] toArray(Object hit) {
  				return new Object[] { hit };
  			}
  		}
@@ -624,7 +628,7 @@ index c6481cc62e..f46722f7b2 100644
  	}
  
  	private static int hintValueToInteger(Object value) {
-@@ -586,7 +479,7 @@ private static int hintValueToInteger(Object value) {
+@@ -586,7 +486,7 @@ private static int hintValueToInteger(Object value) {
  		}
  	}
  


### PR DESCRIPTION
* [HSEARCH-4775](https://hibernate.atlassian.net/browse/HSEARCH-4775): Improve source code compatibility of Hibernate Search with Hibernate ORM 6.2
* [HSEARCH-4768](https://hibernate.atlassian.net/browse/HSEARCH-4768): Fix JavaModulePathTest with ORM 6.2
* [HSEARCH-4757](https://hibernate.atlassian.net/browse/HSEARCH-4757): Adjust tests to address ORM changes introduced in HHH-15767

Backport of #3323, #3366 to branch 6.1.

[HSEARCH-4775]: https://hibernate.atlassian.net/browse/HSEARCH-4775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HSEARCH-4768]: https://hibernate.atlassian.net/browse/HSEARCH-4768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HSEARCH-4757]: https://hibernate.atlassian.net/browse/HSEARCH-4757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ