### PR TITLE
Backport HSEARCH-4830 to branch 6.1 - Test Hibernate Search regularly against Hibernate ORM 6.3.0-SNAPSHOT

### DIFF
--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -27,6 +27,11 @@ Map settings() {
 					updateProperties: ['version.org.hibernate.orm'],
 					onlyRunTestDependingOn: ['hibernate-search-mapper-orm-orm6']
 			]
+		case 'orm6.3':
+			return [
+					updateProperties: ['version.org.hibernate.orm'],
+					onlyRunTestDependingOn: ['hibernate-search-mapper-orm-orm6']
+			]
 		case 'orm6.2':
 			return [
 					updateProperties: ['version.org.hibernate.orm'],
@@ -129,7 +134,7 @@ pipeline {
 					axis {
 						name 'DEPENDENCY_UPDATE_NAME'
 						// NOTE: Remember to update the settings() method above when changing this.
-						values 'orm5.6', 'orm6.0', 'orm6.1', 'orm6.2'
+						values 'orm5.6', 'orm6.0', 'orm6.1', 'orm6.2', 'orm6.3'
 					}
 				}
 				stages {

--- a/ci/dependency-update/rules-orm6.3.xml
+++ b/ci/dependency-update/rules-orm6.3.xml
@@ -1,0 +1,12 @@
+<ruleset comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+  <ignoreVersions>
+    <!-- Ignore Alpha/Beta/CRs versions in the repo, because the versions-maven-plugin considers those
+         as higher priority than snapshots, which is wrong. -->
+    <ignoreVersion type="regex">.*\.(Alpha|Beta|CR).*</ignoreVersion>
+    <!-- Restrict allowed versions to a particular major/minor, because forbidding major/minor upgrades
+         in the version-maven-plugin configuration doesn't always work for some reason. -->
+    <ignoreVersion type="regex">(?!6\.3\.).*</ignoreVersion>
+  </ignoreVersions>
+</ruleset>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4830

Backport of #3460 to branch 6.1
