### PR TITLE
HSEARCH-4789 [HSearch 5] Indexing entities with a shared id across tenants results in removal from those tenants

### DIFF
--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/UpdateExtWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/UpdateExtWorkExecutor.java
@@ -7,47 +7,31 @@
 
 package org.hibernate.search.backend.impl.lucene.works;
 
-import java.io.Serializable;
-import java.util.Map;
-
-import org.apache.lucene.index.Term;
 import org.hibernate.search.exception.AssertionFailure;
-import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.spi.IndexedTypeIdentifier;
-import org.hibernate.search.analyzer.spi.ScopedAnalyzerReference;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.impl.lucene.IndexWriterDelegate;
-import org.hibernate.search.bridge.util.impl.NumericFieldUtils;
 import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.store.Workspace;
-import org.hibernate.search.util.logging.impl.Log;
-import org.hibernate.search.util.logging.impl.LoggerFactory;
-import java.lang.invoke.MethodHandles;
 
 /**
- * This applies the index update operation using the Lucene operation
- * {@link org.apache.lucene.index.IndexWriter#updateDocument(Term, Iterable)}
- *
- * This is the most efficient way to update the index, but we can apply it only if the Document is uniquely identified
- * by a single term (so no index sharing across entities or Numeric ids).
+ * Extension of {@link ByTermUpdateWorkExecutor} bound to a single entity.
+ * <p>
+ * This allows not retrieving the document builder for each document.
+ * <p>
+ * NOTE (yrodiere): This is of dubious interest performance-wise, but kept as-is not to risk regressions.
  *
  * @author Sanne Grinovero (C) 2012 Red Hat Inc.
  */
-public final class UpdateExtWorkExecutor extends UpdateWorkExecutor {
+public final class UpdateExtWorkExecutor extends ByTermUpdateWorkExecutor {
 
-	private static final Log log = LoggerFactory.make( MethodHandles.lookup() );
-
-	private final AddWorkExecutor addDelegate;
 	private final IndexedTypeIdentifier managedType;
 	private final DocumentBuilderIndexedEntity builder;
 	private final boolean idIsNumeric;
-	private final Workspace workspace;
 
 	UpdateExtWorkExecutor(Workspace workspace, AddWorkExecutor addDelegate) {
-		super( null, null );
-		this.workspace = workspace;
-		this.addDelegate = addDelegate;
+		super( workspace, addDelegate );
 		this.managedType = workspace.getEntitiesInIndexManager().iterator().next();
 		this.builder = workspace.getDocumentBuilder( managedType );
 		this.idIsNumeric = DeleteWorkExecutor.isIdNumeric( builder );
@@ -56,31 +40,7 @@ public final class UpdateExtWorkExecutor extends UpdateWorkExecutor {
 	@Override
 	public void performWork(LuceneWork work, IndexWriterDelegate delegate, IndexingMonitor monitor) {
 		checkType( work );
-		final Serializable id = work.getId();
-		try {
-			if ( idIsNumeric ) {
-				log.tracef( "Deleting %s#%s by query using an IndexWriter#updateDocument as id is Numeric", managedType, id );
-				delegate.deleteDocuments( NumericFieldUtils.createExactMatchQuery( builder.getIdFieldName(), id ) );
-				// no need to log the Add operation as we'll log in the delegate
-				this.addDelegate.performWork( work, delegate, monitor );
-			}
-			else {
-				log.tracef( "Updating %s#%s by id using an IndexWriter#updateDocument.", managedType, id );
-				Term idTerm = new Term( builder.getIdFieldName(), work.getIdInString() );
-				Map<String, String> fieldToAnalyzerMap = work.getFieldToAnalyzerMap();
-				ScopedAnalyzerReference analyzerReference = builder.getAnalyzerReference();
-				analyzerReference = AddWorkExecutor.updateAnalyzerMappings( workspace, analyzerReference, fieldToAnalyzerMap );
-				delegate.updateDocument( idTerm, work.getDocument(), analyzerReference );
-			}
-			workspace.notifyWorkApplied( work );
-		}
-		catch (Exception e) {
-			String message = "Unable to update " + managedType + "#" + id + " in index.";
-			throw new SearchException( message, e );
-		}
-		if ( monitor != null ) {
-			monitor.documentsAdded( 1l );
-		}
+		doPerformWork( work, delegate, monitor, managedType, builder, idIsNumeric );
 	}
 
 	private void checkType(final LuceneWork work) {

--- a/orm/src/test/java/org/hibernate/search/test/batchindexing/DatabaseMultitenancyTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/batchindexing/DatabaseMultitenancyTest.java
@@ -170,7 +170,7 @@ public class DatabaseMultitenancyTest extends SearchTestBase {
 				.containsExactlyInAnyOrder( GEOCHRON_MODELS );
 
 		Clock newMetamec;
-		try (Session session = openSessionWithTenantId( METAMEC_TID )) {
+		try ( Session session = openSessionWithTenantId( METAMEC_TID ) ) {
 			session.beginTransaction();
 			newMetamec = session.get( Clock.class, METAMEC_MODELS[0].getId() );
 			newMetamec.setBrand( newMetamec.getBrand() + " foo" );
@@ -190,7 +190,7 @@ public class DatabaseMultitenancyTest extends SearchTestBase {
 		assertThat( searchAll( GEOCHRON_TID ) )
 				.containsExactlyInAnyOrder( GEOCHRON_MODELS );
 
-		try (Session session = openSessionWithTenantId( METAMEC_TID )) {
+		try ( Session session = openSessionWithTenantId( METAMEC_TID ) ) {
 			session.beginTransaction();
 			Clock metamec = session.get( Clock.class, METAMEC_MODELS[0].getId() );
 			session.delete( metamec );


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4789

Note this is Hibernate Search 5, so the code is completely different from 6.

This particular part of the code is... let's say interesting. I cleaned up what was reasonable, but the main goal here is really to just use a common implementation in the executors, one that handles tenant IDs correctly.