### PR TITLE
HSEARCH-4801 Bump japicmp-maven-plugin from 0.17.1 to 0.17.2 /  Ignore spring boot upgrade for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,8 @@ updates:
       # We don't care that much about being on the very latest version of some integration test dependencies
       - dependency-name: "org.springframework.boot:*"
         update-types: [ "version-update:semver-patch" ]
+        # ignore spring boot 3+ for now as some required dependencies are not compatible with this version yet:
+        versions: ["[3.0.0,)"]
       # Upgrading to asciidoctorj-pdf 1.5.0 or later won't work for
       # some reason; we're getting strange errors that led me to think the
       # font-size has the wrong type (string instead of number).

--- a/pom.xml
+++ b/pom.xml
@@ -378,7 +378,7 @@
         <version.install.plugin>3.1.0</version.install.plugin>
         <version.io.takari.maven>0.7.7</version.io.takari.maven>
         <version.jandex.plugin>1.2.3</version.jandex.plugin>
-        <version.japicmp.plugin>0.17.1</version.japicmp.plugin>
+        <version.japicmp.plugin>0.17.2</version.japicmp.plugin>
         <version.jar.plugin>3.3.0</version.jar.plugin>
         <version.javadoc.plugin>3.5.0</version.javadoc.plugin>
         <version.jdeps.plugin>0.5.1</version.jdeps.plugin>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4801

follows up on https://github.com/hibernate/hibernate-search/pull/3428, https://github.com/hibernate/hibernate-search/pull/3419

I've also added that ignore rule for the spring boot 3 as it seems that the Narayana starter won't be coming soon.