### PR TITLE
HSEARCH-4772 Add failsafe to prevent log flooding for mass indexing with lots of non-critical failures

### DIFF
--- a/documentation/src/main/asciidoc/reference/indexing-massindexer.asciidoc
+++ b/documentation/src/main/asciidoc/reference/indexing-massindexer.asciidoc
@@ -345,6 +345,17 @@ starts, and tearing down that environment after mass indexing.
 Implementations should handle their exceptions unless it is an unrecoverable situation in which further mass indexing
 does not make sense: any exception thrown by the `MassIndexingEnvironment` will abort mass indexing.
 
+|`failureFloodingThreshold(long)`
+| `100` with the default failure handler (see description)
+|*This feature is _incubating_: it is still under active development.*
+The maximum number of failures to be handled per indexed type.
+Any failures exceeding this number will be ignored and not sent for processing by `MassIndexingFailureHandler`.
+Can be set to `Long.MAX_VALUE` if none of the failures should be ignored.
+
+Defaults to a threshold defined by the failure handler in use; see `MassIndexingFailureHandler#failureFloodingThreshold`,
+`FailureHandler#failureFloodingThreshold`.
+For the default log-based failure handler, the default threshold is 100.
+
 |===
 
 [[indexing-massindexer-tuning]]

--- a/engine/src/main/java/org/hibernate/search/engine/reporting/FailureHandler.java
+++ b/engine/src/main/java/org/hibernate/search/engine/reporting/FailureHandler.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.engine.reporting;
 
+import org.hibernate.search.util.common.annotation.Incubating;
+
 /**
  * A handler for failures occurring during background operations,
  * which may not have been reported to the caller due to being executed asynchronously.
@@ -47,4 +49,16 @@ public interface FailureHandler {
 	 */
 	void handle(EntityIndexingFailureContext context);
 
+	/**
+	 * When this handler is used for handling mass indexing failures - returns the number of failures during
+	 * one mass indexing beyond which the failure handler will no longer be notified. This threshold is reached
+	 * separately for each indexed type. Otherwise, i.e. not in the context of mass indexing, this value is ignored.
+	 * <p>
+	 * May be overridden by mass indexer parameters
+	 * (see {@code failureFloodingThreshold(long)} in the {@code MassIndexer} interface).
+	 */
+	@Incubating
+	default long failureFloodingThreshold() {
+		return Long.MAX_VALUE;
+	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/reporting/impl/FailSafeFailureHandlerWrapper.java
+++ b/engine/src/main/java/org/hibernate/search/engine/reporting/impl/FailSafeFailureHandlerWrapper.java
@@ -44,4 +44,14 @@ public class FailSafeFailureHandlerWrapper implements FailureHandler {
 		}
 	}
 
+	@Override
+	public long failureFloodingThreshold() {
+		try {
+			return delegate.failureFloodingThreshold();
+		}
+		catch (Throwable t) {
+			log.failureInFailureHandler( t );
+			return FailureHandler.super.failureFloodingThreshold();
+		}
+	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/reporting/impl/LogFailureHandler.java
+++ b/engine/src/main/java/org/hibernate/search/engine/reporting/impl/LogFailureHandler.java
@@ -23,6 +23,7 @@ import org.hibernate.search.util.common.logging.impl.Log;
 public class LogFailureHandler implements FailureHandler {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+	private static final int FAILURE_FLOODING_THRESHOLD = 100;
 
 	public static final String NAME = "log";
 
@@ -34,6 +35,11 @@ public class LogFailureHandler implements FailureHandler {
 	@Override
 	public void handle(EntityIndexingFailureContext context) {
 		log.exceptionOccurred( formatMessage( context ).toString(), context.throwable() );
+	}
+
+	@Override
+	public long failureFloodingThreshold() {
+		return FAILURE_FLOODING_THRESHOLD;
 	}
 
 	private StringBuilder formatMessage(FailureContext context) {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingErrorCustomBackgroundFailureHandlerIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingErrorCustomBackgroundFailureHandlerIT.java
@@ -6,7 +6,8 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.massindexing;
 
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import org.hibernate.search.engine.reporting.FailureHandler;
 import org.hibernate.search.mapper.pojo.massindexing.MassIndexingFailureHandler;
@@ -43,6 +44,7 @@ public class MassIndexingErrorCustomBackgroundFailureHandlerIT extends AbstractM
 
 	@Override
 	protected void assertNoFailureHandling() {
-		verifyNoInteractions( failureHandler );
+		verify( failureHandler ).failureFloodingThreshold();
+		verifyNoMoreInteractions( failureHandler );
 	}
 }

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingErrorCustomMassIndexingFailureHandlerIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingErrorCustomMassIndexingFailureHandlerIT.java
@@ -6,7 +6,8 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.massindexing;
 
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import org.hibernate.search.engine.reporting.FailureHandler;
 import org.hibernate.search.mapper.pojo.massindexing.MassIndexingFailureHandler;
@@ -43,7 +44,8 @@ public class MassIndexingErrorCustomMassIndexingFailureHandlerIT extends Abstrac
 
 	@Override
 	protected void assertNoFailureHandling() {
-		verifyNoInteractions( failureHandler );
+		verify( failureHandler ).failureFloodingThreshold();
+		verifyNoMoreInteractions( failureHandler );
 	}
 
 }

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureCustomMassIndexingFailureHandlerIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureCustomMassIndexingFailureHandlerIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.massindexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -17,6 +18,7 @@ import org.hibernate.search.mapper.pojo.massindexing.MassIndexingFailureContext;
 import org.hibernate.search.mapper.pojo.massindexing.MassIndexingFailureHandler;
 import org.hibernate.search.util.common.SearchException;
 
+import org.junit.Before;
 import org.junit.Rule;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -28,6 +30,8 @@ import org.mockito.junit.MockitoRule;
 import org.mockito.quality.Strictness;
 
 public class MassIndexingFailureCustomMassIndexingFailureHandlerIT extends AbstractMassIndexingFailureIT {
+
+	private static final int DEFAULT_FAILURE_FLOODING_THRESHOLD = 62;
 
 	@Rule
 	public final MockitoRule mockito = MockitoJUnit.rule().strictness( Strictness.STRICT_STUBS );
@@ -60,6 +64,7 @@ public class MassIndexingFailureCustomMassIndexingFailureHandlerIT extends Abstr
 	protected void assertEntityIndexingFailureHandling(String entityName, String entityReferenceAsString,
 			String exceptionMessage, String failingOperationAsString) {
 		verify( failureHandler ).handle( entityFailureContextCapture.capture() );
+		verify( failureHandler ).failureFloodingThreshold();
 		verifyNoMoreInteractions( failureHandler );
 
 		MassIndexingEntityFailureContext context = entityFailureContextCapture.getValue();
@@ -85,6 +90,7 @@ public class MassIndexingFailureCustomMassIndexingFailureHandlerIT extends Abstr
 	protected void assertEntityIdGetterFailureHandling(String entityName, String entityReferenceAsString,
 			String exceptionMessage, String failingOperationAsString) {
 		verify( failureHandler ).handle( entityFailureContextCapture.capture() );
+		verify( failureHandler ).failureFloodingThreshold();
 		verifyNoMoreInteractions( failureHandler );
 
 		MassIndexingEntityFailureContext context = entityFailureContextCapture.getValue();
@@ -113,6 +119,7 @@ public class MassIndexingFailureCustomMassIndexingFailureHandlerIT extends Abstr
 	protected void assertEntityNonIdGetterFailureHandling(String entityName, String entityReferenceAsString,
 			String exceptionMessage, String failingOperationAsString) {
 		verify( failureHandler ).handle( entityFailureContextCapture.capture() );
+		verify( failureHandler ).failureFloodingThreshold();
 		verifyNoMoreInteractions( failureHandler );
 
 		MassIndexingEntityFailureContext context = entityFailureContextCapture.getValue();
@@ -144,6 +151,7 @@ public class MassIndexingFailureCustomMassIndexingFailureHandlerIT extends Abstr
 			Class<? extends Throwable> exceptionType, String exceptionMessage,
 			String failingOperationAsString) {
 		verify( failureHandler ).handle( genericFailureContextCapture.capture() );
+		verify( failureHandler ).failureFloodingThreshold();
 		verifyNoMoreInteractions( failureHandler );
 
 		MassIndexingFailureContext context = genericFailureContextCapture.getValue();
@@ -156,14 +164,16 @@ public class MassIndexingFailureCustomMassIndexingFailureHandlerIT extends Abstr
 
 	@Override
 	protected void expectMassIndexerLoadingOperationFailureHandling(Class<? extends Throwable> exceptionType,
-			String exceptionMessage, String failingOperationAsString, int count) {
+			String exceptionMessage, int count, String failingOperationAsString, String... extraMessages) {
 		// We'll check in the assert*() method, see below.
 	}
 
 	@Override
 	protected void assertMassIndexerLoadingOperationFailureHandling(Class<? extends Throwable> exceptionType,
-			String exceptionMessage, String failingOperationAsString, int count) {
-		verify( failureHandler, times( count ) ).handle( entityFailureContextCapture.capture() );
+			String exceptionMessage, String failingOperationAsString,
+			int failureFloodingThreshold, Class<? extends Throwable> closingExceptionType,
+			String closingExceptionMessage, String closingFailingOperationAsString) {
+		verify( failureHandler, times( failureFloodingThreshold ) ).handle( entityFailureContextCapture.capture() );
 
 		MassIndexingEntityFailureContext context = entityFailureContextCapture.getValue();
 		assertThat( context.throwable() )
@@ -173,6 +183,19 @@ public class MassIndexingFailureCustomMassIndexingFailureHandlerIT extends Abstr
 				.isEqualTo( failingOperationAsString );
 		assertThat( context.entityReferences() )
 				.hasSize( 1 );
+
+		verify( failureHandler, times( 1 ) ).handle( genericFailureContextCapture.capture() );
+
+		MassIndexingFailureContext genericContext = genericFailureContextCapture.getValue();
+		assertThat( genericContext.throwable() )
+				.isInstanceOf( closingExceptionType )
+				.hasMessageContainingAll( closingExceptionMessage );
+		assertThat( genericContext.failingOperation() ).asString()
+				.isEqualTo( closingFailingOperationAsString );
+
+		if ( failureFloodingThreshold == getDefaultFailureFloodingThreshold() ) {
+			verify( failureHandler ).failureFloodingThreshold();
+		}
 
 		verifyNoMoreInteractions( failureHandler );
 	}
@@ -192,6 +215,7 @@ public class MassIndexingFailureCustomMassIndexingFailureHandlerIT extends Abstr
 			String failingMassIndexerOperationExceptionMessage, String failingMassIndexerOperationAsString) {
 		verify( failureHandler ).handle( entityFailureContextCapture.capture() );
 		verify( failureHandler ).handle( genericFailureContextCapture.capture() );
+		verify( failureHandler ).failureFloodingThreshold();
 		verifyNoMoreInteractions( failureHandler );
 
 		MassIndexingEntityFailureContext entityFailureContext = entityFailureContextCapture.getValue();
@@ -212,5 +236,16 @@ public class MassIndexingFailureCustomMassIndexingFailureHandlerIT extends Abstr
 				.hasMessage( failingMassIndexerOperationExceptionMessage );
 		assertThat( massIndexerOperationFailureContext.failingOperation() ).asString()
 				.isEqualTo( failingMassIndexerOperationAsString );
+	}
+
+	@Before
+	public void setUp() {
+		lenient().when( failureHandler.failureFloodingThreshold() ).thenReturn(
+				(long) getDefaultFailureFloodingThreshold() );
+	}
+
+	@Override
+	public int getDefaultFailureFloodingThreshold() {
+		return DEFAULT_FAILURE_FLOODING_THRESHOLD;
 	}
 }

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureDefaultBackgroundFailureHandlerIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureDefaultBackgroundFailureHandlerIT.java
@@ -122,20 +122,23 @@ public class MassIndexingFailureDefaultBackgroundFailureHandlerIT extends Abstra
 
 	@Override
 	protected void expectMassIndexerLoadingOperationFailureHandling(Class<? extends Throwable> exceptionType,
-			String exceptionMessage, String failingOperationAsString, int count) {
+			String exceptionMessage, int count, String failingOperationAsString, String... extraMessages) {
 		logged.expectEvent(
 						Level.ERROR,
 						ExceptionMatcherBuilder.isException( exceptionType )
 								.withMessage( exceptionMessage )
 								.build(),
-						failingOperationAsString
+						failingOperationAsString,
+						extraMessages
 				)
 				.times( count );
 	}
 
 	@Override
 	protected void assertMassIndexerLoadingOperationFailureHandling(Class<? extends Throwable> exceptionType,
-			String exceptionMessage, String failingOperationAsString, int count) {
+			String exceptionMessage, String failingOperationAsString,
+			int failureFloodingThreshold, Class<? extends Throwable> closingExceptionType,
+			String closingExceptionMessage, String closingFailingOperationAsString) {
 		// If we get there, everything works fine.
 	}
 

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingErrorCustomBackgroundFailureHandlerIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingErrorCustomBackgroundFailureHandlerIT.java
@@ -6,7 +6,8 @@
  */
 package org.hibernate.search.integrationtest.mapper.pojo.massindexing;
 
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import org.hibernate.search.engine.reporting.FailureHandler;
 import org.hibernate.search.mapper.pojo.massindexing.MassIndexingFailureHandler;
@@ -43,6 +44,7 @@ public class MassIndexingErrorCustomBackgroundFailureHandlerIT extends AbstractM
 
 	@Override
 	protected void assertNoFailureHandling() {
-		verifyNoInteractions( failureHandler );
+		verify( failureHandler ).failureFloodingThreshold();
+		verifyNoMoreInteractions( failureHandler );
 	}
 }

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingErrorCustomMassIndexingFailureHandlerIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingErrorCustomMassIndexingFailureHandlerIT.java
@@ -6,7 +6,8 @@
  */
 package org.hibernate.search.integrationtest.mapper.pojo.massindexing;
 
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import org.hibernate.search.engine.reporting.FailureHandler;
 import org.hibernate.search.mapper.pojo.massindexing.MassIndexingFailureHandler;
@@ -43,7 +44,8 @@ public class MassIndexingErrorCustomMassIndexingFailureHandlerIT extends Abstrac
 
 	@Override
 	protected void assertNoFailureHandling() {
-		verifyNoInteractions( failureHandler );
+		verify( failureHandler ).failureFloodingThreshold();
+		verifyNoMoreInteractions( failureHandler );
 	}
 
 }

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingFailureCustomBackgroundFailureHandlerIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingFailureCustomBackgroundFailureHandlerIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.pojo.massindexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -17,6 +18,7 @@ import org.hibernate.search.engine.reporting.FailureHandler;
 import org.hibernate.search.mapper.pojo.massindexing.MassIndexingFailureHandler;
 import org.hibernate.search.util.common.SearchException;
 
+import org.junit.Before;
 import org.junit.Rule;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -28,6 +30,8 @@ import org.mockito.junit.MockitoRule;
 import org.mockito.quality.Strictness;
 
 public class MassIndexingFailureCustomBackgroundFailureHandlerIT extends AbstractMassIndexingFailureIT {
+
+	private static final int DEFAULT_FAILURE_FLOODING_THRESHOLD = 100;
 
 	@Rule
 	public final MockitoRule mockito = MockitoJUnit.rule().strictness( Strictness.STRICT_STUBS );
@@ -59,6 +63,7 @@ public class MassIndexingFailureCustomBackgroundFailureHandlerIT extends Abstrac
 	@Override
 	protected void assertEntityIndexingFailureHandling(String entityName, String entityReferenceAsString,
 			String exceptionMessage, String failingOperationAsString) {
+		verify( failureHandler ).failureFloodingThreshold();
 		verify( failureHandler ).handle( entityFailureContextCapture.capture() );
 		verifyNoMoreInteractions( failureHandler );
 
@@ -84,6 +89,7 @@ public class MassIndexingFailureCustomBackgroundFailureHandlerIT extends Abstrac
 	@Override
 	protected void assertEntityIdGetterFailureHandling(String entityName, String entityReferenceAsString,
 			String exceptionMessage, String failingOperationAsString) {
+		verify( failureHandler ).failureFloodingThreshold();
 		verify( failureHandler ).handle( entityFailureContextCapture.capture() );
 		verifyNoMoreInteractions( failureHandler );
 
@@ -112,6 +118,7 @@ public class MassIndexingFailureCustomBackgroundFailureHandlerIT extends Abstrac
 	@Override
 	protected void assertEntityNonIdGetterFailureHandling(String entityName, String entityReferenceAsString,
 			String exceptionMessage, String failingOperationAsString) {
+		verify( failureHandler ).failureFloodingThreshold();
 		verify( failureHandler ).handle( entityFailureContextCapture.capture() );
 		verifyNoMoreInteractions( failureHandler );
 
@@ -143,6 +150,7 @@ public class MassIndexingFailureCustomBackgroundFailureHandlerIT extends Abstrac
 	protected void assertMassIndexerOperationFailureHandling(
 			Class<? extends Throwable> exceptionType, String exceptionMessage,
 			String failingOperationAsString) {
+		verify( failureHandler ).failureFloodingThreshold();
 		verify( failureHandler ).handle( genericFailureContextCapture.capture() );
 		verifyNoMoreInteractions( failureHandler );
 
@@ -156,23 +164,38 @@ public class MassIndexingFailureCustomBackgroundFailureHandlerIT extends Abstrac
 
 	@Override
 	protected void expectMassIndexerLoadingOperationFailureHandling(Class<? extends Throwable> exceptionType,
-			String exceptionMessage, String failingOperationAsString, int count) {
+			String exceptionMessage, int count, String failingOperationAsString, String... extraMessages) {
 		// We'll check in the assert*() method, see below.
 	}
 
 	@Override
-	protected void assertMassIndexerLoadingOperationFailureHandling(Class<? extends Throwable> exceptionType,
-			String exceptionMessage, String failingOperationAsString, int count) {
-		verify( failureHandler, times( count ) ).handle( entityFailureContextCapture.capture() );
+	protected void assertMassIndexerLoadingOperationFailureHandling(
+			Class<? extends Throwable> exceptionType, String exceptionMessage,
+			String failingOperationAsString,
+			int failureFloodingThreshold, Class<? extends Throwable> closingExceptionType,
+			String closingExceptionMessage, String closingFailingOperationAsString) {
+		if ( failureFloodingThreshold == getDefaultFailureFloodingThreshold() ) {
+			verify( failureHandler ).failureFloodingThreshold();
+		}
+		verify( failureHandler, times( failureFloodingThreshold ) ).handle( entityFailureContextCapture.capture() );
 
 		EntityIndexingFailureContext context = entityFailureContextCapture.getValue();
 		assertThat( context.throwable() )
-				.isInstanceOf( SimulatedFailure.class )
+				.isInstanceOf( exceptionType )
 				.hasMessageContainingAll( exceptionMessage );
 		assertThat( context.failingOperation() ).asString()
 				.isEqualTo( failingOperationAsString );
 		assertThat( context.entityReferences() )
 				.hasSize( 1 );
+
+		verify( failureHandler, times( 1 ) ).handle( genericFailureContextCapture.capture() );
+
+		FailureContext genericContext = genericFailureContextCapture.getValue();
+		assertThat( genericContext.throwable() )
+				.isInstanceOf( closingExceptionType )
+				.hasMessageContainingAll( closingExceptionMessage );
+		assertThat( genericContext.failingOperation() ).asString()
+				.isEqualTo( closingFailingOperationAsString );
 
 		verifyNoMoreInteractions( failureHandler );
 	}
@@ -190,6 +213,7 @@ public class MassIndexingFailureCustomBackgroundFailureHandlerIT extends Abstrac
 			String entityReferenceAsString,
 			String failingEntityIndexingExceptionMessage, String failingEntityIndexingOperationAsString,
 			String failingMassIndexerOperationExceptionMessage, String failingMassIndexerOperationAsString) {
+		verify( failureHandler ).failureFloodingThreshold();
 		verify( failureHandler ).handle( entityFailureContextCapture.capture() );
 		verify( failureHandler ).handle( genericFailureContextCapture.capture() );
 		verifyNoMoreInteractions( failureHandler );
@@ -213,4 +237,16 @@ public class MassIndexingFailureCustomBackgroundFailureHandlerIT extends Abstrac
 		assertThat( massIndexerOperationFailureContext.failingOperation() ).asString()
 				.isEqualTo( failingMassIndexerOperationAsString );
 	}
+
+	@Before
+	public void setUp() {
+		lenient().when( failureHandler.failureFloodingThreshold() ).thenReturn(
+				(long) getDefaultFailureFloodingThreshold() );
+	}
+
+	@Override
+	public int getDefaultFailureFloodingThreshold() {
+		return DEFAULT_FAILURE_FLOODING_THRESHOLD;
+	}
+
 }

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingFailureDefaultBackgroundFailureHandlerIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingFailureDefaultBackgroundFailureHandlerIT.java
@@ -122,20 +122,23 @@ public class MassIndexingFailureDefaultBackgroundFailureHandlerIT extends Abstra
 
 	@Override
 	protected void expectMassIndexerLoadingOperationFailureHandling(Class<? extends Throwable> exceptionType,
-			String exceptionMessage, String failingOperationAsString, int count) {
+			String exceptionMessage, int count, String failingOperationAsString, String... extraMessages) {
 		logged.expectEvent(
 						Level.ERROR,
 						ExceptionMatcherBuilder.isException( exceptionType )
 								.withMessage( exceptionMessage )
 								.build(),
-						failingOperationAsString
+						failingOperationAsString,
+						extraMessages
 				)
 				.times( count );
 	}
 
 	@Override
-	protected void assertMassIndexerLoadingOperationFailureHandling(Class<? extends Throwable> exceptionType,
-			String exceptionMessage, String failingOperationAsString, int count) {
+	protected void assertMassIndexerLoadingOperationFailureHandling(Class<? extends Throwable> exceptionType, String exceptionMessage,
+			String failingOperationAsString,
+			int failureFloodingThreshold, Class<? extends Throwable> closingExceptionType,
+			String closingExceptionMessage, String closingFailingOperationAsString) {
 		// If we get there, everything works fine.
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/MassIndexer.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/MassIndexer.java
@@ -208,4 +208,21 @@ public interface MassIndexer {
 	 */
 	@Incubating
 	MassIndexer environment(MassIndexingEnvironment environment);
+
+	/**
+	 * Sets the threshold for failures that will be reported and sent to {@link MassIndexingFailureHandler} per indexed type.
+	 * Any failures exceeding this number will be ignored. A count of such ignored failures together with the operation
+	 * they belong to will be reported to the failure handler upon the completion of indexing process.
+	 *
+	 * @param threshold The number of failures during one mass indexing beyond which the
+	 * failure handler will no longer be notified. This threshold is reached separately for each indexed type.
+	 * Overrides the {@link MassIndexingFailureHandler#failureFloodingThreshold() threshold defined by the failure handler itself}.
+	 * <p>
+	 * Defaults to {@code 100} with the default failure handler.
+	 *
+	 * @return {@code this} for method chaining
+	 */
+	@Incubating
+	MassIndexer failureFloodingThreshold(long threshold);
+
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/HibernateOrmMassIndexer.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/HibernateOrmMassIndexer.java
@@ -120,6 +120,12 @@ public class HibernateOrmMassIndexer implements MassIndexer {
 		return this;
 	}
 
+	@Override
+	public MassIndexer failureFloodingThreshold(long threshold) {
+		delegate.failureFloodingThreshold( threshold );
+		return this;
+	}
+
 	ConditionalExpression reindexOnly(Class<?> type, String conditionalExpression) {
 		return context.reindexOnly( type, conditionalExpression );
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
@@ -774,4 +774,9 @@ public interface Log extends BasicLogger {
 
 	@Message(id = ID_OFFSET + 124, value = "Indexing failure: %1$s.\nThe following entities may not have been updated correctly in the index: %2$s.")
 	SearchException indexingFailure(String causeMessage, List<?> failingEntities, @Cause Throwable cause);
+
+	@Message(id = ID_OFFSET + 125,
+			value = "%1$s failures went unreported for this operation to avoid flooding."
+					+ " To disable flooding protection, use 'massIndexer.failureFloodingThreshold(Long.MAX_VALUE)'.")
+	SearchException notReportedFailures(long count);
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/MassIndexingFailureHandler.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/MassIndexingFailureHandler.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.mapper.pojo.massindexing;
 
+import org.hibernate.search.util.common.annotation.Incubating;
+
 /**
  * A handler for failures occurring during mass indexing.
  * <p>
@@ -47,4 +49,16 @@ public interface MassIndexingFailureHandler {
 		handle( (MassIndexingFailureContext) context );
 	}
 
+	/**
+	 * Returns the number of failures during one mass indexing beyond which
+	 * the failure handler will no longer be notified.
+	 * This threshold is reached separately for each indexed type.
+	 * <p>
+	 * May be overridden by mass indexer parameters
+	 * (see {@code failureFloodingThreshold(long)} in the {@code MassIndexer} interface).
+	 */
+	@Incubating
+	default long failureFloodingThreshold() {
+		return Long.MAX_VALUE;
+	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoDefaultMassIndexer.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoDefaultMassIndexer.java
@@ -62,6 +62,7 @@ public class PojoDefaultMassIndexer implements PojoMassIndexer {
 	private Boolean dropAndCreateSchemaOnStart;
 	private Boolean purgeAtStart;
 	private boolean mergeSegmentsAfterPurge = true;
+	private Long failureFloodingThreshold = null;
 
 	private MassIndexingFailureHandler failureHandler;
 	private MassIndexingMonitor monitor;
@@ -171,7 +172,8 @@ public class PojoDefaultMassIndexer implements PojoMassIndexer {
 		typesToIndexInParallel = Math.min( typesToIndexInParallel, typeGroupsToIndex.size() );
 		PojoMassIndexingNotifier notifier = new PojoMassIndexingNotifier(
 				getOrCreateFailureHandler(),
-				getOrCreateMonitor()
+				getOrCreateMonitor(),
+				failureFloodingThreshold
 		);
 
 		if ( Boolean.TRUE.equals( dropAndCreateSchemaOnStart ) && Boolean.TRUE.equals( purgeAtStart ) ) {
@@ -203,6 +205,12 @@ public class PojoDefaultMassIndexer implements PojoMassIndexer {
 	@Override
 	public PojoMassIndexer environment(MassIndexingEnvironment environment) {
 		this.environment = environment;
+		return this;
+	}
+
+	@Override
+	public PojoMassIndexer failureFloodingThreshold(long threshold) {
+		this.failureFloodingThreshold = threshold;
 		return this;
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingDelegatingFailureHandler.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingDelegatingFailureHandler.java
@@ -39,4 +39,9 @@ public class PojoMassIndexingDelegatingFailureHandler implements MassIndexingFai
 		}
 		delegate.handle( builder.build() );
 	}
+
+	@Override
+	public long failureFloodingThreshold() {
+		return delegate.failureFloodingThreshold();
+	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingFailSafeFailureHandlerWrapper.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingFailSafeFailureHandlerWrapper.java
@@ -44,4 +44,14 @@ public class PojoMassIndexingFailSafeFailureHandlerWrapper implements MassIndexi
 		}
 	}
 
+	@Override
+	public long failureFloodingThreshold() {
+		try {
+			return delegate.failureFloodingThreshold();
+		}
+		catch (Throwable t) {
+			log.failureInMassIndexingFailureHandler( t );
+			return MassIndexingFailureHandler.super.failureFloodingThreshold();
+		}
+	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/spi/PojoMassIndexer.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/spi/PojoMassIndexer.java
@@ -145,4 +145,20 @@ public interface PojoMassIndexer {
 	 */
 	@Incubating
 	PojoMassIndexer environment(MassIndexingEnvironment environment);
+
+	/**
+	 * Sets the threshold for failures that will be reported and sent to {@link MassIndexingFailureHandler} per indexed type.
+	 * Any failures exceeding this number will be ignored. A count of such ignored failures together with the operation
+	 * they belong to will be reported to the failure handler upon the completion of indexing process.
+	 *
+	 * @param threshold The number of failures during one mass indexing beyond which the
+	 * failure handler will no longer be notified. This threshold is reached separately for each indexed type.
+	 * Overrides the {@link MassIndexingFailureHandler#failureFloodingThreshold() threshold defined by the failure handler itself}.
+	 * <p>
+	 * Defaults to {@code 100} with the default failure handler.
+	 *
+	 * @return {@code this} for method chaining
+	 */
+	@Incubating
+	PojoMassIndexer failureFloodingThreshold(long threshold);
 }

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/massindexing/MassIndexer.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/massindexing/MassIndexer.java
@@ -145,6 +145,22 @@ public interface MassIndexer {
 	MassIndexer failureHandler(MassIndexingFailureHandler failureHandler);
 
 	/**
+	 * Sets the threshold for failures that will be reported and sent to {@link MassIndexingFailureHandler} per indexed type.
+	 * Any failures exceeding this number will be ignored. A count of such ignored failures together with the operation
+	 * they belong to will be reported to the failure handler upon the completion of indexing process.
+	 *
+	 * @param threshold The number of failures during one mass indexing beyond which the
+	 * failure handler will no longer be notified. This threshold is reached separately for each indexed type.
+	 * Overrides the {@link MassIndexingFailureHandler#failureFloodingThreshold() threshold defined by the failure handler itself}.
+	 * <p>
+	 * Defaults to {@code 100} with the default failure handler.
+	 *
+	 * @return {@code this} for method chaining
+	 */
+	@Incubating
+	MassIndexer failureFloodingThreshold(long threshold);
+
+	/**
 	 * Sets context for use by the loading strategies.
 	 * <p>
 	 * The context can be retrieved through

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/massindexing/impl/StandalonePojoMassIndexer.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/massindexing/impl/StandalonePojoMassIndexer.java
@@ -90,6 +90,12 @@ public class StandalonePojoMassIndexer implements MassIndexer {
 	}
 
 	@Override
+	public MassIndexer failureFloodingThreshold(long threshold) {
+		delegate.failureFloodingThreshold( threshold );
+		return this;
+	}
+
+	@Override
 	public <T> MassIndexer context(Class<T> contextType, T context) {
 		this.context.context( contextType, context );
 		return this;


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4772

The initial idea was to allow users to set the limit on the `MassIndexer` interface level as that could be something that can change from mass indexer to mass indexer. And then, the work would happen in the notifier. (you'll find this in the first commit). But I didn't like that, as the notifier doesn't look like a good place to decide if something should or shouldn't be logged or handled otherwise. So that's when I've pushed this logic into our own `MassIndexingFailureHandler` (second commit). I liked this approach a tad better, but then if users don't like our default max number - then they would need to come up with their own handler 😃 