### PR TITLE
HSEARCH-4801 Bump maven-javadoc-plugin from 3.4.1 to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -380,7 +380,7 @@
         <version.jandex.plugin>1.2.3</version.jandex.plugin>
         <version.japicmp.plugin>0.17.1</version.japicmp.plugin>
         <version.jar.plugin>3.3.0</version.jar.plugin>
-        <version.javadoc.plugin>3.4.1</version.javadoc.plugin>
+        <version.javadoc.plugin>3.5.0</version.javadoc.plugin>
         <version.jdeps.plugin>0.5.1</version.jdeps.plugin>
         <version.nexus-staging.plugin>1.6.13</version.nexus-staging.plugin>
         <version.processor.plugin>4.5-jdk8</version.processor.plugin>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4801

I've checked if our property collection "plugin" still works with this Javadoc plugin update, and it seems it does. What... I can't say about the ORM version (probably not related to the Javadoc plugin) - https://docs.jboss.org/hibernate/orm/6.2/userguide/html_single/Hibernate_User_Guide.html#_list_of_all_available_configuration_properties (makes me sad 😭)