### PR TITLE
HSEARCH-4781 Mention @ScaledNumberField in error messages when the decimal scale cannot be found

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/impl/ElasticsearchIndexRootBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/impl/ElasticsearchIndexRootBuilder.java
@@ -37,6 +37,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.spi.ImplicitFieldC
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexRootBuilder;
 import org.hibernate.search.engine.backend.document.model.spi.IndexFieldInclusion;
 import org.hibernate.search.engine.backend.document.model.spi.IndexIdentifier;
+import org.hibernate.search.engine.backend.mapping.spi.BackendMapperContext;
 import org.hibernate.search.engine.backend.types.IndexFieldType;
 import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.engine.backend.types.converter.FromDocumentValueConverter;
@@ -53,6 +54,7 @@ public class ElasticsearchIndexRootBuilder extends AbstractElasticsearchIndexCom
 
 	private final ElasticsearchIndexFieldTypeFactoryProvider typeFactoryProvider;
 	private final EventContext indexEventContext;
+	private final BackendMapperContext backendMapperContext;
 	private final List<IndexSchemaRootContributor> schemaRootContributors = new ArrayList<>();
 	private final List<ImplicitFieldContributor> implicitFieldContributors = new ArrayList<>();
 	private final IndexNames indexNames;
@@ -68,13 +70,14 @@ public class ElasticsearchIndexRootBuilder extends AbstractElasticsearchIndexCom
 
 	public ElasticsearchIndexRootBuilder(ElasticsearchIndexFieldTypeFactoryProvider typeFactoryProvider,
 			EventContext indexEventContext,
-			IndexNames indexNames, String mappedTypeName,
+			BackendMapperContext backendMapperContext, IndexNames indexNames, String mappedTypeName,
 			ElasticsearchAnalysisDefinitionRegistry analysisDefinitionRegistry,
 			IndexSettings customIndexSettings, RootTypeMapping customIndexMapping,
 			DynamicMapping dynamicMapping) {
 		super( new ElasticsearchIndexCompositeNodeType.Builder( ObjectStructure.FLATTENED ) );
 		this.typeFactoryProvider = typeFactoryProvider;
 		this.indexEventContext = indexEventContext;
+		this.backendMapperContext = backendMapperContext;
 		this.indexNames = indexNames;
 		this.mappedTypeName = mappedTypeName;
 		this.analysisDefinitionRegistry = analysisDefinitionRegistry;
@@ -93,7 +96,7 @@ public class ElasticsearchIndexRootBuilder extends AbstractElasticsearchIndexCom
 
 	@Override
 	public ElasticsearchIndexFieldTypeFactory createTypeFactory(IndexFieldTypeDefaultsProvider defaultsProvider) {
-		return typeFactoryProvider.create( indexEventContext, defaultsProvider );
+		return typeFactoryProvider.create( indexEventContext, backendMapperContext, defaultsProvider );
 	}
 
 	@Override
@@ -171,7 +174,7 @@ public class ElasticsearchIndexRootBuilder extends AbstractElasticsearchIndexCom
 
 			private ElasticsearchIndexFieldTypeFactory typeFactory = typeFactoryProvider.create(
 					indexEventContext,
-					new IndexFieldTypeDefaultsProvider()
+					backendMapperContext, new IndexFieldTypeDefaultsProvider()
 			);
 
 			@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendImpl.java
@@ -40,6 +40,7 @@ import org.hibernate.search.backend.elasticsearch.types.dsl.provider.impl.Elasti
 import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 import org.hibernate.search.engine.backend.Backend;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerBuilder;
+import org.hibernate.search.engine.backend.mapping.spi.BackendMapperContext;
 import org.hibernate.search.engine.backend.spi.BackendBuildContext;
 import org.hibernate.search.engine.backend.spi.BackendImplementor;
 import org.hibernate.search.engine.backend.spi.BackendStartContext;
@@ -186,8 +187,8 @@ class ElasticsearchBackendImpl implements BackendImplementor,
 
 	@Override
 	public IndexManagerBuilder createIndexManagerBuilder(
-			String hibernateSearchIndexName,
-			String mappedTypeName, BackendBuildContext buildContext,
+			String hibernateSearchIndexName, String mappedTypeName, BackendBuildContext buildContext,
+			BackendMapperContext backendMapperContext,
 			ConfigurationPropertySource propertySource) {
 
 		EventContext indexEventContext = EventContexts.fromIndexName( hibernateSearchIndexName );
@@ -199,11 +200,12 @@ class ElasticsearchBackendImpl implements BackendImplementor,
 
 		return new ElasticsearchIndexManagerBuilder(
 				indexManagerBackendContext,
-				createIndexSchemaRootNodeBuilder( indexEventContext, indexNames, mappedTypeName,
+				createIndexSchemaRootNodeBuilder( indexEventContext, backendMapperContext, indexNames, mappedTypeName,
 						analysisDefinitionRegistry,
 						customIndexSettings( buildContext, propertySource, indexEventContext ),
 						customIndexMappings( buildContext, propertySource, indexEventContext ),
-						DYNAMIC_MAPPING.get( propertySource ) ),
+						DYNAMIC_MAPPING.get( propertySource )
+				),
 				createDocumentMetadataContributors( mappedTypeName )
 		);
 	}
@@ -238,7 +240,7 @@ class ElasticsearchBackendImpl implements BackendImplementor,
 	}
 
 	private ElasticsearchIndexRootBuilder createIndexSchemaRootNodeBuilder(EventContext indexEventContext,
-			IndexNames indexNames, String mappedTypeName,
+			BackendMapperContext backendMapperContext, IndexNames indexNames, String mappedTypeName,
 			ElasticsearchAnalysisDefinitionRegistry analysisDefinitionRegistry,
 			IndexSettings customIndexSettings, RootTypeMapping customIndexMapping,
 			DynamicMapping dynamicMapping) {
@@ -246,6 +248,7 @@ class ElasticsearchBackendImpl implements BackendImplementor,
 		ElasticsearchIndexRootBuilder builder = new ElasticsearchIndexRootBuilder(
 				typeFactoryProvider,
 				indexEventContext,
+				backendMapperContext,
 				indexNames,
 				mappedTypeName,
 				analysisDefinitionRegistry,

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -419,8 +419,8 @@ public interface Log extends BasicLogger {
 	SearchException explainUnknownDocument(URLEncodedString indexName, URLEncodedString id);
 
 	@Message(id = ID_OFFSET + 67, value = "Invalid index field type: missing decimal scale."
-			+ " Define the decimal scale explicitly.")
-	SearchException nullDecimalScale(@Param EventContext eventContext);
+			+ " Define the decimal scale explicitly.  %1$s")
+	SearchException nullDecimalScale(String hint, @Param EventContext eventContext);
 
 	@Message(id = ID_OFFSET + 69,
 			value = "Unable to encode value '%1$s': this field type only supports values ranging from '%2$s' to '%3$s'."

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchBigDecimalIndexFieldTypeOptionsStep.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchBigDecimalIndexFieldTypeOptionsStep.java
@@ -61,6 +61,6 @@ class ElasticsearchBigDecimalIndexFieldTypeOptionsStep
 			return defaultsProvider.decimalScale();
 		}
 
-		throw log.nullDecimalScale( buildContext.getEventContext() );
+		throw log.nullDecimalScale( buildContext.hints().missingDecimalScale(), buildContext.getEventContext() );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchBigIntegerIndexFieldTypeOptionsStep.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchBigIntegerIndexFieldTypeOptionsStep.java
@@ -65,6 +65,6 @@ class ElasticsearchBigIntegerIndexFieldTypeOptionsStep
 			return defaultsProvider.decimalScale();
 		}
 
-		throw log.nullDecimalScale( buildContext.getEventContext() );
+		throw log.nullDecimalScale( buildContext.hints().missingDecimalScale(), buildContext.getEventContext() );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeBuildContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeBuildContext.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.backend.elasticsearch.types.dsl.impl;
 
 import org.hibernate.search.backend.elasticsearch.types.format.impl.ElasticsearchDefaultFieldFormatProvider;
+import org.hibernate.search.engine.backend.reporting.spi.BackendMappingHints;
 import org.hibernate.search.util.common.reporting.EventContext;
 
 import com.google.gson.Gson;
@@ -18,5 +19,7 @@ public interface ElasticsearchIndexFieldTypeBuildContext {
 	Gson getUserFacingGson();
 
 	ElasticsearchDefaultFieldFormatProvider getDefaultFieldFormatProvider();
+
+	BackendMappingHints hints();
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryImpl.java
@@ -24,6 +24,8 @@ import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.backend.elasticsearch.types.dsl.ElasticsearchIndexFieldTypeFactory;
 import org.hibernate.search.backend.elasticsearch.types.dsl.ElasticsearchNativeIndexFieldTypeMappingStep;
 import org.hibernate.search.backend.elasticsearch.types.format.impl.ElasticsearchDefaultFieldFormatProvider;
+import org.hibernate.search.engine.backend.mapping.spi.BackendMapperContext;
+import org.hibernate.search.engine.backend.reporting.spi.BackendMappingHints;
 import org.hibernate.search.engine.backend.types.dsl.ScaledNumberIndexFieldTypeOptionsStep;
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
 import org.hibernate.search.engine.backend.types.dsl.StringIndexFieldTypeOptionsStep;
@@ -42,14 +44,17 @@ public class ElasticsearchIndexFieldTypeFactoryImpl
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final EventContext eventContext;
+	private final BackendMapperContext backendMapperContext;
 	private final Gson userFacingGson;
 	private final ElasticsearchDefaultFieldFormatProvider defaultFieldFormatProvider;
 	private final IndexFieldTypeDefaultsProvider typeDefaultsProvider;
 
-	public ElasticsearchIndexFieldTypeFactoryImpl(EventContext eventContext, Gson userFacingGson,
+	public ElasticsearchIndexFieldTypeFactoryImpl(EventContext eventContext, BackendMapperContext backendMapperContext,
+			Gson userFacingGson,
 			ElasticsearchDefaultFieldFormatProvider defaultFieldFormatProvider,
 			IndexFieldTypeDefaultsProvider typeDefaultsProvider) {
 		this.eventContext = eventContext;
+		this.backendMapperContext = backendMapperContext;
 		this.userFacingGson = userFacingGson;
 		this.defaultFieldFormatProvider = defaultFieldFormatProvider;
 		this.typeDefaultsProvider = typeDefaultsProvider;
@@ -249,5 +254,10 @@ public class ElasticsearchIndexFieldTypeFactoryImpl
 	@Override
 	public ElasticsearchDefaultFieldFormatProvider getDefaultFieldFormatProvider() {
 		return defaultFieldFormatProvider;
+	}
+
+	@Override
+	public BackendMappingHints hints() {
+		return backendMapperContext.hints();
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/provider/impl/Elasticsearch56IndexFieldTypeFactoryProvider.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/provider/impl/Elasticsearch56IndexFieldTypeFactoryProvider.java
@@ -9,6 +9,7 @@ package org.hibernate.search.backend.elasticsearch.types.dsl.provider.impl;
 import org.hibernate.search.backend.elasticsearch.types.dsl.ElasticsearchIndexFieldTypeFactory;
 import org.hibernate.search.backend.elasticsearch.types.dsl.impl.ElasticsearchIndexFieldTypeFactoryImpl;
 import org.hibernate.search.backend.elasticsearch.types.format.impl.Elasticsearch6DefaultFieldFormatProvider;
+import org.hibernate.search.engine.backend.mapping.spi.BackendMapperContext;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexFieldTypeDefaultsProvider;
 import org.hibernate.search.util.common.reporting.EventContext;
 
@@ -30,9 +31,9 @@ public class Elasticsearch56IndexFieldTypeFactoryProvider
 
 	@Override
 	public ElasticsearchIndexFieldTypeFactory create(EventContext eventContext,
-			IndexFieldTypeDefaultsProvider typeDefaultsProvider) {
+			BackendMapperContext backendMapperContext, IndexFieldTypeDefaultsProvider typeDefaultsProvider) {
 		return new ElasticsearchIndexFieldTypeFactoryImpl(
-				eventContext, userFacingGson, defaultFieldFormatProvider, typeDefaultsProvider
+				eventContext, backendMapperContext, userFacingGson, defaultFieldFormatProvider, typeDefaultsProvider
 		);
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/provider/impl/Elasticsearch7IndexFieldTypeFactoryProvider.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/provider/impl/Elasticsearch7IndexFieldTypeFactoryProvider.java
@@ -9,6 +9,7 @@ package org.hibernate.search.backend.elasticsearch.types.dsl.provider.impl;
 import org.hibernate.search.backend.elasticsearch.types.dsl.ElasticsearchIndexFieldTypeFactory;
 import org.hibernate.search.backend.elasticsearch.types.dsl.impl.ElasticsearchIndexFieldTypeFactoryImpl;
 import org.hibernate.search.backend.elasticsearch.types.format.impl.Elasticsearch7DefaultFieldFormatProvider;
+import org.hibernate.search.engine.backend.mapping.spi.BackendMapperContext;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexFieldTypeDefaultsProvider;
 import org.hibernate.search.util.common.reporting.EventContext;
 
@@ -30,9 +31,9 @@ public class Elasticsearch7IndexFieldTypeFactoryProvider
 
 	@Override
 	public ElasticsearchIndexFieldTypeFactory create(EventContext eventContext,
-			IndexFieldTypeDefaultsProvider typeDefaultsProvider) {
+			BackendMapperContext backendMapperContext, IndexFieldTypeDefaultsProvider typeDefaultsProvider) {
 		return new ElasticsearchIndexFieldTypeFactoryImpl(
-				eventContext, userFacingGson, defaultFieldFormatProvider, typeDefaultsProvider
+				eventContext, backendMapperContext, userFacingGson, defaultFieldFormatProvider, typeDefaultsProvider
 		);
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/provider/impl/ElasticsearchIndexFieldTypeFactoryProvider.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/provider/impl/ElasticsearchIndexFieldTypeFactoryProvider.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.backend.elasticsearch.types.dsl.provider.impl;
 
 import org.hibernate.search.backend.elasticsearch.types.dsl.ElasticsearchIndexFieldTypeFactory;
+import org.hibernate.search.engine.backend.mapping.spi.BackendMapperContext;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexFieldTypeDefaultsProvider;
 import org.hibernate.search.util.common.reporting.EventContext;
 
@@ -17,6 +18,7 @@ import org.hibernate.search.util.common.reporting.EventContext;
  */
 public interface ElasticsearchIndexFieldTypeFactoryProvider {
 
-	ElasticsearchIndexFieldTypeFactory create(EventContext eventContext, IndexFieldTypeDefaultsProvider defaultsProvider);
+	ElasticsearchIndexFieldTypeFactory create(EventContext eventContext, BackendMapperContext backendMapperContext,
+			IndexFieldTypeDefaultsProvider defaultsProvider);
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexRootBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexRootBuilder.java
@@ -27,6 +27,7 @@ import org.hibernate.search.backend.lucene.types.impl.LuceneIndexCompositeNodeTy
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexRootBuilder;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaBuildContext;
 import org.hibernate.search.engine.backend.document.model.spi.IndexIdentifier;
+import org.hibernate.search.engine.backend.mapping.spi.BackendMapperContext;
 import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.engine.backend.types.converter.FromDocumentValueConverter;
 import org.hibernate.search.engine.backend.types.converter.ToDocumentValueConverter;
@@ -40,6 +41,7 @@ public class LuceneIndexRootBuilder extends AbstractLuceneIndexCompositeNodeBuil
 		implements IndexRootBuilder, IndexSchemaBuildContext {
 
 	private final EventContext indexEventContext;
+	private final BackendMapperContext backendMapperContext;
 	private final String mappedTypeName;
 	private final LuceneAnalysisDefinitionRegistry analysisDefinitionRegistry;
 
@@ -47,9 +49,10 @@ public class LuceneIndexRootBuilder extends AbstractLuceneIndexCompositeNodeBuil
 	private ProjectionConverter<String, ?> idProjectionConverter;
 
 	public LuceneIndexRootBuilder(EventContext indexEventContext,
-			String mappedTypeName, LuceneAnalysisDefinitionRegistry analysisDefinitionRegistry) {
+			BackendMapperContext backendMapperContext, String mappedTypeName, LuceneAnalysisDefinitionRegistry analysisDefinitionRegistry) {
 		super( new LuceneIndexCompositeNodeType.Builder( ObjectStructure.FLATTENED ) );
 		this.indexEventContext = indexEventContext;
+		this.backendMapperContext = backendMapperContext;
 		this.mappedTypeName = mappedTypeName;
 		this.analysisDefinitionRegistry = analysisDefinitionRegistry;
 	}
@@ -61,7 +64,7 @@ public class LuceneIndexRootBuilder extends AbstractLuceneIndexCompositeNodeBuil
 
 	@Override
 	public LuceneIndexFieldTypeFactory createTypeFactory(IndexFieldTypeDefaultsProvider defaultsProvider) {
-		return new LuceneIndexFieldTypeFactoryImpl( indexEventContext, analysisDefinitionRegistry, defaultsProvider );
+		return new LuceneIndexFieldTypeFactoryImpl( indexEventContext, backendMapperContext, analysisDefinitionRegistry, defaultsProvider );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/impl/LuceneBackendImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/impl/LuceneBackendImpl.java
@@ -22,6 +22,7 @@ import org.hibernate.search.backend.lucene.resources.impl.BackendThreads;
 import org.hibernate.search.backend.lucene.work.impl.LuceneWorkFactory;
 import org.hibernate.search.engine.backend.Backend;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerBuilder;
+import org.hibernate.search.engine.backend.mapping.spi.BackendMapperContext;
 import org.hibernate.search.engine.backend.spi.BackendBuildContext;
 import org.hibernate.search.engine.backend.spi.BackendImplementor;
 import org.hibernate.search.engine.backend.spi.BackendStartContext;
@@ -131,11 +132,11 @@ public class LuceneBackendImpl implements BackendImplementor, LuceneBackend {
 
 	@Override
 	public IndexManagerBuilder createIndexManagerBuilder(
-			String indexName, String mappedTypeName,
-			BackendBuildContext context, ConfigurationPropertySource propertySource) {
+			String indexName, String mappedTypeName, BackendBuildContext context, BackendMapperContext backendMapperContext,
+			ConfigurationPropertySource propertySource) {
 
 		LuceneIndexRootBuilder indexRootBuilder = new LuceneIndexRootBuilder(
-				EventContexts.fromIndexName( indexName ), mappedTypeName, analysisDefinitionRegistry
+				EventContexts.fromIndexName( indexName ), backendMapperContext, mappedTypeName, analysisDefinitionRegistry
 		);
 
 		/*

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
@@ -358,8 +358,8 @@ public interface Log extends BasicLogger {
 			@Cause Exception cause);
 
 	@Message(id = ID_OFFSET + 80, value = "Invalid index field type: missing decimal scale."
-			+ " Define the decimal scale explicitly.")
-	SearchException nullDecimalScale(@Param EventContext eventContext);
+			+ " Define the decimal scale explicitly. %1$s")
+	SearchException nullDecimalScale(String hint, @Param EventContext eventContext);
 
 	@Message(id = ID_OFFSET + 81,
 			value = "Unable to encode value '%1$s': this field type only supports values ranging from '%2$s' to '%3$s'."

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneBigDecimalIndexFieldTypeOptionsStep.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneBigDecimalIndexFieldTypeOptionsStep.java
@@ -63,6 +63,6 @@ class LuceneBigDecimalIndexFieldTypeOptionsStep
 			return defaultsProvider.decimalScale();
 		}
 
-		throw log.nullDecimalScale( buildContext.getEventContext() );
+		throw log.nullDecimalScale( buildContext.hints().missingDecimalScale(), buildContext.getEventContext() );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneBigIntegerIndexFieldTypeOptionsStep.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneBigIntegerIndexFieldTypeOptionsStep.java
@@ -66,6 +66,6 @@ class LuceneBigIntegerIndexFieldTypeOptionsStep
 			return defaultsProvider.decimalScale();
 		}
 
-		throw log.nullDecimalScale( buildContext.getEventContext() );
+		throw log.nullDecimalScale( buildContext.hints().missingDecimalScale(), buildContext.getEventContext() );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeBuildContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeBuildContext.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.backend.lucene.types.dsl.impl;
 
 import org.hibernate.search.backend.lucene.analysis.model.impl.LuceneAnalysisDefinitionRegistry;
+import org.hibernate.search.engine.backend.reporting.spi.BackendMappingHints;
 import org.hibernate.search.util.common.reporting.EventContext;
 
 public interface LuceneIndexFieldTypeBuildContext {
@@ -14,5 +15,7 @@ public interface LuceneIndexFieldTypeBuildContext {
 	EventContext getEventContext();
 
 	LuceneAnalysisDefinitionRegistry getAnalysisDefinitionRegistry();
+
+	BackendMappingHints hints();
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeFactoryImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeFactoryImpl.java
@@ -25,6 +25,8 @@ import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.types.converter.LuceneFieldContributor;
 import org.hibernate.search.backend.lucene.types.converter.LuceneFieldValueExtractor;
 import org.hibernate.search.backend.lucene.types.dsl.LuceneIndexFieldTypeFactory;
+import org.hibernate.search.engine.backend.mapping.spi.BackendMapperContext;
+import org.hibernate.search.engine.backend.reporting.spi.BackendMappingHints;
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeOptionsStep;
 import org.hibernate.search.engine.backend.types.dsl.ScaledNumberIndexFieldTypeOptionsStep;
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
@@ -42,12 +44,14 @@ public class LuceneIndexFieldTypeFactoryImpl
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final EventContext eventContext;
+	private final BackendMapperContext backendMapperContext;
 	private final LuceneAnalysisDefinitionRegistry analysisDefinitionRegistry;
 	private final IndexFieldTypeDefaultsProvider typeDefaultsProvider;
 
 	public LuceneIndexFieldTypeFactoryImpl(EventContext eventContext,
-			LuceneAnalysisDefinitionRegistry analysisDefinitionRegistry, IndexFieldTypeDefaultsProvider typeDefaultsProvider) {
+			BackendMapperContext backendMapperContext, LuceneAnalysisDefinitionRegistry analysisDefinitionRegistry, IndexFieldTypeDefaultsProvider typeDefaultsProvider) {
 		this.eventContext = eventContext;
+		this.backendMapperContext = backendMapperContext;
 		this.analysisDefinitionRegistry = analysisDefinitionRegistry;
 		this.typeDefaultsProvider = typeDefaultsProvider;
 	}
@@ -245,5 +249,10 @@ public class LuceneIndexFieldTypeFactoryImpl
 	@Override
 	public LuceneAnalysisDefinitionRegistry getAnalysisDefinitionRegistry() {
 		return analysisDefinitionRegistry;
+	}
+
+	@Override
+	public BackendMappingHints hints() {
+		return backendMapperContext.hints();
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/backend/mapping/spi/BackendMapperContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/mapping/spi/BackendMapperContext.java
@@ -1,0 +1,13 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.backend.mapping.spi;
+
+import org.hibernate.search.engine.backend.reporting.spi.BackendMappingHints;
+
+public interface BackendMapperContext {
+	BackendMappingHints hints();
+}

--- a/engine/src/main/java/org/hibernate/search/engine/backend/reporting/spi/BackendMappingHints.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/reporting/spi/BackendMappingHints.java
@@ -20,4 +20,7 @@ public interface BackendMappingHints {
 	@Message(value = "")
 	String noEntityProjectionAvailable();
 
+	@Message( "" )
+	String missingDecimalScale();
+
 }

--- a/engine/src/main/java/org/hibernate/search/engine/backend/spi/BackendImplementor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/spi/BackendImplementor.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletableFuture;
 import org.hibernate.search.engine.backend.Backend;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerBuilder;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerStartContext;
+import org.hibernate.search.engine.backend.mapping.spi.BackendMapperContext;
 import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
 import org.hibernate.search.engine.cfg.IndexSettings;
 
@@ -56,6 +57,7 @@ public interface BackendImplementor {
 	 * allowing the mapper to resolve the type of each hit in multi-index searches.
 	 * Each index is mapped to one and only one type.
 	 * @param context The build context
+	 * @param backendMapperContext
 	 * @param propertySource A configuration property source, appropriately masked so that the backend
 	 * doesn't need to care about Hibernate Search prefixes (hibernate.search.*, etc.). All the properties
 	 * can be accessed at the root.
@@ -63,8 +65,8 @@ public interface BackendImplementor {
 	 * are reserved for use by the engine.
 	 * @return A builder for index managers targeting this backend.
 	 */
-	IndexManagerBuilder createIndexManagerBuilder(String indexName,
-			String mappedTypeName, BackendBuildContext context,
+	IndexManagerBuilder createIndexManagerBuilder(String indexName, String mappedTypeName, BackendBuildContext context,
+			BackendMapperContext backendMapperContext,
 			ConfigurationPropertySource propertySource);
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolder.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexRootBuilder;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerBuilder;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor;
+import org.hibernate.search.engine.backend.mapping.spi.BackendMapperContext;
 import org.hibernate.search.engine.backend.spi.BackendBuildContext;
 import org.hibernate.search.engine.backend.spi.BackendFactory;
 import org.hibernate.search.engine.backend.spi.BackendImplementor;
@@ -78,10 +79,10 @@ class IndexManagerBuildingStateHolder {
 		}
 	}
 
-	IndexManagerBuildingState getIndexManagerBuildingState(Optional<String> backendName, String indexName,
+	IndexManagerBuildingState getIndexManagerBuildingState(BackendMapperContext backendMapperContext, Optional<String> backendName, String indexName,
 			String mappedTypeName) {
 		return getBackend( backendName.orElse( null ) )
-				.createIndexManagerBuildingState( indexName, mappedTypeName );
+				.createIndexManagerBuildingState( backendMapperContext, indexName, mappedTypeName );
 	}
 
 	private BackendInitialBuildState getBackend(String backendName) {
@@ -164,7 +165,7 @@ class IndexManagerBuildingStateHolder {
 		}
 
 		IndexManagerInitialBuildState createIndexManagerBuildingState(
-				String indexName, String mappedTypeName) {
+				BackendMapperContext backendMapperContext, String indexName, String mappedTypeName) {
 			IndexManagerInitialBuildState state = indexManagerBuildStateByName.get( indexName );
 			if ( state != null ) {
 				throw log.twoTypesTargetSameIndex( indexName, state.mappedTypeName, mappedTypeName );
@@ -175,7 +176,7 @@ class IndexManagerBuildingStateHolder {
 			ConfigurationPropertySource indexPropertySource = indexPropertySourceExtractor.extract( propertySource );
 
 			IndexManagerBuilder builder = backend.createIndexManagerBuilder(
-					indexName, mappedTypeName, backendBuildContext, indexPropertySource
+					indexName, mappedTypeName, backendBuildContext, backendMapperContext, indexPropertySource
 			);
 			IndexRootBuilder schemaRootNodeBuilder = builder.schemaRootNodeBuilder();
 

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexManagerFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexManagerFactoryImpl.java
@@ -8,6 +8,7 @@ package org.hibernate.search.engine.common.impl;
 
 import java.util.Optional;
 
+import org.hibernate.search.engine.backend.mapping.spi.BackendMapperContext;
 import org.hibernate.search.engine.mapper.mapping.building.impl.MappedIndexManagerBuilderImpl;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexedEntityBindingMapperContext;
 import org.hibernate.search.engine.mapper.mapping.building.spi.MappedIndexManagerBuilder;
@@ -22,12 +23,13 @@ class MappedIndexManagerFactoryImpl implements MappedIndexManagerFactory {
 
 	@Override
 	public MappedIndexManagerBuilder createMappedIndexManager(IndexedEntityBindingMapperContext mapperContext,
+			BackendMapperContext backendMapperContext,
 			Optional<String> backendName, String indexName,
 			String mappedTypeName) {
 		return new MappedIndexManagerBuilderImpl(
 				mapperContext,
 				indexManagerBuildingStateHolder.getIndexManagerBuildingState(
-						backendName, indexName, mappedTypeName
+						backendMapperContext, backendName, indexName, mappedTypeName
 				)
 		);
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/spi/MappedIndexManagerFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/spi/MappedIndexManagerFactory.java
@@ -8,6 +8,8 @@ package org.hibernate.search.engine.mapper.mapping.building.spi;
 
 import java.util.Optional;
 
+import org.hibernate.search.engine.backend.mapping.spi.BackendMapperContext;
+
 /**
  * A factory for {@link org.hibernate.search.engine.mapper.mapping.spi.MappedIndexManager} instances,
  * which will be the interface between the mapping and the index when indexing and searching.
@@ -16,6 +18,7 @@ public interface MappedIndexManagerFactory {
 
 	MappedIndexManagerBuilder createMappedIndexManager(
 			IndexedEntityBindingMapperContext mapperContext,
+			BackendMapperContext backendMapperContext,
 			Optional<String> backendName, String indexName,
 			String mappedTypeName);
 

--- a/engine/src/test/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolderTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolderTest.java
@@ -22,6 +22,8 @@ import java.util.Optional;
 
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexRootBuilder;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerBuilder;
+import org.hibernate.search.engine.backend.mapping.spi.BackendMapperContext;
+import org.hibernate.search.engine.backend.reporting.spi.BackendMappingHints;
 import org.hibernate.search.engine.backend.spi.BackendFactory;
 import org.hibernate.search.engine.backend.spi.BackendImplementor;
 import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
@@ -118,16 +120,14 @@ public class IndexManagerBuildingStateHolderTest {
 		verifyNoOtherBackendInteractionsAndReset();
 
 		when( backendMock.createIndexManagerBuilder(
-				eq( "myIndex" ),
-				eq( "myType" ),
-				any(),
+				eq( "myIndex" ), eq( "myType" ), any(), any(),
 				indexPropertySourceCapture.capture()
 		) )
 				.thenReturn( indexManagerBuilderMock );
 		when( indexManagerBuilderMock.schemaRootNodeBuilder() )
 				.thenReturn( indexRootBuilderMock );
 		holder.getIndexManagerBuildingState(
-				Optional.empty(), "myIndex", "myType"
+				backendMapperContext(), Optional.empty(), "myIndex", "myType"
 		);
 		verifyNoOtherBackendInteractionsAndReset();
 
@@ -183,16 +183,14 @@ public class IndexManagerBuildingStateHolderTest {
 		verifyNoOtherBackendInteractionsAndReset();
 
 		when( backendMock.createIndexManagerBuilder(
-				eq( "myIndex" ),
-				eq( "myType" ),
-				any(),
+				eq( "myIndex" ), eq( "myType" ), any(), any(),
 				indexPropertySourceCapture.capture()
 		) )
 				.thenReturn( indexManagerBuilderMock );
 		when( indexManagerBuilderMock.schemaRootNodeBuilder() )
 				.thenReturn( indexRootBuilderMock );
 		holder.getIndexManagerBuildingState(
-				Optional.of( "myBackend" ), "myIndex", "myType"
+				backendMapperContext(), Optional.of( "myBackend" ), "myIndex", "myType"
 		);
 		verifyNoOtherBackendInteractionsAndReset();
 
@@ -333,5 +331,14 @@ public class IndexManagerBuildingStateHolderTest {
 		BackendsInfo result = new BackendsInfo();
 		result.collect( Optional.of( name ), TenancyMode.SINGLE_TENANCY );
 		return result;
+	}
+
+	static BackendMapperContext backendMapperContext() {
+		return new BackendMapperContext() {
+			@Override
+			public BackendMappingHints hints() {
+				return BackendMappingHints.NONE;
+			}
+		};
 	}
 }

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/mapping/DecimalScaleMappingIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/mapping/DecimalScaleMappingIT.java
@@ -1,0 +1,60 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.orm.realbackend.mapping;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import java.math.BigInteger;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.search.integrationtest.mapper.orm.realbackend.testsupport.BackendConfigurations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+public class DecimalScaleMappingIT {
+
+	@Rule
+	public OrmSetupHelper setupHelper = OrmSetupHelper.withSingleBackend( BackendConfigurations.simple() );
+
+	@Test
+	public void testFailingWithHint() {
+		assertThatThrownBy( () ->
+				setupHelper.start().setup( FailingEntity.class )
+		).isInstanceOf( SearchException.class )
+				.hasMessageContainingAll(
+						"Hibernate Search encountered failures during bootstrap",
+						"Invalid index field type: missing decimal scale. Define the decimal scale explicitly.",
+						"If you used a @*Field annotation here, make sure to use @ScaledNumberField and configure the `decimalScale` attribute as necessary."
+				);
+	}
+
+	@Entity(name = "failing")
+	@Indexed
+	public static class FailingEntity {
+		@Id
+		@Column(name = "id", nullable = false, precision = 18)
+		@GenericField
+		private BigInteger id;
+
+		public BigInteger id() {
+			return id;
+		}
+
+		public FailingEntity withId(BigInteger id) {
+			this.id = id;
+			return this;
+		}
+	}
+
+}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapperDelegate.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapperDelegate.java
@@ -6,9 +6,11 @@
  */
 package org.hibernate.search.mapper.orm.mapping.impl;
 
+import org.hibernate.search.engine.backend.reporting.spi.BackendMappingHints;
 import org.hibernate.search.engine.environment.bean.BeanHolder;
 import org.hibernate.search.mapper.orm.coordination.common.spi.CoordinationStrategy;
 import org.hibernate.search.mapper.orm.model.impl.HibernateOrmBasicTypeMetadataProvider;
+import org.hibernate.search.mapper.orm.reporting.impl.HibernateOrmMappingHints;
 import org.hibernate.search.mapper.orm.session.impl.ConfiguredAutomaticIndexingStrategy;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoContainedTypeExtendedMappingCollector;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoIndexedTypeExtendedMappingCollector;
@@ -57,5 +59,10 @@ public final class HibernateOrmMapperDelegate
 	public HibernateOrmMappingPartialBuildState prepareBuild(PojoMappingDelegate mappingDelegate) {
 		return new HibernateOrmMappingPartialBuildState( mappingDelegate, typeContextContainerBuilder,
 				coordinationStrategyHolder, configuredAutomaticIndexingStrategy );
+	}
+
+	@Override
+	public BackendMappingHints hints() {
+		return HibernateOrmMappingHints.INSTANCE;
 	}
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/reporting/impl/HibernateOrmMappingHints.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/reporting/impl/HibernateOrmMappingHints.java
@@ -22,4 +22,7 @@ public interface HibernateOrmMappingHints extends BackendMappingHints {
 	@Message(value = "This is likely a bug, as Hibernate ORM entities should always be loadable from the database.")
 	String noEntityProjectionAvailable();
 
+	@Override
+	@Message( "If you used a @*Field annotation here, make sure to use @ScaledNumberField and configure the `decimalScale` attribute as necessary." )
+	String missingDecimalScale();
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoMapper.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoMapper.java
@@ -235,7 +235,7 @@ public class PojoMapper<MPBS extends MappingPartialBuildState> implements Mapper
 		String indexName = indexedTypeMetadata.indexName().orElse( entityName );
 
 		MappedIndexManagerBuilder indexManagerBuilder = indexManagerFactory.createMappedIndexManager( this,
-				indexedTypeMetadata.backendName(), indexName, entityName );
+				delegate, indexedTypeMetadata.backendName(), indexName, entityName );
 
 		Optional<RoutingBinder> routingBinderOptional = indexedTypeMetadata.routingBinder();
 		BoundRoutingBridge<E> routingBridge = null;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/spi/PojoMapperDelegate.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/spi/PojoMapperDelegate.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.mapper.pojo.mapping.building.spi;
 
+import org.hibernate.search.engine.backend.mapping.spi.BackendMapperContext;
 import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingDelegate;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeModel;
 
@@ -15,7 +16,7 @@ import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeModel;
  *
  * @param <MPBS> The Java type of the partial build state of the produced mapping.
  */
-public interface PojoMapperDelegate<MPBS> {
+public interface PojoMapperDelegate<MPBS> extends BackendMapperContext {
 
 	/**
 	 * Close any allocated resource.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/spi/PojoMapperDelegate.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/spi/PojoMapperDelegate.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.mapper.pojo.mapping.building.spi;
 
 import org.hibernate.search.engine.backend.mapping.spi.BackendMapperContext;
+import org.hibernate.search.engine.backend.reporting.spi.BackendMappingHints;
 import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingDelegate;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeModel;
 
@@ -25,6 +26,11 @@ public interface PojoMapperDelegate<MPBS> extends BackendMapperContext {
 	 * When this method is called, it is guaranteed to be the last call on this object.
 	 */
 	void closeOnFailure();
+
+	@Override
+	default BackendMappingHints hints() {
+		return BackendMappingHints.NONE;
+	}
 
 	/**
 	 * @param <E> The indexed entity type.

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoMapperDelegate.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoMapperDelegate.java
@@ -6,7 +6,9 @@
  */
 package org.hibernate.search.mapper.pojo.standalone.mapping.impl;
 
+import org.hibernate.search.engine.backend.reporting.spi.BackendMappingHints;
 import org.hibernate.search.mapper.pojo.standalone.mapping.metadata.impl.StandalonePojoEntityTypeMetadataProvider;
+import org.hibernate.search.mapper.pojo.standalone.reporting.impl.StandalonePojoMappingHints;
 import org.hibernate.search.mapper.pojo.standalone.schema.management.impl.SchemaManagementListener;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoContainedTypeExtendedMappingCollector;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoIndexedTypeExtendedMappingCollector;
@@ -50,4 +52,8 @@ public final class StandalonePojoMapperDelegate
 		return new StandalonePojoMappingPartialBuildState( mappingDelegate, typeContextContainerBuilder.build(), schemaManagementListener );
 	}
 
+	@Override
+	public BackendMappingHints hints() {
+		return StandalonePojoMappingHints.INSTANCE;
+	}
 }

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/reporting/impl/StandalonePojoMappingHints.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/reporting/impl/StandalonePojoMappingHints.java
@@ -26,4 +26,7 @@ public interface StandalonePojoMappingHints extends BackendMappingHints {
 	@Override
 	String noEntityProjectionAvailable();
 
+	@Override
+	@Message( "If you used a @*Field annotation here, make sure to use @ScaledNumberField and configure the `decimalScale` attribute as necessary." )
+	String missingDecimalScale();
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubBackend.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubBackend.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletionStage;
 
 import org.hibernate.search.engine.backend.Backend;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerBuilder;
+import org.hibernate.search.engine.backend.mapping.spi.BackendMapperContext;
 import org.hibernate.search.engine.backend.spi.BackendBuildContext;
 import org.hibernate.search.engine.backend.spi.BackendImplementor;
 import org.hibernate.search.engine.backend.spi.BackendStartContext;
@@ -80,8 +81,8 @@ public class StubBackend implements BackendImplementor, Backend {
 	}
 
 	@Override
-	public IndexManagerBuilder createIndexManagerBuilder(String indexName,
-			String mappedTypeName, BackendBuildContext context,
+	public IndexManagerBuilder createIndexManagerBuilder(String indexName, String mappedTypeName,
+			BackendBuildContext context, BackendMapperContext backendMapperContext,
 			ConfigurationPropertySource propertySource) {
 		return new StubIndexManagerBuilder( this, indexName, mappedTypeName );
 	}

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMapper.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMapper.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import org.hibernate.search.engine.backend.mapping.spi.BackendMapperContext;
+import org.hibernate.search.engine.backend.reporting.spi.BackendMappingHints;
 import org.hibernate.search.engine.mapper.mapping.building.spi.BackendsInfo;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexedEmbeddedDefinition;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexedEmbeddedPathTracker;
@@ -27,7 +29,7 @@ import org.hibernate.search.engine.reporting.spi.ContextualFailureCollector;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.engine.tenancy.spi.TenancyMode;
 
-class StubMapper implements Mapper<StubMappingPartialBuildState>, IndexedEntityBindingMapperContext {
+class StubMapper implements Mapper<StubMappingPartialBuildState>, IndexedEntityBindingMapperContext, BackendMapperContext {
 
 	private final ContextualFailureCollector failureCollector;
 	private final TypeMetadataContributorProvider<StubMappedIndex> contributorProvider;
@@ -88,6 +90,7 @@ class StubMapper implements Mapper<StubMappingPartialBuildState>, IndexedEntityB
 		mappedIndexOptional.ifPresent( mappedIndex -> {
 			MappedIndexManagerBuilder indexManagerBuilder = indexManagerFactory.createMappedIndexManager(
 					this,
+					this,
 					mappedIndex.backendName(),
 					mappedIndex.name(),
 					type.name()
@@ -136,5 +139,10 @@ class StubMapper implements Mapper<StubMappingPartialBuildState>, IndexedEntityB
 	@Override
 	public IndexedEmbeddedPathTracker getOrCreatePathTracker(IndexedEmbeddedDefinition definition) {
 		return pathTrackers.computeIfAbsent( definition, IndexedEmbeddedPathTracker::new );
+	}
+
+	@Override
+	public BackendMappingHints hints() {
+		return StubMappingHints.INSTANCE;
 	}
 }

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingHints.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingHints.java
@@ -18,4 +18,9 @@ public final class StubMappingHints implements BackendMappingHints {
 	public String noEntityProjectionAvailable() {
 		return getClass().getName() + "#noEntityProjectionAvailable";
 	}
+
+	@Override
+	public String missingDecimalScale() {
+		return getClass().getName() + "#missingDecimalScale";
+	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4781

As it seems that the hint would be independent of the backend - there are no backend-specific overrides for `BackendMappingHints`