### PR TITLE
HSEARCH-4831 Fix Hibernate Search tests against latest ORM 6.2/6.3

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingErrorIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingErrorIT.java
@@ -38,6 +38,7 @@ import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.SimpleSessionFactoryBuilder;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
+import org.hibernate.search.util.impl.test.reflect.RuntimeHelper;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -542,7 +543,10 @@ public abstract class AbstractMassIndexingErrorIT {
 
 		@Id // This must be on the getter, so that Hibernate Search uses getters instead of direct field access
 		public Integer getId() {
-			if ( id == 2 && errorOnBook2GetId.get() ) {
+			if ( id == 2
+					// Only fail for Hibernate Search, not for Hibernate ORM
+					&& RuntimeHelper.firstNonSelfNonJdkCaller().map( RuntimeHelper::isHibernateSearch ).orElse( false )
+					&& errorOnBook2GetId.getAndSet( false ) ) {
 				throw new SimulatedError( "getId error" );
 			}
 			return id;
@@ -554,7 +558,10 @@ public abstract class AbstractMassIndexingErrorIT {
 
 		@GenericField
 		public String getTitle() {
-			if ( id == 2 && errorOnBook2GetTitle.get() ) {
+			if ( id == 2
+					// Only fail for Hibernate Search, not for Hibernate ORM
+					&& RuntimeHelper.firstNonSelfNonJdkCaller().map( RuntimeHelper::isHibernateSearch ).orElse( false )
+					&& errorOnBook2GetTitle.getAndSet( false ) ) {
 				throw new SimulatedError( "getTitle error" );
 			}
 			return title;

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingErrorIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingErrorIT.java
@@ -358,23 +358,16 @@ public abstract class AbstractMassIndexingErrorIT {
 				expectationSetter.run();
 			}
 
-			// TODO HSEARCH-3728 simplify this when even indexing exceptions are propagated
-			Runnable runnable = () -> {
+			assertThatThrownBy( () -> {
 				try {
 					massIndexer.startAndWait();
 				}
 				catch (InterruptedException e) {
 					fail( "Unexpected InterruptedException: " + e.getMessage() );
 				}
-			};
-			if ( thrownExpectation == null ) {
-				runnable.run();
-			}
-			else {
-				assertThatThrownBy( runnable::run )
-						.asInstanceOf( InstanceOfAssertFactories.type( Throwable.class ) )
-						.satisfies( thrownExpectation );
-			}
+			} )
+					.asInstanceOf( InstanceOfAssertFactories.type( Throwable.class ) )
+					.satisfies( thrownExpectation );
 			backendMock.verifyExpectationsMet();
 
 			switch ( threadExpectation ) {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingFailureIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingFailureIT.java
@@ -41,6 +41,7 @@ import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.SimpleSessionFactoryBuilder;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
+import org.hibernate.search.util.impl.test.reflect.RuntimeHelper;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -843,7 +844,10 @@ public abstract class AbstractMassIndexingFailureIT {
 
 		@Id // This must be on the getter, so that Hibernate Search uses getters instead of direct field access
 		public Integer getId() {
-			if ( id == 2 && failOnBook2GetId.getAndSet( false ) ) {
+			if ( id == 2
+					// Only fail for Hibernate Search, not for Hibernate ORM
+					&& RuntimeHelper.firstNonSelfNonJdkCaller().map( RuntimeHelper::isHibernateSearch ).orElse( false )
+					&& failOnBook2GetId.getAndSet( false ) ) {
 				throw new SimulatedFailure( "getId failure" );
 			}
 			return id;
@@ -855,7 +859,10 @@ public abstract class AbstractMassIndexingFailureIT {
 
 		@GenericField
 		public String getTitle() {
-			if ( id == 2 && failOnBook2GetTitle.get() ) {
+			if ( id == 2
+					// Only fail for Hibernate Search, not for Hibernate ORM
+					&& RuntimeHelper.firstNonSelfNonJdkCaller().map( RuntimeHelper::isHibernateSearch ).orElse( false )
+					&& failOnBook2GetTitle.getAndSet( false ) ) {
 				throw new SimulatedFailure( "getTitle failure" );
 			}
 			return title;

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingFailureIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingFailureIT.java
@@ -655,23 +655,16 @@ public abstract class AbstractMassIndexingFailureIT {
 				expectationSetter.run();
 			}
 
-			// TODO HSEARCH-3728 simplify this when even indexing exceptions are propagated
-			Runnable runnable = () -> {
+			assertThatThrownBy( () -> {
 				try {
 					massIndexer.startAndWait();
 				}
 				catch (InterruptedException e) {
 					fail( "Unexpected InterruptedException: " + e.getMessage() );
 				}
-			};
-			if ( thrownExpectation == null ) {
-				runnable.run();
-			}
-			else {
-				assertThatThrownBy( runnable::run )
-						.asInstanceOf( InstanceOfAssertFactories.type( Throwable.class ) )
-						.satisfies( thrownExpectation );
-			}
+			} )
+					.asInstanceOf( InstanceOfAssertFactories.type( Throwable.class ) )
+					.satisfies( thrownExpectation );
 			backendMock.verifyExpectationsMet();
 
 			switch ( threadExpectation ) {

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/AbstractMassIndexingErrorIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/AbstractMassIndexingErrorIT.java
@@ -356,23 +356,16 @@ public abstract class AbstractMassIndexingErrorIT {
 				expectationSetter.run();
 			}
 
-			// TODO HSEARCH-3728 simplify this when even indexing exceptions are propagated
-			Runnable runnable = () -> {
+			assertThatThrownBy( () -> {
 				try {
 					massIndexer.startAndWait();
 				}
 				catch (InterruptedException e) {
 					fail( "Unexpected InterruptedException: " + e.getMessage() );
 				}
-			};
-			if ( thrownExpectation == null ) {
-				runnable.run();
-			}
-			else {
-				assertThatThrownBy( runnable::run )
-						.asInstanceOf( InstanceOfAssertFactories.type( Throwable.class ) )
-						.satisfies( thrownExpectation );
-			}
+			} )
+					.asInstanceOf( InstanceOfAssertFactories.type( Throwable.class ) )
+					.satisfies( thrownExpectation );
 			backendMock.verifyExpectationsMet();
 		}
 		catch (AssertionError e) {

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/AbstractMassIndexingFailureIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/AbstractMassIndexingFailureIT.java
@@ -654,23 +654,16 @@ public abstract class AbstractMassIndexingFailureIT {
 				expectationSetter.run();
 			}
 
-			// TODO HSEARCH-3728 simplify this when even indexing exceptions are propagated
-			Runnable runnable = () -> {
+			assertThatThrownBy( () -> {
 				try {
 					massIndexer.startAndWait();
 				}
 				catch (InterruptedException e) {
 					fail( "Unexpected InterruptedException: " + e.getMessage() );
 				}
-			};
-			if ( thrownExpectation == null ) {
-				runnable.run();
-			}
-			else {
-				assertThatThrownBy( runnable::run )
-						.asInstanceOf( InstanceOfAssertFactories.type( Throwable.class ) )
-						.satisfies( thrownExpectation );
-			}
+			} )
+					.asInstanceOf( InstanceOfAssertFactories.type( Throwable.class ) )
+					.satisfies( thrownExpectation );
 			backendMock.verifyExpectationsMet();
 		}
 		catch (AssertionError e) {

--- a/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/reflect/RuntimeHelper.java
+++ b/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/reflect/RuntimeHelper.java
@@ -1,0 +1,163 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.test.reflect;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public final class RuntimeHelper {
+
+	private static final CallerClassWalker CALLER_CLASS_WALKER;
+
+	static {
+		Class<?> stackWalkerClass = null;
+		try {
+			stackWalkerClass = Class.forName( "java.lang.StackWalker" );
+		}
+		catch (ClassNotFoundException ignored) {
+		}
+		if ( stackWalkerClass != null ) {
+			// JDK 9+, where StackWalker is available
+			try {
+				CALLER_CLASS_WALKER = new StackWalkerCallerClassWalker( stackWalkerClass );
+			}
+			catch (ClassNotFoundException | NoSuchMethodException | InvocationTargetException | IllegalAccessException | RuntimeException e) {
+				throw new IllegalStateException( "Unable to initialize ClassWalker based on java.lang.StackWaker", e );
+			}
+		}
+		else {
+			// JDK 8
+			CALLER_CLASS_WALKER = new SecurityManagerCallerClassWalker();
+		}
+	}
+
+	private RuntimeHelper() {
+	}
+
+	public static CallerClassWalker callerClassWalker() {
+		return CALLER_CLASS_WALKER;
+	}
+
+	public static Optional<Class<?>> firstNonSelfNonJdkCaller() {
+		return firstNonSelfNonJdkCaller( 1L ); // Skip this method
+	}
+
+	public static Optional<Class<?>> firstNonSelfNonJdkCaller(long skip) {
+		return callerClassWalker().walk( stream -> {
+			Iterator<Class<?>> iterator = stream
+					.skip( 1L + skip ) // Skip this method and whatever was requested
+					.iterator();
+			if ( !iterator.hasNext() ) {
+				// No called class... ?
+				return Optional.empty();
+			}
+			Class<?> calledClass = iterator.next();
+			if ( !iterator.hasNext() ) {
+				// No caller class... ?
+				return Optional.empty();
+			}
+			Class<?> callerClass = iterator.next();
+			// Skip self-calls
+			while ( callerClass.equals( calledClass ) && iterator.hasNext() ) {
+				callerClass = iterator.next();
+			}
+			if ( callerClass.equals( calledClass ) ) {
+				// Only self calls.
+				return Optional.empty();
+			}
+			// Skip JDK calls
+			while ( isJdk( callerClass ) && iterator.hasNext() ) {
+				callerClass = iterator.next();
+			}
+			if ( isJdk( callerClass ) ) {
+				// Only calls from JDK.
+				return Optional.empty();
+			}
+			return Optional.of( callerClass );
+		} );
+	}
+
+	private static boolean isJdk(Class<?> clazz) {
+		Package pakkgage = clazz.getPackage();
+		return pakkgage != null && pakkgage.getName().startsWith( "java." );
+	}
+
+	public static boolean isHibernateSearch(Class<?> clazz) {
+		Package pakkgage = clazz.getPackage();
+		return pakkgage != null && pakkgage.getName().startsWith( "org.hibernate.search." );
+	}
+
+	public interface CallerClassWalker {
+		<T> T walk(Function<? super Stream<Class<?>>, ? extends T> function);
+	}
+
+	/**
+	 * Retrieves the caller stack from the security manager class context.
+	 */
+	@SuppressWarnings("removal")
+	private static class SecurityManagerCallerClassWalker extends SecurityManager
+			implements CallerClassWalker {
+		@Override
+		public <T> T walk(Function<? super Stream<Class<?>>, ? extends T> function) {
+			// The type arguments *are* necessary for some reason.
+			// Without them, we get strange compilation errors when targeting JDK 8.
+			return function.apply( Arrays.<Class<?>>stream( getClassContext() )
+					.skip( 1 ) // Skip this method
+					.filter( c -> !c.isSynthetic() ) // Skip lambdas, like StackWalker does
+			);
+		}
+	}
+
+	/**
+	 * Retrieves the caller stack using a StackWalker.
+	 */
+	private static class StackWalkerCallerClassWalker
+			implements CallerClassWalker {
+		private final Object stackWalker;
+		private final Method stackWalkerWalkMethod;
+		private final Function<Object, Class<?>> stackFrameGetDeclaringClassFunction;
+
+		private StackWalkerCallerClassWalker(Class<?> stackWalkerClass)
+				throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+			Class<?> optionClass = Class.forName( "java.lang.StackWalker$Option" );
+			this.stackWalker = stackWalkerClass.getMethod( "getInstance", optionClass )
+					.invoke( null, optionClass.getEnumConstants()[0] );
+
+			this.stackWalkerWalkMethod = stackWalkerClass.getMethod( "walk", Function.class );
+			Method stackFrameGetDeclaringClass = Class.forName( "java.lang.StackWalker$StackFrame" )
+					.getMethod( "getDeclaringClass" );
+			stackFrameGetDeclaringClassFunction = frame -> {
+				try {
+					return (Class<?>) stackFrameGetDeclaringClass.invoke( frame );
+				}
+				catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+					throw new IllegalStateException( "Unable to get stack frame declaring class", e );
+				}
+			};
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public <T> T walk(Function<? super Stream<Class<?>>, ? extends T> function) {
+			Function<Stream<?>, T> stackFrameExtractFunction =
+					stream -> function.apply( stream
+							.skip( 1 ) // Skip this method
+							.map( stackFrameGetDeclaringClassFunction ) );
+			try {
+				return (T) stackWalkerWalkMethod.invoke( stackWalker, stackFrameExtractFunction );
+			}
+			catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+				throw new IllegalStateException( "Unable to walk the stack using StackWalker", e );
+			}
+		}
+	}
+}

--- a/util/internal/test/common/src/test/java/com/acme/ClassNotInHibernateSearchPackage.java
+++ b/util/internal/test/common/src/test/java/com/acme/ClassNotInHibernateSearchPackage.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package com.acme;
+
+import java.util.function.Supplier;
+
+public final class ClassNotInHibernateSearchPackage {
+	private ClassNotInHibernateSearchPackage() {
+	}
+
+	public static <T> T call(Supplier<T> supplier) {
+		return supplier.get();
+	}
+}

--- a/util/internal/test/common/src/test/java/org/hibernate/search/util/impl/test/reflect/RuntimeHelperTest.java
+++ b/util/internal/test/common/src/test/java/org/hibernate/search/util/impl/test/reflect/RuntimeHelperTest.java
@@ -1,0 +1,77 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.test.reflect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+import com.acme.ClassNotInHibernateSearchPackage;
+
+public class RuntimeHelperTest {
+
+	@Test
+	public void callerClassWalker() {
+		Optional<Class<?>> caller = RuntimeHelper.callerClassWalker().walk( Stream::findFirst );
+		assertThat( caller )
+				.contains( RuntimeHelperTest.class );
+
+		List<Class<?>> callers = Delegate.walkInClass( stream -> stream.limit( 2 ).collect( Collectors.toList() ) );
+		assertThat( callers )
+				.containsExactly( Delegate.class, RuntimeHelperTest.class );
+	}
+
+	@Test
+	public void firstNonJdkCaller() {
+		Supplier<Optional<Class<?>>> called = new Supplier<Optional<Class<?>>>() {
+			@Override
+			public Optional<Class<?>> get() {
+				return RuntimeHelper.firstNonSelfNonJdkCaller();
+			}
+		};
+		assertThat( Delegate.call( called ) )
+				.contains( Delegate.class );
+		assertThat( ClassNotInHibernateSearchPackage.call( called ) )
+				.contains( ClassNotInHibernateSearchPackage.class );
+	}
+
+	// StackWalker ignores lambda by default, so this is important
+	@Test
+	public void firstNonJdkCaller_lambda() {
+		Supplier<Optional<Class<?>>> called = () -> RuntimeHelper.firstNonSelfNonJdkCaller();
+		assertThat( Delegate.<Optional<Class<?>>>call( called ) )
+				.contains( Delegate.class );
+		assertThat( ClassNotInHibernateSearchPackage.<Optional<Class<?>>>call( called ) )
+				.contains( ClassNotInHibernateSearchPackage.class );
+	}
+
+	@Test
+	public void isHibernateSearch() {
+		assertThat( RuntimeHelper.isHibernateSearch( Delegate.class ) )
+				.isTrue();
+		assertThat( RuntimeHelper.isHibernateSearch( ClassNotInHibernateSearchPackage.class ) )
+				.isFalse();
+	}
+
+	private static class Delegate {
+		static <T> T walkInClass(Function<? super Stream<Class<?>>, ? extends T> function) {
+			return RuntimeHelper.callerClassWalker().walk( function );
+		}
+
+		static <T> T call(Supplier<T> supplier) {
+			return supplier.get();
+		}
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4831

Tested locally against the latest 6.2, and this fixes the problem.

Backport to 6.1: #3459