### PR TITLE
HSEARCH-4766 Use single executor for mass indexing agents

### DIFF
--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/impl/OutboxPollingCoordinationStrategy.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/impl/OutboxPollingCoordinationStrategy.java
@@ -144,7 +144,7 @@ public class OutboxPollingCoordinationStrategy implements CoordinationStrategy {
 	@Override
 	public PojoMassIndexerAgent createMassIndexerAgent(PojoMassIndexerAgentCreateContext context) {
 		return tenantDelegate( context.tenantIdentifier() ).massIndexerAgentFactory
-				.create( context, agentRepositoryProvider );
+				.create( agentRepositoryProvider );
 	}
 
 	private TenantDelegate tenantDelegate(String tenantId) {

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexerAgentStartContextImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexerAgentStartContextImpl.java
@@ -6,7 +6,29 @@
  */
 package org.hibernate.search.mapper.pojo.massindexing.impl;
 
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.hibernate.search.engine.reporting.FailureHandler;
 import org.hibernate.search.mapper.pojo.massindexing.spi.PojoMassIndexerAgentStartContext;
 
 class PojoMassIndexerAgentStartContextImpl implements PojoMassIndexerAgentStartContext {
+
+	private final ScheduledExecutorService scheduledExecutorService;
+	private final FailureHandler failureHandler;
+
+	PojoMassIndexerAgentStartContextImpl(ScheduledExecutorService scheduledExecutorService,
+			FailureHandler failureHandler) {
+		this.scheduledExecutorService = scheduledExecutorService;
+		this.failureHandler = failureHandler;
+	}
+
+	@Override
+	public ScheduledExecutorService scheduledExecutor() {
+		return scheduledExecutorService;
+	}
+
+	@Override
+	public FailureHandler failureHandler() {
+		return failureHandler;
+	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/spi/NoOpPojoMassIndexerAgent.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/spi/NoOpPojoMassIndexerAgent.java
@@ -15,7 +15,7 @@ class NoOpPojoMassIndexerAgent implements PojoMassIndexerAgent {
 	}
 
 	@Override
-	public CompletableFuture<?> start() {
+	public CompletableFuture<?> start(PojoMassIndexerAgentStartContext context) {
 		return CompletableFuture.completedFuture( null );
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/spi/PojoMassIndexerAgent.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/spi/PojoMassIndexerAgent.java
@@ -24,7 +24,7 @@ public interface PojoMassIndexerAgent {
 	 * @return A future that completes successfully when other agents have been successfully suspended.
 	 * If no agents can be suspended (e.g. no coordination), returns a successfully completed future immediately.
 	 */
-	CompletableFuture<?> start();
+	CompletableFuture<?> start(PojoMassIndexerAgentStartContext context);
 
 	/**
 	 * Performs preliminary operations necessary to safely stop this agent.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/spi/PojoMassIndexerAgentStartContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/spi/PojoMassIndexerAgentStartContext.java
@@ -6,6 +6,13 @@
  */
 package org.hibernate.search.mapper.pojo.massindexing.spi;
 
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.hibernate.search.engine.reporting.FailureHandler;
+
 public interface PojoMassIndexerAgentStartContext {
 
+	ScheduledExecutorService scheduledExecutor();
+
+	FailureHandler failureHandler();
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4766

I've tried to see if we can use a single mass indexing agent (that would contain multiple `TenantDelegate` in case of multitenancy). The problem with such an approach is that eventually, we are creating `SessionHelper`  that requires a single tenant to start a transaction... 
Hence instead I've just passed the executor to the `OutboxPollingMassIndexerAgent#start ` through a context.