### PR TITLE
HSEARCH-4642 Bump assertj-core from 3.24.1 to 3.24.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
 
         <version.org.hamcrest>2.2</version.org.hamcrest>
         <version.org.mockito>4.11.0</version.org.mockito>
-        <version.org.assertj.assertj-core>3.24.1</version.org.assertj.assertj-core>
+        <version.org.assertj.assertj-core>3.24.2</version.org.assertj.assertj-core>
         <version.org.awaitily>4.2.0</version.org.awaitily>
         <version.org.skyscreamer.jsonassert>1.5.1</version.org.skyscreamer.jsonassert>
         <version.io.takari.junit>1.2.7</version.io.takari.junit>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4642

For HSEARCH-4642, folllows up on https://github.com/hibernate/hibernate-search/pull/3387, https://github.com/hibernate/hibernate-search/pull/3383, https://github.com/hibernate/hibernate-search/pull/3364, https://github.com/hibernate/hibernate-search/pull/3351, https://github.com/hibernate/hibernate-search/pull/3339, https://github.com/hibernate/hibernate-search/pull/3322, https://github.com/hibernate/hibernate-search/pull/3313, https://github.com/hibernate/hibernate-search/pull/3294, https://github.com/hibernate/hibernate-search/pull/3146, https://github.com/hibernate/hibernate-search/pull/3148, https://github.com/hibernate/hibernate-search/pull/3157, https://github.com/hibernate/hibernate-search/pull/3176, https://github.com/hibernate/hibernate-search/pull/3189, https://github.com/hibernate/hibernate-search/pull/3194, https://github.com/hibernate/hibernate-search/pull/3208, https://github.com/hibernate/hibernate-search/pull/3219, https://github.com/hibernate/hibernate-search/pull/3234, https://github.com/hibernate/hibernate-search/pull/3239, https://github.com/hibernate/hibernate-search/pull/3249, https://github.com/hibernate/hibernate-search/pull/3255, https://github.com/hibernate/hibernate-search/pull/3262, https://github.com/hibernate/hibernate-search/pull/3281