### PR TITLE
HSEARCH-4777 + HSEARCH-4778 Elasticsearch 8.6.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -241,12 +241,13 @@ stage('Configure') {
 					new EsLocalBuildEnvironment(version: '7.16.3', condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(version: '7.17.8', condition: TestCondition.AFTER_MERGE),
 					// Not testing 8.0 because we know there are problems in 8.0.1 (see https://hibernate.atlassian.net/browse/HSEARCH-4497)
-					// Not testing 8.1-8.4 to make the build quicker.
+					// Not testing 8.1-8.5 to make the build quicker.
 					new EsLocalBuildEnvironment(version: '8.1.3', condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(version: '8.2.3', condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(version: '8.3.3', condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(version: '8.4.3', condition: TestCondition.ON_DEMAND),
-					new EsLocalBuildEnvironment(version: '8.5.3', condition: TestCondition.BEFORE_MERGE, isDefault: true),
+					new EsLocalBuildEnvironment(version: '8.5.3', condition: TestCondition.ON_DEMAND),
+					new EsLocalBuildEnvironment(version: '8.6.0', condition: TestCondition.BEFORE_MERGE, isDefault: true),
 
 					// --------------------------------------------
 					// OpenSearch

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
@@ -166,7 +166,7 @@ public class ElasticsearchDialectFactory {
 	}
 
 	private ElasticsearchProtocolDialect createProtocolDialectElasticV8(ElasticsearchVersion version, int minor) {
-		if ( minor > 5 ) {
+		if ( minor > 6 ) {
 			log.unknownElasticsearchVersion( version );
 		}
 		else if ( minor == 0 ) {

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -291,7 +291,7 @@ public class ElasticsearchDialectFactoryTest {
 						Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				success(
-						ElasticsearchDistributionName.ELASTIC, "8", "8.5.0",
+						ElasticsearchDistributionName.ELASTIC, "8", "8.6.0",
 						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
 				),
 				success(
@@ -342,12 +342,20 @@ public class ElasticsearchDialectFactoryTest {
 						ElasticsearchDistributionName.ELASTIC, "8.5.0", "8.5.0",
 						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
 				),
-				successWithWarning(
+				success(
 						ElasticsearchDistributionName.ELASTIC, "8.6", "8.6.0",
 						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
 				),
-				successWithWarning(
+				success(
 						ElasticsearchDistributionName.ELASTIC, "8.6.0", "8.6.0",
+						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.ELASTIC, "8.7", "8.7.0",
+						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.ELASTIC, "8.7.0", "8.7.0",
 						Elasticsearch8ModelDialect.class, Elasticsearch81ProtocolDialect.class
 				),
 				successWithWarning(

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -241,17 +241,18 @@ class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 	}
 
 	@Override
-	public boolean supportsMatchOnScaledNumericLossOfPrecision() {
+	public boolean supportsExtremeScaledNumericValues() {
 		// https://github.com/elastic/elasticsearch/issues/91246
-		// Hopefully this will get fixed in 8.5.4.
+		// Hopefully this will get fixed in a future version.
 		return !isBetween( actualVersion, "elastic:7.17.7", "elastic:7.17" )
-				&& !isBetween( actualVersion, "elastic:8.5.0", "elastic:8.5.3" );
+				&& !isBetween( actualVersion, "elastic:8.5.0", "elastic:8.6.0" );
 	}
 
 	@Override
-	public boolean supportsExtremeLongValuesInAggregations() {
+	public boolean supportsExtremeLongValues() {
 		// https://github.com/elastic/elasticsearch/issues/84601
-		// There doesn't seem to be any hope for this to get fixed in older versions.
+		// There doesn't seem to be any hope for this to get fixed in older versions (7.17/8.0),
+		// but it's been fixed in 8.1.
 		return !isBetween( actualVersion, "elastic:7.17.7", "elastic:7.17" )
 				&& !isBetween( actualVersion, "elastic:8.0.0", "elastic:8.0" );
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/model/singlefield/SingleFieldIndexBinding.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/model/singlefield/SingleFieldIndexBinding.java
@@ -189,21 +189,24 @@ public class SingleFieldIndexBinding extends AbstractObjectBinding {
 						);
 					}
 				}
-				DocumentElement nestedObject2 = document.addObject( nestedObject.self );
-				nestedObject2.addValue( nestedObject.discriminator, DISCRIMINATOR_VALUE_EXCLUDED );
-				for ( F value : garbageValues ) {
-					nestedObject2.addValue(
-							nestedObject.fieldWithMultipleValuesModels.get( fieldType ).reference,
-							value
-					);
-				}
-				DocumentElement nestedObject3 = document.addObject( nestedObject.self );
-				nestedObject3.addValue( nestedObject.discriminator, DISCRIMINATOR_VALUE_EXCLUDED );
-				for ( F value : garbageValues ) {
-					nestedObject3.addValue(
-							nestedObject.fieldWithMultipleValuesModels.get( fieldType ).reference,
-							value
-					);
+				// This condition is necessary to avoid triggering https://github.com/elastic/elasticsearch/issues/92814
+				if ( !garbageValues.isEmpty() ) {
+					DocumentElement nestedObject2 = document.addObject( nestedObject.self );
+					nestedObject2.addValue( nestedObject.discriminator, DISCRIMINATOR_VALUE_EXCLUDED );
+					for ( F value : garbageValues ) {
+						nestedObject2.addValue(
+								nestedObject.fieldWithMultipleValuesModels.get( fieldType ).reference,
+								value
+						);
+					}
+					DocumentElement nestedObject3 = document.addObject( nestedObject.self );
+					nestedObject3.addValue( nestedObject.discriminator, DISCRIMINATOR_VALUE_EXCLUDED );
+					for ( F value : garbageValues ) {
+						nestedObject3.addValue(
+								nestedObject.fieldWithMultipleValuesModels.get( fieldType ).reference,
+								value
+						);
+					}
 				}
 				break;
 			case IN_NESTED_TWICE:
@@ -228,21 +231,24 @@ public class SingleFieldIndexBinding extends AbstractObjectBinding {
 						);
 					}
 				}
-				DocumentElement nestedNestedObject2 = nestedObjectFirstLevel0.addObject( nestedObject.nestedObject.self );
-				nestedNestedObject2.addValue( nestedObject.nestedObject.discriminator, DISCRIMINATOR_VALUE_EXCLUDED );
-				for ( F value : garbageValues ) {
-					nestedNestedObject2.addValue(
-							nestedObject.nestedObject.fieldWithMultipleValuesModels.get( fieldType ).reference,
-							value
-					);
-				}
-				DocumentElement nestedNestedObject3 = nestedObjectFirstLevel1.addObject( nestedObject.nestedObject.self );
-				nestedNestedObject3.addValue( nestedObject.nestedObject.discriminator, DISCRIMINATOR_VALUE_EXCLUDED );
-				for ( F value : garbageValues ) {
-					nestedNestedObject3.addValue(
-							nestedObject.nestedObject.fieldWithMultipleValuesModels.get( fieldType ).reference,
-							value
-					);
+				// This condition is necessary to avoid triggering https://github.com/elastic/elasticsearch/issues/92814
+				if ( !garbageValues.isEmpty() ) {
+					DocumentElement nestedNestedObject2 = nestedObjectFirstLevel0.addObject( nestedObject.nestedObject.self );
+					nestedNestedObject2.addValue( nestedObject.nestedObject.discriminator, DISCRIMINATOR_VALUE_EXCLUDED );
+					for ( F value : garbageValues ) {
+						nestedNestedObject2.addValue(
+								nestedObject.nestedObject.fieldWithMultipleValuesModels.get( fieldType ).reference,
+								value
+						);
+					}
+					DocumentElement nestedNestedObject3 = nestedObjectFirstLevel1.addObject( nestedObject.nestedObject.self );
+					nestedNestedObject3.addValue( nestedObject.nestedObject.discriminator, DISCRIMINATOR_VALUE_EXCLUDED );
+					for ( F value : garbageValues ) {
+						nestedNestedObject3.addValue(
+								nestedObject.nestedObject.fieldWithMultipleValuesModels.get( fieldType ).reference,
+								value
+						);
+					}
 				}
 				break;
 		}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/BigDecimalFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/BigDecimalFieldTypeDescriptor.java
@@ -99,7 +99,7 @@ public class BigDecimalFieldTypeDescriptor extends FieldTypeDescriptor<BigDecima
 				BigDecimal.valueOf( 42.42 ),
 				BigDecimal.valueOf( 1584514514.000000184 )
 		) );
-		if ( TckConfiguration.get().getBackendFeatures().supportsMatchOnScaledNumericLossOfPrecision() ) {
+		if ( TckConfiguration.get().getBackendFeatures().supportsExtremeScaledNumericValues() ) {
 			Collections.addAll(
 					list,
 					scaled( Long.MAX_VALUE ),

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LongFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LongFieldTypeDescriptor.java
@@ -31,7 +31,7 @@ public class LongFieldTypeDescriptor extends FieldTypeDescriptor<Long> {
 			@Override
 			protected List<Long> createSingle() {
 				List<Long> list = new ArrayList<>();
-				if ( TckConfiguration.get().getBackendFeatures().supportsMatchOnScaledNumericLossOfPrecision() ) {
+				if ( TckConfiguration.get().getBackendFeatures().supportsExtremeLongValues() ) {
 					list.add( Long.MIN_VALUE );
 				}
 				Collections.addAll(
@@ -45,7 +45,7 @@ public class LongFieldTypeDescriptor extends FieldTypeDescriptor<Long> {
 						2500L,
 						151_484_254L
 				);
-				if ( TckConfiguration.get().getBackendFeatures().supportsMatchOnScaledNumericLossOfPrecision() ) {
+				if ( TckConfiguration.get().getBackendFeatures().supportsExtremeLongValues() ) {
 					list.add( Long.MAX_VALUE );
 				}
 				return list;
@@ -78,7 +78,7 @@ public class LongFieldTypeDescriptor extends FieldTypeDescriptor<Long> {
 		List<Long> list = new ArrayList<>( Arrays.asList(
 				-251_484_254L, -42L, -1L, 0L, 1L, 3L, 42L, 151_484_254L
 		) );
-		if ( TckConfiguration.get().getBackendFeatures().supportsMatchOnScaledNumericLossOfPrecision() ) {
+		if ( TckConfiguration.get().getBackendFeatures().supportsExtremeLongValues() ) {
 			Collections.addAll(
 					list,
 					Long.MIN_VALUE, Long.MAX_VALUE

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
@@ -115,11 +115,11 @@ public abstract class TckBackendFeatures {
 		return true;
 	}
 
-	public boolean supportsMatchOnScaledNumericLossOfPrecision() {
+	public boolean supportsExtremeLongValues() {
 		return true;
 	}
 
-	public boolean supportsExtremeLongValuesInAggregations() {
+	public boolean supportsExtremeScaledNumericValues() {
 		return true;
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
         <!-- The versions of Elasticsearch advertised as compatible with Hibernate Search -->
         <!-- Make sure to only mention tested versions here -->
         <!-- Make sure that 7.10 stays explicitly mentioned here, because that's the last open-source version -->
-        <version.org.elasticsearch.compatible.regularly-tested.text>5.6, 6.8, 7.10, 7.17 or 8.5</version.org.elasticsearch.compatible.regularly-tested.text>
+        <version.org.elasticsearch.compatible.regularly-tested.text>5.6, 6.8, 7.10, 7.17 or 8.6</version.org.elasticsearch.compatible.regularly-tested.text>
         <!-- These are the versions same as above, but pointing only to the major part (used in compatibility section of ES backend documentation
           as versions that Hibernate Search is compatible with. -->
         <!-- NOTE: Adding new major versions would require to update the compatibility table in `backend-elasticsearch-compatibility` section of `backend-elasticsearch.asciidoc`. -->
@@ -220,7 +220,7 @@
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
         <version.org.elasticsearch.compatible.not-regularly-tested.text>7.0 or 8.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest version of Elasticsearch tested against by default -->
-        <version.org.elasticsearch.latest>8.5.3</version.org.elasticsearch.latest>
+        <version.org.elasticsearch.latest>8.6.0</version.org.elasticsearch.latest>
         <!-- The versions of OpenSearch advertised as compatible with Hibernate Search -->
         <!-- Make sure to only mention tested versions here -->
         <version.org.opensearch.compatible.regularly-tested.text>1.3 or 2.4</version.org.opensearch.compatible.regularly-tested.text>

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.5+ -->
-        <version.org.elasticsearch.client>8.5.3</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>8.6.0</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-8.4) becomes the default. -->


### PR DESCRIPTION
* [HSEARCH-4778](https://hibernate.atlassian.net/browse/HSEARCH-4778): Upgrade to Elasticsearch client 8.6.0
* [HSEARCH-4777](https://hibernate.atlassian.net/browse/HSEARCH-4777): Add compatibility with Elasticsearch 8.6



[HSEARCH-4778]: https://hibernate.atlassian.net/browse/HSEARCH-4778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HSEARCH-4777]: https://hibernate.atlassian.net/browse/HSEARCH-4777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ