### PR TITLE
HSEARCH-1809 Introduce the context for the massindexer batch thread work

### DIFF
--- a/documentation/src/main/asciidoc/reference/indexing-massindexer.asciidoc
+++ b/documentation/src/main/asciidoc/reference/indexing-massindexer.asciidoc
@@ -335,7 +335,10 @@ Implementations of `MassIndexingFailureHandler` must be thread-safe.
 
 |`environment(MassIndexingEnvironment)`
 |An empty environment (no threadlocals, ...).
-|
+|*This feature is _incubating_: it is still under active development.*
+The contract of incubating elements (e.g. types, methods, configuration properties, etc.)
+may be altered in a backward-incompatible way -- or even removed -- in subsequent releases.
+
 The component responsible for setting up an environment (threadlocals, ...) on mass indexing threads before mass indexing
 starts, and tearing down that environment after mass indexing.
 

--- a/documentation/src/main/asciidoc/reference/indexing-massindexer.asciidoc
+++ b/documentation/src/main/asciidoc/reference/indexing-massindexer.asciidoc
@@ -333,6 +333,15 @@ or for more advanced use cases, such as cancelling mass indexing on the first fa
 
 Implementations of `MassIndexingFailureHandler` must be thread-safe.
 
+|`environment(MassIndexingEnvironment)`
+|An empty environment (no threadlocals, ...).
+|
+The component responsible for setting up an environment (threadlocals, ...) on mass indexing threads before mass indexing
+starts, and tearing down that environment after mass indexing.
+
+Implementations should handle their exceptions unless it is an unrecoverable situation in which further mass indexing
+does not make sense: any exception thrown by the `MassIndexingEnvironment` will abort mass indexing.
+
 |===
 
 [[indexing-massindexer-tuning]]

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingEnvironmentIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingEnvironmentIT.java
@@ -1,0 +1,184 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.massindexing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+
+import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
+import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
+import org.hibernate.search.mapper.pojo.massindexing.MassIndexingEnvironment;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.loading.PersistenceTypeKey;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.loading.StubLoadingContext;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.loading.StubMassLoadingStrategy;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.standalone.mapping.SearchMapping;
+import org.hibernate.search.mapper.pojo.standalone.massindexing.MassIndexer;
+import org.hibernate.search.mapper.pojo.standalone.session.SearchSession;
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.common.impl.Futures;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.pojo.standalone.StandalonePojoMappingSetupHelper;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class MassIndexingEnvironmentIT {
+
+	@Rule
+	public final BackendMock backendMock = new BackendMock();
+
+	@Rule
+	public final StandalonePojoMappingSetupHelper setupHelper
+			= StandalonePojoMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );
+
+	private SearchMapping mapping;
+
+	private final StubLoadingContext loadingContext = new StubLoadingContext();
+
+	@Before
+	public void setup() {
+		backendMock.expectAnySchema( Entity.INDEX );
+
+		mapping = setupHelper.start()
+				.withConfiguration( b -> {
+					b.addEntityType( Entity.class, c -> c
+							.massLoadingStrategy( new StubMassLoadingStrategy<>( Entity.PERSISTENCE_KEY ) ) );
+				} )
+				.setup( Entity.class );
+
+		backendMock.verifyExpectationsMet();
+
+		initData();
+	}
+
+	@Test
+	public void success() throws InterruptedException {
+		try ( SearchSession searchSession = mapping.createSession() ) {
+			Queue<String> before = new ArrayBlockingQueue<>( 10 );
+			Queue<String> after = new ArrayBlockingQueue<>( 10 );
+
+			MassIndexer indexer = searchSession.massIndexer()
+					// Simulate passing information to connect to a DB, ...
+					.context( StubLoadingContext.class, loadingContext )
+					.mergeSegmentsOnFinish( true )
+					.typesToIndexInParallel( 1 )
+					.threadsToLoadObjects( 1 )
+					.environment( new MassIndexingEnvironment() {
+						@Override
+						public void beforeExecution(Context context) {
+							before.add( Thread.currentThread().getName() );
+						}
+
+						@Override
+						public void afterExecution(Context context) {
+							after.add( Thread.currentThread().getName() );
+						}
+					} );
+
+			backendMock.expectWorks(
+							Entity.INDEX, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
+					)
+					.add( "1", b -> {
+					} );
+
+			// purgeAtStart and mergeSegmentsAfterPurge are enabled by default,
+			// so we expect 1 purge, 1 mergeSegments and 1 flush calls in this order:
+			backendMock.expectIndexScaleWorks( Entity.INDEX, searchSession.tenantIdentifier() )
+					.purge()
+					.mergeSegments()
+					.mergeSegments()
+					.flush()
+					.refresh();
+
+			Futures.unwrappedExceptionGet( indexer.start().toCompletableFuture() );
+
+			assertThat( before ).containsOnly(
+					"Hibernate Search - Mass indexing - Entity - Entity loading - 0",
+					"Hibernate Search - Mass indexing - Entity - ID loading - 0"
+			);
+			assertThat( after ).containsOnly(
+					"Hibernate Search - Mass indexing - Entity - Entity loading - 0",
+					"Hibernate Search - Mass indexing - Entity - ID loading - 0"
+			);
+		}
+
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void failingBeforeHook() throws InterruptedException {
+		try ( SearchSession searchSession = mapping.createSession() ) {
+			Queue<String> after = new ArrayBlockingQueue<>( 10 );
+
+			MassIndexer indexer = searchSession.massIndexer()
+					// Simulate passing information to connect to a DB, ...
+					.context( StubLoadingContext.class, loadingContext )
+					.mergeSegmentsOnFinish( true )
+					.typesToIndexInParallel( 1 )
+					.threadsToLoadObjects( 1 )
+					.environment( new MassIndexingEnvironment() {
+						@Override
+						public void beforeExecution(Context context) {
+							throw new UnsupportedOperationException( "don't call me." );
+						}
+
+						@Override
+						public void afterExecution(Context context) {
+							after.add( Thread.currentThread().getName() );
+						}
+					} );
+
+			// purgeAtStart and mergeSegmentsAfterPurge are enabled by default,
+			// so we expect 1 purge, 1 mergeSegments after that we'll get exceptions so no flush or refresh:
+			backendMock.expectIndexScaleWorks( Entity.INDEX, searchSession.tenantIdentifier() )
+					.purge()
+					.mergeSegments();
+
+			assertThatThrownBy( () -> Futures.unwrappedExceptionGet( indexer.start().toCompletableFuture() ) )
+					.isInstanceOf( SearchException.class )
+					.hasMessageContainingAll(
+							"2 failure(s) occurred during mass indexing",
+							"First failure: don't call me."
+					);
+
+			assertThat( after ).isEmpty();
+		}
+	}
+
+	private void initData() {
+		persist( new Entity( 1 ) );
+	}
+
+	private void persist(Entity entity) {
+		loadingContext.persistenceMap( Entity.PERSISTENCE_KEY ).put( entity.id, entity );
+	}
+
+	@Indexed(index = Entity.INDEX)
+	public static class Entity {
+
+		public static final String INDEX = "Entity";
+		public static final PersistenceTypeKey<Entity, Integer> PERSISTENCE_KEY =
+				new PersistenceTypeKey<>( Entity.class, int.class );
+
+		@DocumentId
+		private int id;
+
+		public Entity() {
+		}
+
+		public Entity(int id) {
+			this.id = id;
+		}
+	}
+}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/MassIndexer.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/MassIndexer.java
@@ -12,6 +12,7 @@ import java.util.concurrent.CompletionStage;
 import org.hibernate.CacheMode;
 import org.hibernate.search.mapper.pojo.massindexing.MassIndexingFailureHandler;
 import org.hibernate.search.mapper.pojo.massindexing.MassIndexingMonitor;
+import org.hibernate.search.mapper.pojo.massindexing.MassIndexingEnvironment;
 import org.hibernate.search.util.common.annotation.Incubating;
 
 /**
@@ -194,4 +195,17 @@ public interface MassIndexer {
 	 * @return {@code this} for method chaining
 	 */
 	MassIndexer failureHandler(MassIndexingFailureHandler failureHandler);
+
+	/**
+	 * Sets the {@link MassIndexingEnvironment}, which can set up an environment (thread locals, ...) in mass indexing threads.
+	 *
+	 * @param environment a component that gets a chance to
+	 * set up e.g. {@link ThreadLocal ThreadLocals} in mass indexing threads before
+	 * mass indexing starts, and to remove them after mass indexing stops.
+	 * @return {@code this} for method chaining
+	 *
+	 * @see MassIndexingEnvironment
+	 */
+	@Incubating
+	MassIndexer environment(MassIndexingEnvironment environment);
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/HibernateOrmMassIndexer.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/HibernateOrmMassIndexer.java
@@ -9,6 +9,7 @@ package org.hibernate.search.mapper.orm.massindexing.impl;
 import java.util.concurrent.CompletionStage;
 
 import org.hibernate.CacheMode;
+import org.hibernate.search.mapper.pojo.massindexing.MassIndexingEnvironment;
 import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
 import org.hibernate.search.mapper.orm.massindexing.MassIndexerFilteringTypeStep;
 import org.hibernate.search.mapper.pojo.massindexing.MassIndexingFailureHandler;
@@ -121,5 +122,11 @@ public class HibernateOrmMassIndexer implements MassIndexer {
 
 	ConditionalExpression reindexOnly(Class<?> type, String conditionalExpression) {
 		return context.reindexOnly( type, conditionalExpression );
+	}
+
+	@Override
+	public MassIndexer environment(MassIndexingEnvironment environment) {
+		delegate.environment( environment );
+		return this;
 	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/MassIndexingEnvironment.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/MassIndexingEnvironment.java
@@ -1,0 +1,51 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.massindexing;
+
+import org.hibernate.search.util.common.annotation.Incubating;
+
+/**
+ * An interface for pluggable components that set up and tear down the environment of mass indexing threads,
+ * for example, to initialize {@link ThreadLocal ThreadLocals}. See interfaces extending {@link Context} to learn which threads will
+ * attempt to execute configured hooks.
+ */
+@Incubating
+public interface MassIndexingEnvironment {
+	/**
+	 * Method is going to be invoked prior to executing the main logic of a {@link Runnable} in the given thread.
+	 */
+	void beforeExecution(Context context);
+
+	/**
+	 * Method is going to be invoked after completion of execution of the main logic of a {@link Runnable} in the given thread.
+	 * Will not be called if {@link #beforeExecution(Context)} results in an exception.
+	 */
+	void afterExecution(Context context);
+
+	interface Context {
+
+		default <T> T unwrap(Class<T> contextClass) {
+			return contextClass.cast( this );
+		}
+	}
+
+	/**
+	 * Context provided to {@link MassIndexingEnvironment} when configured hooks are considered for
+	 * execution around the identifier loading work.
+	 */
+	interface EntityIdentifierLoadingContext extends Context {
+
+	}
+
+	/**
+	 * Context provided to {@link MassIndexingEnvironment} when configured hooks are considered for
+	 * execution around the entity loading work.
+	 */
+	interface EntityLoadingContext extends Context {
+
+	}
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingBatchCoordinator.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingBatchCoordinator.java
@@ -17,6 +17,7 @@ import java.util.function.Function;
 
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.reporting.spi.RootFailureCollector;
+import org.hibernate.search.mapper.pojo.massindexing.MassIndexingEnvironment;
 import org.hibernate.search.mapper.pojo.massindexing.spi.PojoMassIndexerAgent;
 import org.hibernate.search.mapper.pojo.massindexing.spi.PojoMassIndexingMappingContext;
 import org.hibernate.search.mapper.pojo.reporting.impl.PojoEventContextMessages;
@@ -59,9 +60,10 @@ public class PojoMassIndexingBatchCoordinator extends PojoMassIndexingFailureHan
 			PojoScopeSchemaManager scopeSchemaManager,
 			Collection<String> tenantIds,
 			PojoScopeDelegate<?, ?, ?> pojoScopeDelegate,
+			MassIndexingEnvironment environment,
 			int typesToIndexInParallel, int documentBuilderThreads, boolean mergeSegmentsOnFinish,
 			boolean dropAndCreateSchemaOnStart, boolean purgeAtStart, boolean mergeSegmentsAfterPurge) {
-		super( notifier );
+		super( notifier, environment );
 		this.mappingContext = mappingContext;
 		this.typeGroupsToIndex = typeGroupsToIndex;
 
@@ -167,7 +169,7 @@ public class PojoMassIndexingBatchCoordinator extends PojoMassIndexingFailureHan
 	private <E> PojoMassIndexingBatchIndexingWorkspace<E, ?> createBatchIndexingWorkspace(
 			PojoMassIndexingIndexedTypeGroup<E> typeGroup, SessionContext context) {
 		return new PojoMassIndexingBatchIndexingWorkspace<>(
-				mappingContext, getNotifier(), typeGroup,
+				mappingContext, getNotifier(), getMassIndexingEnvironment(), typeGroup,
 				typeGroup.loadingStrategy(),
 				documentBuilderThreads,
 				context.tenantIdentifier()

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingEntityLoadingRunnable.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingEntityLoadingRunnable.java
@@ -19,6 +19,7 @@ import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.mapper.pojo.loading.spi.PojoMassEntityLoader;
 import org.hibernate.search.mapper.pojo.loading.spi.PojoMassEntitySink;
 import org.hibernate.search.mapper.pojo.logging.impl.Log;
+import org.hibernate.search.mapper.pojo.massindexing.MassIndexingEnvironment;
 import org.hibernate.search.mapper.pojo.massindexing.spi.PojoMassIndexingEntityLoadingContext;
 import org.hibernate.search.mapper.pojo.massindexing.spi.PojoMassIndexingLoadingStrategy;
 import org.hibernate.search.mapper.pojo.massindexing.spi.PojoMassIndexingSessionContext;
@@ -37,17 +38,20 @@ public class PojoMassIndexingEntityLoadingRunnable<E, I>
 	private final PojoMassIndexingLoadingStrategy<E, I> loadingStrategy;
 	private final PojoProducerConsumerQueue<List<I>> identifierQueue;
 	private final String tenantId;
+	private final MassIndexingEnvironment.EntityLoadingContext entityLoadingContext;
 
 	protected PojoMassIndexingEntityLoadingRunnable(PojoMassIndexingNotifier notifier,
-			PojoMassIndexingIndexedTypeGroup<E> typeGroup,
+			MassIndexingEnvironment environment, PojoMassIndexingIndexedTypeGroup<E> typeGroup,
 			PojoMassIndexingLoadingStrategy<E, I> loadingStrategy,
 			PojoProducerConsumerQueue<List<I>> identifierQueue,
 			String tenantId) {
-		super( notifier );
+		super( notifier, environment );
 		this.typeGroup = typeGroup;
 		this.loadingStrategy = loadingStrategy;
 		this.identifierQueue = identifierQueue;
 		this.tenantId = tenantId;
+
+		this.entityLoadingContext = new EntityLoadingContextImpl();
 	}
 
 	@Override
@@ -83,6 +87,16 @@ public class PojoMassIndexingEntityLoadingRunnable<E, I>
 	@Override
 	protected void cleanUpOnInterruption() {
 		// Nothing to do
+	}
+
+	@Override
+	protected MassIndexingEnvironment.Context createMassIndexingEnvironmentContext() {
+		return entityLoadingContext;
+	}
+
+	@Override
+	protected boolean supportsThreadLifecycleHooks() {
+		return true;
 	}
 
 	@Override
@@ -242,4 +256,6 @@ public class PojoMassIndexingEntityLoadingRunnable<E, I>
 		}
 	}
 
+	private static final class EntityLoadingContextImpl implements MassIndexingEnvironment.EntityLoadingContext {
+	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/spi/PojoMassIndexer.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/spi/PojoMassIndexer.java
@@ -8,8 +8,11 @@ package org.hibernate.search.mapper.pojo.massindexing.spi;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+
+import org.hibernate.search.mapper.pojo.massindexing.MassIndexingEnvironment;
 import org.hibernate.search.mapper.pojo.massindexing.MassIndexingFailureHandler;
 import org.hibernate.search.mapper.pojo.massindexing.MassIndexingMonitor;
+import org.hibernate.search.util.common.annotation.Incubating;
 
 /**
  * A MassIndexer is useful to rebuild the indexes from the
@@ -130,4 +133,16 @@ public interface PojoMassIndexer {
 	 * @return {@code this} for method chaining
 	 */
 	PojoMassIndexer failureHandler(MassIndexingFailureHandler failureHandler);
+
+	/**
+	 * Sets the {@link MassIndexingEnvironment}, which can set up an environment (thread locals, ...) in mass indexing threads.
+	 *
+	 * @param environment a component that gets a chance to
+	 * set up e.g. {@link ThreadLocal ThreadLocals} in mass indexing threads before
+	 * mass indexing starts, and to remove them after mass indexing stops.
+	 *
+	 * @see MassIndexingEnvironment
+	 */
+	@Incubating
+	PojoMassIndexer environment(MassIndexingEnvironment environment);
 }

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/massindexing/MassIndexer.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/massindexing/MassIndexer.java
@@ -9,6 +9,7 @@ package org.hibernate.search.mapper.pojo.standalone.massindexing;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import org.hibernate.search.mapper.pojo.massindexing.MassIndexingEnvironment;
 import org.hibernate.search.mapper.pojo.standalone.loading.MassLoadingOptions;
 import org.hibernate.search.mapper.pojo.massindexing.MassIndexingFailureHandler;
 import org.hibernate.search.mapper.pojo.massindexing.MassIndexingMonitor;
@@ -157,4 +158,15 @@ public interface MassIndexer {
 	 */
 	<T> MassIndexer context(Class<T> contextType, T context);
 
+	/**
+	 * Sets the {@link MassIndexingEnvironment}, which can set up an environment (thread locals, ...) in mass indexing threads.
+	 *
+	 * @param environment a component that gets a chance to
+	 * set up e.g. {@link ThreadLocal ThreadLocals} in mass indexing threads before
+	 * mass indexing starts, and to remove them after mass indexing stops.
+	 *
+	 * @see MassIndexingEnvironment
+	 */
+	@Incubating
+	MassIndexer environment(MassIndexingEnvironment environment);
 }

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/massindexing/impl/StandalonePojoMassIndexer.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/massindexing/impl/StandalonePojoMassIndexer.java
@@ -8,6 +8,7 @@ package org.hibernate.search.mapper.pojo.standalone.massindexing.impl;
 
 import java.util.concurrent.CompletionStage;
 
+import org.hibernate.search.mapper.pojo.massindexing.MassIndexingEnvironment;
 import org.hibernate.search.mapper.pojo.standalone.loading.impl.StandalonePojoLoadingContext;
 import org.hibernate.search.mapper.pojo.standalone.massindexing.MassIndexer;
 import org.hibernate.search.mapper.pojo.massindexing.MassIndexingFailureHandler;
@@ -94,4 +95,9 @@ public class StandalonePojoMassIndexer implements MassIndexer {
 		return this;
 	}
 
+	@Override
+	public MassIndexer environment(MassIndexingEnvironment environment) {
+		delegate.environment( environment );
+		return this;
+	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-1809

I was cleaning up some local branches and noticed this one lying around. IIRC this was asked by someone on discourse for `5->6 ` migration. I've rebased and cleaned it up a bit.

You'll notice `BatchingThreadContext` being passed all the way to `PojoMassIndexingFailureHandledRunnable`. While it is not necessarily needed for all the classes extending this runnable, it seemed simpler to have it stored there.

Also, I wasn't sure if we really need to have this context for a workspace (`PojoMassIndexingBatchIndexingWorkspace`). It seems to make more sense for identifier and entity loading. Which ... begs the question - would such generic context be ok, or should we be more granular and allow a user to tell us what to do when loading identifiers and what to do when loading entities? In such case, I'd probably convert the `BatchingThreadContext` to more of a builder thing asking a user to provide consumers for all the exposed hook points.