### PR TITLE
HSEARCH-4814 Use failure reporter in offloading operation submitter

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/backend/orchestration/spi/BatchingExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/orchestration/spi/BatchingExecutor.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
@@ -32,6 +33,7 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 public final class BatchingExecutor<P extends BatchedWorkProcessor, W extends BatchedWork<? super P>> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+	private static final BiConsumer<? super BatchedWork<?>, Throwable> ASYNC_FAILURE_REPORTER = BatchedWork::markAsFailed;
 
 	private final String name;
 
@@ -127,7 +129,7 @@ public final class BatchingExecutor<P extends BatchedWorkProcessor, W extends Ba
 					"Attempt to submit a work to executor '" + name + "', which is stopped."
 			);
 		}
-		operationSubmitter.submitToQueue( workQueue, work, blockingRetryProducer );
+		operationSubmitter.submitToQueue( workQueue, work, blockingRetryProducer, ASYNC_FAILURE_REPORTER );
 		processingTask.ensureScheduled();
 	}
 

--- a/engine/src/test/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitterQueueTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/backend/work/execution/OperationSubmitterQueueTest.java
@@ -29,15 +29,15 @@ public class OperationSubmitterQueueTest {
 	public void setUp() throws Exception {
 		this.queue = new ArrayBlockingQueue<>( 2 );
 
-		OperationSubmitter.blocking().submitToQueue( queue, 1, i -> { } );
-		OperationSubmitter.blocking().submitToQueue( queue, 2, i -> { } );
+		OperationSubmitter.blocking().submitToQueue( queue, 1, i -> { }, (e, t) -> { } );
+		OperationSubmitter.blocking().submitToQueue( queue, 2, i -> { }, (e, t) -> { } );
 	}
 
 	@Test
 	public void blockingOperationSubmitterBlocksTheOperation() throws InterruptedException {
 		CompletableFuture<Boolean> future = CompletableFuture.supplyAsync( () -> {
 			try {
-				OperationSubmitter.blocking().submitToQueue( queue, 3, i -> { } );
+				OperationSubmitter.blocking().submitToQueue( queue, 3, i -> { }, (e, t) -> { } );
 			}
 			catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
@@ -60,7 +60,7 @@ public class OperationSubmitterQueueTest {
 	@Test
 	public void nonBlockingOperationSubmitterThrowsException() {
 		Integer element = 3;
-		assertThatThrownBy( () -> OperationSubmitter.rejecting().submitToQueue( queue, element, i -> { } ) )
+		assertThatThrownBy( () -> OperationSubmitter.rejecting().submitToQueue( queue, element, i -> { }, (e, t) -> { } ) )
 				.isInstanceOf( RejectedExecutionException.class );
 	}
 
@@ -68,7 +68,21 @@ public class OperationSubmitterQueueTest {
 	public void offloadingSubmitterOffloads() throws Exception {
 		// we won't submit to the queue but just make sure that work got offloaded
 		AtomicBoolean worked = new AtomicBoolean( false );
-		OperationSubmitter.offloading( Runnable::run ).submitToQueue( queue, 1, i -> { worked.set( true ); } );
+		OperationSubmitter.offloading( Runnable::run ).submitToQueue( queue, 1, i -> { worked.set( true ); }, (e, t) -> { } );
+
+		await().untilAsserted( () -> assertThat( worked ).isTrue() );
+	}
+
+	@Test
+	public void offloadingSubmitterFailsToOffloadExceptionInProducer() throws Exception {
+		AtomicBoolean worked = new AtomicBoolean( false );
+		OperationSubmitter.offloading( Runnable::run ).submitToQueue( queue, 1, i -> { throw new IllegalStateException( "fail" ); },
+				(e, t) -> {
+					assertThat( t )
+							.isInstanceOf( IllegalStateException.class )
+							.hasMessageContaining( "fail" );
+					worked.set( true );
+				} );
 
 		await().untilAsserted( () -> assertThat( worked ).isTrue() );
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4814

I might've missed the point, but I didn't find a use for the `T` in a `BiConsumer<T, Throwable>`, so I just went with a simple `Consumer<Throwable>`. 
I also went ahead and wrapped the call to the `executor.accept(..)` with a try/catch even though it should happen in the same thread, but since we already have a reporter in place... 
And replaced the offloading lambdas with a class.
BTW did this happen anywhere, or it's more of a precaution?