### PR TITLE
HSEARCH-4801 Update build dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -361,7 +361,7 @@
 
         <version.assembly.plugin>3.4.2</version.assembly.plugin>
         <version.buildhelper.plugin>3.3.0</version.buildhelper.plugin>
-        <version.checkstyle.plugin>3.2.1</version.checkstyle.plugin>
+        <version.checkstyle.plugin>3.2.2</version.checkstyle.plugin>
         <version.bundle.plugin>5.1.8</version.bundle.plugin>
         <version.clean.plugin>3.2.0</version.clean.plugin>
         <!-- Needing 3.6.2 at least because of MCOMPILER-294 -->

--- a/pom.xml
+++ b/pom.xml
@@ -401,7 +401,7 @@
         <version.scripting.plugin>3.0.0</version.scripting.plugin>
         <version.gpg.plugin>3.0.1</version.gpg.plugin>
         <version.org.codehaus.groovy-jsr223>3.0.17</version.org.codehaus.groovy-jsr223>
-        <version.com.puppycrawl.tools.checkstyle>10.3.4</version.com.puppycrawl.tools.checkstyle>
+        <version.com.puppycrawl.tools.checkstyle>10.9.3</version.com.puppycrawl.tools.checkstyle>
         <version.versions.plugin>2.12.0</version.versions.plugin>
 
         <!-- Asciidoctor -->

--- a/pom.xml
+++ b/pom.xml
@@ -384,7 +384,7 @@
         <version.jdeps.plugin>0.5.1</version.jdeps.plugin>
         <version.nexus-staging.plugin>1.6.13</version.nexus-staging.plugin>
         <version.processor.plugin>4.5-jdk8</version.processor.plugin>
-        <version.project-info.plugin>3.4.2</version.project-info.plugin>
+        <version.project-info.plugin>3.4.3</version.project-info.plugin>
         <version.release.plugin>3.0.0</version.release.plugin>
         <version.resources.plugin>3.3.1</version.resources.plugin>
         <version.shade.plugin>3.4.1</version.shade.plugin>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4801

follows up on https://github.com/hibernate/hibernate-search/pull/3473, https://github.com/hibernate/hibernate-search/pull/3465, https://github.com/hibernate/hibernate-search/pull/3456, https://github.com/hibernate/hibernate-search/pull/3446, https://github.com/hibernate/hibernate-search/pull/3441, https://github.com/hibernate/hibernate-search/pull/3435, https://github.com/hibernate/hibernate-search/pull/3428, https://github.com/hibernate/hibernate-search/pull/3419