### PR TITLE
HSEARCH-4801 Bump groovy-jsr223 from 3.0.15 to 3.0.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -400,7 +400,7 @@
         <version.sonar.plugin>3.9.1.2184</version.sonar.plugin>
         <version.scripting.plugin>3.0.0</version.scripting.plugin>
         <version.gpg.plugin>3.0.1</version.gpg.plugin>
-        <version.org.codehaus.groovy-jsr223>3.0.15</version.org.codehaus.groovy-jsr223>
+        <version.org.codehaus.groovy-jsr223>3.0.16</version.org.codehaus.groovy-jsr223>
         <version.com.puppycrawl.tools.checkstyle>10.3.4</version.com.puppycrawl.tools.checkstyle>
         <version.versions.plugin>2.12.0</version.versions.plugin>
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4801

follows up on https://github.com/hibernate/hibernate-search/pull/3435, https://github.com/hibernate/hibernate-search/pull/3428, https://github.com/hibernate/hibernate-search/pull/3419