### PR TITLE
HSEARCH-4803 Ignore service loading errors from non aggregated classloader

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
@@ -13,6 +13,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.Collection;
 import java.util.List;
+import java.util.ServiceConfigurationError;
 import java.util.Set;
 
 import org.hibernate.search.engine.environment.bean.BeanReference;
@@ -531,4 +532,8 @@ public interface Log extends BasicLogger {
 	SearchException unableToResolveField(String absolutePath, String causeMessage, @Cause SearchException e,
 			@Param EventContext context);
 
+	@LogMessage(level = Logger.Level.WARN)
+	@Message(id = ID_OFFSET + 116,
+			value = "Ignoring ServiceConfigurationError caught while trying to instantiate service '%s'.")
+	void ignoringServiceConfigurationError(Class<?> serviceContract, @Cause ServiceConfigurationError error);
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4803

this results in that other error in quarkus:
```
Caused by: java.io.IOException: HSEARCH900016: Cannot open filesystem for code source at 'quarkus:/': HSEARCH900017: Cannot interpret 'quarkus:/' as a local directory or JAR.
	at org.hibernate.search.util.common.jar.impl.CodeSource.initFileSystem(CodeSource.java:130)
	at org.hibernate.search.util.common.jar.impl.CodeSource.classesPathOrFail(CodeSource.java:96)
	at org.hibernate.search.util.common.jar.impl.CodeSource.readOrNull(CodeSource.java:50)
	... 68 more
	Suppressed: java.lang.NullPointerException: Cannot read the array length because "buf" is null
		at java.base/java.io.ByteArrayInputStream.<init>(ByteArrayInputStream.java:108)
		at io.quarkus.bootstrap.classloading.MemoryClassPathElement$MemoryUrlStreamHandler$1.getInputStream(MemoryClassPathElement.java:147)
		at java.base/java.net.URL.openStream(URL.java:1161)
		at org.hibernate.search.util.common.jar.impl.CodeSource.readOrNull(CodeSource.java:80)
		... 68 more

```
that we are to address later. Also found that in that quarkus patch there was a mix of jakarta/orm6 artifacts so pinged Sanne to apply a patch to make those aligned.