### PR TITLE
HSEARCH-4795 Follow-up: Don't collect configuration properties if javadoc generation is disabled

### DIFF
--- a/build/parents/public/pom.xml
+++ b/build/parents/public/pom.xml
@@ -268,7 +268,7 @@
                                 <goals>
                                     <goal>java</goal>
                                 </goals>
-                                <phase>process-resources</phase>
+                                <phase>${documentation.config.properties.phase}</phase>
                                 <configuration>
                                     <skip>${documentation.config.properties.skip}</skip>
                                     <mainClass>org.hibernate.search.configuration.properties.collector.impl.ConfigurationPropertyProcessor</mainClass>

--- a/pom.xml
+++ b/pom.xml
@@ -528,8 +528,13 @@
         <!-- We control whether we should download javadoc based on this property
              that defines the phase of some Maven plugin executions,
              because just skipping those plugins doesn't skip dependency resolution,
-             which will fail if javadco wasn't downloaded. -->
+             which will fail if javadoc wasn't downloaded. -->
         <javadoc.download.phase>generate-resources</javadoc.download.phase>
+        <!--
+            Some profiles might want to ignore running a property collection processor entirely.
+            In such case set this property to `none`.
+        -->
+        <documentation.config.properties.phase>process-resources</documentation.config.properties.phase>
 
         <!-- Test settings -->
         <!-- Set empty default values to avoid Maven leaving property references (${...}) when it doesn't find a value -->
@@ -2495,6 +2500,7 @@
                 <maven.javadoc.skip>true</maven.javadoc.skip>
                 <javadoc.download.phase>none</javadoc.download.phase>
                 <enforcer.dependencyconvergence.skip>true</enforcer.dependencyconvergence.skip>
+                <documentation.config.properties.phase>none</documentation.config.properties.phase>
             </properties>
             <build>
                 <plugins>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4795

this should also help even if not in the dependency upgrade profile but someone still disables the Javadoc generation