### PR TITLE
HSEARCH-4800 Update configuration property collection 

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchBackendSettings.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchBackendSettings.java
@@ -110,7 +110,7 @@ public final class ElasticsearchBackendSettings {
 	 * The version of Elasticsearch running on the Elasticsearch cluster.
 	 * <p>
 	 * Expects either an {@link ElasticsearchVersion} object,
-	 * or a String that can be {{@link ElasticsearchVersion#of(String) parsed} in such an object.
+	 * or a String that can be {@link ElasticsearchVersion#of(String) parsed} in such an object.
 	 * <p>
 	 * No default: if not provided, the version will be resolved automatically
 	 * by sending a request to the Elasticsearch cluster on startup.

--- a/build/configuration-properties-collector/src/main/java/org/hibernate/search/configuration/properties/collector/impl/AsciiDocWriter.java
+++ b/build/configuration-properties-collector/src/main/java/org/hibernate/search/configuration/properties/collector/impl/AsciiDocWriter.java
@@ -64,10 +64,7 @@ public class AsciiDocWriter implements BiConsumer<Map<String, ConfigurationPrope
 					writer.write( '`' );
 					writer.write( "::\n" );
 
-					// using inline passthrough for javadocs to not render HTML.
-					writer.write( "+++ " );
 					writer.write( el.javadoc() );
-					writer.write( " +++ " );
 
 					String defaultValue = Objects.toString( el.defaultValue(), "" );
 					if ( !defaultValue.trim().isEmpty() ) {

--- a/build/parents/public/pom.xml
+++ b/build/parents/public/pom.xml
@@ -22,8 +22,6 @@
 
     <properties>
         <javadoc.packagelists.directory>${project.build.directory}/dependencies-javadoc-packagelists</javadoc.packagelists.directory>
-        <!-- Output for property collection -->
-        <documentation.config.properties.output.directory>${rootProject.directory}/target</documentation.config.properties.output.directory>
         <documentation.config.properties.skip>false</documentation.config.properties.skip>
     </properties>
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/AnnotationMappingConfigurationContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/AnnotationMappingConfigurationContext.java
@@ -77,7 +77,7 @@ public interface AnnotationMappingConfigurationContext {
 
 	/**
 	 * @param jandexIndex A Jandex index to use when
-	 * {{@link #discoverAnnotatedTypesFromRootMappingAnnotations(boolean)} discovering annotated types that are also annotated with root mapping annotations}.
+	 * {@link #discoverAnnotatedTypesFromRootMappingAnnotations(boolean)} discovering annotated types that are also annotated with root mapping annotations}.
 	 * @return {@code this}, for method chaining.
 	 * @see #discoverAnnotatedTypesFromRootMappingAnnotations(boolean)
 	 * @see #discoverJandexIndexesFromAddedTypes(boolean)

--- a/pom.xml
+++ b/pom.xml
@@ -535,6 +535,8 @@
             In such case set this property to `none`.
         -->
         <documentation.config.properties.phase>process-resources</documentation.config.properties.phase>
+        <!-- Output for property collection -->
+        <documentation.config.properties.output.directory>${rootProject.directory}/target</documentation.config.properties.output.directory>
 
         <!-- Test settings -->
         <!-- Set empty default values to avoid Maven leaving property references (${...}) when it doesn't find a value -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4800

```
[INFO] asciidoctor: INFO: reference/configuration-properties-aggregated.asciidoc: line 4: optional include dropped because include file not found: /hibernate-search-engine.asciidoc
[INFO] asciidoctor: INFO: reference/configuration-properties-aggregated.asciidoc: line 5: optional include dropped because include file not found: /hibernate-search-backend-lucene.asciidoc
[INFO] asciidoctor: INFO: reference/configuration-properties-aggregated.asciidoc: line 6: optional include dropped because include file not found: /hibernate-search-backend-elasticsearch.asciidoc
[INFO] asciidoctor: INFO: reference/configuration-properties-aggregated.asciidoc: line 7: optional include dropped because include file not found: /hibernate-search-backend-elasticsearch-aws.asciidoc
[INFO] asciidoctor: INFO: reference/configuration-properties-aggregated.asciidoc: line 8: optional include dropped because include file not found: /hibernate-search-mapper-orm.asciidoc
[INFO] asciidoctor: INFO: reference/configuration-properties-aggregated.asciidoc: line 9: optional include dropped because include file not found: /hibernate-search-mapper-orm-coordination-outbox-polling.asciidoc
[INFO] asciidoctor: INFO: reference/configuration-properties-aggregated.asciidoc: line 10: optional include dropped because include file not found: /hibernate-search-mapper-pojo-standalone.asciidoc
```
The build ignored the files as it tried to look for them who-knows-where. The `documentation.config.properties.output.directory` wasn't initialized correctly as the documentation module is using the integration test parent while the property was in the public parent. Moving the property to a main pom should solve that.

Then with the PDF rendering - "simplifying" HTML didn't help much, so instead, I've made some changes to not rely on passthrough at all but instead convert the doc to asciidoc format. 

I've found a few typos while checking if the docs were rendered correctly - there's a small commit to address those.