### PR TITLE
HSEARCH-4779 Reference the Hibernate Search 6.0 migration guide from the reference documentation

### DIFF
--- a/documentation/src/main/asciidoc/migration/index.asciidoc
+++ b/documentation/src/main/asciidoc/migration/index.asciidoc
@@ -22,6 +22,19 @@ If you're looking to migrate from an earlier version,
 you should migrate step-by-step, from one minor version to the next,
 following the migration guide of link:https://hibernate.org/search/documentation/[each version].
 
+[WARNING]
+====
+**To Hibernate Search 5 users**
+
+Be aware that a lot of APIs have changed since Hibernate Search 5, some only because of a package change,
+others because of more fundamental changes
+(like moving away from using Lucene types in Hibernate Search APIs).
+
+When migrating from Hibernate Search 5, you are encouraged to migrate first to Hibernate Search 6.0
+using the https://docs.jboss.org/hibernate/search/6.0/migration/html_single/[6.0 migration guide],
+and only then to later versions (which will be significantly easier).
+====
+
 [[requirements]]
 == Requirements
 

--- a/documentation/src/main/asciidoc/reference/migrating.asciidoc
+++ b/documentation/src/main/asciidoc/reference/migrating.asciidoc
@@ -1,5 +1,5 @@
 [[migrating]]
-== [[getting-started-migrating]] Migrating
+= [[getting-started-migrating]] Migrating
 
 If you are upgrading an existing application from an earlier version of Hibernate Search to the latest release,
 make sure to check out the http://hibernate.org/search/documentation/migrate/[migration guide].

--- a/documentation/src/main/asciidoc/reference/migrating.asciidoc
+++ b/documentation/src/main/asciidoc/reference/migrating.asciidoc
@@ -16,7 +16,10 @@ most of the artifact IDs changed to reflect the new mapper/backend design,
 and the Lucene integration now requires an explicit dependency instead of being available by default.
 Read <<mapper-orm-getting-started-dependencies>> for more information.
 
-Additionally, be aware that a lot of APIs changed, some only because of a package change,
+Additionally, be aware that a lot of APIs have changed, some only because of a package change,
 others because of more fundamental changes
 (like moving away from using Lucene types in Hibernate Search APIs).
+For that reason, you are encouraged to migrate first to Hibernate Search 6.0
+using the https://docs.jboss.org/hibernate/search/6.0/migration/html_single/[6.0 migration guide],
+and only then to later versions (which will be significantly easier).
 ====


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4779
