### PR TITLE
HSEARCH-4804 Fix flaky test OutboxPollingAutomaticIndexingLifecycleIT with postgresql 

### DIFF
--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingBackendFailureIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingBackendFailureIT.java
@@ -51,7 +51,7 @@ public class OutboxPollingAutomaticIndexingBackendFailureIT {
 
 	private final OutboxEventFilter eventFilter = new OutboxEventFilter()
 			// Disable the filter by default: only some of the tests actually need it.
-			.enableFilter( false );
+			.showAllEvents();
 
 	private SessionFactory sessionFactory;
 	private TestFailureHandler failureHandler;

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingEdgeCasesIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingEdgeCasesIT.java
@@ -69,7 +69,7 @@ public class OutboxPollingAutomaticIndexingEdgeCasesIT {
 	public void resetFilter() {
 		eventFilter.reset();
 		// Disable the filter by default: only some of the tests actually need it.
-		eventFilter.enableFilter( false );
+		eventFilter.showAllEvents();
 	}
 
 	@Test
@@ -144,7 +144,7 @@ public class OutboxPollingAutomaticIndexingEdgeCasesIT {
 		} );
 		backendMock.verifyExpectationsMet();
 
-		eventFilter.enableFilter( true );
+		eventFilter.hideAllEvents();
 
 		setupHolder.runInTransaction( session -> {
 			IndexedEntity containing = session.getReference( IndexedEntity.class, 1 );

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingLifecycleIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingLifecycleIT.java
@@ -52,7 +52,7 @@ public class OutboxPollingAutomaticIndexingLifecycleIT {
 	public void stopWhileOutboxEventsIsBeingProcessed() {
 		SessionFactory sessionFactory = setup();
 		backendMock.verifyExpectationsMet();
-		int size = 1000;
+		int size = 10000;
 
 		with( sessionFactory ).runInTransaction( session -> {
 			for ( int i = 1; i <= size; i++ ) {
@@ -60,6 +60,10 @@ public class OutboxPollingAutomaticIndexingLifecycleIT {
 				entity.setId( i );
 				entity.setIndexedField( "value for the field" );
 				session.persist( entity );
+				if ( i % 1000 == 0 ) {
+					session.flush();
+					session.clear();
+				}
 			}
 
 			BackendMock.DocumentWorkCallListContext context = backendMock.expectWorks( IndexedEntity.NAME );

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/DefaultOutboxEventFinder.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/DefaultOutboxEventFinder.java
@@ -11,6 +11,7 @@ import static org.hibernate.search.mapper.orm.coordination.outboxpolling.event.i
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 import org.hibernate.Session;
 import org.hibernate.query.Query;
@@ -50,24 +51,45 @@ public final class DefaultOutboxEventFinder implements OutboxEventFinder {
 
 	private final String queryString;
 	private final Optional<OutboxEventPredicate> predicate;
+	private final OutboxEventOrder order;
 
 	private DefaultOutboxEventFinder(Optional<OutboxEventPredicate> predicate, OutboxEventOrder order) {
-		this.queryString = "select e from " + ENTITY_NAME + " e "
-				+ ( predicate.isPresent() ? " where " + predicate.get().queryPart( "e" ) : "" )
-				+ order.queryPart( "e" );
+		this.queryString = createQueryString( predicate, alias -> alias, order );
 		this.predicate = predicate;
+		this.order = order;
 	}
 
 	@Override
 	public List<OutboxEvent> findOutboxEvents(Session session, int maxResults) {
+		Query<OutboxEvent> query = createOutboxEventQuery( session );
+		query.setMaxResults( maxResults );
+		return query.list();
+	}
+
+	public Query<OutboxEvent> createOutboxEventQuery(Session session) {
 		Query<OutboxEvent> query = session.createQuery( queryString, OutboxEvent.class );
 		if ( predicate.isPresent() ) {
 			predicate.get().setParams( query );
 		}
+		return query;
+	}
 
-		query.setMaxResults( maxResults );
+	public <T> Query<T> createOutboxEventQueryForTests(Session session,
+			Function<String, String> selectClauseFunction, Class<T> resultType, OutboxEventOrder order) {
+		String queryStringForTests = createQueryString( predicate, selectClauseFunction, order != null ? order : this.order );
+		Query<T> query = session.createQuery( queryStringForTests, resultType );
+		if ( predicate.isPresent() ) {
+			predicate.get().setParams( query );
+		}
+		return query;
+	}
 
-		return query.list();
+	private String createQueryString(Optional<OutboxEventPredicate> predicate, Function<String, String> selectClauseFunction,
+			OutboxEventOrder order) {
+		return "select " + selectClauseFunction.apply( "e" )
+				+ " from " + ENTITY_NAME + " e "
+				+ ( predicate.isPresent() ? " where " + predicate.get().queryPart( "e" ) : "" )
+				+ order.queryPart( "e" );
 	}
 
 	private static class ProcessAfterFilter implements OutboxEventPredicate {
@@ -78,7 +100,7 @@ public final class DefaultOutboxEventFinder implements OutboxEventFinder {
 		}
 
 		@Override
-		public void setParams(Query<OutboxEvent> query) {
+		public void setParams(Query<?> query) {
 			query.setParameter( "now", Instant.now() );
 		}
 	}
@@ -91,7 +113,7 @@ public final class DefaultOutboxEventFinder implements OutboxEventFinder {
 		}
 
 		@Override
-		public void setParams(Query<OutboxEvent> query) {
+		public void setParams(Query<?> query) {
 			query.setParameter( "status", OutboxEvent.Status.PENDING );
 		}
 	}

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/EntityIdHashRangeOutboxEventPredicate.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/EntityIdHashRangeOutboxEventPredicate.java
@@ -68,7 +68,7 @@ public final class EntityIdHashRangeOutboxEventPredicate implements OutboxEventP
 	}
 
 	@Override
-	public void setParams(Query<OutboxEvent> query) {
+	public void setParams(Query<?> query) {
 		if ( lowerBoundIncluded != null ) {
 			query.setParameter( LOWER_BOUND_PARAM_NAME, lowerBoundIncluded );
 		}

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxEventAndPredicate.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxEventAndPredicate.java
@@ -28,7 +28,7 @@ public class OutboxEventAndPredicate implements OutboxEventPredicate {
 	}
 
 	@Override
-	public void setParams(Query<OutboxEvent> query) {
+	public void setParams(Query<?> query) {
 		// Assuming no conflicts...
 		left.setParams( query );
 		right.setParams( query );

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxEventPredicate.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxEventPredicate.java
@@ -12,6 +12,6 @@ public interface OutboxEventPredicate {
 
 	String queryPart(String eventAlias);
 
-	void setParams(Query<OutboxEvent> query);
+	void setParams(Query<?> query);
 
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4804

I'm going blind here since I couldn't reproduce the problem locally, but I think there's a decent chance of at least reducing, if not eliminating, flakiness.

See the commit messages for details.