### PR TITLE
HSEARCH-2366 Follow-up: Make tests compatible with non-default build

### DIFF
--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerExporterIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerExporterIT.java
@@ -15,6 +15,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.engine.backend.schema.management.spi.IndexSchemaCollector;
@@ -77,12 +79,18 @@ public class ElasticsearchIndexSchemaManagerExporterIT {
 						"    }" +
 						"  }" +
 						"}",
-				Files.readString( directory.resolve( testIndexName ).resolve( "create-index.json" ) )
+				readString( directory.resolve( testIndexName ).resolve( "create-index.json" ) )
 		);
 
 		assertJsonEquals(
 				"{}",
-				Files.readString( directory.resolve( testIndexName ).resolve( "create-index-query-params.json" ) )
+				readString( directory.resolve( testIndexName ).resolve( "create-index-query-params.json" ) )
 		);
+	}
+
+	private String readString(Path path) throws IOException {
+		try ( Stream<String> lines = Files.lines( path ) ) {
+			return lines.collect( Collectors.joining( "\n" ) );
+		}
 	}
 }

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/schema/management/ElasticsearchSchemaManagerExporterIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/schema/management/ElasticsearchSchemaManagerExporterIT.java
@@ -14,6 +14,8 @@ import static org.junit.Assume.assumeFalse;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.search.integrationtest.mapper.orm.realbackend.testsupport.BackendConfigurations;
@@ -45,7 +47,7 @@ public class ElasticsearchSchemaManagerExporterIT {
 						osVersion -> false
 				)
 		);
-		String version = ElasticsearchTestDialect.getActualVersion().versionString();
+		String version = ElasticsearchTestDialect.getActualVersion().toString();
 		entityManagerFactory = setupHelper.start()
 				// so that we don't try to do anything with the schema and allow to run without ES being up:
 				.withProperty( "hibernate.search.schema_management.strategy", "none" )
@@ -84,7 +86,7 @@ public class ElasticsearchSchemaManagerExporterIT {
 						"  }," +
 						"  \"settings\": {}" +
 						"}",
-				Files.readString(
+				readString(
 						directory.resolve( "backend" ) // as we are using the default backend
 								.resolve( "indexes" )
 								.resolve( Book.NAME )
@@ -93,7 +95,7 @@ public class ElasticsearchSchemaManagerExporterIT {
 
 		assertJsonEquals(
 				"{}",
-				Files.readString(
+				readString(
 						directory.resolve( "backend" ) // as we are using the default backend
 								.resolve( "indexes" )
 								.resolve( Book.NAME )
@@ -129,7 +131,7 @@ public class ElasticsearchSchemaManagerExporterIT {
 						"  }," +
 						"  \"settings\": {}" +
 						"}",
-				Files.readString(
+				readString(
 						directory.resolve( "backends" ) // as we are not using the default backend
 								.resolve( Article.BACKEND_NAME ) // name of a backend
 								.resolve( "indexes" )
@@ -139,12 +141,18 @@ public class ElasticsearchSchemaManagerExporterIT {
 
 		assertJsonEquals(
 				"{}",
-				Files.readString(
+				readString(
 						directory.resolve( "backends" ) // as we are not using the default backend
 								.resolve( Article.BACKEND_NAME ) // name of a backend
 								.resolve( "indexes" )
 								.resolve( Article.NAME )
 								.resolve( "create-index-query-params.json" ) )
 		);
+	}
+
+	private String readString(Path path) throws IOException {
+		try ( Stream<String> lines = Files.lines( path ) ) {
+			return lines.collect( Collectors.joining( "\n" ) );
+		}
 	}
 }

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/schema/management/LuceneSchemaManagerExporterIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/schema/management/LuceneSchemaManagerExporterIT.java
@@ -11,6 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.search.integrationtest.mapper.orm.realbackend.testsupport.BackendConfigurations;
@@ -43,19 +45,25 @@ public class LuceneSchemaManagerExporterIT {
 		Path directory = temporaryFolder.newFolder().toPath();
 		Search.mapping( entityManagerFactory ).scope( Object.class ).schemaManager().exportExpectedSchema( directory );
 
-		String bookIndex = Files.readString(
+		String bookIndex = readString(
 				directory.resolve( "backend" ) // as we are using the default backend
 						.resolve( "indexes" )
 						.resolve( Book.NAME )
 						.resolve( "no-schema.txt" ) );
 		assertThat( bookIndex ).isEqualTo( "The Lucene backend does not support exporting the schema." );
 
-		String articleIndex = Files.readString(
+		String articleIndex = readString(
 				directory.resolve( "backends" ) // as we are not using the default backend
 						.resolve( Article.BACKEND_NAME ) // name of a backend
 						.resolve( "indexes" )
 						.resolve( Article.NAME )
 						.resolve( "no-schema.txt" ) );
 		assertThat( articleIndex ).isEqualTo( "The Lucene backend does not support exporting the schema." );
+	}
+
+	private String readString(Path path) throws IOException {
+		try ( Stream<String> lines = Files.lines( path ) ) {
+			return lines.collect( Collectors.joining( "\n" ) );
+		}
 	}
 }

--- a/integrationtest/mapper/pojo-standalone-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/standalone/realbackend/schema/management/LuceneSchemaManagerExporterIT.java
+++ b/integrationtest/mapper/pojo-standalone-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/standalone/realbackend/schema/management/LuceneSchemaManagerExporterIT.java
@@ -12,6 +12,8 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.hibernate.search.integrationtest.mapper.pojo.standalone.realbackend.testsupport.BackendConfigurations;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
@@ -44,14 +46,14 @@ public class LuceneSchemaManagerExporterIT {
 		Path directory = temporaryFolder.newFolder().toPath();
 		mapping.scope( Object.class ).schemaManager().exportExpectedSchema( directory );
 
-		String bookIndex = Files.readString(
+		String bookIndex = readString(
 				directory.resolve( "backend" ) // as we are using the default backend
 						.resolve( "indexes" )
 						.resolve( Book.NAME )
 						.resolve( "no-schema.txt" ) );
 		assertThat( bookIndex ).isEqualTo( "The Lucene backend does not support exporting the schema." );
 
-		String articleIndex = Files.readString(
+		String articleIndex = readString(
 				directory.resolve( "backends" ) // as we are not using the default backend
 						.resolve( Article.BACKEND_NAME ) // name of a backend
 						.resolve( "indexes" )
@@ -109,6 +111,12 @@ public class LuceneSchemaManagerExporterIT {
 
 		public void setTitle(String title) {
 			this.title = title;
+		}
+	}
+
+	private String readString(Path path) throws IOException {
+		try ( Stream<String> lines = Files.lines( path ) ) {
+			return lines.collect( Collectors.joining( "\n" ) );
 		}
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2366

- don't use 11+ Files API
- use a version of ES including the distribution part

follows up on https://github.com/hibernate/hibernate-search/pull/3437