### PR TITLE
HSEARCH-4840 Test against AWS OpenSearch Service 2.5

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -291,7 +291,8 @@ stage('Configure') {
 					// --------------------------------------------
 					// AWS OpenSearch service
 					new OpenSearchAwsBuildEnvironment(version: '1.3', condition: TestCondition.AFTER_MERGE),
-					new OpenSearchAwsBuildEnvironment(version: '2.3', condition: TestCondition.AFTER_MERGE),
+					new OpenSearchAwsBuildEnvironment(version: '2.3', condition: TestCondition.ON_DEMAND),
+					new OpenSearchAwsBuildEnvironment(version: '2.5', condition: TestCondition.AFTER_MERGE),
 					// Also test static credentials, but only for the latest version
 					new OpenSearchAwsBuildEnvironment(version: '2.3', condition: TestCondition.AFTER_MERGE, staticCredentials: true)
 			]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -814,7 +814,7 @@ void keepOnlyEnvironmentsFromSet(String environmentSetName) {
 			enableDefaultEnv = true
 			enableBeforeMergeEnvs = true
 			enableAfterMergeEnvs = true
-			enableOptional = true
+			enableOnDemandEnvs = true
 			break
 		case 'AUTOMATIC':
 			if (helper.scmSource.pullRequest) {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4840

The OpenSearch service is still being created on AWS, I'll launch a CI run on this PR when it's ready.