### PR TITLE
HSEARCH-4810 Fix flaky test with MSSQL

### DIFF
--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
@@ -107,6 +107,12 @@ public class BackendMock implements TestRule {
 		backendBehavior().verifyExpectationsMet();
 	}
 
+	public long remainingExpectedIndexingCount() {
+		return backendBehavior().getDocumentWorkExecuteCalls().values().stream()
+				.mapToLong( CallQueue::remainingExpectedCallCount )
+				.sum();
+	}
+
 	public void inLenientMode(Runnable action) {
 		backendBehavior().lenient( true );
 		try {

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/CallQueue.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/CallQueue.java
@@ -239,4 +239,8 @@ public class CallQueue<C extends Call<? super C>> {
 		}
 	}
 
+	public synchronized long remainingExpectedCallCount() {
+		return ( (long) callsExpectedInOrder.size() ) + callsExpectedOutOfOrder.size();
+	}
+
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/VerifyingStubBackendBehavior.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/VerifyingStubBackendBehavior.java
@@ -142,6 +142,10 @@ class VerifyingStubBackendBehavior extends StubBackendBehavior {
 				ignored -> new CallQueue<>( indexingCallQueueSettings ) );
 	}
 
+	Map<DocumentKey, CallQueue<DocumentWorkExecuteCall>> getDocumentWorkExecuteCalls() {
+		return documentWorkExecuteCalls;
+	}
+
 	CallQueue<DocumentWorkExecuteCall> getDocumentWorkExecuteCalls(DocumentKey documentKey) {
 		return documentWorkExecuteCalls.computeIfAbsent( documentKey,
 				ignored -> new CallQueue<>( indexingCallQueueSettings ) );


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4810

It was easier this time, as I was able to simply avoid hitting the database concurrently, as the concurrent access was an assertion in tests.