### PR TITLE
HSEARCH-4642 Revert back to Mockito 4.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,3 +65,7 @@ updates:
       # (see https://search.maven.org/artifact/software.amazon.awssdk/aws-sdk-java-pom/2.17.257/pom)
       - dependency-name: "org.slf4j:*"
         update-types: ["version-update:semver-major"]
+      # Mockito 5 requires Java 11 which is not possible with Hibernate Search 6 series.
+      # https://github.com/mockito/mockito/releases/tag/v5.0.0
+      - dependency-name: "org.mockito:*"
+        versions: ["[5.0.0,)"]

--- a/pom.xml
+++ b/pom.xml
@@ -303,7 +303,7 @@
         <version.org.osgi.core>6.0.0</version.org.osgi.core>
 
         <version.org.hamcrest>2.2</version.org.hamcrest>
-        <version.org.mockito>5.0.0</version.org.mockito>
+        <version.org.mockito>4.11.0</version.org.mockito>
         <version.org.assertj.assertj-core>3.24.1</version.org.assertj.assertj-core>
         <version.org.awaitily>4.2.0</version.org.awaitily>
         <version.org.skyscreamer.jsonassert>1.5.1</version.org.skyscreamer.jsonassert>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4642

For HSEARCH-4642, folllows up on https://github.com/hibernate/hibernate-search/pull/3383, https://github.com/hibernate/hibernate-search/pull/3364, https://github.com/hibernate/hibernate-search/pull/3351, https://github.com/hibernate/hibernate-search/pull/3339, https://github.com/hibernate/hibernate-search/pull/3322, https://github.com/hibernate/hibernate-search/pull/3313, https://github.com/hibernate/hibernate-search/pull/3294, https://github.com/hibernate/hibernate-search/pull/3146, https://github.com/hibernate/hibernate-search/pull/3148, https://github.com/hibernate/hibernate-search/pull/3157, https://github.com/hibernate/hibernate-search/pull/3176, https://github.com/hibernate/hibernate-search/pull/3189, https://github.com/hibernate/hibernate-search/pull/3194, https://github.com/hibernate/hibernate-search/pull/3208, https://github.com/hibernate/hibernate-search/pull/3219, https://github.com/hibernate/hibernate-search/pull/3234, https://github.com/hibernate/hibernate-search/pull/3239, https://github.com/hibernate/hibernate-search/pull/3249, https://github.com/hibernate/hibernate-search/pull/3255, https://github.com/hibernate/hibernate-search/pull/3262, https://github.com/hibernate/hibernate-search/pull/3281