### PR TITLE
HSEARCH-4736 Add offloading operation submitter

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchBatchingWorkOrchestrator.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchBatchingWorkOrchestrator.java
@@ -57,7 +57,7 @@ public class ElasticsearchBatchingWorkOrchestrator
 	private final BackendThreads threads;
 	private final FailureHandler failureHandler;
 
-	private HashTable<BatchingExecutor<ElasticsearchBatchedWorkProcessor>> executors;
+	private HashTable<BatchingExecutor<ElasticsearchBatchedWorkProcessor, ElasticsearchBatchedWork<?>>> executors;
 
 	/**
 	 * @param name The name of the orchestrator thread (and of this orchestrator when reporting errors)
@@ -102,7 +102,7 @@ public class ElasticsearchBatchingWorkOrchestrator
 			) );
 		}
 
-		for ( BatchingExecutor<?> executor : executors ) {
+		for ( BatchingExecutor<?, ?> executor : executors ) {
 			executor.start( threads.getWorkExecutor() );
 		}
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchBatchingWorkOrchestrator.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchBatchingWorkOrchestrator.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.backend.elasticsearch.orchestration.impl;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
 
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.backend.elasticsearch.link.impl.ElasticsearchLink;
@@ -98,7 +97,8 @@ public class ElasticsearchBatchingWorkOrchestrator
 					processor,
 					queueSize,
 					true,
-					failureHandler
+					failureHandler,
+					blockingRetryProducer
 			) );
 		}
 
@@ -108,9 +108,8 @@ public class ElasticsearchBatchingWorkOrchestrator
 	}
 
 	@Override
-	protected void doSubmit(ElasticsearchBatchedWork<?> work, OperationSubmitter operationSubmitter,
-			Function<ElasticsearchBatchedWork<?>, Runnable> blockingRetryProducer) throws InterruptedException {
-		executors.get( work.getQueuingKey() ).submit( work, operationSubmitter, blockingRetryProducer );
+	protected void doSubmit(ElasticsearchBatchedWork<?> work, OperationSubmitter operationSubmitter) throws InterruptedException {
+		executors.get( work.getQueuingKey() ).submit( work, operationSubmitter );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchBatchingWorkOrchestrator.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchBatchingWorkOrchestrator.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.backend.elasticsearch.orchestration.impl;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.backend.elasticsearch.link.impl.ElasticsearchLink;
@@ -107,8 +108,13 @@ public class ElasticsearchBatchingWorkOrchestrator
 	}
 
 	@Override
-	protected void doSubmit(ElasticsearchBatchedWork<?> work, OperationSubmitter operationSubmitter) throws InterruptedException {
-		executors.get( work.getQueuingKey() ).submit( work, operationSubmitter );
+	protected void doSubmit(ElasticsearchBatchedWork<?> work, OperationSubmitter operationSubmitter,
+			Function<ElasticsearchBatchedWork<?>, Runnable> blockingRetryProducer) throws InterruptedException {
+		executors.get( work.getQueuingKey() ).submit(
+				work,
+				operationSubmitter,
+				w -> blockingRetryProducer.apply( (ElasticsearchBatchedWork<?>) w )
+		);
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchBatchingWorkOrchestrator.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchBatchingWorkOrchestrator.java
@@ -110,11 +110,7 @@ public class ElasticsearchBatchingWorkOrchestrator
 	@Override
 	protected void doSubmit(ElasticsearchBatchedWork<?> work, OperationSubmitter operationSubmitter,
 			Function<ElasticsearchBatchedWork<?>, Runnable> blockingRetryProducer) throws InterruptedException {
-		executors.get( work.getQueuingKey() ).submit(
-				work,
-				operationSubmitter,
-				w -> blockingRetryProducer.apply( (ElasticsearchBatchedWork<?>) w )
-		);
+		executors.get( work.getQueuingKey() ).submit( work, operationSubmitter, blockingRetryProducer );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchSimpleWorkOrchestrator.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchSimpleWorkOrchestrator.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.backend.elasticsearch.orchestration.impl;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
 
 import org.hibernate.search.backend.elasticsearch.link.impl.ElasticsearchLink;
 import org.hibernate.search.backend.elasticsearch.work.impl.ElasticsearchWorkExecutionContext;
@@ -38,8 +37,7 @@ public class ElasticsearchSimpleWorkOrchestrator
 	}
 
 	@Override
-	protected void doSubmit(WorkExecution<?> work, OperationSubmitter ignore,
-			Function<WorkExecution<?>, Runnable> blockingRetryProducer) {
+	protected void doSubmit(WorkExecution<?> work, OperationSubmitter ignore) {
 		// ignoring the submitter as WorkExecution#execute will eventually call nonblocking REST client.
 		work.execute( executionContext );
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchSimpleWorkOrchestrator.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchSimpleWorkOrchestrator.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.backend.elasticsearch.orchestration.impl;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 import org.hibernate.search.backend.elasticsearch.link.impl.ElasticsearchLink;
 import org.hibernate.search.backend.elasticsearch.work.impl.ElasticsearchWorkExecutionContext;
@@ -37,7 +38,8 @@ public class ElasticsearchSimpleWorkOrchestrator
 	}
 
 	@Override
-	protected void doSubmit(WorkExecution<?> work, OperationSubmitter ignore) {
+	protected void doSubmit(WorkExecution<?> work, OperationSubmitter ignore,
+			Function<WorkExecution<?>, Runnable> blockingRetryProducer) {
 		// ignoring the submitter as WorkExecution#execute will eventually call nonblocking REST client.
 		work.execute( executionContext );
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/resources/impl/DefaultElasticsearchWorkExecutorProvider.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/resources/impl/DefaultElasticsearchWorkExecutorProvider.java
@@ -31,7 +31,8 @@ public class DefaultElasticsearchWorkExecutorProvider implements ElasticsearchWo
 				context.threadPoolProvider().newScheduledExecutor(
 						threadPoolSize,
 						context.recommendedThreadNamePrefix()
-				)
+				),
+				context.threadPoolProvider().isScheduledExecutorBlocking()
 		);
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryImpl.java
@@ -122,7 +122,7 @@ public class ElasticsearchSearchQueryImpl<H> extends AbstractSearchQuery<H, Elas
 				.build();
 
 		ElasticsearchSearchResultImpl<H> result = Futures.unwrappedExceptionJoin(
-				queryOrchestrator.submit( work, OperationSubmitter.BLOCKING ) )
+				queryOrchestrator.submit( work, OperationSubmitter.blocking() ) )
 				/*
 				 * WARNING: the following call must run in the user thread.
 				 * If we introduce async query execution, we will have to add a loadAsync method here,
@@ -150,7 +150,7 @@ public class ElasticsearchSearchQueryImpl<H> extends AbstractSearchQuery<H, Elas
 				.build();
 
 		ElasticsearchSearchResultImpl<H> result = Futures.unwrappedExceptionJoin(
-				queryOrchestrator.submit( work, OperationSubmitter.BLOCKING ) )
+				queryOrchestrator.submit( work, OperationSubmitter.blocking() ) )
 				/*
 				 * WARNING: the following call must run in the user thread.
 				 * If we introduce async query execution, we will have to add a loadAsync method here,
@@ -190,7 +190,7 @@ public class ElasticsearchSearchQueryImpl<H> extends AbstractSearchQuery<H, Elas
 						ElasticsearchSearchRequestTransformerContextImpl.createTransformerFunction( requestTransformer )
 				);
 		NonBulkableWork<Long> work = builder.build();
-		Long result = Futures.unwrappedExceptionJoin( queryOrchestrator.submit( work, OperationSubmitter.BLOCKING ) );
+		Long result = Futures.unwrappedExceptionJoin( queryOrchestrator.submit( work, OperationSubmitter.blocking() ) );
 		timeoutManager.stop();
 		return result;
 	}
@@ -284,7 +284,7 @@ public class ElasticsearchSearchQueryImpl<H> extends AbstractSearchQuery<H, Elas
 				)
 				.build();
 
-		ExplainResult explainResult = Futures.unwrappedExceptionJoin( queryOrchestrator.submit( work, OperationSubmitter.BLOCKING ) );
+		ExplainResult explainResult = Futures.unwrappedExceptionJoin( queryOrchestrator.submit( work, OperationSubmitter.blocking() ) );
 		return explainResult.getJsonObject();
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchScrollImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchScrollImpl.java
@@ -49,7 +49,7 @@ public class ElasticsearchSearchScrollImpl<H> implements ElasticsearchSearchScro
 			Futures.unwrappedExceptionJoin(
 					queryOrchestrator.submit(
 							workFactory.clearScroll( scrollId ).build(),
-							OperationSubmitter.BLOCKING
+							OperationSubmitter.blocking()
 					)
 			);
 		}
@@ -67,7 +67,7 @@ public class ElasticsearchSearchScrollImpl<H> implements ElasticsearchSearchScro
 		ElasticsearchLoadableSearchResult<H> loadableSearchResult = Futures.unwrappedExceptionJoin(
 				queryOrchestrator.submit(
 						scroll,
-						OperationSubmitter.BLOCKING
+						OperationSubmitter.blocking()
 				)
 		);
 		ElasticsearchSearchResultImpl<H> searchResult = loadableSearchResult.loadBlocking();

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/ElasticsearchIndexIndexingPlanExecutionTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/ElasticsearchIndexIndexingPlanExecutionTest.java
@@ -79,10 +79,10 @@ public class ElasticsearchIndexIndexingPlanExecutionTest {
 		);
 		verifyNoOtherOrchestratorInteractionsAndReset();
 
-		planExecutionFuture = execution.execute( OperationSubmitter.BLOCKING );
-		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.BLOCKING ) );
+		planExecutionFuture = execution.execute( OperationSubmitter.blocking() );
+		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.blocking() ) );
 		verifyNoOtherOrchestratorInteractionsAndReset();
 		assertThatFuture( planExecutionFuture ).isPending();
 
@@ -125,10 +125,10 @@ public class ElasticsearchIndexIndexingPlanExecutionTest {
 		);
 		verifyNoOtherOrchestratorInteractionsAndReset();
 
-		planExecutionFuture = execution.execute( OperationSubmitter.BLOCKING );
-		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.BLOCKING ) );
+		planExecutionFuture = execution.execute( OperationSubmitter.blocking() );
+		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.blocking() ) );
 		verifyNoOtherOrchestratorInteractionsAndReset();
 		assertThatFuture( planExecutionFuture ).isPending();
 
@@ -174,11 +174,11 @@ public class ElasticsearchIndexIndexingPlanExecutionTest {
 		);
 		verifyNoOtherOrchestratorInteractionsAndReset();
 
-		planExecutionFuture = execution.execute( OperationSubmitter.BLOCKING );
-		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work4FutureCaptor.capture(), eq( workMocks.get( 3 ) ), eq( OperationSubmitter.BLOCKING ) );
+		planExecutionFuture = execution.execute( OperationSubmitter.blocking() );
+		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work4FutureCaptor.capture(), eq( workMocks.get( 3 ) ), eq( OperationSubmitter.blocking() ) );
 		verifyNoOtherOrchestratorInteractionsAndReset();
 		assertThatFuture( planExecutionFuture ).isPending();
 
@@ -230,11 +230,11 @@ public class ElasticsearchIndexIndexingPlanExecutionTest {
 		);
 		verifyNoOtherOrchestratorInteractionsAndReset();
 
-		planExecutionFuture = execution.execute( OperationSubmitter.BLOCKING );
-		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work4FutureCaptor.capture(), eq( workMocks.get( 3 ) ), eq( OperationSubmitter.BLOCKING ) );
+		planExecutionFuture = execution.execute( OperationSubmitter.blocking() );
+		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work4FutureCaptor.capture(), eq( workMocks.get( 3 ) ), eq( OperationSubmitter.blocking() ) );
 		verifyNoOtherOrchestratorInteractionsAndReset();
 		assertThatFuture( planExecutionFuture ).isPending();
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/LuceneIndexManagerImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/LuceneIndexManagerImpl.java
@@ -207,7 +207,7 @@ public class LuceneIndexManagerImpl
 
 	@Override
 	public CompletableFuture<Long> computeSizeInBytesAsync() {
-		return computeSizeInBytesAsync( OperationSubmitter.REJECTED_EXECUTION_EXCEPTION );
+		return computeSizeInBytesAsync( OperationSubmitter.rejecting() );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneParallelWorkOrchestratorImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneParallelWorkOrchestratorImpl.java
@@ -8,7 +8,6 @@ package org.hibernate.search.backend.lucene.orchestration.impl;
 
 import java.lang.invoke.MethodHandles;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
 
 import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.lowlevel.index.impl.IndexAccessor;
@@ -65,8 +64,7 @@ public class LuceneParallelWorkOrchestratorImpl
 	}
 
 	@Override
-	protected void doSubmit(WorkExecution<?> workExecution, OperationSubmitter operationSubmitter,
-			Function<WorkExecution<?>, Runnable> blockingRetryProducer) {
+	protected void doSubmit(WorkExecution<?> workExecution, OperationSubmitter operationSubmitter) {
 		if ( !OperationSubmitter.blocking().equals( operationSubmitter ) && threads.isWriteExecutorBlocking() ) {
 			throw log.nonblockingOperationSubmitterNotSupported();
 		}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneParallelWorkOrchestratorImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneParallelWorkOrchestratorImpl.java
@@ -67,7 +67,7 @@ public class LuceneParallelWorkOrchestratorImpl
 	@Override
 	protected void doSubmit(WorkExecution<?> workExecution, OperationSubmitter operationSubmitter,
 			Function<WorkExecution<?>, Runnable> blockingRetryProducer) {
-		if ( !OperationSubmitter.BLOCKING.equals( operationSubmitter ) && threads.isWriteExecutorBlocking() ) {
+		if ( !OperationSubmitter.blocking().equals( operationSubmitter ) && threads.isWriteExecutorBlocking() ) {
 			throw log.nonblockingOperationSubmitterNotSupported();
 		}
 		executor.submit( workExecution );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneParallelWorkOrchestratorImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneParallelWorkOrchestratorImpl.java
@@ -65,7 +65,7 @@ public class LuceneParallelWorkOrchestratorImpl
 
 	@Override
 	protected void doSubmit(WorkExecution<?> workExecution, OperationSubmitter operationSubmitter) {
-		if ( !OperationSubmitter.blocking().equals( operationSubmitter ) && threads.isWriteExecutorBlocking() ) {
+		if ( !OperationSubmitter.blocking().equals( operationSubmitter ) && executor.isBlocking() ) {
 			throw log.nonblockingOperationSubmitterNotSupported();
 		}
 		executor.submit( workExecution );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneParallelWorkOrchestratorImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneParallelWorkOrchestratorImpl.java
@@ -6,26 +6,21 @@
  */
 package org.hibernate.search.backend.lucene.orchestration.impl;
 
-import java.lang.invoke.MethodHandles;
 import java.util.concurrent.CompletableFuture;
 
-import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.lowlevel.index.impl.IndexAccessor;
 import org.hibernate.search.backend.lucene.resources.impl.BackendThreads;
 import org.hibernate.search.backend.lucene.work.impl.IndexManagementWork;
 import org.hibernate.search.backend.lucene.work.impl.IndexManagementWorkExecutionContext;
 import org.hibernate.search.engine.backend.orchestration.spi.AbstractWorkOrchestrator;
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
-import org.hibernate.search.engine.common.execution.spi.SimpleScheduledExecutor;
 import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
-import org.hibernate.search.util.common.logging.impl.LoggerFactory;
+import org.hibernate.search.engine.common.execution.spi.SimpleScheduledExecutor;
 import org.hibernate.search.util.common.reporting.EventContext;
 
 public class LuceneParallelWorkOrchestratorImpl
 		extends AbstractWorkOrchestrator<LuceneParallelWorkOrchestratorImpl.WorkExecution<?>>
 		implements LuceneParallelWorkOrchestrator {
-
-	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final IndexAccessor indexAccessor;
 	private final IndexAccessorWorkExecutionContext context;
@@ -64,11 +59,8 @@ public class LuceneParallelWorkOrchestratorImpl
 	}
 
 	@Override
-	protected void doSubmit(WorkExecution<?> workExecution, OperationSubmitter operationSubmitter) {
-		if ( !OperationSubmitter.blocking().equals( operationSubmitter ) && executor.isBlocking() ) {
-			throw log.nonblockingOperationSubmitterNotSupported();
-		}
-		executor.submit( workExecution );
+	protected void doSubmit(WorkExecution<?> workExecution, OperationSubmitter operationSubmitter) throws InterruptedException {
+		operationSubmitter.submitToExecutor( executor, workExecution, blockingRetryExecutorProducer );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneParallelWorkOrchestratorImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneParallelWorkOrchestratorImpl.java
@@ -60,7 +60,7 @@ public class LuceneParallelWorkOrchestratorImpl
 
 	@Override
 	protected void doSubmit(WorkExecution<?> workExecution, OperationSubmitter operationSubmitter) throws InterruptedException {
-		operationSubmitter.submitToExecutor( executor, workExecution, blockingRetryExecutorProducer );
+		operationSubmitter.submitToExecutor( executor, workExecution, blockingRetryProducer );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneParallelWorkOrchestratorImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneParallelWorkOrchestratorImpl.java
@@ -8,6 +8,7 @@ package org.hibernate.search.backend.lucene.orchestration.impl;
 
 import java.lang.invoke.MethodHandles;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.lowlevel.index.impl.IndexAccessor;
@@ -64,7 +65,8 @@ public class LuceneParallelWorkOrchestratorImpl
 	}
 
 	@Override
-	protected void doSubmit(WorkExecution<?> workExecution, OperationSubmitter operationSubmitter) {
+	protected void doSubmit(WorkExecution<?> workExecution, OperationSubmitter operationSubmitter,
+			Function<WorkExecution<?>, Runnable> blockingRetryProducer) {
 		if ( !OperationSubmitter.BLOCKING.equals( operationSubmitter ) && threads.isWriteExecutorBlocking() ) {
 			throw log.nonblockingOperationSubmitterNotSupported();
 		}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneSerialWorkOrchestratorImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneSerialWorkOrchestratorImpl.java
@@ -94,11 +94,7 @@ public class LuceneSerialWorkOrchestratorImpl
 	@Override
 	protected void doSubmit(LuceneBatchedWork<?> work, OperationSubmitter operationSubmitter,
 			Function<LuceneBatchedWork<?>, Runnable> blockingRetryProducer) throws InterruptedException {
-		executors.get( work.getQueuingKey() ).submit(
-				work,
-				operationSubmitter,
-				w -> blockingRetryProducer.apply( (LuceneBatchedWork<?>) w )
-		);
+		executors.get( work.getQueuingKey() ).submit( work, operationSubmitter, blockingRetryProducer );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneSerialWorkOrchestratorImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneSerialWorkOrchestratorImpl.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.backend.lucene.orchestration.impl;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 import org.hibernate.search.backend.lucene.cfg.LuceneIndexSettings;
 import org.hibernate.search.backend.lucene.resources.impl.BackendThreads;
@@ -91,8 +92,13 @@ public class LuceneSerialWorkOrchestratorImpl
 	}
 
 	@Override
-	protected void doSubmit(LuceneBatchedWork<?> work, OperationSubmitter operationSubmitter) throws InterruptedException {
-		executors.get( work.getQueuingKey() ).submit( work, operationSubmitter );
+	protected void doSubmit(LuceneBatchedWork<?> work, OperationSubmitter operationSubmitter,
+			Function<LuceneBatchedWork<?>, Runnable> blockingRetryProducer) throws InterruptedException {
+		executors.get( work.getQueuingKey() ).submit(
+				work,
+				operationSubmitter,
+				w -> blockingRetryProducer.apply( (LuceneBatchedWork<?>) w )
+		);
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneSerialWorkOrchestratorImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneSerialWorkOrchestratorImpl.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.backend.lucene.orchestration.impl;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
 
 import org.hibernate.search.backend.lucene.cfg.LuceneIndexSettings;
 import org.hibernate.search.backend.lucene.resources.impl.BackendThreads;
@@ -82,7 +81,8 @@ public class LuceneSerialWorkOrchestratorImpl
 					processor,
 					queueSize,
 					true,
-					failureHandler
+					failureHandler,
+					blockingRetryProducer
 			) );
 		}
 
@@ -92,9 +92,8 @@ public class LuceneSerialWorkOrchestratorImpl
 	}
 
 	@Override
-	protected void doSubmit(LuceneBatchedWork<?> work, OperationSubmitter operationSubmitter,
-			Function<LuceneBatchedWork<?>, Runnable> blockingRetryProducer) throws InterruptedException {
-		executors.get( work.getQueuingKey() ).submit( work, operationSubmitter, blockingRetryProducer );
+	protected void doSubmit(LuceneBatchedWork<?> work, OperationSubmitter operationSubmitter) throws InterruptedException {
+		executors.get( work.getQueuingKey() ).submit( work, operationSubmitter );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneSerialWorkOrchestratorImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneSerialWorkOrchestratorImpl.java
@@ -41,7 +41,7 @@ public class LuceneSerialWorkOrchestratorImpl
 	private final BackendThreads threads;
 	private final FailureHandler failureHandler;
 
-	private HashTable<BatchingExecutor<LuceneBatchedWorkProcessor>> executors;
+	private HashTable<BatchingExecutor<LuceneBatchedWorkProcessor, LuceneBatchedWork<?>>> executors;
 
 	/**
 	 * @param name The name of the orchestrator thread (and of this orchestrator when reporting errors)
@@ -86,7 +86,7 @@ public class LuceneSerialWorkOrchestratorImpl
 			) );
 		}
 
-		for ( BatchingExecutor<?> executor : executors ) {
+		for ( BatchingExecutor<?, ?> executor : executors ) {
 			executor.start( threads.getWriteExecutor() );
 		}
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneSyncWorkOrchestratorImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneSyncWorkOrchestratorImpl.java
@@ -58,7 +58,7 @@ public class LuceneSyncWorkOrchestratorImpl
 		);
 		Throwable throwable = null;
 		try {
-			submit( workExecution, OperationSubmitter.BLOCKING );
+			submit( workExecution, OperationSubmitter.blocking() );
 			// If we get there, the task succeeded and we are sure there is a result.
 			return workExecution.getResult();
 		}
@@ -87,10 +87,10 @@ public class LuceneSyncWorkOrchestratorImpl
 	@Override
 	protected void doSubmit(WorkExecution<?> work, OperationSubmitter operationSubmitter,
 			Function<WorkExecution<?>, Runnable> blockingRetryProducer) throws InterruptedException {
-		if ( OperationSubmitter.REJECTED_EXECUTION_EXCEPTION.equals( operationSubmitter ) ) {
+		if ( OperationSubmitter.rejecting().equals( operationSubmitter ) ) {
 			throw log.nonblockingOperationSubmitterNotSupported();
 		}
-		else if ( OperationSubmitter.BLOCKING.equals( operationSubmitter ) ) {
+		else if ( OperationSubmitter.blocking().equals( operationSubmitter ) ) {
 			work.execute();
 		}
 		else {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/resources/impl/BackendThreads.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/resources/impl/BackendThreads.java
@@ -80,10 +80,6 @@ public class BackendThreads {
 		return writeExecutor;
 	}
 
-	public boolean isWriteExecutorBlocking() {
-		return threadPoolProvider.isScheduledExecutorBlocking();
-	}
-
 	private void checkStarted() {
 		if ( writeExecutor == null ) {
 			throw new AssertionFailure(

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/resources/impl/DefaultLuceneWorkExecutorProvider.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/resources/impl/DefaultLuceneWorkExecutorProvider.java
@@ -33,7 +33,8 @@ public class DefaultLuceneWorkExecutorProvider implements LuceneWorkExecutorProv
 				context.threadPoolProvider().newScheduledExecutor(
 						threadPoolSize,
 						context.recommendedThreadNamePrefix()
-				)
+				),
+				context.threadPoolProvider().isScheduledExecutorBlocking()
 		);
 	}
 }

--- a/backend/lucene/src/test/java/org/hibernate/search/backend/lucene/work/execution/impl/LuceneIndexIndexingPlanExecutionTest.java
+++ b/backend/lucene/src/test/java/org/hibernate/search/backend/lucene/work/execution/impl/LuceneIndexIndexingPlanExecutionTest.java
@@ -111,10 +111,10 @@ public class LuceneIndexIndexingPlanExecutionTest {
 		);
 		verifyNoOtherOrchestratorInteractionsAndReset();
 
-		planExecutionFuture = execution.execute( OperationSubmitter.BLOCKING );
-		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.BLOCKING ) );
+		planExecutionFuture = execution.execute( OperationSubmitter.blocking() );
+		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.blocking() ) );
 		verifyNoOtherOrchestratorInteractionsAndReset();
 		assertThatFuture( planExecutionFuture ).isPending();
 
@@ -166,10 +166,10 @@ public class LuceneIndexIndexingPlanExecutionTest {
 		);
 		verifyNoOtherOrchestratorInteractionsAndReset();
 
-		planExecutionFuture = execution.execute( OperationSubmitter.BLOCKING );
-		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.BLOCKING ) );
+		planExecutionFuture = execution.execute( OperationSubmitter.blocking() );
+		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.blocking() ) );
 		verifyNoOtherOrchestratorInteractionsAndReset();
 		assertThatFuture( planExecutionFuture ).isPending();
 
@@ -224,11 +224,11 @@ public class LuceneIndexIndexingPlanExecutionTest {
 		);
 		verifyNoOtherOrchestratorInteractionsAndReset();
 
-		planExecutionFuture = execution.execute( OperationSubmitter.BLOCKING );
-		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work4FutureCaptor.capture(), eq( workMocks.get( 3 ) ), eq( OperationSubmitter.BLOCKING ) );
+		planExecutionFuture = execution.execute( OperationSubmitter.blocking() );
+		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work4FutureCaptor.capture(), eq( workMocks.get( 3 ) ), eq( OperationSubmitter.blocking() ) );
 		verifyNoOtherOrchestratorInteractionsAndReset();
 		assertThatFuture( planExecutionFuture ).isPending();
 
@@ -289,11 +289,11 @@ public class LuceneIndexIndexingPlanExecutionTest {
 		);
 		verifyNoOtherOrchestratorInteractionsAndReset();
 
-		planExecutionFuture = execution.execute( OperationSubmitter.BLOCKING );
-		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work4FutureCaptor.capture(), eq( workMocks.get( 3 ) ), eq( OperationSubmitter.BLOCKING ) );
+		planExecutionFuture = execution.execute( OperationSubmitter.blocking() );
+		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work4FutureCaptor.capture(), eq( workMocks.get( 3 ) ), eq( OperationSubmitter.blocking() ) );
 		verifyNoOtherOrchestratorInteractionsAndReset();
 		assertThatFuture( planExecutionFuture ).isPending();
 
@@ -363,10 +363,10 @@ public class LuceneIndexIndexingPlanExecutionTest {
 		);
 		verifyNoOtherOrchestratorInteractionsAndReset();
 
-		planExecutionFuture = execution.execute( OperationSubmitter.BLOCKING );
-		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.BLOCKING ) );
+		planExecutionFuture = execution.execute( OperationSubmitter.blocking() );
+		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.blocking() ) );
 		verifyNoOtherOrchestratorInteractionsAndReset();
 
 		work2FutureCaptor.getValue().complete( work2Result );
@@ -421,10 +421,10 @@ public class LuceneIndexIndexingPlanExecutionTest {
 		);
 		verifyNoOtherOrchestratorInteractionsAndReset();
 
-		planExecutionFuture = execution.execute( OperationSubmitter.BLOCKING );
-		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.BLOCKING ) );
+		planExecutionFuture = execution.execute( OperationSubmitter.blocking() );
+		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.blocking() ) );
 		verifyNoOtherOrchestratorInteractionsAndReset();
 
 		work2FutureCaptor.getValue().complete( work2Result );
@@ -481,10 +481,10 @@ public class LuceneIndexIndexingPlanExecutionTest {
 		);
 		verifyNoOtherOrchestratorInteractionsAndReset();
 
-		planExecutionFuture = execution.execute( OperationSubmitter.BLOCKING );
-		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.BLOCKING ) );
+		planExecutionFuture = execution.execute( OperationSubmitter.blocking() );
+		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.blocking() ) );
 		verifyNoOtherOrchestratorInteractionsAndReset();
 
 		work2FutureCaptor.getValue().complete( work2Result );
@@ -540,10 +540,10 @@ public class LuceneIndexIndexingPlanExecutionTest {
 		);
 		verifyNoOtherOrchestratorInteractionsAndReset();
 
-		planExecutionFuture = execution.execute( OperationSubmitter.BLOCKING );
-		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.BLOCKING ) );
-		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.BLOCKING ) );
+		planExecutionFuture = execution.execute( OperationSubmitter.blocking() );
+		verify( orchestratorMock ).submit( work1FutureCaptor.capture(), eq( workMocks.get( 0 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work2FutureCaptor.capture(), eq( workMocks.get( 1 ) ), eq( OperationSubmitter.blocking() ) );
+		verify( orchestratorMock ).submit( work3FutureCaptor.capture(), eq( workMocks.get( 2 ) ), eq( OperationSubmitter.blocking() ) );
 		verifyNoOtherOrchestratorInteractionsAndReset();
 
 		work2FutureCaptor.getValue().complete( work2Result );

--- a/build/jqassistant/rules.xml
+++ b/build/jqassistant/rules.xml
@@ -394,6 +394,8 @@
                 (method.visibility="public" OR method.visibility="protected")
                 // Exclude extensions from SPI leak rules: they are *meant* to allow SPI leaks
                 AND NOT type.name =~ ".*Extension"
+                // Exclude OperationSubmitter from SPI leak rules: it is *expected* for submitter to access SPI executor leading to SPI leaks
+                AND NOT type.name =~ "OperationSubmitter"
             RETURN
                 method AS ExposingSite, parameterType AS ExposedType
 

--- a/engine/src/main/java/org/hibernate/search/engine/backend/orchestration/spi/AbstractWorkOrchestrator.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/orchestration/spi/AbstractWorkOrchestrator.java
@@ -11,7 +11,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
@@ -34,7 +33,6 @@ public abstract class AbstractWorkOrchestrator<W> {
 	private final ReadWriteLock lifecycleLock = new ReentrantReadWriteLock();
 
 	protected final Consumer<? super W> blockingRetryProducer = w -> submit( w, OperationSubmitter.blocking() );
-	protected final Function<? super W, Runnable> blockingRetryExecutorProducer = BlockingRetry::new;
 
 	protected AbstractWorkOrchestrator(String name) {
 		this.name = name;
@@ -153,19 +151,5 @@ public abstract class AbstractWorkOrchestrator<W> {
 		RUNNING,
 		PRE_STOPPING,
 		STOPPED;
-	}
-
-	private class BlockingRetry implements Runnable {
-		private final W work;
-
-		private BlockingRetry(W work) {
-			this.work = work;
-		}
-
-		@Override
-		public void run() {
-			// at this point we've offloaded submit call to some other executor so we just want to block the operation:
-			AbstractWorkOrchestrator.this.submit( work, OperationSubmitter.blocking() );
-		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/backend/orchestration/spi/AbstractWorkOrchestrator.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/orchestration/spi/AbstractWorkOrchestrator.java
@@ -162,7 +162,7 @@ public abstract class AbstractWorkOrchestrator<W> {
 		@Override
 		public void run() {
 			// at this point we've offloaded submit call to some other executor so we just want to block the operation:
-			AbstractWorkOrchestrator.this.submit( work, OperationSubmitter.BLOCKING );
+			AbstractWorkOrchestrator.this.submit( work, OperationSubmitter.blocking() );
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/backend/orchestration/spi/AbstractWorkOrchestrator.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/orchestration/spi/AbstractWorkOrchestrator.java
@@ -32,7 +32,7 @@ public abstract class AbstractWorkOrchestrator<W> {
 	private State state = State.STOPPED; // Guarded by lifecycleLock
 	private final ReadWriteLock lifecycleLock = new ReentrantReadWriteLock();
 
-	protected final Consumer<? extends W> blockingRetryProducer = w -> submit( w, OperationSubmitter.blocking() );
+	protected final Consumer<? super W> blockingRetryProducer = w -> submit( w, OperationSubmitter.blocking() );
 
 	protected AbstractWorkOrchestrator(String name) {
 		this.name = name;

--- a/engine/src/main/java/org/hibernate/search/engine/backend/orchestration/spi/BatchingExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/orchestration/spi/BatchingExecutor.java
@@ -121,8 +121,8 @@ public final class BatchingExecutor<P extends BatchedWorkProcessor> {
 	 * @param blockingRetryProducer
 	 * @throws InterruptedException If the current thread is interrupted while enqueuing the work.
 	 */
-	public void submit(BatchedWork<? super P> work, OperationSubmitter operationSubmitter,
-			Function<BatchedWork<? super P>, Runnable> blockingRetryProducer) throws InterruptedException {
+	public <W extends BatchedWork<? super P>> void submit(W work, OperationSubmitter operationSubmitter,
+			Function<? super W, Runnable> blockingRetryProducer) throws InterruptedException {
 		if ( processingTask == null ) {
 			throw new AssertionFailure(
 					"Attempt to submit a work to executor '" + name + "', which is stopped."

--- a/engine/src/main/java/org/hibernate/search/engine/backend/orchestration/spi/BatchingExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/orchestration/spi/BatchingExecutor.java
@@ -107,7 +107,7 @@ public final class BatchingExecutor<P extends BatchedWorkProcessor> {
 	 */
 	@Deprecated
 	public void submit(BatchedWork<? super P> work) throws InterruptedException {
-		submit( work, OperationSubmitter.BLOCKING, w -> () -> {
+		submit( work, OperationSubmitter.blocking(), w -> () -> {
 			throw new IllegalStateException( "Blocking executor does not offload work." );
 		} );
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitter.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitter.java
@@ -46,8 +46,8 @@ public abstract class OperationSubmitter {
 	 * Depending on the implementation might throw {@link RejectedExecutionException} or offload the submit operation to a provided executor.
 	 *
 	 */
-	public abstract <T> void submitToQueue(BlockingQueue<T> queue, T element,
-			Function<T, Runnable> blockingRetryProducer) throws InterruptedException;
+	public abstract <T> void submitToQueue(BlockingQueue<? super T> queue, T element,
+			Function<? super T, Runnable> blockingRetryProducer) throws InterruptedException;
 
 	/**
 	 * @see #BLOCKING
@@ -76,7 +76,8 @@ public abstract class OperationSubmitter {
 
 	private static final class BlockingOperationSubmitter extends OperationSubmitter {
 		@Override
-		public <T> void submitToQueue(BlockingQueue<T> queue, T element, Function<T, Runnable> blockingRetryProducer)
+		public <T> void submitToQueue(BlockingQueue<? super T> queue, T element,
+				Function<? super T, Runnable> blockingRetryProducer)
 				throws InterruptedException {
 			queue.put( element );
 		}
@@ -84,7 +85,8 @@ public abstract class OperationSubmitter {
 
 	private static final class RejectedExecutionExceptionOperationSubmitter extends OperationSubmitter {
 		@Override
-		public <T> void submitToQueue(BlockingQueue<T> queue, T element, Function<T, Runnable> blockingRetryProducer) {
+		public <T> void submitToQueue(BlockingQueue<? super T> queue, T element,
+				Function<? super T, Runnable> blockingRetryProducer) {
 			if ( !queue.offer( element ) ) {
 				throw new RejectedExecutionException();
 			}
@@ -99,7 +101,8 @@ public abstract class OperationSubmitter {
 		}
 
 		@Override
-		public <T> void submitToQueue(BlockingQueue<T> queue, T element, Function<T, Runnable> blockingRetryProducer) {
+		public <T> void submitToQueue(BlockingQueue<? super T> queue, T element,
+				Function<? super T, Runnable> blockingRetryProducer) {
 			if ( !queue.offer( element ) ) {
 				executor.accept( blockingRetryProducer.apply( element ) );
 			}

--- a/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitter.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitter.java
@@ -8,6 +8,8 @@ package org.hibernate.search.engine.backend.work.execution;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.hibernate.search.util.common.annotation.Incubating;
 
@@ -16,44 +18,105 @@ import org.hibernate.search.util.common.annotation.Incubating;
  * Interface defining how operation should be submitted to the queue.
  */
 @Incubating
-public enum OperationSubmitter {
+public final class OperationSubmitter {
 
 	/**
 	 * When using this submitter, dding a new element will block the thread when the underlying
 	 * queue is a {@link java.util.concurrent.BlockingQueue} and it is at its maximum capacity, until some elements
 	 * are removed from the queue
 	 */
-	BLOCKING {
-		@Override
-		public <T> void submitToQueue(BlockingQueue<T> queue, T element) throws InterruptedException {
-			queue.put( element );
-		}
-	},
+	public static final OperationSubmitter BLOCKING = new OperationSubmitter( new BlockingOperation() );
 	/**
 	 * When using this submitter adding a new element will cause a {@link RejectedExecutionException} when the underlying
 	 * queue is a {@link java.util.concurrent.BlockingQueue} and it is at its maximum capacity.
 	 */
-	REJECTED_EXECUTION_EXCEPTION {
-		@Override
-		public <T> void submitToQueue(BlockingQueue<T> queue, T element) {
-			if ( !queue.offer( element ) ) {
-				throw new RejectedExecutionException();
-			}
-		}
-	};
+	public static final OperationSubmitter REJECTED_EXECUTION_EXCEPTION = new OperationSubmitter(
+			new RejectedExecutionExceptionOperation() );
+
+	private final Operation operation;
+
+	private OperationSubmitter(Operation operation) {
+		this.operation = operation;
+	}
 
 	/**
 	 * Defines how an element will be submitted to the queue. Currently supported implementations:
 	 * <ul>
-	 *     <li>{@link #BLOCKING}</li>
-	 *     <li>{@link #REJECTED_EXECUTION_EXCEPTION}</li>
+	 *     <li>{@link #blocking()}</li>
+	 *     <li>{@link #rejectedExecutionException()}</li>
+	 *     <li>{@link #offloading(Consumer)}</li>
 	 * </ul>
 	 * <p>
-	 * Depending on the implementation might throw {@link RejectedExecutionException}.
+	 * Depending on the implementation might throw {@link RejectedExecutionException} or offload the submit operation to a provided executor.
 	 *
-	 * @param queue
-	 * @param element
 	 */
-	public abstract <T> void submitToQueue(BlockingQueue<T> queue, T element) throws InterruptedException;
+	public <T> void submitToQueue(BlockingQueue<T> queue, T element, Function<T, Runnable> blockingRetryProducer)
+			throws InterruptedException {
+		operation.accept( queue, element, blockingRetryProducer );
+	}
+
+	/**
+	 * @see #BLOCKING
+	 */
+	public static OperationSubmitter blocking() {
+		return BLOCKING;
+	}
+
+	/**
+	 * @see #REJECTED_EXECUTION_EXCEPTION
+	 */
+	public static OperationSubmitter rejectedExecutionException() {
+		return REJECTED_EXECUTION_EXCEPTION;
+	}
+
+	/**
+	 * Creates an operation submitter that would attempt to submit work to a queue, but in case the queue is full it
+	 * would offload the submitting of the operation to provided executor.
+	 * This would never block the current thread, but the one to which the work is offloaded.
+	 *
+	 * @param executor executor to offload submit operation to if the queue is full
+	 */
+	public static OperationSubmitter offloading(Consumer<Runnable> executor) {
+		return new OperationSubmitter( new OffloadingExecutorOperation( executor ) );
+	}
+
+	@FunctionalInterface
+	private interface Operation {
+		<T> void accept(BlockingQueue<T> queue, T element, Function<T, Runnable> blockingRetryProducer)
+				throws InterruptedException;
+	}
+
+	private static final class BlockingOperation implements Operation {
+		@Override
+		public <T> void accept(BlockingQueue<T> queue, T element, Function<T, Runnable> blockingRetryProducer)
+				throws InterruptedException {
+			queue.put( element );
+		}
+	}
+
+	private static final class RejectedExecutionExceptionOperation implements Operation {
+		@Override
+		public <T> void accept(BlockingQueue<T> queue, T element, Function<T, Runnable> blockingRetryProducer) {
+			if ( !queue.offer( element ) ) {
+				throw new RejectedExecutionException();
+			}
+		}
+	}
+
+	private static final class OffloadingExecutorOperation implements Operation {
+		private final Consumer<Runnable> executor;
+
+		private OffloadingExecutorOperation(Consumer<Runnable> executor) {
+			this.executor = executor;
+		}
+
+		@Override
+		public <T> void accept(BlockingQueue<T> queue, T element, Function<T, Runnable> blockingRetryProducer)
+				throws InterruptedException {
+			if ( !queue.offer( element ) ) {
+				executor.accept( blockingRetryProducer.apply( element ) );
+			}
+		}
+	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitter.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitter.java
@@ -18,6 +18,10 @@ import org.hibernate.search.util.common.annotation.Incubating;
 /**
  * Interface defining how operation should be submitted to the queue or executor.
  * <p>
+ * <strong>WARNING:</strong> while this type is API, because instances should be manipulated by users,
+ * all of its methods are considered SPIs and therefore should never be called directly by users.
+ * In short, users are only expected to get instances of this type from an API and pass it to another API.
+ * <p>
  * Currently supported implementations:
  * <ul>
  *     <li>{@link #blocking()}</li>

--- a/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitter.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitter.java
@@ -20,17 +20,8 @@ import org.hibernate.search.util.common.annotation.Incubating;
 @Incubating
 public abstract class OperationSubmitter {
 
-	/**
-	 * When using this submitter, dding a new element will block the thread when the underlying
-	 * queue is a {@link java.util.concurrent.BlockingQueue} and it is at its maximum capacity, until some elements
-	 * are removed from the queue
-	 */
-	public static final OperationSubmitter BLOCKING = new BlockingOperationSubmitter();
-	/**
-	 * When using this submitter adding a new element will cause a {@link RejectedExecutionException} when the underlying
-	 * queue is a {@link java.util.concurrent.BlockingQueue} and it is at its maximum capacity.
-	 */
-	public static final OperationSubmitter REJECTED_EXECUTION_EXCEPTION = new RejectedExecutionExceptionOperationSubmitter();
+	private static final OperationSubmitter BLOCKING = new BlockingOperationSubmitter();
+	private static final OperationSubmitter REJECTED_EXECUTION_EXCEPTION = new RejectedExecutionExceptionOperationSubmitter();
 
 	private OperationSubmitter() {
 	}
@@ -39,7 +30,7 @@ public abstract class OperationSubmitter {
 	 * Defines how an element will be submitted to the queue. Currently supported implementations:
 	 * <ul>
 	 *     <li>{@link #blocking()}</li>
-	 *     <li>{@link #rejectedExecutionException()}</li>
+	 *     <li>{@link #rejecting()}</li>
 	 *     <li>{@link #offloading(Consumer)}</li>
 	 * </ul>
 	 * <p>
@@ -50,16 +41,19 @@ public abstract class OperationSubmitter {
 			Function<? super T, Runnable> blockingRetryProducer) throws InterruptedException;
 
 	/**
-	 * @see #BLOCKING
+	 * When using this submitter, dding a new element will block the thread when the underlying
+	 * queue is a {@link java.util.concurrent.BlockingQueue} and it is at its maximum capacity, until some elements
+	 * are removed from the queue
 	 */
 	public static OperationSubmitter blocking() {
 		return BLOCKING;
 	}
 
 	/**
-	 * @see #REJECTED_EXECUTION_EXCEPTION
+	 * When using this submitter adding a new element will cause a {@link RejectedExecutionException} when the underlying
+	 * queue is a {@link java.util.concurrent.BlockingQueue} and it is at its maximum capacity.
 	 */
-	public static OperationSubmitter rejectedExecutionException() {
+	public static OperationSubmitter rejecting() {
 		return REJECTED_EXECUTION_EXCEPTION;
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitter.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitter.java
@@ -127,7 +127,12 @@ public abstract class OperationSubmitter {
 		@Override
 		public <T extends Runnable> void submitToExecutor(SimpleScheduledExecutor executor, T element,
 				Consumer<? super T> blockingRetryProducer) {
-			this.executor.accept( () -> blockingRetryProducer.accept( element ) );
+			try {
+				executor.offer( element );
+			}
+			catch (RejectedExecutionException e) {
+				this.executor.accept( () -> blockingRetryProducer.accept( element ) );
+			}
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitter.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitter.java
@@ -9,7 +9,6 @@ package org.hibernate.search.engine.backend.work.execution;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import org.hibernate.search.engine.common.execution.spi.SimpleScheduledExecutor;
 import org.hibernate.search.util.common.annotation.Incubating;
@@ -50,7 +49,7 @@ public abstract class OperationSubmitter {
 	 * Depending on the implementation might throw {@link RejectedExecutionException} or offload the submit operation to an offload executor.
 	 */
 	public abstract <T extends Runnable> void submitToExecutor(SimpleScheduledExecutor executor, T element,
-			Function<? super T, Runnable> blockingRetryProducer) throws InterruptedException;
+			Consumer<? super T> blockingRetryProducer) throws InterruptedException;
 
 	/**
 	 * When using this submitter, dding a new element will block the thread when the underlying
@@ -90,7 +89,7 @@ public abstract class OperationSubmitter {
 
 		@Override
 		public <T extends Runnable> void submitToExecutor(SimpleScheduledExecutor executor, T element,
-				Function<? super T, Runnable> blockingRetryProducer) {
+				Consumer<? super T> blockingRetryProducer) {
 			executor.submit( element );
 		}
 	}
@@ -106,7 +105,7 @@ public abstract class OperationSubmitter {
 
 		@Override
 		public <T extends Runnable> void submitToExecutor(SimpleScheduledExecutor executor, T element,
-				Function<? super T, Runnable> blockingRetryProducer) {
+				Consumer<? super T> blockingRetryProducer) {
 			executor.offer( element );
 		}
 	}
@@ -127,8 +126,8 @@ public abstract class OperationSubmitter {
 
 		@Override
 		public <T extends Runnable> void submitToExecutor(SimpleScheduledExecutor executor, T element,
-				Function<? super T, Runnable> blockingRetryProducer) {
-			this.executor.accept( blockingRetryProducer.apply( element ) );
+				Consumer<? super T> blockingRetryProducer) {
+			this.executor.accept( () -> blockingRetryProducer.accept( element ) );
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/common/execution/spi/DelegatingSimpleScheduledExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/execution/spi/DelegatingSimpleScheduledExecutor.java
@@ -17,9 +17,11 @@ import org.hibernate.search.util.common.annotation.Incubating;
 public class DelegatingSimpleScheduledExecutor implements SimpleScheduledExecutor {
 
 	private final ScheduledExecutorService delegate;
+	private final boolean blocking;
 
-	public DelegatingSimpleScheduledExecutor(ScheduledExecutorService executorService) {
-		this.delegate = executorService;
+	public DelegatingSimpleScheduledExecutor(ScheduledExecutorService delegate, boolean blocking) {
+		this.delegate = delegate;
+		this.blocking = blocking;
 	}
 
 	@Override
@@ -35,5 +37,10 @@ public class DelegatingSimpleScheduledExecutor implements SimpleScheduledExecuto
 	@Override
 	public void shutdownNow() {
 		delegate.shutdownNow();
+	}
+
+	@Override
+	public boolean isBlocking() {
+		return blocking;
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/common/execution/spi/SimpleScheduledExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/execution/spi/SimpleScheduledExecutor.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.engine.common.execution.spi;
 
+import java.util.Locale;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
@@ -37,6 +38,29 @@ public interface SimpleScheduledExecutor {
 	 * @throws RejectedExecutionException if the task cannot be  scheduled for execution
 	 */
 	ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit);
+
+	/**
+	 * Makes an attempt to submit a {@link Runnable task} for execution. If the attempt is successful - returns
+	 * a {@link Future} representing that task. Otherwise, in case submitting a task would result in blocking -
+	 * task is not submitted and an {@link RejectedExecutionException exception} is thrown.
+	 *
+	 * @param task the task to submit
+	 * @return a {@link Future} representing pending completion of the task
+	 *
+	 * @throws RejectedExecutionException if the task cannot be scheduled for execution, or doing so would result in blocking the tread.
+	 */
+	default Future<?> offer(Runnable task) {
+		if ( isBlocking() ) {
+			throw new RejectedExecutionException(
+					String.format( Locale.ROOT,
+							"Unable to accept '%1$s' task for execution. '%2$s' is a blocking executor and it does not implement `SimpleScheduledExecutor#offer(Runnable)`.",
+							task, this
+					) );
+		}
+		else {
+			return submit( task );
+		}
+	}
 
 	/**
 	 * Attempts to stop all actively executing tasks, halts the processing of waiting tasks.

--- a/engine/src/main/java/org/hibernate/search/engine/common/execution/spi/SimpleScheduledExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/execution/spi/SimpleScheduledExecutor.java
@@ -43,4 +43,9 @@ public interface SimpleScheduledExecutor {
 	 */
 	void shutdownNow();
 
+	/**
+	 * @return {@code true} if this executor may block when a task is submitted to it;
+	 * {@code false} if it never block (e.g. throws an {@link RejectedExecutionException}).
+	 */
+	boolean isBlocking();
 }

--- a/engine/src/test/java/org/hibernate/search/engine/backend/orchestration/spi/BatchingExecutorTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/backend/orchestration/spi/BatchingExecutorTest.java
@@ -556,7 +556,7 @@ public class BatchingExecutorTest {
 		// the batching executor takes care of executing in only one thread at a time.
 		this.executorService = threadPoolProvider.newScheduledExecutor( 4, "BatchingExecutorTest" );
 
-		executor.start( new DelegatingSimpleScheduledExecutor( executorService ) );
+		executor.start( new DelegatingSimpleScheduledExecutor( executorService, true ) );
 		verifyAsynchronouslyAndReset( inOrder -> {
 			// No calls expected yet
 		} );

--- a/engine/src/test/java/org/hibernate/search/engine/backend/orchestration/spi/BatchingExecutorTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/backend/orchestration/spi/BatchingExecutorTest.java
@@ -67,7 +67,7 @@ public class BatchingExecutorTest {
 	public static Object[][] params() {
 		return new Object[][] {
 				{ "BLOCKING", OperationSubmitter.blocking() },
-				{ "REJECTED_EXECUTION_EXCEPTION", OperationSubmitter.rejectedExecutionException() },
+				{ "REJECTING", OperationSubmitter.rejecting() },
 				{ "OFFLOADING", OperationSubmitter.offloading( CompletableFuture::runAsync ) }
 		};
 	}
@@ -351,7 +351,7 @@ public class BatchingExecutorTest {
 
 		assumeTrue(
 				"This test only makes sense for nonblocking submitter",
-				OperationSubmitter.REJECTED_EXECUTION_EXCEPTION.equals( operationSubmitter )
+				OperationSubmitter.rejecting().equals( operationSubmitter )
 		);
 
 		Runnable unblockExecutorSwitch = blockExecutor();
@@ -387,7 +387,7 @@ public class BatchingExecutorTest {
 
 		assumeTrue(
 				"This test only makes sense for blocking submitter",
-				OperationSubmitter.BLOCKING.equals( operationSubmitter )
+				OperationSubmitter.blocking().equals( operationSubmitter )
 		);
 
 		Runnable unblockExecutorSwitch = blockExecutor();
@@ -453,8 +453,8 @@ public class BatchingExecutorTest {
 
 		assumeFalse(
 				"This test only makes sense for offloading submitter",
-				OperationSubmitter.BLOCKING.equals( operationSubmitter ) ||
-						OperationSubmitter.REJECTED_EXECUTION_EXCEPTION.equals( operationSubmitter )
+				OperationSubmitter.blocking().equals( operationSubmitter ) ||
+						OperationSubmitter.rejecting().equals( operationSubmitter )
 		);
 
 		Runnable unblockExecutorSwitch = blockExecutor();

--- a/engine/src/test/java/org/hibernate/search/engine/backend/orchestration/spi/BatchingExecutorTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/backend/orchestration/spi/BatchingExecutorTest.java
@@ -89,7 +89,7 @@ public class BatchingExecutorTest {
 	private final ForkJoinPool asyncExecutor = new ForkJoinPool( 12 );
 
 	private ScheduledExecutorService executorService;
-	private BatchingExecutor<StubWorkProcessor> executor;
+	private BatchingExecutor<StubWorkProcessor, StubWork> executor;
 
 	private final OperationSubmitter operationSubmitter;
 

--- a/engine/src/test/java/org/hibernate/search/engine/backend/orchestration/spi/BatchingExecutorTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/backend/orchestration/spi/BatchingExecutorTest.java
@@ -122,7 +122,7 @@ public class BatchingExecutorTest {
 		// allowing the executor to handle the next batch immediately.
 		CompletableFuture<Object> batch1Future = CompletableFuture.completedFuture( null );
 		when( processorMock.endBatch() ).thenReturn( (CompletableFuture) batch1Future );
-		executor.submit( work1Mock, operationSubmitter, w -> () -> { fail( "shouldn't be offloaded!" ); } );
+		executor.submit( work1Mock, operationSubmitter );
 		verifyAsynchronouslyAndReset( inOrder -> {
 			inOrder.verify( processorMock ).beginBatch();
 			inOrder.verify( work1Mock ).submitTo( processorMock );
@@ -144,7 +144,7 @@ public class BatchingExecutorTest {
 		// forcing the executor to wait before it handles the next batch.
 		CompletableFuture<Object> batch1Future = new CompletableFuture<>();
 		when( processorMock.endBatch() ).thenReturn( (CompletableFuture) batch1Future );
-		executor.submit( work1Mock, operationSubmitter, w -> () -> { } );
+		executor.submit( work1Mock, operationSubmitter );
 		verifyAsynchronouslyAndReset( inOrder -> {
 			inOrder.verify( processorMock ).beginBatch();
 			inOrder.verify( work1Mock ).submitTo( processorMock );
@@ -157,8 +157,8 @@ public class BatchingExecutorTest {
 		// Submit other works before the first batch ends
 		StubWork work2Mock = workMock( 2 );
 		StubWork work3Mock = workMock( 3 );
-		executor.submit( work2Mock, operationSubmitter, w -> () -> { fail( "shouldn't be offloaded!" ); } );
-		executor.submit( work3Mock, operationSubmitter, w -> () -> { fail( "shouldn't be offloaded!" ); } );
+		executor.submit( work2Mock, operationSubmitter );
+		executor.submit( work3Mock, operationSubmitter );
 		verifyAsynchronouslyAndReset( inOrder -> {
 			// No calls expected yet
 		} );
@@ -202,7 +202,7 @@ public class BatchingExecutorTest {
 		// forcing the executor to wait before it handles the next batch.
 		CompletableFuture<Object> batch1Future = new CompletableFuture<>();
 		when( processorMock.endBatch() ).thenReturn( (CompletableFuture) batch1Future );
-		executor.submit( work1Mock, operationSubmitter, w -> () -> { fail( "shouldn't be offloaded!" ); } );
+		executor.submit( work1Mock, operationSubmitter );
 		verifyAsynchronouslyAndReset( inOrder -> {
 			inOrder.verify( processorMock ).beginBatch();
 			inOrder.verify( work1Mock ).submitTo( processorMock );
@@ -233,7 +233,7 @@ public class BatchingExecutorTest {
 		Runnable unblockExecutorSwitch = blockExecutor();
 
 		StubWork work1Mock = workMock( 1 );
-		executor.submit( work1Mock, operationSubmitter, w -> () -> { fail( "shouldn't be offloaded!" ); } );
+		executor.submit( work1Mock, operationSubmitter );
 		verifyAsynchronouslyAndReset( inOrder -> {
 			// No calls expected yet
 		} );
@@ -273,9 +273,9 @@ public class BatchingExecutorTest {
 		StubWork work1Mock = workMock( 1 );
 		StubWork work2Mock = workMock( 2 );
 		StubWork work3Mock = workMock( 3 );
-		executor.submit( work1Mock, operationSubmitter, w -> () -> { fail( "shouldn't be offloaded!" ); } );
-		executor.submit( work2Mock, operationSubmitter, w -> () -> { fail( "shouldn't be offloaded!" ); } );
-		executor.submit( work3Mock, operationSubmitter, w -> () -> { fail( "shouldn't be offloaded!" ); } );
+		executor.submit( work1Mock, operationSubmitter );
+		executor.submit( work2Mock, operationSubmitter );
+		executor.submit( work3Mock, operationSubmitter );
 		verifyAsynchronouslyAndReset( inOrder -> {
 			// No calls expected yet
 		} );
@@ -313,8 +313,8 @@ public class BatchingExecutorTest {
 
 		StubWork work1Mock = workMock( 1 );
 		StubWork work2Mock = workMock( 2 );
-		executor.submit( work1Mock, operationSubmitter, w -> () -> { fail( "shouldn't be offloaded!" ); } );
-		executor.submit( work2Mock, operationSubmitter, w -> () -> { fail( "shouldn't be offloaded!" ); } );
+		executor.submit( work1Mock, operationSubmitter );
+		executor.submit( work2Mock, operationSubmitter );
 		verifyAsynchronouslyAndReset( inOrder -> {
 			// No calls expected yet
 		} );
@@ -359,10 +359,10 @@ public class BatchingExecutorTest {
 		StubWork work1Mock = workMock( 1 );
 		StubWork work2Mock = workMock( 2 );
 		StubWork work3Mock = workMock( 3 );
-		executor.submit( work1Mock, operationSubmitter, w -> () -> { fail( "shouldn't be offloaded!" ); } );
-		executor.submit( work2Mock, operationSubmitter, w -> () -> { fail( "shouldn't be offloaded!" ); } );
+		executor.submit( work1Mock, operationSubmitter );
+		executor.submit( work2Mock, operationSubmitter );
 
-		assertThatThrownBy( () -> executor.submit( work3Mock, operationSubmitter, w -> () -> { fail( "shouldn't be offloaded!" ); } ) )
+		assertThatThrownBy( () -> executor.submit( work3Mock, operationSubmitter ) )
 				.isInstanceOf( RejectedExecutionException.class );
 
 		when( processorMock.endBatch() ).thenReturn( CompletableFuture.completedFuture( null ) );
@@ -396,14 +396,14 @@ public class BatchingExecutorTest {
 		StubWork work2Mock = workMock( 2 );
 		StubWork work3Mock = workMock( 3 );
 
-		executor.submit( work1Mock, operationSubmitter, w -> () -> { fail( "shouldn't be offloaded!" ); } );
-		executor.submit( work2Mock, operationSubmitter, w -> () -> { fail( "shouldn't be offloaded!" ); } );
+		executor.submit( work1Mock, operationSubmitter );
+		executor.submit( work2Mock, operationSubmitter );
 
 		AtomicReference<Thread> work3SubmitThread = new AtomicReference<>();
 		CompletableFuture<Boolean> future = CompletableFuture.supplyAsync( () -> {
 			try {
 				work3SubmitThread.set( Thread.currentThread() );
-				executor.submit( work3Mock, operationSubmitter, w -> () -> { fail( "shouldn't be offloaded!" ); } );
+				executor.submit( work3Mock, operationSubmitter );
 			}
 			catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
@@ -449,7 +449,8 @@ public class BatchingExecutorTest {
 
 	@Test
 	public void simple_newTasksBlockedAndOffloadedCompletes() throws InterruptedException {
-		createAndStartExecutor( 2, true );
+		AtomicReference<Runnable> offloadAction = new AtomicReference<>( () -> { } );
+		createAndStartExecutor( 2, true, w -> offloadAction.get().run() );
 
 		assumeFalse(
 				"This test only makes sense for offloading submitter",
@@ -463,21 +464,22 @@ public class BatchingExecutorTest {
 		StubWork work2Mock = workMock( 2 );
 		StubWork work3Mock = workMock( 3 );
 
-		executor.submit( work1Mock, operationSubmitter, w -> () -> { fail( "shouldn't be offloaded!" ); } );
-		executor.submit( work2Mock, operationSubmitter, w -> () -> { fail( "shouldn't be offloaded!" ); } );
+		executor.submit( work1Mock, operationSubmitter );
+		executor.submit( work2Mock, operationSubmitter );
 
 		AtomicReference<Thread> work3SubmitThread = new AtomicReference<>();
 		AtomicBoolean work3Submitted = new AtomicBoolean( false );
-		executor.submit( work3Mock, operationSubmitter, w -> () -> {
+		offloadAction.set( () -> {
 			work3SubmitThread.set( Thread.currentThread() );
 			try {
-				executor.submit( work3Mock, OperationSubmitter.blocking(), w2 -> () -> { } );
+				executor.submit( work3Mock, OperationSubmitter.blocking() );
 				work3Submitted.set( true );
 			}
 			catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
 			}
 		} );
+		executor.submit( work3Mock, operationSubmitter );
 
 		// wait until the thread submitting work3 is submitting and blocked
 		Awaitility.await().untilAsserted( () -> assertThat( work3SubmitThread )
@@ -531,7 +533,7 @@ public class BatchingExecutorTest {
 		StubWork blockingWorkMock = workMock( 0 );
 		CompletableFuture<Object> blockingBatchFuture = new CompletableFuture<>();
 		when( processorMock.endBatch() ).thenReturn( (CompletableFuture) blockingBatchFuture );
-		executor.submit( blockingWorkMock, operationSubmitter, w -> () -> { } );
+		executor.submit( blockingWorkMock, operationSubmitter );
 		verifyAsynchronouslyAndReset( inOrder -> {
 			inOrder.verify( processorMock ).beginBatch();
 			inOrder.verify( blockingWorkMock ).submitTo( processorMock );
@@ -543,8 +545,11 @@ public class BatchingExecutorTest {
 	}
 
 	private void createAndStartExecutor(int maxTasksPerBatch, boolean fair) {
+		createAndStartExecutor( maxTasksPerBatch, fair, w -> fail( "Work shouldn't be offloaded." ) );
+	}
+	private void createAndStartExecutor(int maxTasksPerBatch, boolean fair, Consumer<? super BatchedWork<? super StubWorkProcessor>> blockingRetryProducer) {
 		this.executor = new BatchingExecutor<>(
-				NAME, processorMock, maxTasksPerBatch, fair, failureHandlerMock
+				NAME, processorMock, maxTasksPerBatch, fair, failureHandlerMock, blockingRetryProducer
 		);
 
 		// Having multiple threads should not matter:
@@ -591,7 +596,7 @@ public class BatchingExecutorTest {
 		StubWork workMock = workMock( 42 );
 		CompletableFuture<Object> batchFuture = CompletableFuture.completedFuture( null );
 		when( processorMock.endBatch() ).thenReturn( (CompletableFuture) batchFuture );
-		executor.submit( workMock, operationSubmitter, w -> () -> { } );
+		executor.submit( workMock, operationSubmitter );
 		verifyAsynchronouslyAndReset( inOrder -> {
 			inOrder.verify( processorMock ).beginBatch();
 			inOrder.verify( workMock ).submitTo( processorMock );

--- a/engine/src/test/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitterExecutorTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitterExecutorTest.java
@@ -1,0 +1,175 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.backend.work.execution;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.hibernate.search.engine.common.execution.spi.SimpleScheduledExecutor;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class OperationSubmitterExecutorTest {
+
+	private SimpleScheduledExecutor executor;
+	@Before
+	public void setUp() throws Exception {
+		this.executor = new SimpleScheduledExecutor() {
+			private BlockingQueue<Runnable> queue = new ArrayBlockingQueue<>( 1 );
+			private ThreadPoolExecutor delegate = new ThreadPoolExecutor( 1, 1,
+					0L, TimeUnit.MILLISECONDS,
+					queue
+			);
+
+			@Override
+			public Future<?> submit(Runnable task) {
+				while ( queue.size() == 1 ) {
+					// should be ok in our controlled env to simulate a blocking submit.
+				}
+				return delegate.submit( task );
+			}
+
+			@Override
+			public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+				throw new UnsupportedOperationException( "" );
+			}
+
+			@Override
+			public void shutdownNow() {
+				delegate.shutdownNow();
+			}
+
+			@Override
+			public boolean isBlocking() {
+				return true;
+			}
+		};
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		this.executor.shutdownNow();
+	}
+
+	@Test
+	public void blockingOperationSubmitterBlocksTheOperation() throws InterruptedException {
+		BlockingTask blockingTask = new BlockingTask();
+		executor.submit( blockingTask );
+		executor.submit( blockingTask );
+
+		CompletableFuture<Boolean> future = CompletableFuture.supplyAsync( () -> {
+			try {
+				OperationSubmitter.blocking().submitToExecutor( executor, () -> { }, r -> { } );
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+			return true;
+		} );
+
+		// wait to give some time for the above future to actually block
+		TimeUnit.SECONDS.sleep( 2 );
+
+		//queue is full so future won't complete.
+		assertThat( future.isDone() ).isFalse();
+
+		//make some room in the queue:
+		blockingTask.working.set( false );
+		await().untilAsserted( () -> assertThat( future.isDone() ).isTrue() );
+	}
+
+
+	@Test
+	public void nonBlockingOperationSubmitterThrowsException() {
+		// rejecting submitter would just fail with exception all the time as our executor is blocking
+		assertThatThrownBy( () -> OperationSubmitter.rejecting().submitToExecutor( executor, () -> { }, r -> { } ) )
+				.isInstanceOf( RejectedExecutionException.class );
+	}
+
+	@Test
+	public void nonBlockingOperationSubmitterWorksOk() throws InterruptedException {
+		AtomicBoolean check = new AtomicBoolean( false );
+		// if executor implements offer() rejecting can finish successfully:
+		OperationSubmitter.rejecting().submitToExecutor(
+				new SimpleScheduledExecutor() {
+					@Override
+					public Future<?> submit(Runnable task) {
+						// doesn't matter as we implement offer()
+						throw new UnsupportedOperationException();
+					}
+
+					@Override
+					public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+						// doesn't matter as we implement offer()
+						throw new UnsupportedOperationException();
+					}
+
+					@Override
+					public void shutdownNow() {
+						// doesn't matter as we implement offer()
+						throw new UnsupportedOperationException();
+					}
+
+					@Override
+					public boolean isBlocking() {
+						// doesn't matter as we implement offer()
+						throw new UnsupportedOperationException();
+					}
+
+					@Override
+					public Future<?> offer(Runnable task) {
+						return CompletableFuture.runAsync( task );
+					}
+				},
+				() -> { check.set( true ); }, r -> { fail( "shouldn't happen." ); }
+		);
+
+		await().untilAsserted( () -> assertThat( check ).isTrue() );
+	}
+
+	@Test
+	public void offloadingSubmitterOffloads() throws Exception {
+		BlockingTask blockingTask = new BlockingTask();
+		executor.submit( blockingTask );
+
+		// we won't submit to the queue but just make sure that work got offloaded
+		AtomicBoolean worked = new AtomicBoolean( false );
+		OperationSubmitter.offloading( Runnable::run ).submitToExecutor( executor, () -> { }, r -> { worked.set( true ); } );
+
+		await().untilAsserted( () -> assertThat( worked ).isTrue() );
+	}
+
+	private static class BlockingTask implements Runnable {
+		AtomicBoolean working = new AtomicBoolean( true );
+		@Override
+		public void run() {
+			while ( working.get() ) {
+				try {
+					Thread.sleep( 1000 );
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+			}
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitterQueueTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitterQueueTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Before;
 import org.junit.Test;
 
-public class OperationSubmitterTest {
+public class OperationSubmitterQueueTest {
 
 	private BlockingQueue<Integer> queue;
 

--- a/engine/src/test/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitterTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitterTest.java
@@ -29,15 +29,15 @@ public class OperationSubmitterTest {
 	public void setUp() throws Exception {
 		this.queue = new ArrayBlockingQueue<>( 2 );
 
-		OperationSubmitter.blocking().submitToQueue( queue, 1, i -> () -> { } );
-		OperationSubmitter.blocking().submitToQueue( queue, 2, i -> () -> { } );
+		OperationSubmitter.blocking().submitToQueue( queue, 1, i -> { } );
+		OperationSubmitter.blocking().submitToQueue( queue, 2, i -> { } );
 	}
 
 	@Test
 	public void blockingOperationSubmitterBlocksTheOperation() throws InterruptedException {
 		CompletableFuture<Boolean> future = CompletableFuture.supplyAsync( () -> {
 			try {
-				OperationSubmitter.blocking().submitToQueue( queue, 3, i -> () -> { } );
+				OperationSubmitter.blocking().submitToQueue( queue, 3, i -> { } );
 			}
 			catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
@@ -60,7 +60,7 @@ public class OperationSubmitterTest {
 	@Test
 	public void nonBlockingOperationSubmitterThrowsException() {
 		Integer element = 3;
-		assertThatThrownBy( () -> OperationSubmitter.rejecting().submitToQueue( queue, element, i -> () -> { } ) )
+		assertThatThrownBy( () -> OperationSubmitter.rejecting().submitToQueue( queue, element, i -> { } ) )
 				.isInstanceOf( RejectedExecutionException.class );
 	}
 
@@ -68,7 +68,7 @@ public class OperationSubmitterTest {
 	public void offloadingSubmitterOffloads() throws Exception {
 		// we won't submit to the queue but just make sure that work got offloaded
 		AtomicBoolean worked = new AtomicBoolean( false );
-		OperationSubmitter.offloading( Runnable::run ).submitToQueue( queue, 1, i -> () -> { worked.set( true ); } );
+		OperationSubmitter.offloading( Runnable::run ).submitToQueue( queue, 1, i -> { worked.set( true ); } );
 
 		await().untilAsserted( () -> assertThat( worked ).isTrue() );
 	}

--- a/engine/src/test/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitterTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitterTest.java
@@ -29,15 +29,15 @@ public class OperationSubmitterTest {
 	public void setUp() throws Exception {
 		this.queue = new ArrayBlockingQueue<>( 2 );
 
-		OperationSubmitter.BLOCKING.submitToQueue( queue, 1, i -> () -> { } );
-		OperationSubmitter.BLOCKING.submitToQueue( queue, 2, i -> () -> { } );
+		OperationSubmitter.blocking().submitToQueue( queue, 1, i -> () -> { } );
+		OperationSubmitter.blocking().submitToQueue( queue, 2, i -> () -> { } );
 	}
 
 	@Test
 	public void blockingOperationSubmitterBlocksTheOperation() throws InterruptedException {
 		CompletableFuture<Boolean> future = CompletableFuture.supplyAsync( () -> {
 			try {
-				OperationSubmitter.BLOCKING.submitToQueue( queue, 3, i -> () -> { } );
+				OperationSubmitter.blocking().submitToQueue( queue, 3, i -> () -> { } );
 			}
 			catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
@@ -60,7 +60,7 @@ public class OperationSubmitterTest {
 	@Test
 	public void nonBlockingOperationSubmitterThrowsException() {
 		Integer element = 3;
-		assertThatThrownBy( () -> OperationSubmitter.REJECTED_EXECUTION_EXCEPTION.submitToQueue( queue, element, i -> () -> { } ) )
+		assertThatThrownBy( () -> OperationSubmitter.rejecting().submitToQueue( queue, element, i -> () -> { } ) )
 				.isInstanceOf( RejectedExecutionException.class );
 	}
 

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapIT.java
@@ -348,7 +348,7 @@ public class ElasticsearchBootstrapIT {
 	}
 
 	private void checkBackendWorks() {
-		index.schemaManager().createIfMissing( OperationSubmitter.BLOCKING ).join();
+		index.schemaManager().createIfMissing( OperationSubmitter.blocking() ).join();
 		assertThatQuery( index.query().where( f -> f.matchAll() ) ).hasNoHits();
 		index.index( "1", document -> { } );
 		assertThatQuery( index.query().where( f -> f.matchAll() ) ).hasDocRefHitsAnyOrder( index.typeName(), "1" );

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/client/ElasticsearchClientFactoryImplIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/client/ElasticsearchClientFactoryImplIT.java
@@ -1048,7 +1048,7 @@ public class ElasticsearchClientFactoryImplIT {
 		);
 		return new ElasticsearchClientFactoryImpl().create( beanResolver, clientPropertySource,
 				threadPoolProvider.threadProvider(), "Client",
-				new DelegatingSimpleScheduledExecutor( timeoutExecutorService ),
+				new DelegatingSimpleScheduledExecutor( timeoutExecutorService, true ),
 				GsonProvider.create( GsonBuilder::new, true )
 		);
 	}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/client/ElasticsearchContentLengthIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/client/ElasticsearchContentLengthIT.java
@@ -218,7 +218,7 @@ public class ElasticsearchContentLengthIT {
 		BeanResolver beanResolver = testConfigurationProvider.createBeanResolverForTest();
 		return new ElasticsearchClientFactoryImpl().create( beanResolver, clientPropertySource,
 				threadPoolProvider.threadProvider(), "Client",
-				new DelegatingSimpleScheduledExecutor( timeoutExecutorService ),
+				new DelegatingSimpleScheduledExecutor( timeoutExecutorService, true ),
 				GsonProvider.create( GsonBuilder::new, true ) );
 	}
 

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerDropAndCreateIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerDropAndCreateIT.java
@@ -118,7 +118,7 @@ public class ElasticsearchIndexSchemaManagerDropAndCreateIT {
 				.setup();
 
 		Futures.unwrappedExceptionJoin(
-				index.schemaManager().dropAndCreate( OperationSubmitter.BLOCKING )
+				index.schemaManager().dropAndCreate( OperationSubmitter.blocking() )
 		);
 	}
 

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerDropIfExistingIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerDropIfExistingIT.java
@@ -87,7 +87,7 @@ public class ElasticsearchIndexSchemaManagerDropIfExistingIT {
 				)
 				.setup();
 
-		Futures.unwrappedExceptionJoin( index.schemaManager().dropIfExisting( OperationSubmitter.BLOCKING ) );
+		Futures.unwrappedExceptionJoin( index.schemaManager().dropIfExisting( OperationSubmitter.blocking() ) );
 	}
 
 }

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerOperation.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerOperation.java
@@ -24,37 +24,37 @@ enum ElasticsearchIndexSchemaManagerOperation {
 	CREATE_IF_MISSING {
 		@Override
 		public CompletableFuture<?> apply(IndexSchemaManager schemaManager) {
-			return schemaManager.createIfMissing( OperationSubmitter.BLOCKING );
+			return schemaManager.createIfMissing( OperationSubmitter.blocking() );
 		}
 	},
 	DROP_AND_CREATE {
 		@Override
 		public CompletableFuture<?> apply(IndexSchemaManager schemaManager) {
-			return schemaManager.dropAndCreate( OperationSubmitter.BLOCKING );
+			return schemaManager.dropAndCreate( OperationSubmitter.blocking() );
 		}
 	},
 	CREATE_OR_VALIDATE {
 		@Override
 		public CompletableFuture<?> apply(IndexSchemaManager schemaManager) {
-			return schemaManager.createOrValidate( new StubUnusedContextualFailureCollector(), OperationSubmitter.BLOCKING );
+			return schemaManager.createOrValidate( new StubUnusedContextualFailureCollector(), OperationSubmitter.blocking() );
 		}
 	},
 	CREATE_OR_UPDATE {
 		@Override
 		public CompletableFuture<?> apply(IndexSchemaManager schemaManager) {
-			return schemaManager.createOrUpdate( OperationSubmitter.BLOCKING );
+			return schemaManager.createOrUpdate( OperationSubmitter.blocking() );
 		}
 	},
 	DROP_IF_EXISTING {
 		@Override
 		public CompletableFuture<?> apply(IndexSchemaManager schemaManager) {
-			return schemaManager.dropIfExisting( OperationSubmitter.BLOCKING );
+			return schemaManager.dropIfExisting( OperationSubmitter.blocking() );
 		}
 	},
 	VALIDATE {
 		@Override
 		public CompletableFuture<?> apply(IndexSchemaManager schemaManager) {
-			return schemaManager.validate( new StubUnusedContextualFailureCollector(), OperationSubmitter.BLOCKING );
+			return schemaManager.validate( new StubUnusedContextualFailureCollector(), OperationSubmitter.blocking() );
 		}
 	};
 

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateAliasesIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateAliasesIT.java
@@ -228,7 +228,7 @@ public class ElasticsearchIndexSchemaManagerUpdateAliasesIT {
 				.withIndex( index )
 				.setup();
 
-		index.schemaManager().createOrUpdate( OperationSubmitter.BLOCKING ).join();
+		index.schemaManager().createOrUpdate( OperationSubmitter.blocking() ).join();
 	}
 
 }

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateAnalyzerIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateAnalyzerIT.java
@@ -501,7 +501,7 @@ public class ElasticsearchIndexSchemaManagerUpdateAnalyzerIT {
 				.withIndex( index )
 				.setup();
 
-		index.schemaManager().createOrUpdate( OperationSubmitter.BLOCKING ).join();
+		index.schemaManager().createOrUpdate( OperationSubmitter.blocking() ).join();
 	}
 
 }

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateCustomMappingIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateCustomMappingIT.java
@@ -189,6 +189,6 @@ public class ElasticsearchIndexSchemaManagerUpdateCustomMappingIT {
 				.withIndex( index )
 				.setup();
 
-		Futures.unwrappedExceptionJoin( index.schemaManager().createOrUpdate( OperationSubmitter.BLOCKING ) );
+		Futures.unwrappedExceptionJoin( index.schemaManager().createOrUpdate( OperationSubmitter.blocking() ) );
 	}
 }

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateCustomSettingsIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateCustomSettingsIT.java
@@ -248,7 +248,7 @@ public class ElasticsearchIndexSchemaManagerUpdateCustomSettingsIT {
 				.withIndex( index )
 				.setup();
 
-		Futures.unwrappedExceptionJoin( index.schemaManager().createOrUpdate( OperationSubmitter.BLOCKING ) );
+		Futures.unwrappedExceptionJoin( index.schemaManager().createOrUpdate( OperationSubmitter.blocking() ) );
 	}
 
 }

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateMappingBaseIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateMappingBaseIT.java
@@ -399,7 +399,7 @@ public class ElasticsearchIndexSchemaManagerUpdateMappingBaseIT {
 				.withIndex( index )
 				.setup();
 
-		Futures.unwrappedExceptionJoin( index.schemaManager().createOrUpdate( OperationSubmitter.BLOCKING ) );
+		Futures.unwrappedExceptionJoin( index.schemaManager().createOrUpdate( OperationSubmitter.blocking() ) );
 	}
 
 	private String generateAnalysisSettings() {

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateMappingFieldTemplateIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateMappingFieldTemplateIT.java
@@ -668,7 +668,7 @@ public class ElasticsearchIndexSchemaManagerUpdateMappingFieldTemplateIT {
 				.withIndex( index )
 				.setup();
 
-		Futures.unwrappedExceptionJoin( index.schemaManager().createOrUpdate( OperationSubmitter.BLOCKING ) );
+		Futures.unwrappedExceptionJoin( index.schemaManager().createOrUpdate( OperationSubmitter.blocking() ) );
 	}
 
 	private String integerMappingForExpectations() {

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateNormalizerIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateNormalizerIT.java
@@ -320,7 +320,7 @@ public class ElasticsearchIndexSchemaManagerUpdateNormalizerIT {
 				.withIndex( index )
 				.setup();
 
-		index.schemaManager().createOrUpdate( OperationSubmitter.BLOCKING ).join();
+		index.schemaManager().createOrUpdate( OperationSubmitter.blocking() ).join();
 	}
 
 }

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerValidationOperation.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerValidationOperation.java
@@ -28,13 +28,13 @@ enum ElasticsearchIndexSchemaManagerValidationOperation {
 	CREATE_OR_VALIDATE {
 		@Override
 		protected CompletableFuture<?> apply(IndexSchemaManager schemaManager, ContextualFailureCollector failureCollector) {
-			return schemaManager.createOrValidate( failureCollector, OperationSubmitter.BLOCKING );
+			return schemaManager.createOrValidate( failureCollector, OperationSubmitter.blocking() );
 		}
 	},
 	VALIDATE {
 		@Override
 		protected CompletableFuture<?> apply(IndexSchemaManager schemaManager, ContextualFailureCollector failureCollector) {
-			return schemaManager.validate( failureCollector, OperationSubmitter.BLOCKING );
+			return schemaManager.validate( failureCollector, OperationSubmitter.blocking() );
 		}
 	};
 

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchBackendWorkExecutorProviderIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchBackendWorkExecutorProviderIT.java
@@ -44,7 +44,7 @@ public class ElasticsearchBackendWorkExecutorProviderIT {
 	@Test
 	public void test() {
 		when( backendWorkExecutorProvider.workExecutor( any() ) ).thenReturn(
-				new DelegatingSimpleScheduledExecutor( new ScheduledThreadPoolExecutor( 1 ) )
+				new DelegatingSimpleScheduledExecutor( new ScheduledThreadPoolExecutor( 1 ), true )
 		);
 		setupHelper.start()
 				.withIndex( index )

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchIndexingIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchIndexingIT.java
@@ -100,7 +100,7 @@ public class ElasticsearchIndexingIT {
 						.build(),
 				ElasticsearchRequestAssertionMode.EXTENSIBLE
 		);
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 		clientSpy.verifyExpectationsMet();
 
 		plan.addOrUpdate( referenceProvider( "1" ), document -> {
@@ -116,7 +116,7 @@ public class ElasticsearchIndexingIT {
 						.build(),
 				ElasticsearchRequestAssertionMode.EXTENSIBLE
 		);
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 		clientSpy.verifyExpectationsMet();
 
 		plan.delete( referenceProvider( "1" ) );
@@ -129,7 +129,7 @@ public class ElasticsearchIndexingIT {
 						.build(),
 				ElasticsearchRequestAssertionMode.EXTENSIBLE
 		);
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 		clientSpy.verifyExpectationsMet();
 	}
 
@@ -154,7 +154,7 @@ public class ElasticsearchIndexingIT {
 						.build(),
 				ElasticsearchRequestAssertionMode.EXTENSIBLE
 		);
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 		clientSpy.verifyExpectationsMet();
 
 		plan.addOrUpdate( referenceProvider( "1", routingKey ), document -> {
@@ -171,7 +171,7 @@ public class ElasticsearchIndexingIT {
 						.build(),
 				ElasticsearchRequestAssertionMode.EXTENSIBLE
 		);
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 		clientSpy.verifyExpectationsMet();
 
 		plan.delete( referenceProvider( "1", routingKey ) );
@@ -185,7 +185,7 @@ public class ElasticsearchIndexingIT {
 						.build(),
 				ElasticsearchRequestAssertionMode.EXTENSIBLE
 		);
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 		clientSpy.verifyExpectationsMet();
 	}
 

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchZeroDowntimeReindexingIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchZeroDowntimeReindexingIT.java
@@ -63,9 +63,9 @@ public class ElasticsearchZeroDowntimeReindexingIT {
 				document -> document.addValue( index.binding().text, "text1" ),
 				DocumentCommitStrategy.NONE,
 				DocumentRefreshStrategy.NONE,
-				OperationSubmitter.BLOCKING
+				OperationSubmitter.blocking()
 		).join();
-		workspace.refresh( OperationSubmitter.BLOCKING ).join();
+		workspace.refresh( OperationSubmitter.blocking() ).join();
 
 		SearchQuery<DocumentReference> text1Query = index
 				.createScope().query()
@@ -100,9 +100,9 @@ public class ElasticsearchZeroDowntimeReindexingIT {
 				document -> document.addValue( index.binding().text, "text2" ),
 				DocumentCommitStrategy.NONE,
 				DocumentRefreshStrategy.NONE,
-				OperationSubmitter.BLOCKING
+				OperationSubmitter.blocking()
 		).join();
-		workspace.refresh( OperationSubmitter.BLOCKING ).join();
+		workspace.refresh( OperationSubmitter.blocking() ).join();
 
 		// Search queries are unaffected: text == "text1"
 		assertThatQuery( text1Query ).hasTotalHitCount( 1 );

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/index/LuceneIndexManagerIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/index/LuceneIndexManagerIT.java
@@ -95,7 +95,7 @@ public class LuceneIndexManagerIT {
 				) )
 				.join();
 
-		index.createWorkspace().flush( OperationSubmitter.BLOCKING ).join();
+		index.createWorkspace().flush( OperationSubmitter.blocking() ).join();
 
 		long finalSize = indexApi.computeSizeInBytes();
 		assertThat( finalSize ).isGreaterThan( 0L );
@@ -118,7 +118,7 @@ public class LuceneIndexManagerIT {
 				) )
 				.join();
 
-		index.createWorkspace().flush( OperationSubmitter.BLOCKING ).join();
+		index.createWorkspace().flush( OperationSubmitter.blocking() ).join();
 
 		CompletableFuture<Long> finalSizeFuture = indexApi.computeSizeInBytesAsync().toCompletableFuture();
 		await().untilAsserted( () -> assertThat( finalSizeFuture ).isCompleted() );

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lifecycle/LuceneCleanupIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lifecycle/LuceneCleanupIT.java
@@ -121,7 +121,7 @@ public class LuceneCleanupIT {
 				document.addValue( binding.integer.reference, id );
 			} );
 		}
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 	}
 
 	private StubMapping setup(OpenResourceTracker tracker) {

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/AbstractDirectoryIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/AbstractDirectoryIT.java
@@ -53,7 +53,7 @@ public abstract class AbstractDirectoryIT {
 		plan.add( referenceProvider( DOCUMENT_3 ), document -> {
 			document.addValue( index.binding().string, "text 3" );
 		} );
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = index.createScope();

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/MultiDirectoryIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/MultiDirectoryIT.java
@@ -117,7 +117,7 @@ public class MultiDirectoryIT {
 		plan.add( referenceProvider( DOCUMENT_3 ), document -> {
 			document.addValue( index.binding().string, "text 3" );
 		} );
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		// Check that all documents are searchable
 		assertThatQuery( index.query().where( f -> f.matchAll() ) )

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/reader/LuceneIndexReaderRefreshBaseIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/reader/LuceneIndexReaderRefreshBaseIT.java
@@ -83,7 +83,7 @@ public class LuceneIndexReaderRefreshBaseIT {
 				DocumentRefreshStrategy.NONE // The refresh should be executed regardless of this parameter
 		);
 		plan.add( referenceProvider( "1" ), document -> document.addValue( index.binding().textField, "text1" ) );
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		// Readers should be up-to-date immediately after indexing finishes
 		assertThatQuery( query ).hasTotalHitCount( 1 );
@@ -104,7 +104,7 @@ public class LuceneIndexReaderRefreshBaseIT {
 				DocumentRefreshStrategy.NONE // The refresh should be executed regardless of this parameter
 		);
 		plan.add( referenceProvider( "1" ), document -> document.addValue( index.binding().textField, "text1" ) );
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		// Readers should be up-to-date immediately after indexing finishes
 		assertThatQuery( query ).hasTotalHitCount( 1 );
@@ -125,7 +125,7 @@ public class LuceneIndexReaderRefreshBaseIT {
 				DocumentRefreshStrategy.NONE // This means no refresh will take place until after the refresh interval
 		);
 		plan.add( referenceProvider( "1" ), document -> document.addValue( index.binding().textField, "text1" ) );
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		// Readers should *not* be up-to-date immediately after indexing finishes
 		assertThatQuery( query ).hasNoHits();
@@ -149,7 +149,7 @@ public class LuceneIndexReaderRefreshBaseIT {
 				DocumentRefreshStrategy.FORCE // This will force a refresh before the end of the refresh interval
 		);
 		plan.add( referenceProvider( "1" ), document -> document.addValue( index.binding().textField, "text1" ) );
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		// Readers should be up-to-date immediately after indexing finishes
 		assertThatQuery( query ).hasTotalHitCount( 1 );
@@ -170,7 +170,7 @@ public class LuceneIndexReaderRefreshBaseIT {
 				DocumentRefreshStrategy.NONE // The refresh should be executed regardless of this parameter
 		);
 		plan.add( referenceProvider( "1" ), document -> document.addValue( index.binding().textField, "text1" ) );
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		// Readers should be up-to-date immediately after indexing finishes
 		assertThatQuery( query ).hasTotalHitCount( 1 );

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/reader/LuceneIndexReaderRefreshSettingsPerShardIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/reader/LuceneIndexReaderRefreshSettingsPerShardIT.java
@@ -59,7 +59,7 @@ public class LuceneIndexReaderRefreshSettingsPerShardIT extends AbstractSettings
 		for ( int i = 0; i < 400; i++ ) {
 			plan.add( referenceProvider( String.valueOf( i ), routingKey( i ) ), document -> { } );
 		}
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		// Readers should be up-to-date immediately after indexing finishes for shard 2
 		// but not (yet) for shards 0, 1 and 3,

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/writer/LuceneIndexWriterCommitIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/writer/LuceneIndexWriterCommitIT.java
@@ -81,7 +81,7 @@ public class LuceneIndexWriterCommitIT {
 				DocumentRefreshStrategy.NONE // This is irrelevant
 		);
 		plan.add( referenceProvider( "1" ), document -> { } );
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		// Commit will happen some time after indexing finished
 		Awaitility.await().untilAsserted( () -> {
@@ -108,7 +108,7 @@ public class LuceneIndexWriterCommitIT {
 				DocumentRefreshStrategy.NONE // This is irrelevant
 		);
 		plan.add( referenceProvider( "1" ), document -> { } );
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		// Commit should have happened before indexing finished
 		assertThat( countDocsOnDisk() ).isEqualTo( 1 );
@@ -130,7 +130,7 @@ public class LuceneIndexWriterCommitIT {
 				DocumentRefreshStrategy.NONE // The refresh should be done regardless of this parameter
 		);
 		plan.add( referenceProvider( "1" ), document -> { } );
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		// Stop Hibernate Search
 		mapping.close();

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/writer/LuceneIndexWriterSettingsIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/writer/LuceneIndexWriterSettingsIT.java
@@ -88,7 +88,7 @@ public class LuceneIndexWriterSettingsIT {
 		// Add a document to the index
 		IndexIndexingPlan plan = index.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), document -> { } );
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		// Check that writing succeeded
 		assertThatQuery( index.createScope().query().where( f -> f.matchAll() ).toQuery() )
@@ -151,7 +151,7 @@ public class LuceneIndexWriterSettingsIT {
 		// Add a document to the index
 		IndexIndexingPlan plan = index.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), document -> { } );
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		// Check that writing succeeded
 		assertThatQuery( index.createScope().query().where( f -> f.matchAll() ).toQuery() )

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/schema/management/LuceneIndexSchemaManagerCreationIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/schema/management/LuceneIndexSchemaManagerCreationIT.java
@@ -61,7 +61,7 @@ public class LuceneIndexSchemaManagerCreationIT {
 	}
 
 	private void create() {
-		Futures.unwrappedExceptionJoin( operation.apply( index.schemaManager(), OperationSubmitter.BLOCKING ) );
+		Futures.unwrappedExceptionJoin( operation.apply( index.schemaManager(), OperationSubmitter.blocking() ) );
 	}
 
 	private void setup() {

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/schema/management/LuceneIndexSchemaManagerCreationOrPreservationIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/schema/management/LuceneIndexSchemaManagerCreationOrPreservationIT.java
@@ -69,7 +69,7 @@ public class LuceneIndexSchemaManagerCreationOrPreservationIT {
 		IndexIndexingPlan plan = index.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), document -> {
 		} );
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		assertThat( countDocsOnDisk() ).isEqualTo( 1 );
 
@@ -91,7 +91,7 @@ public class LuceneIndexSchemaManagerCreationOrPreservationIT {
 	}
 
 	private void createOrPreserve() {
-		Futures.unwrappedExceptionJoin( operation.apply( index.schemaManager(), OperationSubmitter.BLOCKING ) );
+		Futures.unwrappedExceptionJoin( operation.apply( index.schemaManager(), OperationSubmitter.blocking() ) );
 	}
 
 	private void setup() {

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/schema/management/LuceneIndexSchemaManagerDropAndCreateIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/schema/management/LuceneIndexSchemaManagerDropAndCreateIT.java
@@ -46,7 +46,7 @@ public class LuceneIndexSchemaManagerDropAndCreateIT {
 		IndexIndexingPlan plan = index.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), document -> {
 		} );
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		assertThat( countDocsOnDisk() ).isEqualTo( 1 );
 
@@ -70,7 +70,7 @@ public class LuceneIndexSchemaManagerDropAndCreateIT {
 	private void dropAndCreate() {
 		Futures.unwrappedExceptionJoin(
 				LuceneIndexSchemaManagerOperation.DROP_AND_CREATE.apply( index.schemaManager(),
-						OperationSubmitter.BLOCKING
+						OperationSubmitter.blocking()
 				)
 		);
 	}

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/schema/management/LuceneIndexSchemaManagerDropIfExistingIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/schema/management/LuceneIndexSchemaManagerDropIfExistingIT.java
@@ -43,7 +43,7 @@ public class LuceneIndexSchemaManagerDropIfExistingIT {
 		// The setup currently creates the index: work around that.
 		Futures.unwrappedExceptionJoin(
 				LuceneIndexSchemaManagerOperation.DROP_IF_EXISTING.apply( index.schemaManager(),
-						OperationSubmitter.BLOCKING
+						OperationSubmitter.blocking()
 				)
 		);
 
@@ -51,7 +51,7 @@ public class LuceneIndexSchemaManagerDropIfExistingIT {
 
 		Futures.unwrappedExceptionJoin(
 				LuceneIndexSchemaManagerOperation.DROP_IF_EXISTING.apply( index.schemaManager(),
-						OperationSubmitter.BLOCKING
+						OperationSubmitter.blocking()
 				)
 		);
 
@@ -67,7 +67,7 @@ public class LuceneIndexSchemaManagerDropIfExistingIT {
 		setup();
 		Futures.unwrappedExceptionJoin(
 				LuceneIndexSchemaManagerOperation.CREATE_IF_MISSING.apply( index.schemaManager(),
-						OperationSubmitter.BLOCKING
+						OperationSubmitter.blocking()
 				)
 		);
 
@@ -76,13 +76,13 @@ public class LuceneIndexSchemaManagerDropIfExistingIT {
 		IndexIndexingPlan plan = index.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), document -> {
 		} );
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		assertThat( countDocsOnDisk() ).isEqualTo( 1 );
 
 		Futures.unwrappedExceptionJoin(
 				LuceneIndexSchemaManagerOperation.DROP_IF_EXISTING.apply( index.schemaManager(),
-						OperationSubmitter.BLOCKING
+						OperationSubmitter.blocking()
 				)
 		);
 

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/schema/management/LuceneIndexSchemaManagerValidationIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/schema/management/LuceneIndexSchemaManagerValidationIT.java
@@ -39,7 +39,7 @@ public class LuceneIndexSchemaManagerValidationIT {
 		// The setup currently creates the index: work around that.
 		Futures.unwrappedExceptionJoin(
 				LuceneIndexSchemaManagerOperation.DROP_IF_EXISTING.apply( index.schemaManager(),
-						OperationSubmitter.BLOCKING
+						OperationSubmitter.blocking()
 				)
 		);
 
@@ -73,7 +73,7 @@ public class LuceneIndexSchemaManagerValidationIT {
 
 	private void validate() {
 		Futures.unwrappedExceptionJoin(
-				LuceneIndexSchemaManagerOperation.VALIDATE.apply( index.schemaManager(), OperationSubmitter.BLOCKING )
+				LuceneIndexSchemaManagerOperation.VALIDATE.apply( index.schemaManager(), OperationSubmitter.blocking() )
 		);
 	}
 

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/work/LuceneBackendWorkExecutorProviderIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/work/LuceneBackendWorkExecutorProviderIT.java
@@ -44,7 +44,7 @@ public class LuceneBackendWorkExecutorProviderIT {
 	@Test
 	public void test() {
 		when( backendWorkExecutorProvider.writeExecutor( any() ) ).thenReturn(
-				new DelegatingSimpleScheduledExecutor( new ScheduledThreadPoolExecutor( 1 ) )
+				new DelegatingSimpleScheduledExecutor( new ScheduledThreadPoolExecutor( 1 ), true )
 		);
 		setupHelper.start()
 				.withIndex( index )

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/work/LuceneIndexingNestedIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/work/LuceneIndexingNestedIT.java
@@ -63,7 +63,7 @@ public class LuceneIndexingNestedIT {
 			DocumentElement nested = document.addObject( index.binding().nestedObject.self );
 			nested.addValue( index.binding().nestedObject.field2, "value" );
 		} );
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		assertThat( countWithField( "nestedObject.field2" ) ).isEqualTo( 1 );
 		// This used to fail before HSEARCH-3834, because the nested document was left in the index.
@@ -81,7 +81,7 @@ public class LuceneIndexingNestedIT {
 			DocumentElement nested = document.addObject( index.binding().nestedObject.self );
 			nested.addValue( index.binding().nestedObject.field2, "value" );
 		} );
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		assertThat( countWithField( "nestedObject.field2" ) ).isEqualTo( 1 );
 		// This used to fail before HSEARCH-3834, because the nested document was left in the index.
@@ -95,7 +95,7 @@ public class LuceneIndexingNestedIT {
 
 		IndexIndexingPlan plan = index.createIndexingPlan( sessionContext );
 		plan.delete( referenceProvider( "1" ) );
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		// This used to fail before HSEARCH-3834, because the nested document was left in the index.
 		assertThat( countWithField( "nestedObject.field1" ) ).isEqualTo( 0 );
@@ -108,7 +108,7 @@ public class LuceneIndexingNestedIT {
 
 		IndexIndexingPlan plan = index.createIndexingPlan( sessionContext );
 		plan.delete( referenceProvider( "1" ) );
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		// This used to fail before HSEARCH-3834, because the nested document was left in the index.
 		assertThat( countWithField( "nestedObject.field1" ) ).isEqualTo( 0 );
@@ -118,8 +118,8 @@ public class LuceneIndexingNestedIT {
 	public void purge() throws IOException {
 		setup( MultiTenancyStrategyName.NONE );
 
-		index.createWorkspace( sessionContext ).purge( Collections.emptySet(), OperationSubmitter.BLOCKING ).join();
-		index.createWorkspace( sessionContext ).refresh( OperationSubmitter.BLOCKING ).join();
+		index.createWorkspace( sessionContext ).purge( Collections.emptySet(), OperationSubmitter.blocking() ).join();
+		index.createWorkspace( sessionContext ).refresh( OperationSubmitter.blocking() ).join();
 
 		assertThat( countWithField( "nestedObject.field1" ) ).isEqualTo( 0 );
 	}
@@ -150,7 +150,7 @@ public class LuceneIndexingNestedIT {
 			DocumentElement nested = document.addObject( index.binding().nestedObject.self );
 			nested.addValue( index.binding().nestedObject.field1, "value" );
 		} );
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 	}
 
 	private int countWithField(String absoluteFieldPath) throws IOException {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/dynamic/FieldTemplateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/dynamic/FieldTemplateIT.java
@@ -259,7 +259,7 @@ public class FieldTemplateIT {
 				document -> initDocument( document, "parent.foo",
 						"matchedValue", "notMatchedValue1", "notMatchedValue2"
 				),
-				DocumentCommitStrategy.FORCE, DocumentRefreshStrategy.NONE, OperationSubmitter.BLOCKING
+				DocumentCommitStrategy.FORCE, DocumentRefreshStrategy.NONE, OperationSubmitter.blocking()
 		) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll(

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/multitenancy/MultiTenancyBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/multitenancy/MultiTenancyBaseIT.java
@@ -190,7 +190,7 @@ public class MultiTenancyBaseIT {
 
 		plan.delete( referenceProvider( DOCUMENT_ID_1 ) );
 
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		assertThatQuery( query )
 				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_ID_2 );
@@ -234,7 +234,7 @@ public class MultiTenancyBaseIT {
 			nestedObject.addValue( index.binding().nestedObject.integer, INTEGER_VALUE_4 );
 		} );
 
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		// The tenant 2 has been updated properly.
 
@@ -343,7 +343,7 @@ public class MultiTenancyBaseIT {
 				nestedObject.addValue( index.binding().nestedObject.integer, INTEGER_VALUE_5 );
 			} );
 
-			plan.execute( OperationSubmitter.BLOCKING ).join();
+			plan.execute( OperationSubmitter.blocking() ).join();
 		} )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll( "Missing tenant identifier",
@@ -364,7 +364,7 @@ public class MultiTenancyBaseIT {
 				nestedObject.addValue( index.binding().nestedObject.integer, INTEGER_VALUE_4 );
 			} );
 
-			plan.execute( OperationSubmitter.BLOCKING ).join();
+			plan.execute( OperationSubmitter.blocking() ).join();
 		} )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll( "Missing tenant identifier",
@@ -376,7 +376,7 @@ public class MultiTenancyBaseIT {
 		assertThatThrownBy( () -> {
 			IndexIndexingPlan plan = index.createIndexingPlan();
 			plan.delete( referenceProvider( DOCUMENT_ID_1 ) );
-			plan.execute( OperationSubmitter.BLOCKING ).join();
+			plan.execute( OperationSubmitter.blocking() ).join();
 		} )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll( "Missing tenant identifier",
@@ -403,7 +403,7 @@ public class MultiTenancyBaseIT {
 			nestedObject.addValue( index.binding().nestedObject.integer, INTEGER_VALUE_2 );
 		} );
 
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		plan = index.createIndexingPlan( tenant2SessionContext );
 		plan.add( referenceProvider( DOCUMENT_ID_1 ), document -> {
@@ -424,7 +424,7 @@ public class MultiTenancyBaseIT {
 			nestedObject.addValue( index.binding().nestedObject.integer, INTEGER_VALUE_4 );
 		} );
 
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = index.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/multitenancy/MultiTenancyMismatchIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/multitenancy/MultiTenancyMismatchIT.java
@@ -98,7 +98,7 @@ public class MultiTenancyMismatchIT {
 		assertThatThrownBy( () -> {
 			IndexIndexingPlan plan = index.createIndexingPlan( tenant1Session );
 			plan.addOrUpdate( referenceProvider( "1" ), document -> { } );
-			plan.execute( OperationSubmitter.BLOCKING ).join();
+			plan.execute( OperationSubmitter.blocking() ).join();
 		} )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll(
@@ -116,7 +116,7 @@ public class MultiTenancyMismatchIT {
 		assertThatThrownBy( () -> {
 			IndexIndexingPlan plan = index.createIndexingPlan( tenant1Session );
 			plan.addOrUpdate( referenceProvider( "1" ), document -> { } );
-			plan.execute( OperationSubmitter.BLOCKING ).join();
+			plan.execute( OperationSubmitter.blocking() ).join();
 		} )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll(
@@ -134,7 +134,7 @@ public class MultiTenancyMismatchIT {
 		assertThatThrownBy( () -> {
 			IndexIndexingPlan plan = index.createIndexingPlan( tenant1Session );
 			plan.delete( referenceProvider( "1" ) );
-			plan.execute( OperationSubmitter.BLOCKING ).join();
+			plan.execute( OperationSubmitter.blocking() ).join();
 		} )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll(

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/AbstractShardingRoutingKeyIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/AbstractShardingRoutingKeyIT.java
@@ -134,10 +134,10 @@ public abstract class AbstractShardingRoutingKeyIT extends AbstractShardingIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3824")
 	public void purge_noRoutingKey() {
-		index.createWorkspace().purge( Collections.emptySet(), OperationSubmitter.BLOCKING ).join();
+		index.createWorkspace().purge( Collections.emptySet(), OperationSubmitter.blocking() ).join();
 
 		// No routing key => all documents should be purged
-		index.createWorkspace().refresh( OperationSubmitter.BLOCKING ).join();
+		index.createWorkspace().refresh( OperationSubmitter.blocking() ).join();
 		assertThatQuery( index.createScope().query().where( f -> f.matchAll() ).toQuery() )
 				.hasNoHits();
 	}
@@ -151,13 +151,13 @@ public abstract class AbstractShardingRoutingKeyIT extends AbstractShardingIT {
 		Set<String> otherRoutingKeys = new LinkedHashSet<>( routingKeys );
 		otherRoutingKeys.remove( someRoutingKey );
 
-		index.createWorkspace().purge( Collections.singleton( someRoutingKey ), OperationSubmitter.BLOCKING ).join();
+		index.createWorkspace().purge( Collections.singleton( someRoutingKey ), OperationSubmitter.blocking() ).join();
 
 		/*
 		 * One routing key => all documents indexed with that routing key should be purged,
 		 * and only those documents.
 		 */
-		index.createWorkspace().refresh( OperationSubmitter.BLOCKING ).join();
+		index.createWorkspace().refresh( OperationSubmitter.blocking() ).join();
 		assertThatQuery( index.createScope().query().where( f -> f.matchAll() ).toQuery() )
 				.hits().asNormalizedDocRefs()
 				.containsExactlyInAnyOrder( docRefsForRoutingKeys( otherRoutingKeys, docIdByRoutingKey ) );
@@ -172,13 +172,13 @@ public abstract class AbstractShardingRoutingKeyIT extends AbstractShardingIT {
 		Set<String> otherRoutingKeys = new LinkedHashSet<>( routingKeys );
 		otherRoutingKeys.removeAll( twoRoutingKeys );
 
-		index.createWorkspace().purge( twoRoutingKeys, OperationSubmitter.BLOCKING ).join();
+		index.createWorkspace().purge( twoRoutingKeys, OperationSubmitter.blocking() ).join();
 
 		/*
 		 * Two routing keys => all documents indexed with these routing keys should be returned,
 		 * and only those documents.
 		 */
-		index.createWorkspace().refresh( OperationSubmitter.BLOCKING ).join();
+		index.createWorkspace().refresh( OperationSubmitter.blocking() ).join();
 		assertThatQuery( index.createScope().query().where( f -> f.matchAll() ).toQuery() )
 				.hits().asNormalizedDocRefs()
 				.containsExactlyInAnyOrder( docRefsForRoutingKeys( otherRoutingKeys, docIdByRoutingKey ) );
@@ -187,10 +187,10 @@ public abstract class AbstractShardingRoutingKeyIT extends AbstractShardingIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3824")
 	public void purge_allRoutingKeys() {
-		index.createWorkspace().purge( routingKeys, OperationSubmitter.BLOCKING ).join();
+		index.createWorkspace().purge( routingKeys, OperationSubmitter.blocking() ).join();
 
 		// All routing keys => all documents should be purged
-		index.createWorkspace().refresh( OperationSubmitter.BLOCKING ).join();
+		index.createWorkspace().refresh( OperationSubmitter.blocking() ).join();
 		assertThatQuery( index.createScope().query().where( f -> f.matchAll() ).toQuery() )
 				.hasNoHits();
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/ShardingHashDocumentIdIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/ShardingHashDocumentIdIT.java
@@ -105,10 +105,10 @@ public class ShardingHashDocumentIdIT extends AbstractShardingIT {
 		Iterator<String> iterator = docIds.iterator();
 		String someDocumentId = iterator.next();
 
-		index.createWorkspace().purge( Collections.singleton( someDocumentId ), OperationSubmitter.BLOCKING ).join();
+		index.createWorkspace().purge( Collections.singleton( someDocumentId ), OperationSubmitter.blocking() ).join();
 
 		// One or more explicit routing key => no document should be purged, since no documents was indexed with that routing key.
-		index.createWorkspace().refresh( OperationSubmitter.BLOCKING ).join();
+		index.createWorkspace().refresh( OperationSubmitter.blocking() ).join();
 		assertThatQuery( index.createScope().query().where( f -> f.matchAll() ).toQuery() )
 				.hits().asNormalizedDocRefs()
 				.hasSize( TOTAL_DOCUMENT_COUNT )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexerIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexerIT.java
@@ -89,7 +89,7 @@ public class IndexIndexerIT {
 			tasks[i] = indexer.add(
 					referenceProvider( id ),
 					document -> document.addValue( index.binding().title, "The Lord of the Rings chap. " + id ),
-					commitStrategy, refreshStrategy, OperationSubmitter.BLOCKING
+					commitStrategy, refreshStrategy, OperationSubmitter.blocking()
 			);
 		}
 		CompletableFuture<?> future = CompletableFuture.allOf( tasks );
@@ -114,7 +114,7 @@ public class IndexIndexerIT {
 			tasks[i] = indexer.addOrUpdate(
 					referenceProvider( id ),
 					document -> document.addValue( index.binding().title, "The Boss of the Rings chap. " + id ),
-					commitStrategy, refreshStrategy, OperationSubmitter.BLOCKING
+					commitStrategy, refreshStrategy, OperationSubmitter.blocking()
 			);
 		}
 		future = CompletableFuture.allOf( tasks );
@@ -138,7 +138,7 @@ public class IndexIndexerIT {
 			final String id = String.valueOf( i + booksToUpdate );
 			tasks[i] = indexer.delete(
 					referenceProvider( id ),
-					commitStrategy, refreshStrategy, OperationSubmitter.BLOCKING
+					commitStrategy, refreshStrategy, OperationSubmitter.blocking()
 			);
 		}
 		future = CompletableFuture.allOf( tasks );
@@ -166,7 +166,7 @@ public class IndexIndexerIT {
 		CompletableFuture<?> future = indexer.add(
 				referenceProvider( "1" ),
 				document -> document.addValue( index.binding().title, "Document #1" ),
-				commitStrategy, refreshStrategy, OperationSubmitter.BLOCKING
+				commitStrategy, refreshStrategy, OperationSubmitter.blocking()
 		);
 		Awaitility.await().until( future::isDone );
 
@@ -192,7 +192,7 @@ public class IndexIndexerIT {
 		CompletableFuture<?> future = indexer.addOrUpdate(
 				referenceProvider( "1" ),
 				document -> document.addValue( index.binding().title, "Document #1" ),
-				commitStrategy, refreshStrategy, OperationSubmitter.BLOCKING
+				commitStrategy, refreshStrategy, OperationSubmitter.blocking()
 		);
 		Awaitility.await().until( future::isDone );
 
@@ -216,7 +216,7 @@ public class IndexIndexerIT {
 		setupHelper.getBackendAccessor().ensureIndexingOperationsFail( index.name() );
 
 		CompletableFuture<?> future = indexer.delete(
-				referenceProvider( "1" ), commitStrategy, refreshStrategy, OperationSubmitter.BLOCKING
+				referenceProvider( "1" ), commitStrategy, refreshStrategy, OperationSubmitter.blocking()
 		);
 		Awaitility.await().until( future::isDone );
 
@@ -235,7 +235,7 @@ public class IndexIndexerIT {
 	private void refreshIfNecessary() {
 		if ( DocumentRefreshStrategy.NONE.equals( refreshStrategy ) ) {
 			IndexWorkspace workspace = index.createWorkspace();
-			workspace.refresh( OperationSubmitter.BLOCKING ).join();
+			workspace.refresh( OperationSubmitter.blocking() ).join();
 		}
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexerLargeDocumentsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexerLargeDocumentsIT.java
@@ -98,7 +98,7 @@ public class IndexIndexerLargeDocumentsIT {
 
 		indexAndWait( count, valueProvider, operation );
 
-		index.createWorkspace().refresh( OperationSubmitter.BLOCKING ).join();
+		index.createWorkspace().refresh( OperationSubmitter.blocking() ).join();
 
 		assertThatQuery( index.query()
 				.where( f -> f.matchAll() ) )
@@ -153,7 +153,7 @@ public class IndexIndexerLargeDocumentsIT {
 			public CompletableFuture<?> apply(IndexIndexer indexer, DocumentReferenceProvider referenceProvider,
 					DocumentContributor documentContributor) {
 				return indexer.add( referenceProvider, documentContributor,
-						DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE, OperationSubmitter.BLOCKING );
+						DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE, OperationSubmitter.blocking() );
 			}
 		},
 		ADD_OR_UPDATE {
@@ -161,7 +161,7 @@ public class IndexIndexerLargeDocumentsIT {
 			public CompletableFuture<?> apply(IndexIndexer indexer, DocumentReferenceProvider referenceProvider,
 					DocumentContributor documentContributor) {
 				return indexer.addOrUpdate( referenceProvider, documentContributor,
-						DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE, OperationSubmitter.BLOCKING
+						DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE, OperationSubmitter.blocking()
 				);
 			}
 		};

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexingPlanIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexingPlanIT.java
@@ -105,7 +105,7 @@ public class IndexIndexingPlanIT {
 		plan.add( referenceProvider( "1" ), document -> document.addValue( index.binding().title, "The Lord of the Rings chap. 1" ) );
 		plan.add( referenceProvider( "2" ), document -> document.addValue( index.binding().title, "The Lord of the Rings chap. 2" ) );
 		plan.add( referenceProvider( "3" ), document -> document.addValue( index.binding().title, "The Lord of the Rings chap. 3" ) );
-		CompletableFuture<?> future = plan.execute( OperationSubmitter.BLOCKING );
+		CompletableFuture<?> future = plan.execute( OperationSubmitter.blocking() );
 		Awaitility.await().until( future::isDone );
 		// The operations should succeed.
 		assertThatFuture( future ).isSuccessful();
@@ -117,7 +117,7 @@ public class IndexIndexingPlanIT {
 
 		// Update
 		plan.addOrUpdate( referenceProvider( "2" ), document -> document.addValue( index.binding().title, "The Boss of the Rings chap. 2" ) );
-		future = plan.execute( OperationSubmitter.BLOCKING );
+		future = plan.execute( OperationSubmitter.blocking() );
 		Awaitility.await().until( future::isDone );
 		// The operations should succeed.
 		assertThatFuture( future ).isSuccessful();
@@ -129,7 +129,7 @@ public class IndexIndexingPlanIT {
 
 		// Delete
 		plan.delete( referenceProvider( "1" ) );
-		future = plan.execute( OperationSubmitter.BLOCKING );
+		future = plan.execute( OperationSubmitter.blocking() );
 		Awaitility.await().until( future::isDone );
 		// The operations should succeed.
 		assertThatFuture( future ).isSuccessful();
@@ -148,7 +148,7 @@ public class IndexIndexingPlanIT {
 		plan.discard();
 		plan.add( referenceProvider( "2" ), document -> document.addValue( index.binding().title, "Title of Book 2" ) );
 
-		CompletableFuture<?> future = plan.execute( OperationSubmitter.BLOCKING );
+		CompletableFuture<?> future = plan.execute( OperationSubmitter.blocking() );
 		Awaitility.await().until( future::isDone );
 		// The operations should succeed.
 		assertThatFuture( future ).isSuccessful();
@@ -168,7 +168,7 @@ public class IndexIndexingPlanIT {
 		// Trigger failures in the next operations
 		setupHelper.getBackendAccessor().ensureIndexingOperationsFail( index.name() );
 
-		CompletableFuture<?> future = plan.execute( OperationSubmitter.BLOCKING );
+		CompletableFuture<?> future = plan.execute( OperationSubmitter.blocking() );
 		Awaitility.await().until( future::isDone );
 
 		// The operation should fail.
@@ -194,7 +194,7 @@ public class IndexIndexingPlanIT {
 		// Trigger failures in the next operations
 		setupHelper.getBackendAccessor().ensureIndexingOperationsFail( index.name() );
 
-		CompletableFuture<?> future = plan.execute( OperationSubmitter.BLOCKING );
+		CompletableFuture<?> future = plan.execute( OperationSubmitter.blocking() );
 		Awaitility.await().until( future::isDone );
 
 		// The operation should fail.
@@ -220,7 +220,7 @@ public class IndexIndexingPlanIT {
 		// Trigger failures in the next operations
 		setupHelper.getBackendAccessor().ensureIndexingOperationsFail( index.name() );
 
-		CompletableFuture<?> future = plan.execute( OperationSubmitter.BLOCKING );
+		CompletableFuture<?> future = plan.execute( OperationSubmitter.blocking() );
 		Awaitility.await().until( future::isDone );
 
 		// The operation should fail.
@@ -248,7 +248,7 @@ public class IndexIndexingPlanIT {
 		setupHelper.getBackendAccessor().ensureIndexingOperationsFail( index.name() );
 
 		CompletableFuture<MultiEntityOperationExecutionReport<StubEntityReference>> future =
-				plan.executeAndReport( StubEntityReference.FACTORY, OperationSubmitter.BLOCKING );
+				plan.executeAndReport( StubEntityReference.FACTORY, OperationSubmitter.blocking() );
 		Awaitility.await().until( future::isDone );
 
 		// The operation should succeed, but the report should indicate a failure.

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceFlushIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceFlushIT.java
@@ -22,7 +22,7 @@ public class IndexWorkspaceFlushIT extends AbstractIndexWorkspaceSimpleOperation
 
 	@Override
 	protected CompletableFuture<?> executeAsync(IndexWorkspace workspace) {
-		return workspace.flush( OperationSubmitter.REJECTED_EXECUTION_EXCEPTION );
+		return workspace.flush( OperationSubmitter.rejecting() );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceIT.java
@@ -59,16 +59,16 @@ public class IndexWorkspaceIT {
 		IndexWorkspace workspace = index.createWorkspace();
 		createBookIndexes( noTenantSessionContext );
 
-		workspace.refresh( OperationSubmitter.BLOCKING ).join();
+		workspace.refresh( OperationSubmitter.blocking() ).join();
 		assertBookNumberIsEqualsTo( NUMBER_OF_BOOKS, noTenantSessionContext );
 
-		workspace.mergeSegments( OperationSubmitter.BLOCKING ).join();
+		workspace.mergeSegments( OperationSubmitter.blocking() ).join();
 		assertBookNumberIsEqualsTo( NUMBER_OF_BOOKS, noTenantSessionContext );
 
 		// purge without providing a tenant
-		workspace.purge( Collections.emptySet(), OperationSubmitter.BLOCKING ).join();
-		workspace.flush( OperationSubmitter.BLOCKING ).join();
-		workspace.refresh( OperationSubmitter.BLOCKING ).join();
+		workspace.purge( Collections.emptySet(), OperationSubmitter.blocking() ).join();
+		workspace.flush( OperationSubmitter.blocking() ).join();
+		workspace.refresh( OperationSubmitter.blocking() ).join();
 
 		assertBookNumberIsEqualsTo( 0, noTenantSessionContext );
 	}
@@ -84,18 +84,18 @@ public class IndexWorkspaceIT {
 
 		createBookIndexes( tenant1SessionContext );
 		createBookIndexes( tenant2SessionContext );
-		workspace.refresh( OperationSubmitter.BLOCKING ).join();
+		workspace.refresh( OperationSubmitter.blocking() ).join();
 
 		assertBookNumberIsEqualsTo( NUMBER_OF_BOOKS, tenant1SessionContext );
 		assertBookNumberIsEqualsTo( NUMBER_OF_BOOKS, tenant2SessionContext );
 
-		workspace.mergeSegments( OperationSubmitter.BLOCKING ).join();
+		workspace.mergeSegments( OperationSubmitter.blocking() ).join();
 		assertBookNumberIsEqualsTo( NUMBER_OF_BOOKS, tenant1SessionContext );
 		assertBookNumberIsEqualsTo( NUMBER_OF_BOOKS, tenant2SessionContext );
 
-		workspace.purge( Collections.emptySet(), OperationSubmitter.BLOCKING ).join();
-		workspace.flush( OperationSubmitter.BLOCKING ).join();
-		workspace.refresh( OperationSubmitter.BLOCKING ).join();
+		workspace.purge( Collections.emptySet(), OperationSubmitter.blocking() ).join();
+		workspace.flush( OperationSubmitter.blocking() ).join();
+		workspace.refresh( OperationSubmitter.blocking() ).join();
 
 		// check that only TENANT_1 is affected by the purge
 		assertBookNumberIsEqualsTo( 0, tenant1SessionContext );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceMergeSegmentsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceMergeSegmentsIT.java
@@ -22,7 +22,7 @@ public class IndexWorkspaceMergeSegmentsIT extends AbstractIndexWorkspaceSimpleO
 
 	@Override
 	protected CompletableFuture<?> executeAsync(IndexWorkspace workspace) {
-		return workspace.mergeSegments( OperationSubmitter.REJECTED_EXECUTION_EXCEPTION );
+		return workspace.mergeSegments( OperationSubmitter.rejecting() );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspacePurgeIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspacePurgeIT.java
@@ -25,19 +25,19 @@ public class IndexWorkspacePurgeIT extends AbstractIndexWorkspaceSimpleOperation
 
 	@Override
 	protected CompletableFuture<?> executeAsync(IndexWorkspace workspace) {
-		return workspace.purge( Collections.emptySet(), OperationSubmitter.REJECTED_EXECUTION_EXCEPTION );
+		return workspace.purge( Collections.emptySet(), OperationSubmitter.rejecting() );
 	}
 
 	@Override
 	protected void afterInitData(StubMappedIndex index) {
 		// Make sure to flush the index, otherwise the test won't fail as expected with Lucene,
 		// probably because the index writer optimizes purges when changes are not committed yet.
-		index.createWorkspace().flush( OperationSubmitter.BLOCKING ).join();
+		index.createWorkspace().flush( OperationSubmitter.blocking() ).join();
 	}
 
 	@Override
 	protected void assertPreconditions(StubMappedIndex index) {
-		index.createWorkspace().refresh( OperationSubmitter.BLOCKING ).join();
+		index.createWorkspace().refresh( OperationSubmitter.blocking() ).join();
 		long count = index.createScope().query().where( f -> f.matchAll() )
 				.fetchTotalHitCount();
 		assertThat( count ).isGreaterThan( 0 );
@@ -45,7 +45,7 @@ public class IndexWorkspacePurgeIT extends AbstractIndexWorkspaceSimpleOperation
 
 	@Override
 	protected void assertSuccess(StubMappedIndex index) {
-		index.createWorkspace().refresh( OperationSubmitter.BLOCKING ).join();
+		index.createWorkspace().refresh( OperationSubmitter.blocking() ).join();
 		long count = index.createScope().query().where( f -> f.matchAll() )
 				.fetchTotalHitCount();
 		assertThat( count ).isEqualTo( 0 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceRefreshIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceRefreshIT.java
@@ -29,7 +29,7 @@ public class IndexWorkspaceRefreshIT extends AbstractIndexWorkspaceSimpleOperati
 
 	@Override
 	protected CompletableFuture<?> executeAsync(IndexWorkspace workspace) {
-		return workspace.refresh( OperationSubmitter.REJECTED_EXECUTION_EXCEPTION );
+		return workspace.refresh( OperationSubmitter.rejecting() );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexingFieldTypesIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexingFieldTypesIT.java
@@ -83,7 +83,7 @@ public class IndexingFieldTypesIT<F> {
 			} );
 			expectedDocuments.add( new IdAndValue<>( documentId, value ) );
 		}
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		// If we get here, indexing went well.
 		// However, it may have failed silently... Let's check the documents are there, with the right value.
@@ -120,7 +120,7 @@ public class IndexingFieldTypesIT<F> {
 			} );
 			expectedDocuments.add( new IdAndValue<>( documentId, value ) );
 		}
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		// If we get here, indexing went well.
 		// However, it may have failed silently... Let's check the documents are there, with the right value.
@@ -164,7 +164,7 @@ public class IndexingFieldTypesIT<F> {
 			} );
 			expectedDocuments.add( new IdAndValue<>( documentId, value ) );
 		}
-		plan.execute( OperationSubmitter.BLOCKING ).join();
+		plan.execute( OperationSubmitter.blocking() ).join();
 
 		// If we get here, indexing went well.
 		// However, it may have failed silently... Let's check the documents are there, with the right value.

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/session/AutomaticIndexingSynchronizationStrategyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/session/AutomaticIndexingSynchronizationStrategyIT.java
@@ -225,7 +225,7 @@ public class AutomaticIndexingSynchronizationStrategyIT {
 		AtomicReference<CompletableFuture<?>> futureThatTookTooLong = new AtomicReference<>( null );
 
 		SessionFactory sessionFactory = setup(
-				new CustomAutomaticIndexingSynchronizationStrategy( futureThatTookTooLong, OperationSubmitter.BLOCKING )
+				new CustomAutomaticIndexingSynchronizationStrategy( futureThatTookTooLong, OperationSubmitter.blocking() )
 		);
 		CompletableFuture<?> indexingWorkFuture = new CompletableFuture<>();
 
@@ -247,7 +247,7 @@ public class AutomaticIndexingSynchronizationStrategyIT {
 		AtomicReference<CompletableFuture<?>> futureThatTookTooLong = new AtomicReference<>( null );
 
 		SessionFactory sessionFactory = setup(
-				new CustomAutomaticIndexingSynchronizationStrategy( futureThatTookTooLong, OperationSubmitter.REJECTED_EXECUTION_EXCEPTION )
+				new CustomAutomaticIndexingSynchronizationStrategy( futureThatTookTooLong, OperationSubmitter.rejecting() )
 		);
 		CompletableFuture<?> indexingWorkFuture = new CompletableFuture<>();
 
@@ -656,7 +656,7 @@ public class AutomaticIndexingSynchronizationStrategyIT {
 		private final OperationSubmitter operationSubmitter;
 
 		private CustomAutomaticIndexingSynchronizationStrategy(AtomicReference<CompletableFuture<?>> futureThatTookTooLong) {
-			this( futureThatTookTooLong, OperationSubmitter.BLOCKING );
+			this( futureThatTookTooLong, OperationSubmitter.blocking() );
 		}
 
 		private CustomAutomaticIndexingSynchronizationStrategy(

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/AbstractMassIndexingBenchmarks.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/AbstractMassIndexingBenchmarks.java
@@ -71,7 +71,7 @@ public abstract class AbstractMassIndexingBenchmarks extends AbstractBackendBenc
 			futures[i] = indexer.add(
 					StubMapperUtils.referenceProvider( String.valueOf( documentId ) ),
 					document -> dataset.populate( index, document, documentId, 0L ),
-					commitStrategy, DocumentRefreshStrategy.NONE, OperationSubmitter.BLOCKING
+					commitStrategy, DocumentRefreshStrategy.NONE, OperationSubmitter.blocking()
 			);
 		}
 

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/AbstractOnTheFlyIndexingBenchmarks.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/AbstractOnTheFlyIndexingBenchmarks.java
@@ -143,7 +143,7 @@ public abstract class AbstractOnTheFlyIndexingBenchmarks extends AbstractBackend
 		}
 
 		// Do not return until works are *actually* executed
-		Futures.unwrappedExceptionJoin( indexingPlan.execute( OperationSubmitter.BLOCKING ) );
+		Futures.unwrappedExceptionJoin( indexingPlan.execute( OperationSubmitter.blocking() ) );
 
 		counters.write += 3 * worksPerTypePerWritePlan;
 

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/IndexInitializer.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/IndexInitializer.java
@@ -75,12 +75,12 @@ public class IndexInitializer {
 					StubMapperUtils.referenceProvider( String.valueOf( id ) ),
 					document -> dataset.populate( index, document, id, 0L ),
 					DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE,
-					OperationSubmitter.BLOCKING
+					OperationSubmitter.blocking()
 			);
 			futures.add( future );
 		} );
 		CompletableFuture.allOf( futures.toArray( new CompletableFuture[0] ) ).join();
-		workspace.flush( OperationSubmitter.BLOCKING ).join();
+		workspace.flush( OperationSubmitter.blocking() ).join();
 
 		log( index, " ... added " + futures.size() + " documents to the index." );
 	}
@@ -89,7 +89,7 @@ public class IndexInitializer {
 		log( index, "Starting index initialization..." );
 		log( index, "Purging..." );
 		IndexWorkspace workspace = index.createWorkspace();
-		workspace.purge( Collections.emptySet(), OperationSubmitter.BLOCKING ).join();
+		workspace.purge( Collections.emptySet(), OperationSubmitter.blocking() ).join();
 		log( index, "Finished purge." );
 
 		addToIndex( index, idStream );

--- a/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/massindexing/step/impl/EntityWriter.java
+++ b/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/massindexing/step/impl/EntityWriter.java
@@ -154,13 +154,13 @@ public class EntityWriter extends AbstractItemWriter {
 		if ( WriteMode.ADD.equals( writeMode ) ) {
 			return indexer.add( typeIdentifier, null, null, entity,
 					// Commit and refresh are handled globally after all documents are indexed.
-					DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE, OperationSubmitter.BLOCKING
+					DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE, OperationSubmitter.blocking()
 			);
 		}
 
 		return indexer.addOrUpdate( typeIdentifier, null, null, entity,
 				// Commit and refresh are handled globally after all documents are indexed.
-				DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE, OperationSubmitter.BLOCKING
+				DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE, OperationSubmitter.blocking()
 		);
 	}
 

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxEventProcessingPlan.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxEventProcessingPlan.java
@@ -45,7 +45,7 @@ final class OutboxEventProcessingPlan {
 		try {
 			addEventsToThePlan();
 			reportBackendResult(
-					Futures.unwrappedExceptionGet( processingPlan.executeAndReport( OperationSubmitter.BLOCKING ) ) );
+					Futures.unwrappedExceptionGet( processingPlan.executeAndReport( OperationSubmitter.blocking() ) ) );
 		}
 		catch (Throwable throwable) {
 			if ( throwable instanceof InterruptedException ) {

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingOutboxEventSendingPlan.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingOutboxEventSendingPlan.java
@@ -56,7 +56,7 @@ public final class OutboxPollingOutboxEventSendingPlan implements AutomaticIndex
 	@Override
 	public <R> CompletableFuture<MultiEntityOperationExecutionReport<R>> sendAndReport(
 			EntityReferenceFactory<R> entityReferenceFactory, OperationSubmitter operationSubmitter) {
-		if ( !OperationSubmitter.BLOCKING.equals( operationSubmitter ) ) {
+		if ( !OperationSubmitter.blocking().equals( operationSubmitter ) ) {
 			throw log.nonblockingOperationSubmitterNotSupported();
 		}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/automaticindexing/session/AutomaticIndexingSynchronizationConfigurationContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/automaticindexing/session/AutomaticIndexingSynchronizationConfigurationContext.java
@@ -55,7 +55,7 @@ public interface AutomaticIndexingSynchronizationConfigurationContext {
 	/**
 	 * Set operation submitter to be applied while executing underlying plans.
 	 *
-	 * Using {@link OperationSubmitter#BLOCKING} by default.
+	 * Using {@link OperationSubmitter#blocking()} by default.
 	 *
 	 * @param operationSubmitter How to handle request to submit operation when the queue is full
 	 * @see OperationSubmitter

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/automaticindexing/session/impl/ConfiguredAutomaticIndexingSynchronizationStrategy.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/automaticindexing/session/impl/ConfiguredAutomaticIndexingSynchronizationStrategy.java
@@ -62,7 +62,7 @@ public final class ConfiguredAutomaticIndexingSynchronizationStrategy {
 		private DocumentRefreshStrategy documentRefreshStrategy = DocumentRefreshStrategy.NONE;
 		private Consumer<CompletableFuture<SearchIndexingPlanExecutionReport>> indexingFutureHandler = future -> {
 		};
-		private OperationSubmitter operationSubmitter = OperationSubmitter.BLOCKING;
+		private OperationSubmitter operationSubmitter = OperationSubmitter.blocking();
 
 		private final EntityReferenceFactory<EntityReference> entityReferenceFactory;
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/schema/management/impl/SchemaManagementListener.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/schema/management/impl/SchemaManagementListener.java
@@ -28,16 +28,16 @@ public class SchemaManagementListener {
 		ContextualFailureCollector failureCollector = context.failureCollector();
 		switch ( strategyName ) {
 			case CREATE:
-				return manager.createIfMissing( failureCollector, OperationSubmitter.BLOCKING );
+				return manager.createIfMissing( failureCollector, OperationSubmitter.blocking() );
 			case DROP_AND_CREATE:
 			case DROP_AND_CREATE_AND_DROP:
-				return manager.dropAndCreate( failureCollector, OperationSubmitter.BLOCKING );
+				return manager.dropAndCreate( failureCollector, OperationSubmitter.blocking() );
 			case CREATE_OR_UPDATE:
-				return manager.createOrUpdate( failureCollector, OperationSubmitter.BLOCKING );
+				return manager.createOrUpdate( failureCollector, OperationSubmitter.blocking() );
 			case CREATE_OR_VALIDATE:
-				return manager.createOrValidate( failureCollector, OperationSubmitter.BLOCKING );
+				return manager.createOrValidate( failureCollector, OperationSubmitter.blocking() );
 			case VALIDATE:
-				return manager.validate( failureCollector, OperationSubmitter.BLOCKING );
+				return manager.validate( failureCollector, OperationSubmitter.blocking() );
 			case NONE:
 				// Nothing to do
 				return CompletableFuture.completedFuture( null );
@@ -50,7 +50,7 @@ public class SchemaManagementListener {
 		ContextualFailureCollector failureCollector = context.failureCollector();
 		switch ( strategyName ) {
 			case DROP_AND_CREATE_AND_DROP:
-				return manager.dropIfExisting( failureCollector, OperationSubmitter.BLOCKING );
+				return manager.dropIfExisting( failureCollector, OperationSubmitter.blocking() );
 			case CREATE:
 			case DROP_AND_CREATE:
 			case CREATE_OR_UPDATE:

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/schema/management/impl/SearchSchemaManagerImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/schema/management/impl/SearchSchemaManagerImpl.java
@@ -61,7 +61,7 @@ public class SearchSchemaManagerImpl implements SearchSchemaManager {
 				HibernateOrmEventContextMessages.INSTANCE.schemaManagement()
 		);
 		try {
-			Futures.unwrappedExceptionJoin( operation.apply( delegate, failureCollector, OperationSubmitter.BLOCKING ) );
+			Futures.unwrappedExceptionJoin( operation.apply( delegate, failureCollector, OperationSubmitter.blocking() ) );
 		}
 		catch (RuntimeException e) {
 			failureCollector.withContext( EventContexts.defaultContext() )

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchWorkspaceImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchWorkspaceImpl.java
@@ -24,12 +24,12 @@ public class SearchWorkspaceImpl implements SearchWorkspace {
 
 	@Override
 	public void mergeSegments() {
-		Futures.unwrappedExceptionJoin( delegate.mergeSegments( OperationSubmitter.BLOCKING ) );
+		Futures.unwrappedExceptionJoin( delegate.mergeSegments( OperationSubmitter.blocking() ) );
 	}
 
 	@Override
 	public CompletableFuture<?> mergeSegmentsAsync() {
-		return delegate.mergeSegments( OperationSubmitter.REJECTED_EXECUTION_EXCEPTION );
+		return delegate.mergeSegments( OperationSubmitter.rejecting() );
 	}
 
 	@Override
@@ -44,31 +44,31 @@ public class SearchWorkspaceImpl implements SearchWorkspace {
 
 	@Override
 	public void purge(Set<String> routingKeys) {
-		Futures.unwrappedExceptionJoin( delegate.purge( routingKeys, OperationSubmitter.BLOCKING ) );
+		Futures.unwrappedExceptionJoin( delegate.purge( routingKeys, OperationSubmitter.blocking() ) );
 	}
 
 	@Override
 	public CompletableFuture<?> purgeAsync(Set<String> routingKeys) {
-		return delegate.purge( routingKeys, OperationSubmitter.REJECTED_EXECUTION_EXCEPTION );
+		return delegate.purge( routingKeys, OperationSubmitter.rejecting() );
 	}
 
 	@Override
 	public void flush() {
-		Futures.unwrappedExceptionJoin( delegate.flush( OperationSubmitter.BLOCKING ) );
+		Futures.unwrappedExceptionJoin( delegate.flush( OperationSubmitter.blocking() ) );
 	}
 
 	@Override
 	public CompletableFuture<?> flushAsync() {
-		return delegate.flush( OperationSubmitter.REJECTED_EXECUTION_EXCEPTION );
+		return delegate.flush( OperationSubmitter.rejecting() );
 	}
 
 	@Override
 	public void refresh() {
-		Futures.unwrappedExceptionJoin( delegate.refresh( OperationSubmitter.BLOCKING ) );
+		Futures.unwrappedExceptionJoin( delegate.refresh( OperationSubmitter.blocking() ) );
 	}
 
 	@Override
 	public CompletableFuture<?> refreshAsync() {
-		return delegate.refresh( OperationSubmitter.REJECTED_EXECUTION_EXCEPTION );
+		return delegate.refresh( OperationSubmitter.rejecting() );
 	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingBatchCoordinator.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingBatchCoordinator.java
@@ -122,13 +122,13 @@ public class PojoMassIndexingBatchCoordinator extends PojoMassIndexingFailureHan
 			RootFailureCollector failureCollector = new RootFailureCollector(
 					PojoEventContextMessages.INSTANCE.schemaManagement()
 			);
-			Futures.unwrappedExceptionGet( scopeSchemaManager.dropAndCreate( failureCollector, OperationSubmitter.BLOCKING ) );
+			Futures.unwrappedExceptionGet( scopeSchemaManager.dropAndCreate( failureCollector, OperationSubmitter.blocking() ) );
 			failureCollector.checkNoFailure();
 		}
 
 		if ( purgeAtStart ) {
 			applyToAllContexts(
-					context -> context.scopeWorkspace().purge( Collections.emptySet(), OperationSubmitter.BLOCKING )
+					context -> context.scopeWorkspace().purge( Collections.emptySet(), OperationSubmitter.blocking() )
 			);
 			if ( mergeSegmentsAfterPurge ) {
 				// TODO: HSEARCH-4767 Note this only works fine as long as we have only a discriminator-based multitenancy.
@@ -136,7 +136,7 @@ public class PojoMassIndexingBatchCoordinator extends PojoMassIndexingFailureHan
 				// and calling it for multiple tenants would just request doing the same work.
 				Futures.unwrappedExceptionGet(
 						sessionContexts.iterator().next()
-								.scopeWorkspace().mergeSegments( OperationSubmitter.BLOCKING )
+								.scopeWorkspace().mergeSegments( OperationSubmitter.blocking() )
 				);
 			}
 		}
@@ -185,7 +185,7 @@ public class PojoMassIndexingBatchCoordinator extends PojoMassIndexingFailureHan
 			// We deliberately are targeting a single context as the underlying operation at this point is not tenant dependent
 			// and calling it for multiple tenants would just request doing the same work.
 			Futures.unwrappedExceptionGet( sessionContexts.iterator().next()
-					.scopeWorkspace().mergeSegments( OperationSubmitter.BLOCKING )
+					.scopeWorkspace().mergeSegments( OperationSubmitter.blocking() )
 			);
 		}
 		flushAndRefresh();
@@ -205,8 +205,8 @@ public class PojoMassIndexingBatchCoordinator extends PojoMassIndexingFailureHan
 		// We deliberately are targeting a single context as the underlying operation at this point is not tenant dependent
 		// and calling it for multiple tenants would just request doing the same work.
 		SessionContext context = sessionContexts.iterator().next();
-		Futures.unwrappedExceptionGet( context.scopeWorkspace().flush( OperationSubmitter.BLOCKING ) );
-		Futures.unwrappedExceptionGet( context.scopeWorkspace().refresh( OperationSubmitter.BLOCKING ) );
+		Futures.unwrappedExceptionGet( context.scopeWorkspace().flush( OperationSubmitter.blocking() ) );
+		Futures.unwrappedExceptionGet( context.scopeWorkspace().refresh( OperationSubmitter.blocking() ) );
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingEntityLoadingRunnable.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingEntityLoadingRunnable.java
@@ -235,7 +235,7 @@ public class PojoMassIndexingEntityLoadingRunnable<E, I>
 				PojoRawTypeIdentifier<?> typeIdentifier = detectTypeIdentifier( sessionContext, entity );
 				future = indexer.add( typeIdentifier, null, null, entity,
 						// Commit and refresh are handled globally after all documents are indexed.
-						DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE, OperationSubmitter.BLOCKING
+						DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE, OperationSubmitter.blocking()
 				);
 			}
 			catch (RuntimeException e) {

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/schema/management/spi/PojoScopeSchemaManager.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/schema/management/spi/PojoScopeSchemaManager.java
@@ -23,42 +23,42 @@ public interface PojoScopeSchemaManager {
 
 	@Deprecated
 	default CompletableFuture<?> createIfMissing(FailureCollector failureCollector) {
-		return createIfMissing( failureCollector, OperationSubmitter.BLOCKING );
+		return createIfMissing( failureCollector, OperationSubmitter.blocking() );
 	}
 
 	CompletableFuture<?> createOrValidate(FailureCollector failureCollector, OperationSubmitter operationSubmitter);
 
 	@Deprecated
 	default CompletableFuture<?> createOrValidate(FailureCollector failureCollector) {
-		return createOrValidate( failureCollector, OperationSubmitter.BLOCKING );
+		return createOrValidate( failureCollector, OperationSubmitter.blocking() );
 	}
 
 	CompletableFuture<?> createOrUpdate(FailureCollector failureCollector, OperationSubmitter operationSubmitter);
 
 	@Deprecated
 	default CompletableFuture<?> createOrUpdate(FailureCollector failureCollector) {
-		return createOrUpdate( failureCollector, OperationSubmitter.BLOCKING );
+		return createOrUpdate( failureCollector, OperationSubmitter.blocking() );
 	}
 
 	CompletableFuture<?> dropAndCreate(FailureCollector failureCollector, OperationSubmitter operationSubmitter);
 
 	@Deprecated
 	default CompletableFuture<?> dropAndCreate(FailureCollector failureCollector) {
-		return dropAndCreate( failureCollector, OperationSubmitter.BLOCKING );
+		return dropAndCreate( failureCollector, OperationSubmitter.blocking() );
 	}
 
 	CompletableFuture<?> dropIfExisting(FailureCollector failureCollector, OperationSubmitter operationSubmitter);
 
 	@Deprecated
 	default CompletableFuture<?> dropIfExisting(FailureCollector failureCollector) {
-		return dropIfExisting( failureCollector, OperationSubmitter.BLOCKING );
+		return dropIfExisting( failureCollector, OperationSubmitter.blocking() );
 	}
 
 	CompletableFuture<?> validate(FailureCollector failureCollector, OperationSubmitter operationSubmitter);
 
 	@Deprecated
 	default CompletableFuture<?> validate(FailureCollector failureCollector) {
-		return validate( failureCollector, OperationSubmitter.BLOCKING );
+		return validate( failureCollector, OperationSubmitter.blocking() );
 	}
 
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexer.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexer.java
@@ -60,7 +60,7 @@ public interface PojoIndexer {
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		return add(
 				typeIdentifier, providedId, providedRoutes, entity, commitStrategy, refreshStrategy,
-				OperationSubmitter.BLOCKING
+				OperationSubmitter.blocking()
 		);
 	}
 
@@ -98,7 +98,7 @@ public interface PojoIndexer {
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		return addOrUpdate(
 				typeIdentifier, providedId, providedRoutes, entity, commitStrategy, refreshStrategy,
-				OperationSubmitter.BLOCKING
+				OperationSubmitter.blocking()
 		);
 	}
 
@@ -138,7 +138,7 @@ public interface PojoIndexer {
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		return delete(
 				typeIdentifier, providedId, providedRoutes, entity, commitStrategy, refreshStrategy,
-				OperationSubmitter.BLOCKING
+				OperationSubmitter.blocking()
 		);
 	}
 
@@ -176,7 +176,7 @@ public interface PojoIndexer {
 	) {
 		return delete(
 				typeIdentifier, providedId, providedRoutes, commitStrategy, refreshStrategy,
-				OperationSubmitter.BLOCKING
+				OperationSubmitter.blocking()
 		);
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingPlan.java
@@ -196,7 +196,7 @@ public interface PojoIndexingPlan {
 	@Deprecated
 	default <R> CompletableFuture<MultiEntityOperationExecutionReport<R>> executeAndReport(
 			EntityReferenceFactory<R> entityReferenceFactory) {
-		return executeAndReport( entityReferenceFactory, OperationSubmitter.BLOCKING );
+		return executeAndReport( entityReferenceFactory, OperationSubmitter.blocking() );
 	}
 
 	/**

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingQueueEventProcessingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingQueueEventProcessingPlan.java
@@ -44,7 +44,7 @@ public interface PojoIndexingQueueEventProcessingPlan {
 	@Deprecated
 	default <R> CompletableFuture<MultiEntityOperationExecutionReport<R>> executeAndReport(
 			EntityReferenceFactory<R> entityReferenceFactory) {
-		return executeAndReport( entityReferenceFactory, OperationSubmitter.BLOCKING );
+		return executeAndReport( entityReferenceFactory, OperationSubmitter.blocking() );
 	}
 
 	/**

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingQueueEventSendingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingQueueEventSendingPlan.java
@@ -60,7 +60,7 @@ public interface PojoIndexingQueueEventSendingPlan {
 	@Deprecated
 	default <R> CompletableFuture<MultiEntityOperationExecutionReport<R>> sendAndReport(
 			EntityReferenceFactory<R> entityReferenceFactory) {
-		return sendAndReport( entityReferenceFactory, OperationSubmitter.BLOCKING );
+		return sendAndReport( entityReferenceFactory, OperationSubmitter.blocking() );
 	}
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoScopeWorkspace.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoScopeWorkspace.java
@@ -15,28 +15,28 @@ public interface PojoScopeWorkspace {
 
 	@Deprecated
 	default CompletableFuture<?> mergeSegments() {
-		return mergeSegments( OperationSubmitter.BLOCKING );
+		return mergeSegments( OperationSubmitter.blocking() );
 	}
 
 	CompletableFuture<?> mergeSegments(OperationSubmitter operationSubmitter);
 
 	@Deprecated
 	default CompletableFuture<?> purge(Set<String> routingKeys) {
-		return purge( routingKeys, OperationSubmitter.BLOCKING );
+		return purge( routingKeys, OperationSubmitter.blocking() );
 	}
 
 	CompletableFuture<?> purge(Set<String> routingKeys, OperationSubmitter operationSubmitter);
 
 	@Deprecated
 	default CompletableFuture<?> flush() {
-		return flush( OperationSubmitter.BLOCKING );
+		return flush( OperationSubmitter.blocking() );
 	}
 
 	CompletableFuture<?> flush(OperationSubmitter operationSubmitter);
 
 	@Deprecated
 	default CompletableFuture<?> refresh() {
-		return refresh( OperationSubmitter.BLOCKING );
+		return refresh( OperationSubmitter.blocking() );
 	}
 
 	CompletableFuture<?> refresh(OperationSubmitter operationSubmitter);

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/schema/management/impl/SchemaManagementListener.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/schema/management/impl/SchemaManagementListener.java
@@ -28,16 +28,16 @@ public class SchemaManagementListener {
 		ContextualFailureCollector failureCollector = context.failureCollector();
 		switch ( strategyName ) {
 			case CREATE:
-				return manager.createIfMissing( failureCollector, OperationSubmitter.BLOCKING );
+				return manager.createIfMissing( failureCollector, OperationSubmitter.blocking() );
 			case DROP_AND_CREATE:
 			case DROP_AND_CREATE_AND_DROP:
-				return manager.dropAndCreate( failureCollector, OperationSubmitter.BLOCKING );
+				return manager.dropAndCreate( failureCollector, OperationSubmitter.blocking() );
 			case CREATE_OR_UPDATE:
-				return manager.createOrUpdate( failureCollector, OperationSubmitter.BLOCKING );
+				return manager.createOrUpdate( failureCollector, OperationSubmitter.blocking() );
 			case CREATE_OR_VALIDATE:
-				return manager.createOrValidate( failureCollector, OperationSubmitter.BLOCKING );
+				return manager.createOrValidate( failureCollector, OperationSubmitter.blocking() );
 			case VALIDATE:
-				return manager.validate( failureCollector, OperationSubmitter.BLOCKING );
+				return manager.validate( failureCollector, OperationSubmitter.blocking() );
 			case NONE:
 				// Nothing to do
 				return CompletableFuture.completedFuture( null );
@@ -50,7 +50,7 @@ public class SchemaManagementListener {
 		ContextualFailureCollector failureCollector = context.failureCollector();
 		switch ( strategyName ) {
 			case DROP_AND_CREATE_AND_DROP:
-				return manager.dropIfExisting( failureCollector, OperationSubmitter.BLOCKING );
+				return manager.dropIfExisting( failureCollector, OperationSubmitter.blocking() );
 			case CREATE:
 			case DROP_AND_CREATE:
 			case CREATE_OR_UPDATE:

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/schema/management/impl/SearchSchemaManagerImpl.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/schema/management/impl/SearchSchemaManagerImpl.java
@@ -61,7 +61,7 @@ public class SearchSchemaManagerImpl implements SearchSchemaManager {
 				StandalonePojoEventContextMessages.INSTANCE.schemaManagement()
 		);
 		try {
-			Futures.unwrappedExceptionJoin( operation.apply( delegate, failureCollector, OperationSubmitter.BLOCKING ) );
+			Futures.unwrappedExceptionJoin( operation.apply( delegate, failureCollector, OperationSubmitter.blocking() ) );
 		}
 		catch (RuntimeException e) {
 			failureCollector.withContext( EventContexts.defaultContext() )

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/work/impl/SearchIndexerImpl.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/work/impl/SearchIndexerImpl.java
@@ -36,37 +36,37 @@ public class SearchIndexerImpl implements SearchIndexer {
 	@Override
 	public CompletionStage<?> add(Object providedId, DocumentRoutesDescriptor providedRoutes, Object entity) {
 		return delegate.add( getTypeIdentifier( entity ), providedId, providedRoutes, entity,
-				commitStrategy, refreshStrategy, OperationSubmitter.BLOCKING );
+				commitStrategy, refreshStrategy, OperationSubmitter.blocking() );
 	}
 
 	@Override
 	public CompletionStage<?> add(Class<?> entityClass, Object providedId, DocumentRoutesDescriptor providedRoutes) {
 		return delegate.add( getTypeIdentifier( entityClass ), providedId, providedRoutes, null,
-				commitStrategy, refreshStrategy, OperationSubmitter.BLOCKING );
+				commitStrategy, refreshStrategy, OperationSubmitter.blocking() );
 	}
 
 	@Override
 	public CompletionStage<?> addOrUpdate(Object providedId, DocumentRoutesDescriptor providedRoutes, Object entity) {
 		return delegate.addOrUpdate( getTypeIdentifier( entity ), providedId, providedRoutes, entity,
-				commitStrategy, refreshStrategy, OperationSubmitter.BLOCKING );
+				commitStrategy, refreshStrategy, OperationSubmitter.blocking() );
 	}
 
 	@Override
 	public CompletionStage<?> addOrUpdate(Class<?> entityClass, Object providedId, DocumentRoutesDescriptor providedRoutes) {
 		return delegate.addOrUpdate( getTypeIdentifier( entityClass ), providedId, providedRoutes, null,
-				commitStrategy, refreshStrategy, OperationSubmitter.BLOCKING );
+				commitStrategy, refreshStrategy, OperationSubmitter.blocking() );
 	}
 
 	@Override
 	public CompletionStage<?> delete(Object providedId, DocumentRoutesDescriptor providedRoutes, Object entity) {
 		return delegate.delete( getTypeIdentifier( entity ), providedId, providedRoutes, entity,
-				commitStrategy, refreshStrategy, OperationSubmitter.BLOCKING );
+				commitStrategy, refreshStrategy, OperationSubmitter.blocking() );
 	}
 
 	@Override
 	public CompletionStage<?> delete(Class<?> entityClass, Object providedId, DocumentRoutesDescriptor providedRoutes) {
 		return delegate.delete( getTypeIdentifier( entityClass ), providedId, providedRoutes,
-				commitStrategy, refreshStrategy, OperationSubmitter.BLOCKING );
+				commitStrategy, refreshStrategy, OperationSubmitter.blocking() );
 	}
 
 	private <T> PojoRawTypeIdentifier<? extends T> getTypeIdentifier(T entity) {

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/work/impl/SearchIndexingPlanImpl.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/work/impl/SearchIndexingPlanImpl.java
@@ -115,7 +115,7 @@ public class SearchIndexingPlanImpl implements SearchIndexingPlan {
 	}
 
 	public CompletableFuture<?> execute() {
-		return delegate.executeAndReport( entityReferenceFactory, OperationSubmitter.BLOCKING ).thenApply( report -> {
+		return delegate.executeAndReport( entityReferenceFactory, OperationSubmitter.blocking() ).thenApply( report -> {
 			report.throwable().ifPresent( t -> {
 				throw Throwables.toRuntimeException( t );
 			} );

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/work/impl/SearchWorkspaceImpl.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/work/impl/SearchWorkspaceImpl.java
@@ -24,12 +24,12 @@ public class SearchWorkspaceImpl implements SearchWorkspace {
 
 	@Override
 	public void mergeSegments() {
-		Futures.unwrappedExceptionJoin( delegate.mergeSegments( OperationSubmitter.BLOCKING ) );
+		Futures.unwrappedExceptionJoin( delegate.mergeSegments( OperationSubmitter.blocking() ) );
 	}
 
 	@Override
 	public CompletableFuture<?> mergeSegmentsAsync() {
-		return delegate.mergeSegments( OperationSubmitter.REJECTED_EXECUTION_EXCEPTION );
+		return delegate.mergeSegments( OperationSubmitter.rejecting() );
 	}
 
 	@Override
@@ -44,31 +44,31 @@ public class SearchWorkspaceImpl implements SearchWorkspace {
 
 	@Override
 	public void purge(Set<String> routingKeys) {
-		Futures.unwrappedExceptionJoin( delegate.purge( routingKeys, OperationSubmitter.BLOCKING ) );
+		Futures.unwrappedExceptionJoin( delegate.purge( routingKeys, OperationSubmitter.blocking() ) );
 	}
 
 	@Override
 	public CompletableFuture<?> purgeAsync(Set<String> routingKeys) {
-		return delegate.purge( routingKeys, OperationSubmitter.REJECTED_EXECUTION_EXCEPTION );
+		return delegate.purge( routingKeys, OperationSubmitter.rejecting() );
 	}
 
 	@Override
 	public void flush() {
-		Futures.unwrappedExceptionJoin( delegate.flush( OperationSubmitter.BLOCKING ) );
+		Futures.unwrappedExceptionJoin( delegate.flush( OperationSubmitter.blocking() ) );
 	}
 
 	@Override
 	public CompletableFuture<?> flushAsync() {
-		return delegate.flush( OperationSubmitter.REJECTED_EXECUTION_EXCEPTION );
+		return delegate.flush( OperationSubmitter.rejecting() );
 	}
 
 	@Override
 	public void refresh() {
-		Futures.unwrappedExceptionJoin( delegate.refresh( OperationSubmitter.BLOCKING ) );
+		Futures.unwrappedExceptionJoin( delegate.refresh( OperationSubmitter.blocking() ) );
 	}
 
 	@Override
 	public CompletableFuture<?> refreshAsync() {
-		return delegate.refresh( OperationSubmitter.REJECTED_EXECUTION_EXCEPTION );
+		return delegate.refresh( OperationSubmitter.rejecting() );
 	}
 }

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/rule/TestElasticsearchClient.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/rule/TestElasticsearchClient.java
@@ -520,8 +520,12 @@ public class TestElasticsearchClient implements TestRule, Closeable {
 		 */
 		client = new ElasticsearchClientFactoryImpl().create( beanResolver, backendProperties,
 				threadPoolProvider.threadProvider(), "Client",
-				new DelegatingSimpleScheduledExecutor( timeoutExecutorService ),
-				GsonProvider.create( GsonBuilder::new, true ) );
+				new DelegatingSimpleScheduledExecutor(
+						timeoutExecutorService,
+						threadPoolProvider.isScheduledExecutorBlocking()
+				),
+				GsonProvider.create( GsonBuilder::new, true )
+		);
 	}
 
 	@Override

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/BulkIndexer.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/BulkIndexer.java
@@ -120,7 +120,7 @@ public class BulkIndexer {
 		CompletableFuture<?> future = CompletableFuture.allOf( indexingFutures );
 		if ( refresh ) {
 			IndexWorkspace workspace = indexManager.createWorkspace( mappingContext, tenantId );
-			future = future.thenCompose( ignored -> workspace.refresh( OperationSubmitter.BLOCKING ) );
+			future = future.thenCompose( ignored -> workspace.refresh( OperationSubmitter.blocking() ) );
 		}
 		return future;
 	}
@@ -148,7 +148,7 @@ public class BulkIndexer {
 					batchFutures[i] = indexer.add(
 							documentProvider.getReferenceProvider(), documentProvider.getContributor(),
 							DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE,
-							OperationSubmitter.BLOCKING
+							OperationSubmitter.blocking()
 					);
 				}
 				return CompletableFuture.allOf( batchFutures );

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingImpl.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingImpl.java
@@ -99,7 +99,7 @@ public class StubMappingImpl implements StubMapping, MappingImplementor<StubMapp
 			case DROP_AND_CREATE_AND_DROP:
 			case DROP_AND_CREATE_ON_STARTUP_ONLY:
 				return doSchemaManagementOperation(
-						indexSchemaManager -> indexSchemaManager.dropAndCreate( OperationSubmitter.BLOCKING ),
+						indexSchemaManager -> indexSchemaManager.dropAndCreate( OperationSubmitter.blocking() ),
 						context.failureCollector()
 				);
 			case DROP_ON_SHUTDOWN_ONLY:
@@ -116,7 +116,7 @@ public class StubMappingImpl implements StubMapping, MappingImplementor<StubMapp
 			case DROP_AND_CREATE_AND_DROP:
 			case DROP_ON_SHUTDOWN_ONLY:
 				return doSchemaManagementOperation(
-						indexSchemaManager -> indexSchemaManager.dropIfExisting( OperationSubmitter.BLOCKING ),
+						indexSchemaManager -> indexSchemaManager.dropIfExisting( OperationSubmitter.blocking() ),
 						context.failureCollector()
 				);
 			case DROP_AND_CREATE_ON_STARTUP_ONLY:


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4736

I've tried to keep `OperationSubmitter` closed for the users, so they are forced to use whatever is provided with Search. 
Also, with this new submitter type, it is somewhat possible to offload work in `LuceneSyncWorkOrchestratorImpl` but I wasn't sure if that's something worth supporting, so I left it more on the "idea level".

I've kept the same "hacks" for the BatchExecutor test as in the blocking case as it seems we might stumble upon the same issue with offloading. 