### PR TITLE
HSEARCH-4675 Use and()/or() where applicable instead of bool() in tests

### DIFF
--- a/documentation/src/main/asciidoc/reference/search-dsl-predicate.asciidoc
+++ b/documentation/src/main/asciidoc/reference/search-dsl-predicate.asciidoc
@@ -456,9 +456,9 @@ include::{sourcedir}/org/hibernate/search/documentation/search/predicate/Predica
 There isn't any built-in predicate to match documents for which a given field is null,
 but you can easily create one yourself by negating an `exists` predicate.
 
-This can be achieved by using an `exists` predicate
-in a <<search-dsl-predicate-boolean-mustNot,`mustNot` clause in a boolean predicate>>,
-or in an <<search-dsl-predicate-match-all-except,`except` clause in a `matchAll` predicate>>.
+This can be achieved by passing in an `exists` predicate
+to a <<search-dsl-predicate-not, `not` predicate>>,
+or by using it in an <<search-dsl-predicate-match-all-except,`except` clause in a `matchAll` predicate>>.
 ====
 
 [[search-dsl-predicate-exists-object-field]]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/containers/property/DependenciesContainersPropertyIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/containers/property/DependenciesContainersPropertyIT.java
@@ -59,10 +59,10 @@ public class DependenciesContainersPropertyIT {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )
-					.where( f -> f.bool()
-							.must( f.match().field( "editionsForSale" ).matching( "paperback" ) )
-							.must( f.match().field( "editionsForSale" ).matching( "kindle" ) )
-					)
+					.where( f -> f.and(
+							f.match().field( "editionsForSale" ).matching( "paperback" ),
+							f.match().field( "editionsForSale" ).matching( "kindle" )
+					) )
 					.fetchHits( 20 );
 			assertThat( result ).hasSize( 1 );
 		} );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/containers/simple/DependenciesContainersSimpleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/dependencies/containers/simple/DependenciesContainersSimpleIT.java
@@ -59,10 +59,10 @@ public class DependenciesContainersSimpleIT {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )
-					.where( f -> f.bool()
-							.must( f.match().field( "editionsForSale" ).matching( "paperback" ) )
-							.must( f.match().field( "editionsForSale" ).matching( "kindle" ) )
-					)
+					.where( f -> f.and(
+							f.match().field( "editionsForSale" ).matching( "paperback" ),
+							f.match().field( "editionsForSale" ).matching( "kindle" )
+					) )
 					.fetchHits( 20 );
 			assertThat( result ).hasSize( 1 );
 		} );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/object/DocumentModelDslObjectIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/object/DocumentModelDslObjectIT.java
@@ -53,18 +53,17 @@ public class DocumentModelDslObjectIT {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Invoice> result = searchSession.search( Invoice.class )
-					.where( f -> f.bool()
-							.must( f.range().field( "summary.total" )
-									.atLeast( new BigDecimal( "20.0" ) ) )
-							.must( f.range().field( "summary.shipping" )
-									.atMost( new BigDecimal( "10.0" ) ) )
-							.must( f.nested( "lineItems" )
+					.where( f -> f.and(
+							f.range().field( "summary.total" )
+									.atLeast( new BigDecimal( "20.0" ) ),
+							f.range().field( "summary.shipping" )
+									.atMost( new BigDecimal( "10.0" ) ),
+							f.nested( "lineItems" )
 									.add( f.range().field( "lineItems.amount" )
 											.between( new BigDecimal( "7.0" ), new BigDecimal( "9.0" ) ) )
 									.add( f.match().field( "lineItems.category" )
-											.matching( "BOOK" )
-							) )
-					)
+											.matching( "BOOK" ) )
+					) )
 					.fetchHits( 20 );
 
 			assertThat( result ).hasSize( 1 );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/simple/DocumentModelDslSimpleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/document/model/dsl/simple/DocumentModelDslSimpleIT.java
@@ -52,18 +52,18 @@ public class DocumentModelDslSimpleIT {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Object> result = searchSession.search( Arrays.asList( Book.class, Author.class ) )
-					.where( f -> f.bool()
-							.should( f.bool()
-									.must( f.match().field( "fullName" )
-											.matching( "isaac asimov" ) )
-									.must( f.match().field( "names" )
-											.matching( "isaac" ) )
-									.must( f.match().field( "names" )
-											.matching( "asimov" ) )
-							)
-							.should( f.match().field( "isbn" )
-									.matching( "978-0-58-600835-5" ) )
-					)
+					.where( f -> f.or(
+							f.and(
+									f.match().field( "fullName" )
+											.matching( "isaac asimov" ),
+									f.match().field( "names" )
+											.matching( "isaac" ),
+									f.match().field( "names" )
+											.matching( "asimov" )
+							),
+							f.match().field( "isbn" )
+									.matching( "978-0-58-600835-5" )
+					) )
 					.fetchHits( 20 );
 
 			assertThat( result ).hasSize( 2 );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/bridgedelement/PropertyBridgeBridgedElementIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/bridgedelement/PropertyBridgeBridgedElementIT.java
@@ -73,12 +73,12 @@ public class PropertyBridgeBridgedElementIT {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Invoice> result = searchSession.search( Invoice.class )
-					.where( f -> f.bool()
-							.must( f.range().field( "lineItems.total" )
-									.atLeast( new BigDecimal( "20.0" ) ) )
-							.must( f.range().field( "lineItems.shipping" )
-									.atMost( new BigDecimal( "10.0" ) ) )
-					)
+					.where( f -> f.and(
+							f.range().field( "lineItems.total" )
+									.atLeast( new BigDecimal( "20.0" ) ),
+							f.range().field( "lineItems.shipping" )
+									.atMost( new BigDecimal( "10.0" ) )
+					) )
 					.fetchHits( 20 );
 
 			assertThat( result ).hasSize( 1 );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/param/PropertyBridgeParamIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/param/PropertyBridgeParamIT.java
@@ -72,12 +72,12 @@ public class PropertyBridgeParamIT {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Invoice> result = searchSession.search( Invoice.class )
-					.where( f -> f.bool()
-							.must( f.range().field( "itemSummary.total" )
-									.atLeast( new BigDecimal( "20.0" ) ) )
-							.must( f.range().field( "itemSummary.shipping" )
-									.atMost( new BigDecimal( "10.0" ) ) )
-					)
+					.where( f -> f.and(
+							f.range().field( "itemSummary.total" )
+									.atLeast( new BigDecimal( "20.0" ) ),
+							f.range().field( "itemSummary.shipping" )
+									.atMost( new BigDecimal( "10.0" ) )
+					) )
 					.fetchHits( 20 );
 
 			assertThat( result ).hasSize( 1 );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/param/context/PropertyBridgeParamIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/param/context/PropertyBridgeParamIT.java
@@ -75,12 +75,12 @@ public class PropertyBridgeParamIT {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Invoice> result = searchSession.search( Invoice.class )
-					.where( f -> f.bool()
-							.must( f.range().field( "itemSummary.total" )
-									.atLeast( new BigDecimal( "20.0" ) ) )
-							.must( f.range().field( "itemSummary.shipping" )
-									.atMost( new BigDecimal( "10.0" ) ) )
-					)
+					.where( f -> f.and(
+							f.range().field( "itemSummary.total" )
+									.atLeast( new BigDecimal( "20.0" ) ),
+							f.range().field( "itemSummary.shipping" )
+									.atMost( new BigDecimal( "10.0" ) )
+					) )
 					.fetchHits( 20 );
 
 			assertThat( result ).hasSize( 1 );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/simple/PropertyBridgeSimpleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/simple/PropertyBridgeSimpleIT.java
@@ -53,12 +53,12 @@ public class PropertyBridgeSimpleIT {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Invoice> result = searchSession.search( Invoice.class )
-					.where( f -> f.bool()
-							.must( f.range().field( "summary.total" )
-									.atLeast( new BigDecimal( "20.0" ) ) )
-							.must( f.range().field( "summary.shipping" )
-									.atMost( new BigDecimal( "10.0" ) ) )
-					)
+					.where( f -> f.and(
+							f.range().field( "summary.total" )
+									.atLeast( new BigDecimal( "20.0" ) ),
+							f.range().field( "summary.shipping" )
+									.atMost( new BigDecimal( "10.0" ) )
+					) )
 					.fetchHits( 20 );
 
 			assertThat( result ).hasSize( 1 );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/containerextractor/ContainerExtractorIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/containerextractor/ContainerExtractorIT.java
@@ -85,11 +85,11 @@ public class ContainerExtractorIT {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )
-					.where( f -> f.bool()
-							.must( f.match().field( "availableFormats" ).matching( BookFormat.AUDIOBOOK ) )
-							.must( f.match().field( "availableFormats" ).matching( BookFormat.HARDCOVER ) )
-							.must( f.match().field( "authorCount" ).matching( 1, ValueConvert.NO ) )
-					)
+					.where( f -> f.and(
+							f.match().field( "availableFormats" ).matching( BookFormat.AUDIOBOOK ),
+							f.match().field( "availableFormats" ).matching( BookFormat.HARDCOVER ),
+							f.match().field( "authorCount" ).matching( 1, ValueConvert.NO )
+					) )
 					.fetchHits( 20 );
 			assertThat( result ).hasSize( 1 );
 		} );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/includepaths/IndexedEmbeddedIncludePathsIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/includepaths/IndexedEmbeddedIncludePathsIT.java
@@ -75,13 +75,13 @@ public class IndexedEmbeddedIncludePathsIT {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Human> result = searchSession.search( Human.class )
-					.where( f -> f.bool()
-							.must( f.match().field( "name" ).matching( "fourth" ) )
-							.must( f.match().field( "nickname" ).matching( "babe" ) )
-							.must( f.match().field( "parents.name" ).matching( "third" ) )
-							.must( f.match().field( "parents.nickname" ).matching( "young" ) )
-							.must( f.match().field( "parents.parents.name" ).matching( "junior" ) )
-					)
+					.where( f -> f.and(
+							f.match().field( "name" ).matching( "fourth" ),
+							f.match().field( "nickname" ).matching( "babe" ),
+							f.match().field( "parents.name" ).matching( "third" ),
+							f.match().field( "parents.nickname" ).matching( "young" ),
+							f.match().field( "parents.parents.name" ).matching( "junior" )
+					) )
 					.fetchHits( 20 );
 			assertThat( result ).hasSize( 1 );
 		} );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/includepathsanddepth/IndexedEmbeddedIncludePathsAndDepthIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/includepathsanddepth/IndexedEmbeddedIncludePathsAndDepthIT.java
@@ -75,15 +75,15 @@ public class IndexedEmbeddedIncludePathsAndDepthIT {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Human> result = searchSession.search( Human.class )
-					.where( f -> f.bool()
-							.must( f.match().field( "name" ).matching( "fourth" ) )
-							.must( f.match().field( "nickname" ).matching( "babe" ) )
-							.must( f.match().field( "parents.name" ).matching( "third" ) )
-							.must( f.match().field( "parents.nickname" ).matching( "young" ) )
-							.must( f.match().field( "parents.parents.name" ).matching( "junior" ) )
-							.must( f.match().field( "parents.parents.nickname" ).matching( "old" ) )
-							.must( f.match().field( "parents.parents.parents.name" ).matching( "senior" ) )
-					)
+					.where( f -> f.and(
+							f.match().field( "name" ).matching( "fourth" ),
+							f.match().field( "nickname" ).matching( "babe" ),
+							f.match().field( "parents.name" ).matching( "third" ),
+							f.match().field( "parents.nickname" ).matching( "young" ),
+							f.match().field( "parents.parents.name" ).matching( "junior" ),
+							f.match().field( "parents.parents.nickname" ).matching( "old" ),
+							f.match().field( "parents.parents.parents.name" ).matching( "senior" )
+					) )
 					.fetchHits( 20 );
 			assertThat( result ).hasSize( 1 );
 		} );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/onelevel/IndexedEmbeddedOneLevelIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/onelevel/IndexedEmbeddedOneLevelIT.java
@@ -78,10 +78,10 @@ public class IndexedEmbeddedOneLevelIT {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )
-					.where( f -> f.bool()
-							.must( f.match().field( "title" ).matching( "robot" ) )
-							.must( f.match().field( "authors.name" ).matching( "isaac" ) )
-					)
+					.where( f -> f.and(
+							f.match().field( "title" ).matching( "robot" ),
+							f.match().field( "authors.name" ).matching( "isaac" )
+					) )
 					.fetchHits( 20 );
 			assertThat( result ).hasSize( 1 );
 		} );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/twolevels/IndexedEmbeddedTwoLevelsIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/twolevels/IndexedEmbeddedTwoLevelsIT.java
@@ -59,11 +59,11 @@ public class IndexedEmbeddedTwoLevelsIT {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )
-					.where( f -> f.bool()
-							.must( f.match().field( "title" ).matching( "robot" ) )
-							.must( f.match().field( "authors.name" ).matching( "isaac" ) )
-							.must( f.match().field( "authors.placeOfBirth.country" ).matching( "russia" ) )
-					)
+					.where( f -> f.and(
+							f.match().field( "title" ).matching( "robot" ),
+							f.match().field( "authors.name" ).matching( "isaac" ),
+							f.match().field( "authors.placeOfBirth.country" ).matching( "russia" )
+					) )
 					.fetchHits( 20 );
 			assertThat( result ).hasSize( 1 );
 		} );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/associationinverseside/AssociationInverseSideIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/associationinverseside/AssociationInverseSideIT.java
@@ -86,10 +86,10 @@ public class AssociationInverseSideIT {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class )
-					.where( f -> f.bool()
-							.must( f.match().field( "editionsForSale.label" ).matching( "paperback" ) )
-							.must( f.match().field( "editionsForSale.label" ).matching( "kindle" ) )
-					)
+					.where( f -> f.and(
+							f.match().field( "editionsForSale.label" ).matching( "paperback" ),
+							f.match().field( "editionsForSale.label" ).matching( "kindle" )
+					) )
 					.fetchHits( 20 );
 			assertThat( result ).hasSize( 1 );
 		} );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/reindexonupdate/no/correct/ReindexOnUpdateNoIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/reindexonupdate/no/correct/ReindexOnUpdateNoIT.java
@@ -113,9 +113,9 @@ public class ReindexOnUpdateNoIT {
 
 	private long countSensorsWithinOperatingParameters(EntityManager entityManager) {
 		return Search.session( entityManager ).search( Sensor.class )
-				.where( f -> f.bool()
-						.must( f.match().field( "status" ).matching( SensorStatus.ONLINE ) )
-						.must( f.range().field( "rollingAverage" ).between( 0.9, 1.1 ) ) )
+				.where( f -> f.and(
+						f.match().field( "status" ).matching( SensorStatus.ONLINE ),
+						f.range().field( "rollingAverage" ).between( 0.9, 1.1 ) ) )
 				.fetchTotalHitCount();
 	}
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/reindexonupdate/no/incorrect/ReindexOnUpdateNoIncorrectIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/reindexing/reindexonupdate/no/incorrect/ReindexOnUpdateNoIncorrectIT.java
@@ -78,9 +78,9 @@ public class ReindexOnUpdateNoIncorrectIT {
 
 	private long countSensorsWithinOperatingParameters(EntityManager entityManager) {
 		return Search.session( entityManager ).search( Sensor.class )
-				.where( f -> f.bool()
-						.must( f.match().field( "status" ).matching( SensorStatus.ONLINE ) )
-						.must( f.range().field( "rollingAverage" ).between( 0.9, 1.1 ) ) )
+				.where( f -> f.and(
+						f.match().field( "status" ).matching( SensorStatus.ONLINE ),
+						f.range().field( "rollingAverage" ).between( 0.9, 1.1 ) ) )
 				.fetchTotalHitCount();
 	}
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/spatial/geopointbinding/multiple/GeoPointBindingMultipleIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/spatial/geopointbinding/multiple/GeoPointBindingMultipleIT.java
@@ -51,12 +51,12 @@ public class GeoPointBindingMultipleIT {
 			SearchSession searchSession = Search.session( entityManager );
 
 			List<Author> result = searchSession.search( Author.class )
-					.where( f -> f.bool()
-							.must( f.spatial().within().field( "placeOfBirth" )
-									.circle( 53.970000, 32.150000, 50, DistanceUnit.KILOMETERS ) )
-							.must( f.spatial().within().field( "placeOfDeath" )
-									.circle( 40.6500000, -73.9800000, 50, DistanceUnit.KILOMETERS ) )
-					)
+					.where( f -> f.and(
+							f.spatial().within().field( "placeOfBirth" )
+									.circle( 53.970000, 32.150000, 50, DistanceUnit.KILOMETERS ),
+							f.spatial().within().field( "placeOfDeath" )
+									.circle( 40.6500000, -73.9800000, 50, DistanceUnit.KILOMETERS )
+					) )
 					.fetchAllHits();
 			assertThat( result ).hasSize( 1 );
 		} );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/paths/FieldPathsIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/paths/FieldPathsIT.java
@@ -97,12 +97,12 @@ public class FieldPathsIT {
 		withinSearchSession( searchSession -> {
 			// tag::withRoot[]
 			List<Book> hits = searchSession.search( Book.class )
-					.where( f -> f.bool()
-							.should( f.nested( "writers" )
+					.where( f -> f.or()
+							.add( f.nested( "writers" )
 									.add( matchFirstAndLastName( // <1>
 											f.withRoot( "writers" ), // <2>
 											"bob", "kane" ) ) )
-							.should( f.nested( "artists" )
+							.add( f.nested( "artists" )
 									.add( matchFirstAndLastName( // <3>
 											f.withRoot( "artists" ), // <4>
 											"bill", "finger" ) ) ) )

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
@@ -958,10 +958,10 @@ public class PredicateDslIT {
 		withinSearchSession( searchSession -> {
 			// tag::nested-implicit-form[]
 			List<Book> hits = searchSession.search( Book.class )
-					.where( f -> f.bool()
-							.must( f.match().field( "authors.firstName" ) // <1>
+					.where( f -> f.and()
+							.add( f.match().field( "authors.firstName" ) // <1>
 									.matching( "isaac" ) ) // <2>
-							.must( f.match().field( "authors.lastName" )
+							.add( f.match().field( "authors.lastName" )
 									.matching( "asimov" ) ) ) // <3>
 					.fetchHits( 20 ); // <4>
 			// end::nested-implicit-form[]
@@ -978,10 +978,10 @@ public class PredicateDslIT {
 			// tag::nested-deprecated[]
 			List<Book> hits = searchSession.search( Book.class )
 					.where( f -> f.nested().objectField( "authors" ) // <1>
-							.nest( f.bool()
-									.must( f.match().field( "authors.firstName" )
+							.nest( f.and()
+									.add( f.match().field( "authors.firstName" )
 											.matching( "isaac" ) ) // <2>
-									.must( f.match().field( "authors.lastName" )
+									.add( f.match().field( "authors.lastName" )
 											.matching( "asimov" ) ) ) ) // <3>
 					.fetchHits( 20 ); // <4>
 			// end::nested-deprecated[]

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -382,14 +382,12 @@ public class ElasticsearchExtensionIT {
 		StubMappingScope scope = mainIndex.createScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.where( f -> f.bool()
-						.should( f.extension( ElasticsearchExtension.get() )
-								.fromJson( gson.fromJson( "{'match': {'nativeField_string': 'text 1'}}", JsonObject.class ) )
-						)
-						.should( f.extension( ElasticsearchExtension.get() )
-								.fromJson( gson.fromJson( "{'match': {'nativeField_integer': 2}}", JsonObject.class ) )
-						)
-						.should( f.extension( ElasticsearchExtension.get() )
+				.where( f -> f.or(
+						f.extension( ElasticsearchExtension.get() )
+								.fromJson( gson.fromJson( "{'match': {'nativeField_string': 'text 1'}}", JsonObject.class ) ),
+						f.extension( ElasticsearchExtension.get() )
+								.fromJson( gson.fromJson( "{'match': {'nativeField_integer': 2}}", JsonObject.class ) ),
+						f.extension( ElasticsearchExtension.get() )
 								.fromJson( gson.fromJson(
 										"{"
 											+ "'geo_distance': {"
@@ -433,11 +431,11 @@ public class ElasticsearchExtensionIT {
 						JsonObject.class
 				) )
 				.toPredicate();
-		SearchPredicate booleanPredicate = scope.predicate().bool()
-				.should( predicate1 )
-				.should( predicate2 )
-				.should( predicate3 )
-				.toPredicate();
+		SearchPredicate booleanPredicate = scope.predicate().or(
+						predicate1,
+						predicate2,
+						predicate3
+				).toPredicate();
 
 		SearchQuery<DocumentReference> query = scope.query()
 				.where( booleanPredicate )
@@ -452,14 +450,12 @@ public class ElasticsearchExtensionIT {
 		StubMappingScope scope = mainIndex.createScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.where( f -> f.bool()
-						.should( f.extension( ElasticsearchExtension.get() )
-								.fromJson( "{'match': {'nativeField_string': 'text 1'}}" )
-						)
-						.should( f.extension( ElasticsearchExtension.get() )
-								.fromJson( "{'match': {'nativeField_integer': 2}}" )
-						)
-						.should( f.extension( ElasticsearchExtension.get() )
+				.where( f -> f.or(
+						f.extension( ElasticsearchExtension.get() )
+								.fromJson( "{'match': {'nativeField_string': 'text 1'}}" ),
+						f.extension( ElasticsearchExtension.get() )
+								.fromJson( "{'match': {'nativeField_integer': 2}}" ),
+						f.extension( ElasticsearchExtension.get() )
 								.fromJson(
 										"{"
 											+ "'geo_distance': {"
@@ -500,11 +496,11 @@ public class ElasticsearchExtensionIT {
 						+ "}"
 				)
 				.toPredicate();
-		SearchPredicate booleanPredicate = scope.predicate().bool()
-				.should( predicate1 )
-				.should( predicate2 )
-				.should( predicate3 )
-				.toPredicate();
+		SearchPredicate booleanPredicate = scope.predicate().or(
+						predicate1,
+						predicate2,
+						predicate3
+				).toPredicate();
 
 		SearchQuery<DocumentReference> query = scope.query()
 				.where( booleanPredicate )

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/ElasticsearchImplicitFieldsIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/ElasticsearchImplicitFieldsIT.java
@@ -65,7 +65,7 @@ public class ElasticsearchImplicitFieldsIT {
 	public void implicit_fields_id() {
 		StubMappingScope scope = mainIndex.createScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.where( f -> f.bool().must( ff -> ff.terms().field( "_id" ).matchingAny( "4" ) ) )
+				.where( f -> f.terms().field( "_id" ).matchingAny( "4" ) )
 				.toQuery();
 		assertThatQuery( query )
 				.hasDocRefHitsAnyOrder( "mainType", "4" );
@@ -75,7 +75,7 @@ public class ElasticsearchImplicitFieldsIT {
 	public void implicit_fields_index() {
 		StubMappingScope scope = mainIndex.createScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.where( f -> f.bool().must( ff -> ff.match().field( "_index" ).matching( "main-000001" ) ) )
+				.where( f -> f.match().field( "_index" ).matching( "main-000001" ) )
 				.toQuery();
 		assertThatQuery( query )
 				.hasTotalHitCount( 6 )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/ObjectStructureIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/ObjectStructureIT.java
@@ -99,12 +99,12 @@ public class ObjectStructureIT {
 		StubMappingScope scope = index.createScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.where( f -> f.bool()
-						.must( f.match().field( "flattenedObject.string" ).matching( MATCHING_STRING ) )
-						.must( f.match().field( "flattenedObject.string_analyzed" ).matching( MATCHING_STRING_ANALYZED ) )
-						.must( f.match().field( "flattenedObject.integer" ).matching( MATCHING_INTEGER ) )
-						.must( f.match().field( "flattenedObject.localDate" ).matching( MATCHING_LOCAL_DATE ) )
-				)
+				.where( f -> f.and(
+						f.match().field( "flattenedObject.string" ).matching( MATCHING_STRING ),
+						f.match().field( "flattenedObject.string_analyzed" ).matching( MATCHING_STRING_ANALYZED ),
+						f.match().field( "flattenedObject.integer" ).matching( MATCHING_INTEGER ),
+						f.match().field( "flattenedObject.localDate" ).matching( MATCHING_LOCAL_DATE )
+				) )
 				.toQuery();
 		assertThatQuery( query )
 				.hasDocRefHitsAnyOrder( index.typeName(), EXPECTED_NON_NESTED_MATCH_ID )
@@ -128,17 +128,14 @@ public class ObjectStructureIT {
 		StubMappingScope scope = index.createScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.where( f -> f.bool()
-						.must( f.range().field( "flattenedObject.string" )
-								.between( MATCHING_STRING, MATCHING_STRING )
-						)
-						.must( f.range().field( "flattenedObject.integer" )
-								.between( MATCHING_INTEGER - 1, MATCHING_INTEGER + 1 )
-						)
-						.must( f.range().field( "flattenedObject.localDate" )
+				.where( f -> f.and(
+						f.range().field( "flattenedObject.string" )
+								.between( MATCHING_STRING, MATCHING_STRING ),
+						f.range().field( "flattenedObject.integer" )
+								.between( MATCHING_INTEGER - 1, MATCHING_INTEGER + 1 ),
+						f.range().field( "flattenedObject.localDate" )
 								.between( MATCHING_LOCAL_DATE.minusDays( 1 ), MATCHING_LOCAL_DATE.plusDays( 1 ) )
-						)
-				)
+				) )
 				.toQuery();
 		assertThatQuery( query )
 				.hasDocRefHitsAnyOrder( index.typeName(), EXPECTED_NON_NESTED_MATCH_ID )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AbstractPredicateFieldScoreIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AbstractPredicateFieldScoreIT.java
@@ -37,17 +37,16 @@ public abstract class AbstractPredicateFieldScoreIT<V extends AbstractPredicateT
 	@Test
 	public void fieldLevelBoost() {
 		assertThatQuery( index.query()
-				.where( f -> f.bool()
-						.should( predicate( f, field0Path(), 0 ) )
-						.should( predicateWithFieldLevelBoost( f, field0Path(), 42f, 1 ) ) )
+				.where( f -> f.or(
+						predicate( f, field0Path(), 0 ),
+						predicateWithFieldLevelBoost( f, field0Path(), 42f, 1 ) ) )
 				.routing( dataSet.routingKey ) )
 				.hasDocRefHitsExactOrder( index.typeName(), dataSet.docId( 1 ), dataSet.docId( 0 ) );
 
 		assertThatQuery( index.query()
-				.where( f -> f.bool()
-						.should( predicateWithFieldLevelBoost( f, field0Path(), 42f,
-								0 ) )
-						.should( predicate( f, field0Path(), 1 ) ) )
+				.where( f -> f.or(
+						predicateWithFieldLevelBoost( f, field0Path(), 42f, 0 ),
+						predicate( f, field0Path(), 1 ) ) )
 				.routing( dataSet.routingKey ) )
 				.hasDocRefHitsExactOrder( index.typeName(), dataSet.docId( 0 ), dataSet.docId( 1 ) );
 	}
@@ -55,23 +54,23 @@ public abstract class AbstractPredicateFieldScoreIT<V extends AbstractPredicateT
 	@Test
 	public void predicateLevelBoost_fieldLevelBoost() {
 		assertThatQuery( index.query()
-				.where( f -> f.bool()
+				.where( f -> f.or(
 						// 2 * 2 => boost x4
-						.should( predicateWithFieldLevelBoostAndPredicateLevelBoost( f, field0Path(), 2f,
-								0, 2f ) )
+						predicateWithFieldLevelBoostAndPredicateLevelBoost( f, field0Path(), 2f,
+								0, 2f ),
 						// 3 * 3 => boost x9
-						.should( predicateWithFieldLevelBoostAndPredicateLevelBoost( f, field0Path(), 3f,
+						predicateWithFieldLevelBoostAndPredicateLevelBoost( f, field0Path(), 3f,
 								1, 3f ) ) )
 				.routing( dataSet.routingKey ) )
 				.hasDocRefHitsExactOrder( index.typeName(), dataSet.docId( 1 ), dataSet.docId( 0 ) );
 
 		assertThatQuery( index.query()
-				.where( f -> f.bool()
+				.where( f -> f.or(
 						// 1 * 3 => boost x3
-						.should( predicateWithFieldLevelBoostAndPredicateLevelBoost( f, field0Path(), 1f,
-								0, 3f ) )
+						predicateWithFieldLevelBoostAndPredicateLevelBoost( f, field0Path(), 1f,
+								0, 3f ),
 						// 0.1 * 3 => boost x0.3
-						.should( predicateWithFieldLevelBoostAndPredicateLevelBoost( f, field0Path(), 0.1f,
+						predicateWithFieldLevelBoostAndPredicateLevelBoost( f, field0Path(), 0.1f,
 								1, 3f ) ) )
 				.routing( dataSet.routingKey ) )
 				.hasDocRefHitsExactOrder( index.typeName(), dataSet.docId( 0 ), dataSet.docId( 1 ) );
@@ -94,19 +93,19 @@ public abstract class AbstractPredicateFieldScoreIT<V extends AbstractPredicateT
 	@Test
 	public void predicateLevelBoost_multiFields() {
 		assertThatQuery( index.query()
-				.where( f -> f.bool()
-						.should( predicateWithPredicateLevelBoost( f, new String[] { field0Path(), field1Path() },
-								0, 7f ) )
-						.should( predicateWithPredicateLevelBoost( f, new String[] { field0Path(), field1Path() },
+				.where( f -> f.or(
+						predicateWithPredicateLevelBoost( f, new String[] { field0Path(), field1Path() },
+								0, 7f ),
+						predicateWithPredicateLevelBoost( f, new String[] { field0Path(), field1Path() },
 								1, 39f ) ) )
 				.routing( dataSet.routingKey ) )
 				.hasDocRefHitsExactOrder( index.typeName(), dataSet.docId( 1 ), dataSet.docId( 0 ) );
 
 		assertThatQuery( index.query()
-				.where( f -> f.bool()
-						.should( predicateWithPredicateLevelBoost( f, new String[] { field0Path(), field1Path() },
-								0, 39f ) )
-						.should( predicateWithPredicateLevelBoost( f, new String[] { field0Path(), field1Path() },
+				.where( f -> f.or(
+						predicateWithPredicateLevelBoost( f, new String[] { field0Path(), field1Path() },
+								0, 39f ),
+						predicateWithPredicateLevelBoost( f, new String[] { field0Path(), field1Path() },
 								1, 7f ) ) )
 				.routing( dataSet.routingKey ) )
 				.hasDocRefHitsExactOrder( index.typeName(), dataSet.docId( 0 ), dataSet.docId( 1 ) );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AbstractPredicateInObjectFieldIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AbstractPredicateInObjectFieldIT.java
@@ -151,9 +151,9 @@ public abstract class AbstractPredicateInObjectFieldIT {
 		// ... but it should not prevent the query from executing either:
 		// if the "nested" predicate is optional, it should be ignored for missingFieldIndex.
 		assertThatQuery( scope.query()
-				.where( f -> f.bool()
-						.should( predicate( f, binding.nested.nested, 0 ) )
-						.should( f.id().matching( dataSet.docId( MISSING_FIELD_INDEX_DOC_ORDINAL ) ) ) )
+				.where( f -> f.or(
+						predicate( f, binding.nested.nested, 0 ),
+						f.id().matching( dataSet.docId( MISSING_FIELD_INDEX_DOC_ORDINAL ) ) ) )
 				.routing( dataSet.routingKey ) )
 				.hasDocRefHitsAnyOrder( c -> c
 						.doc( mainIndex.typeName(), dataSet.docId( 0 ) )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AbstractPredicateScoreIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AbstractPredicateScoreIT.java
@@ -26,16 +26,16 @@ public abstract class AbstractPredicateScoreIT {
 	@Test
 	public void predicateLevelBoost() {
 		assertThatQuery( index.query()
-				.where( f -> f.bool()
-						.should( predicate( f, 0 ) )
-						.should( predicateWithBoost( f, 1, 7f ) ) )
+				.where( f -> f.or(
+						predicate( f, 0 ),
+						predicateWithBoost( f, 1, 7f ) ) )
 				.routing( dataSet.routingKey ) )
 				.hasDocRefHitsExactOrder( index.typeName(), dataSet.docId( 1 ), dataSet.docId( 0 ) );
 
 		assertThatQuery( index.query()
-				.where( f -> f.bool()
-						.should( predicateWithBoost( f, 0, 39f ) )
-						.should( predicate( f, 1 ) ) )
+				.where( f -> f.or(
+						predicateWithBoost( f, 0, 39f ),
+						predicate( f, 1 ) ) )
 				.routing( dataSet.routingKey ) )
 				.hasDocRefHitsExactOrder( index.typeName(), dataSet.docId( 0 ), dataSet.docId( 1 ) );
 	}
@@ -45,20 +45,20 @@ public abstract class AbstractPredicateScoreIT {
 		assumeConstantScoreSupported();
 
 		assertThatQuery( index.query()
-				.where( f -> f.bool()
+				.where( f -> f.or(
 						// Very low boost, so score << 1
-						.should( predicateWithBoost( f, 0, 0.01f ) )
+						predicateWithBoost( f, 0, 0.01f ),
 						// Constant score, so score = 1
-						.should( predicateWithConstantScore( f, 1 ) ) )
+						predicateWithConstantScore( f, 1 ) ) )
 				.routing( dataSet.routingKey ) )
 				.hasDocRefHitsExactOrder( index.typeName(), dataSet.docId( 1 ), dataSet.docId( 0 ) );
 
 		assertThatQuery( index.query()
-				.where( f -> f.bool()
+				.where( f -> f.or(
 						// Constant score, so score = 1
-						.should( predicateWithConstantScore( f, 0 ) )
+						predicateWithConstantScore( f, 0 ),
 						// Very low boost, so score << 1
-						.should( predicateWithBoost( f, 1, 0.01f ) ) )
+						predicateWithBoost( f, 1, 0.01f ) ) )
 				.routing( dataSet.routingKey ) )
 				.hasDocRefHitsExactOrder( index.typeName(), dataSet.docId( 0 ), dataSet.docId( 1 ) );
 	}
@@ -68,16 +68,16 @@ public abstract class AbstractPredicateScoreIT {
 		assumeConstantScoreSupported();
 
 		assertThatQuery( index.query()
-				.where( f -> f.bool()
-						.should( predicateWithConstantScoreAndBoost( f, 0, 7f ) )
-						.should( predicateWithConstantScoreAndBoost( f, 1, 39f ) ) )
+				.where( f -> f.or(
+						predicateWithConstantScoreAndBoost( f, 0, 7f ),
+						predicateWithConstantScoreAndBoost( f, 1, 39f ) ) )
 				.routing( dataSet.routingKey ) )
 				.hasDocRefHitsExactOrder( index.typeName(), dataSet.docId( 1 ), dataSet.docId( 0 ) );
 
 		assertThatQuery( index.query()
-				.where( f -> f.bool()
-						.should( predicateWithConstantScoreAndBoost( f, 0, 39f ) )
-						.should( predicateWithConstantScoreAndBoost( f, 1, 7f ) ) )
+				.where( f -> f.or(
+						predicateWithConstantScoreAndBoost( f, 0, 39f ),
+						predicateWithConstantScoreAndBoost( f, 1, 7f ) ) )
 				.routing( dataSet.routingKey ) )
 				.hasDocRefHitsExactOrder( index.typeName(), dataSet.docId( 0 ), dataSet.docId( 1 ) );
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AbstractPredicateTypeCheckingAndConversionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AbstractPredicateTypeCheckingAndConversionIT.java
@@ -288,10 +288,9 @@ public abstract class AbstractPredicateTypeCheckingAndConversionIT<V extends Abs
 		// ... but it should not prevent the query from executing either:
 		// if the predicate is optional, it should be ignored for missingFieldIndex.
 		assertThatQuery( scope.query()
-				.where( f -> f.bool()
-						.should( predicate( f, defaultDslConverterField0Path(), unwrappedMatchingParam( 0 ),
-								ValueConvert.YES ) )
-						.should( f.id().matching( dataSet.docId( DataSet.MISSING_FIELD_INDEX_DOC_ORDINAL ) ) ) ) )
+				.where( f -> f.or(
+						predicate( f, defaultDslConverterField0Path(), unwrappedMatchingParam( 0 ), ValueConvert.YES ),
+						f.id().matching( dataSet.docId( DataSet.MISSING_FIELD_INDEX_DOC_ORDINAL ) ) ) ) )
 				.hasDocRefHitsAnyOrder( c -> c
 						.doc( index.typeName(), dataSet.docId( 0 ) )
 						.doc( missingFieldIndex.typeName(), dataSet.docId( DataSet.MISSING_FIELD_INDEX_DOC_ORDINAL ) ) )
@@ -319,10 +318,9 @@ public abstract class AbstractPredicateTypeCheckingAndConversionIT<V extends Abs
 		// ... but it should not prevent the query from executing either:
 		// if the predicate is optional, it should be ignored for missingFieldIndex.
 		assertThatQuery( scope.query()
-				.where( f -> f.bool()
-						.should( predicate( f, defaultDslConverterField0Path(), unwrappedMatchingParam( 0 ),
-								ValueConvert.NO ) )
-						.should( f.id().matching( dataSet.docId( DataSet.MISSING_FIELD_INDEX_DOC_ORDINAL ) ) ) ) )
+				.where( f -> f.or(
+						predicate( f, defaultDslConverterField0Path(), unwrappedMatchingParam( 0 ), ValueConvert.NO ),
+						f.id().matching( dataSet.docId( DataSet.MISSING_FIELD_INDEX_DOC_ORDINAL ) ) ) ) )
 				.hasDocRefHitsAnyOrder( c -> c
 						.doc( index.typeName(), dataSet.docId( 0 ) )
 						.doc( missingFieldIndex.typeName(), dataSet.docId( DataSet.MISSING_FIELD_INDEX_DOC_ORDINAL ) ) )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AbstractPredicateTypeCheckingNoConversionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AbstractPredicateTypeCheckingNoConversionIT.java
@@ -130,9 +130,9 @@ public abstract class AbstractPredicateTypeCheckingNoConversionIT<V extends Abst
 		// ... but it should not prevent the query from executing either:
 		// if the predicate is optional, it should be ignored for missingFieldIndex.
 		assertThatQuery( scope.query()
-				.where( f -> f.bool()
-						.should( predicate( f, defaultDslConverterField0Path(), 0 ) )
-						.should( f.id().matching( dataSet.docId( DataSet.MISSING_FIELD_INDEX_DOC_ORDINAL ) ) ) ) )
+				.where( f -> f.or(
+						predicate( f, defaultDslConverterField0Path(), 0 ),
+						f.id().matching( dataSet.docId( DataSet.MISSING_FIELD_INDEX_DOC_ORDINAL ) ) ) ) )
 				.hasDocRefHitsAnyOrder( c -> c
 						.doc( index.typeName(), dataSet.docId( 0 ) )
 						.doc( missingFieldIndex.typeName(), dataSet.docId( DataSet.MISSING_FIELD_INDEX_DOC_ORDINAL ) ) )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/ExistsPredicateSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/ExistsPredicateSpecificsIT.java
@@ -92,7 +92,7 @@ public class ExistsPredicateSpecificsIT<F> {
 		String fieldPath = mainIndex.binding().fieldWithDefaults.get( dataSet.fieldType ).relativeFieldName;
 
 		assertThatQuery( mainIndex.query()
-				.where( f -> f.bool().mustNot( f.exists().field( fieldPath ) ) )
+				.where( f -> f.not( f.exists().field( fieldPath ) ) )
 				.routing( dataSet.routingKey ) )
 				.hasDocRefHitsAnyOrder( mainIndex.typeName(), dataSet.docId( 2 ), dataSet.docId( 3 ) );
 	}
@@ -134,7 +134,7 @@ public class ExistsPredicateSpecificsIT<F> {
 				+ mainIndex.binding().nestedObject.fieldWithDocValues.get( dataSet.fieldType ).relativeFieldName;
 
 		assertThatQuery( mainIndex.query()
-				.where( f -> f.bool().mustNot( f.exists().field( fieldPath ) ) )
+				.where( f -> f.not( f.exists().field( fieldPath ) ) )
 				.routing( dataSet.routingKey ) )
 				.hasDocRefHitsAnyOrder( mainIndex.typeName(), dataSet.docId( 2 ), dataSet.docId( 3 ) );
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchNonePredicateSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchNonePredicateSpecificsIT.java
@@ -54,18 +54,16 @@ public class MatchNonePredicateSpecificsIT {
 		//check that we will find something with a single match predicate
 		assertThatQuery( index.query()
 				.where(
-						f -> f.bool()
-								.must( f.match().field( "string" ).matching( STRING_1 ).toPredicate() )
+						f -> f.match().field( "string" ).matching( STRING_1 )
 				)
 		).hasTotalHitCount( 1 );
 
 		// make sure that matchNone will "override" the other matching predicate
 		assertThatQuery( index.query()
-				.where(
-						f -> f.bool()
-								.must( f.match().field( "string" ).matching( STRING_1 ).toPredicate() )
-								.must( f.matchNone() )
-				)
+				.where( f -> f.and(
+						f.match().field( "string" ).matching( STRING_1 ),
+						f.matchNone()
+				) )
 		).hasNoHits();
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NamedPredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NamedPredicateBaseIT.java
@@ -240,10 +240,10 @@ public class NamedPredicateBaseIT {
 			String word1 = (String) context.param( "value1" );
 			String word2 = (String) context.param( "value2" );
 			SearchPredicateFactory f = context.predicate();
-			return f.bool()
-					.must( f.match().field( field1Name ).matching( word1 ) )
-					.must( f.match().field( field2Name ).matching( word2 ) )
-					.toPredicate();
+			return f.and(
+					f.match().field( field1Name ).matching( word1 ),
+					f.match().field( field2Name ).matching( word2 )
+			).toPredicate();
 		}
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NestedPredicateLegacyIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NestedPredicateLegacyIT.java
@@ -69,34 +69,28 @@ public class NestedPredicateLegacyIT {
 	public void search_nestedOnTwoLevels() {
 		assertThatQuery( mainIndex.query()
 				.where( f -> f.nested().objectField( "nestedObject" )
-						.nest( f.bool()
+						.nest( f.and(
 								// This is referred to as "condition 1" in the data initialization method
-								.must( f.nested().objectField( "nestedObject.nestedObject" )
-										.nest( f.bool()
-												.must( f.match()
+								f.nested().objectField( "nestedObject.nestedObject" )
+										.nest( f.and(
+												f.match()
 														.field( "nestedObject.nestedObject.field1" )
-														.matching( MATCHING_SECOND_LEVEL_CONDITION1_FIELD1 )
-												)
-												.must( f.match()
+														.matching( MATCHING_SECOND_LEVEL_CONDITION1_FIELD1 ),
+												f.match()
 														.field( "nestedObject.nestedObject.field2" )
 														.matching( MATCHING_SECOND_LEVEL_CONDITION1_FIELD2 )
-												)
-										)
-								)
+										) ),
 								// This is referred to as "condition 2" in the data initialization method
-								.must( f.nested().objectField( "nestedObject.nestedObject" )
-										.nest( f.bool()
-												.must( f.match()
+								f.nested().objectField( "nestedObject.nestedObject" )
+										.nest( f.and(
+												f.match()
 														.field( "nestedObject.nestedObject.field1" )
-														.matching( MATCHING_SECOND_LEVEL_CONDITION2_FIELD1 )
-												)
-												.must( f.match()
+														.matching( MATCHING_SECOND_LEVEL_CONDITION2_FIELD1 ),
+												f.match()
 														.field( "nestedObject.nestedObject.field2" )
 														.matching( MATCHING_SECOND_LEVEL_CONDITION2_FIELD2 )
-												)
-										)
-								)
-						)
+										) )
+						) )
 				) )
 				.hasDocRefHitsAnyOrder( mainIndex.typeName(), DOCUMENT_1 )
 				.hasTotalHitCount( 1 );
@@ -105,34 +99,28 @@ public class NestedPredicateLegacyIT {
 	@Test
 	public void search_nestedOnTwoLevels_onlySecondLevel() {
 		assertThatQuery( mainIndex.query()
-				.where( f -> f.bool()
+				.where( f -> f.and(
 						// This is referred to as "condition 1" in the data initialization method
-						.must( f.nested().objectField( "nestedObject.nestedObject" )
-								.nest( f.bool()
-										.must( f.match()
+						f.nested().objectField( "nestedObject.nestedObject" )
+								.nest( f.and(
+										f.match()
 												.field( "nestedObject.nestedObject.field1" )
-												.matching( MATCHING_SECOND_LEVEL_CONDITION1_FIELD1 )
-										)
-										.must( f.match()
+												.matching( MATCHING_SECOND_LEVEL_CONDITION1_FIELD1 ),
+										f.match()
 												.field( "nestedObject.nestedObject.field2" )
 												.matching( MATCHING_SECOND_LEVEL_CONDITION1_FIELD2 )
-										)
-								)
-						)
+								) ),
 						// This is referred to as "condition 2" in the data initialization method
-						.must( f.nested().objectField( "nestedObject.nestedObject" )
-								.nest( f.bool()
-										.must( f.match()
+						f.nested().objectField( "nestedObject.nestedObject" )
+								.nest( f.and(
+										f.match()
 												.field( "nestedObject.nestedObject.field1" )
-												.matching( MATCHING_SECOND_LEVEL_CONDITION2_FIELD1 )
-										)
-										.must( f.match()
+												.matching( MATCHING_SECOND_LEVEL_CONDITION2_FIELD1 ),
+										f.match()
 												.field( "nestedObject.nestedObject.field2" )
 												.matching( MATCHING_SECOND_LEVEL_CONDITION2_FIELD2 )
-										)
-								)
-						)
-				) )
+								) )
+				) ) )
 				.hasDocRefHitsAnyOrder( mainIndex.typeName(), DOCUMENT_1, DOCUMENT_2 )
 				.hasTotalHitCount( 2 );
 	}
@@ -141,25 +129,21 @@ public class NestedPredicateLegacyIT {
 	public void search_nestedOnTwoLevels_conditionOnFirstLevel() {
 		assertThatQuery( mainIndex.query()
 				.where( f -> f.nested().objectField( "nestedObject" )
-						.nest( f.bool()
-								.must( f.match()
+						.nest( f.and(
+								f.match()
 										.field( "nestedObject.string" )
-										.matching( MATCHING_STRING )
-								)
+										.matching( MATCHING_STRING ),
 								// This is referred to as "condition 2" in the data initialization method
-								.must( f.nested().objectField( "nestedObject.nestedObject" )
-										.nest( f.bool()
-												.must( f.match()
+								f.nested().objectField( "nestedObject.nestedObject" )
+										.nest( f.and(
+												f.match()
 														.field( "nestedObject.nestedObject.field1" )
-														.matching( MATCHING_SECOND_LEVEL_CONDITION2_FIELD1 )
-												)
-												.must( f.match()
+														.matching( MATCHING_SECOND_LEVEL_CONDITION2_FIELD1 ),
+												f.match()
 														.field( "nestedObject.nestedObject.field2" )
 														.matching( MATCHING_SECOND_LEVEL_CONDITION2_FIELD2 )
-												)
-										)
-								)
-						)
+										) )
+						) )
 				) )
 				.hasDocRefHitsAnyOrder( mainIndex.typeName(), DOCUMENT_2 )
 				.hasTotalHitCount( 1 );
@@ -170,27 +154,25 @@ public class NestedPredicateLegacyIT {
 		StubMappingScope scope = mainIndex.createScope();
 
 		SearchPredicate predicate1 = scope.predicate().nested().objectField( "nestedObject.nestedObject" )
-				.nest( f -> f.bool()
-						.must( f.match()
+				.nest( f -> f.and(
+						f.match()
 								.field( "nestedObject.nestedObject.field1" )
-								.matching( MATCHING_SECOND_LEVEL_CONDITION1_FIELD1 )
-						).must( f.match()
+								.matching( MATCHING_SECOND_LEVEL_CONDITION1_FIELD1 ),
+						f.match()
 								.field( "nestedObject.nestedObject.field2" )
 								.matching( MATCHING_SECOND_LEVEL_CONDITION1_FIELD2 )
-						)
-				)
+				) )
 				.toPredicate();
 
 		SearchPredicate predicate2 = scope.predicate().nested().objectField( "nestedObject.nestedObject" )
-				.nest( f -> f.bool()
-						.must( f.match()
+				.nest( f -> f.and(
+						f.match()
 								.field( "nestedObject.nestedObject.field1" )
-								.matching( MATCHING_SECOND_LEVEL_CONDITION2_FIELD1 )
-						).must( f.match()
+								.matching( MATCHING_SECOND_LEVEL_CONDITION2_FIELD1 ),
+						f.match()
 								.field( "nestedObject.nestedObject.field2" )
 								.matching( MATCHING_SECOND_LEVEL_CONDITION2_FIELD2 )
-						)
-				)
+				) )
 				.toPredicate();
 
 		assertThatQuery( scope.query()
@@ -213,16 +195,14 @@ public class NestedPredicateLegacyIT {
 
 		assertThatThrownBy( () -> mainIndex.query()
 				.where( f -> f.nested().objectField( objectFieldPath )
-						.nest( f.bool()
-								.must( f.match()
+						.nest( f.and(
+								f.match()
+										.field( fieldInParentPath )
+										.matching( "irrelevant_because_this_will_fail" ),
+								f.match()
 										.field( fieldInParentPath )
 										.matching( "irrelevant_because_this_will_fail" )
-								)
-								.must( f.match()
-										.field( fieldInParentPath )
-										.matching( "irrelevant_because_this_will_fail" )
-								)
-						)
+						) )
 				) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll( "Invalid search predicate",
@@ -239,16 +219,14 @@ public class NestedPredicateLegacyIT {
 
 		assertThatThrownBy( () -> mainIndex.query()
 				.where( f -> f.nested().objectField( objectFieldPath )
-						.nest( f.bool()
-								.must( f.match()
+						.nest( f.and(
+								f.match()
+										.field( fieldInSiblingPath )
+										.matching( "irrelevant_because_this_will_fail" ),
+								f.match()
 										.field( fieldInSiblingPath )
 										.matching( "irrelevant_because_this_will_fail" )
-								)
-								.must( f.match()
-										.field( fieldInSiblingPath )
-										.matching( "irrelevant_because_this_will_fail" )
-								)
-						)
+						) )
 				) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll( "Invalid search predicate",
@@ -268,34 +246,28 @@ public class NestedPredicateLegacyIT {
 		StubMappingScope scope = mainIndex.createScope( missingFieldIndex );
 		SearchPredicateFactory f = scope.predicate();
 		SearchPredicate nestedPredicate = f.nested().objectField( "nestedObject" )
-				.nest( f.bool()
+				.nest( f.and(
 						// This is referred to as "condition 1" in the data initialization method
-						.must( f.nested().objectField( "nestedObject.nestedObject" )
-								.nest( f.bool()
-										.must( f.match()
+						f.nested().objectField( "nestedObject.nestedObject" )
+								.nest( f.and(
+										f.match()
 												.field( "nestedObject.nestedObject.field1" )
-												.matching( MATCHING_SECOND_LEVEL_CONDITION1_FIELD1 )
-										)
-										.must( f.match()
+												.matching( MATCHING_SECOND_LEVEL_CONDITION1_FIELD1 ),
+										f.match()
 												.field( "nestedObject.nestedObject.field2" )
 												.matching( MATCHING_SECOND_LEVEL_CONDITION1_FIELD2 )
-										)
-								)
-						)
+								) ),
 						// This is referred to as "condition 2" in the data initialization method
-						.must( f.nested().objectField( "nestedObject.nestedObject" )
-								.nest( f.bool()
-										.must( f.match()
+						f.nested().objectField( "nestedObject.nestedObject" )
+								.nest( f.and(
+										f.match()
 												.field( "nestedObject.nestedObject.field1" )
-												.matching( MATCHING_SECOND_LEVEL_CONDITION2_FIELD1 )
-										)
-										.must( f.match()
+												.matching( MATCHING_SECOND_LEVEL_CONDITION2_FIELD1 ),
+										f.match()
 												.field( "nestedObject.nestedObject.field2" )
 												.matching( MATCHING_SECOND_LEVEL_CONDITION2_FIELD2 )
-										)
-								)
-						)
-				)
+								) )
+				) )
 				.toPredicate();
 
 		// The "nested" predicate should not match anything in missingFieldIndex

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NestedPredicateSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NestedPredicateSpecificsIT.java
@@ -306,10 +306,10 @@ public class NestedPredicateSpecificsIT {
 		// ... but it should not prevent the query from executing either:
 		// if the "nested" predicate is optional, it should be ignored for missingFieldIndex.
 		assertThatQuery( mainIndex.createScope( missingFieldIndex ).query()
-				.where( f.bool()
-						.should( nestedPredicate )
-						.should( f.id().matching( MISSING_FIELD_INDEX_DOCUMENT_1 ) )
-						.toPredicate() ) )
+				.where( f.or(
+						nestedPredicate,
+						f.id().matching( MISSING_FIELD_INDEX_DOCUMENT_1 ).toPredicate()
+				).toPredicate() ) )
 				.hasDocRefHitsAnyOrder( c -> c
 						.doc( mainIndex.typeName(), DOCUMENT_1 )
 						.doc( missingFieldIndex.typeName(), MISSING_FIELD_INDEX_DOCUMENT_1 ) )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SearchPredicateIT.java
@@ -194,10 +194,10 @@ public class SearchPredicateIT {
 		assertThatQuery( query ).hasDocRefHitsAnyOrder( mainIndex.typeName(), DOCUMENT_1 );
 
 		query = otherIndex.createScope( mainIndex ).query()
-				.where( f -> f.bool()
-						.should( multiIndexScopedPredicate )
-						.should( f.match().field( "string" ).matching( STRING_2 ) )
-				)
+				.where( f -> f.or(
+						multiIndexScopedPredicate,
+						f.match().field( "string" ).matching( STRING_2 ).toPredicate()
+				) )
 				.toQuery();
 
 		assertThatQuery( query ).hasDocRefHitsAnyOrder( mainIndex.typeName(), DOCUMENT_1, DOCUMENT_2 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryBaseIT.java
@@ -280,10 +280,10 @@ public class SearchQueryBaseIT {
 		}
 
 		public SearchQuery<T> extendedFeature(String fieldName, String value1, String value2) {
-			return delegate.where( f -> f.bool()
-					.should( f.match().field( fieldName ).matching( value1 ) )
-					.should( f.match().field( fieldName ).matching( value2 ) )
-			)
+			return delegate.where( f -> f.or(
+							f.match().field( fieldName ).matching( value1 ),
+							f.match().field( fieldName ).matching( value2 )
+					) )
 					.sort( f -> f.field( fieldName ) )
 					.toQuery();
 		}

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/limitations/ConcurrentEmbeddedUpdateLimitationIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/limitations/ConcurrentEmbeddedUpdateLimitationIT.java
@@ -184,9 +184,10 @@ public class ConcurrentEmbeddedUpdateLimitationIT {
 			SearchSession searchSession = Search.session( session );
 
 			return searchSession.search( Book.class )
-					.where( f -> f.bool()
-							.must( f.match().field( "editions.label" ).matching( editionLabel ) )
-							.must( f.match().field( "authors.name" ).matching( authorName ) ) )
+					.where( f -> f.and(
+							f.match().field( "editions.label" ).matching( editionLabel ),
+							f.match().field( "authors.name" ).matching( authorName )
+					) )
 					.fetchTotalHitCount();
 		} );
 	}

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchDocumentRepositoryImpl.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchDocumentRepositoryImpl.java
@@ -94,9 +94,9 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 					// Bridged query with complex bridge: TODO HSEARCH-3320 rely on the bridge to split the String
 					String[] splitTags = tags == null ? null : tags.split( "," );
 					if ( splitTags != null && splitTags.length > 0 ) {
-						root.add( f.bool().with( b2 -> {
+						root.add( f.and().with( and -> {
 							for ( String tag : splitTags ) {
-								b2.must( f.match()
+								and.add( f.match()
 										.field( "tags" )
 										.matching( tag )
 								);


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4675

I had to switch to something else for a bit before I started to `<em> highlight </em>` things everywhere 😆 

There are not that many `bool()` predicates in the doc examples. Most seem to be about the bool operator itself. From what it seems there's only one example that we can update in the ref doc itself:

```java
// Example 345. Targeting a field using relative paths
List<Book> hits = searchSession.search( Book.class )
        .where( f -> f.bool()
                .should( f.nested( "writers" )
                        .add( matchFirstAndLastName( 
                                f.withRoot( "writers" ), 
                                "bob", "kane" ) ) )
                .should( f.nested( "artists" )
                        .add( matchFirstAndLastName( 
                                f.withRoot( "artists" ), 
                                "bill", "finger" ) ) ) )
        .fetchHits( 20 );
```
Some of the examples in `16.2.15. bool: advanced combinations of predicates (or/and/…​)` could probably be done as and/or/not combination but I suppose it is a section on bool rather than these shortcuts 😃 

`bool()` was also used in some tests in the documentation module that were not part of the examples in ref docs - those got updated where possible.
TCK is updated where was possible, bool specific tests remain unchanged.
Removed call to `bool()` in some places where that seemed redundant (especially that we already have that optimization to do so anyway. tests for optimization are unchanged). 