### PR TITLE
HSEARCH-4801 Bump version.log4j from 2.19.0 to 2.20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,7 +312,7 @@
         <!-- Test dependencies -->
 
         <!-- >>> Common -->
-        <version.log4j>2.19.0</version.log4j>
+        <version.log4j>2.20.0</version.log4j>
         <version.junit>4.13.2</version.junit>
         <version.org.osgi.core>6.0.0</version.org.osgi.core>
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4801

follows up on https://github.com/hibernate/hibernate-search/pull/3419