### PR TITLE
HSEARCH-1809 Follow-up: Update asserts to check if failed threads didn't call `afterExecution()`

### DIFF
--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingEnvironmentIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingEnvironmentIT.java
@@ -9,6 +9,7 @@ package org.hibernate.search.integrationtest.mapper.pojo.massindexing;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
+import static org.awaitility.Awaitility.await;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Queue;
@@ -182,7 +183,7 @@ public class MassIndexingEnvironmentIT {
 							message
 					);
 
-			assertThat( threadNames ).isEmpty();
+			await().untilAsserted( () -> assertThat( threadNames ).isEmpty() );
 		}
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-1809

the failing line on CI was this one:
```java
assertThat( threadNames ).isEmpty();
```
where the `threadNames` is a `Queue`. The only reason I could think of why that happened is that the `afterExecution` wasn't yet called when `isEmpty` was checked. And the thread wasn't removed yet. But when it failed and was generating a message `afterExecution` finished and the queue was now empty. Based on this code from the assertj:
```java
public void assertEmpty(AssertionInfo info, Iterable<?> actual) {
    assertNotNull(info, actual);
    if (!isNullOrEmpty(actual)) throw failures.failure(info, shouldBeEmpty(actual));
  }
```

I thought about changing the test so that we collect the names of failed threads and check if the ones called `afterExecution` does not include the names of the failed ones. But that might lead to a similar issue when the list of threads called `afterExecution` is still empty at the moment of the assert. and trying to use something like:
```java
assertThat( successfulThreadNames ).satisfiesAnyOf(
					names -> assertThat( names ).isEmpty(),
					names -> assertThat( names ).doesNotContain( "failedThreadName.get()" )
			);
```
just makes the compiler crazy 😄 