### PR TITLE
HSEARCH-4836 Move the ES client property to SPI settings

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchBackendSettings.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchBackendSettings.java
@@ -51,8 +51,6 @@ public final class ElasticsearchBackendSettings {
 	 * <p>
 	 * Setting this property at the same time as {@link #URIS} will lead to an exception being thrown on startup.
 	 * <p>
-	 * This property is ignored when {@value #CLIENT_INSTANCE} is set.
-	 * <p>
 	 * Defaults to {@link Defaults#HOSTS}.
 	 */
 	public static final String HOSTS = "hosts";
@@ -63,8 +61,6 @@ public final class ElasticsearchBackendSettings {
 	 * Expects a String: either {@code http} or {@code https}.
 	 * <p>
 	 * Setting this property at the same time as {@link #URIS} will lead to an exception being thrown on startup.
-	 * <p>
-	 * This property is ignored when {@value #CLIENT_INSTANCE} is set.
 	 * <p>
 	 * Defaults to {@link Defaults#PROTOCOL}.
 	 */
@@ -82,8 +78,6 @@ public final class ElasticsearchBackendSettings {
 	 * <p>
 	 * Setting this property at the same time as {@link #HOSTS} or {@link #PROTOCOL} will lead to an exception being thrown on startup.
 	 * <p>
-	 * This property is ignored when {@value #CLIENT_INSTANCE} is set.
-	 * <p>
 	 * Defaults to {@code http://localhost:9200}, unless {@link #HOSTS} or {@link #PROTOCOL} are set, in which case they take precedence.
 	 */
 	public static final String URIS = "uris";
@@ -91,8 +85,6 @@ public final class ElasticsearchBackendSettings {
 	/**
 	 * Property for specifying the path prefix prepended to the request end point.
 	 * Use the path prefix if your Elasticsearch instance is located at a specific context path.
-	 * <p>
-	 * This property is ignored when {@value #CLIENT_INSTANCE} is set.
 	 * <p>
 	 * Defaults to {@link Defaults#PATH_PREFIX}.
 	 */
@@ -124,8 +116,6 @@ public final class ElasticsearchBackendSettings {
 	 * <p>
 	 * Expects a String.
 	 * <p>
-	 * This property is ignored when {@value #CLIENT_INSTANCE} is set.
-	 * <p>
 	 * Defaults to no username (anonymous access).
 	 */
 	public static final String USERNAME = "username";
@@ -134,8 +124,6 @@ public final class ElasticsearchBackendSettings {
 	 * The password to send when connecting to the Elasticsearch servers (HTTP authentication).
 	 * <p>
 	 * Expects a String.
-	 * <p>
-	 * This property is ignored when {@value #CLIENT_INSTANCE} is set.
 	 * <p>
 	 * Defaults to no username (anonymous access).
 	 */
@@ -149,8 +137,6 @@ public final class ElasticsearchBackendSettings {
 	 * Expects a positive Integer value in milliseconds, such as 60000,
 	 * or a String that can be parsed into such Integer value.
 	 * <p>
-	 * This property is ignored when {@value #CLIENT_INSTANCE} is set.
-	 * <p>
 	 * Defaults to no request timeout.
 	 */
 	public static final String REQUEST_TIMEOUT = "request_timeout";
@@ -161,8 +147,6 @@ public final class ElasticsearchBackendSettings {
 	 * Expects a positive Integer value in milliseconds, such as {@code 60000},
 	 * or a String that can be parsed into such Integer value.
 	 * <p>
-	 * This property is ignored when {@value #CLIENT_INSTANCE} is set.
-	 * <p>
 	 * Defaults to {@link Defaults#READ_TIMEOUT}.
 	 */
 	public static final String READ_TIMEOUT = "read_timeout";
@@ -172,8 +156,6 @@ public final class ElasticsearchBackendSettings {
 	 * <p>
 	 * Expects a positive Integer value in milliseconds, such as {@code 3000},
 	 * or a String that can be parsed into such Integer value.
-	 * <p>
-	 * This property is ignored when {@value #CLIENT_INSTANCE} is set.
 	 * <p>
 	 * Defaults to {@link Defaults#CONNECTION_TIMEOUT}.
 	 */
@@ -186,8 +168,6 @@ public final class ElasticsearchBackendSettings {
 	 * Expects a positive Integer value, such as {@code 20},
 	 * or a String that can be parsed into such Integer value.
 	 * <p>
-	 * This property is ignored when {@value #CLIENT_INSTANCE} is set.
-	 * <p>
 	 * Defaults to {@link Defaults#MAX_CONNECTIONS}.
 	 */
 	public static final String MAX_CONNECTIONS = "max_connections";
@@ -197,8 +177,6 @@ public final class ElasticsearchBackendSettings {
 	 * <p>
 	 * Expects a positive Integer value, such as {@code 10},
 	 * or a String that can be parsed into such Integer value.
-	 * <p>
-	 * This property is ignored when {@value #CLIENT_INSTANCE} is set.
 	 * <p>
 	 * Defaults to {@link Defaults#MAX_CONNECTIONS_PER_ROUTE}.
 	 */
@@ -210,8 +188,6 @@ public final class ElasticsearchBackendSettings {
 	 * Expects a Boolean value such as {@code true} or {@code false},
 	 * or a string that can be parsed into a Boolean value.
 	 * <p>
-	 * This property is ignored when {@value #CLIENT_INSTANCE} is set.
-	 * <p>
 	 * Defaults to {@link Defaults#DISCOVERY_ENABLED}.
 	 */
 	public static final String DISCOVERY_ENABLED = "discovery.enabled";
@@ -221,8 +197,6 @@ public final class ElasticsearchBackendSettings {
 	 * <p>
 	 * Expects a positive Integer value in seconds, such as {@code 2},
 	 * or a String that can be parsed into such Integer value.
-	 * <p>
-	 * This property is ignored when {@value #CLIENT_INSTANCE} is set.
 	 * <p>
 	 * Defaults to {@link Defaults#DISCOVERY_REFRESH_INTERVAL}.
 	 */
@@ -236,30 +210,9 @@ public final class ElasticsearchBackendSettings {
 	 * <p>
 	 * Expects a reference to a bean of type {@link ElasticsearchHttpClientConfigurer}.
 	 * <p>
-	 * This property is ignored when {@value #CLIENT_INSTANCE} is set.
-	 * <p>
 	 * Defaults to no value.
 	 */
 	public static final String CLIENT_CONFIGURER = "client.configurer";
-
-	/**
-	 * An external Elasticsearch client instance that Hibernate Search should use for all requests to Elasticsearch.
-	 * <p>
-	 * If this is set, Hibernate Search will not attempt to create its own Elasticsearch,
-	 * and all other client-related configuration properties
-	 * (hosts/uris, authentication, discovery, timeouts, max connections, configurer, ...)
-	 * will be ignored.
-	 * <p>
-	 * Expects a reference to a bean of type {@link org.elasticsearch.client.RestClient}.
-	 * <p>
-	 * Defaults to nothing: if no client instance is provided, Hibernate Search will create its own.
-	 * <p>
-	 * <strong>WARNING - Incubating API:</strong> the underlying client class may change without prior notice.
-	 *
-	 * @see org.hibernate.search.engine.cfg The core documentation of configuration properties,
-	 * which includes a description of the "bean reference" properties and accepted values.
-	 */
-	public static final String CLIENT_INSTANCE = "client.instance";
 
 	/**
 	 * Whether JSON included in logs should be pretty-printed (indented, with line breaks).

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/spi/ElasticsearchBackendSpiSettings.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/spi/ElasticsearchBackendSpiSettings.java
@@ -30,6 +30,25 @@ public final class ElasticsearchBackendSpiSettings {
 	 */
 	public static final String BACKEND_WORK_EXECUTOR_PROVIDER = PREFIX + Radicals.BACKEND_WORK_EXECUTOR_PROVIDER;
 
+	/**
+	 * An external Elasticsearch client instance that Hibernate Search should use for all requests to Elasticsearch.
+	 * <p>
+	 * If this is set, Hibernate Search will not attempt to create its own Elasticsearch,
+	 * and all other client-related configuration properties
+	 * (hosts/uris, authentication, discovery, timeouts, max connections, configurer, ...)
+	 * will be ignored.
+	 * <p>
+	 * Expects a reference to a bean of type {@link org.elasticsearch.client.RestClient}.
+	 * <p>
+	 * Defaults to nothing: if no client instance is provided, Hibernate Search will create its own.
+	 * <p>
+	 * <strong>WARNING - Incubating API:</strong> the underlying client class may change without prior notice.
+	 *
+	 * @see org.hibernate.search.engine.cfg The core documentation of configuration properties,
+	 * which includes a description of the "bean reference" properties and accepted values.
+	 */
+	public static final String CLIENT_INSTANCE = "client.instance";
+
 	private ElasticsearchBackendSpiSettings() {
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/ElasticsearchClientFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/ElasticsearchClientFactoryImpl.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.spi.ElasticsearchBackendSpiSettings;
 import org.hibernate.search.backend.elasticsearch.client.ElasticsearchHttpClientConfigurer;
 import org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchClientFactory;
 import org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchClientImplementor;
@@ -48,7 +49,7 @@ public class ElasticsearchClientFactoryImpl implements ElasticsearchClientFactor
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private static final OptionalConfigurationProperty<BeanReference<? extends RestClient>>
-			CLIENT_INSTANCE = ConfigurationProperty.forKey( ElasticsearchBackendSettings.CLIENT_INSTANCE )
+			CLIENT_INSTANCE = ConfigurationProperty.forKey( ElasticsearchBackendSpiSettings.CLIENT_INSTANCE )
 					.asBeanReference( RestClient.class )
 					.build();
 

--- a/documentation/src/main/asciidoc/internals/index.asciidoc
+++ b/documentation/src/main/asciidoc/internals/index.asciidoc
@@ -549,4 +549,24 @@ and in the `resolveEntitiesToReindex` method of `PojoImplicitReindexingResolverD
 
 The JSON mapper does not currently exist, but there are plans to work on it.
 
+[[backend-elasticsearch-configuration-client-instance]]
+== Providing a client instance
+
+If you already use a low-level Elasticsearch client (an instance of `org.elasticsearch.client.RestClient`)
+in your application,
+you can tell Hibernate Search to use that client instead of creating its own.
+
+Providing a `RestClient` requires two steps:
+
+. Define the `org.elasticsearch.client.RestClient` instance
+as a bean in your supported dependency injection framework,
+for example by defining a CDI bean producer annotated with `@Named("myRestClient")`.
+. Configure Hibernate Search to use that instance by setting the configuration property
+`hibernate.search.backend.client.instance`
+to a bean reference pointing to the bean,
+for example `bean:myRestClient`.
+
+IMPORTANT: If Hibernate Search uses a provided client, it won't create its own client,
+and thus all other client configuration properties will be ignored.
+
 include::configuration-properties-aggregated.asciidoc[]

--- a/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
+++ b/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
@@ -351,26 +351,6 @@ include::{resourcesdir}/configuration/http-client-configurer.properties[]
 Any setting defined by a custom http client configurer will override any other setting defined by Hibernate Search.
 ====
 
-[[backend-elasticsearch-configuration-client-instance]]
-== Providing a client instance
-
-If you already use a low-level Elasticsearch client (an instance of `org.elasticsearch.client.RestClient`)
-in your application,
-you can tell Hibernate Search to use that client instead of creating its own.
-
-Providing a `RestClient` requires two steps:
-
-. Define the `org.elasticsearch.client.RestClient` instance
-as a bean in your <<configuration-bean-frameworks,supported dependency injection framework>>,
-for example by defining a CDI bean producer annotated with `@Named("myRestClient")`.
-. Configure Hibernate Search to use that instance by setting the configuration property
-`hibernate.search.backend.client.instance`
-to a <<configuration-bean-reference-parsing,bean reference>> pointing to the bean,
-for example `bean:myRestClient`.
-
-IMPORTANT: If Hibernate Search uses a provided client, it won't create its own client,
-and thus all other <<backend-elasticsearch-configuration-client,client configuration properties>> will be ignored.
-
 [[backend-elasticsearch-configuration-version]]
 == [[backend-elasticsearch-configuration-dialect]] Version compatibility
 

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/client/ElasticsearchClientFactoryImplIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/client/ElasticsearchClientFactoryImplIT.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 import javax.net.ssl.SSLContext;
 
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.spi.ElasticsearchBackendSpiSettings;
 import org.hibernate.search.backend.elasticsearch.client.ElasticsearchHttpClientConfigurationContext;
 import org.hibernate.search.backend.elasticsearch.client.ElasticsearchHttpClientConfigurer;
 import org.hibernate.search.backend.elasticsearch.client.impl.ElasticsearchClientFactoryImpl;
@@ -1007,7 +1008,7 @@ public class ElasticsearchClientFactoryImplIT {
 							.withBody( responseBody ) ) );
 
 			try ( ElasticsearchClientImplementor client = createClient( properties -> {
-				properties.accept( ElasticsearchBackendSettings.CLIENT_INSTANCE, BeanReference.ofInstance( myRestClient ) );
+				properties.accept( ElasticsearchBackendSpiSettings.CLIENT_INSTANCE, BeanReference.ofInstance( myRestClient ) );
 			} ) ) {
 				ElasticsearchResponse result = doPost( client, "/myIndex/myType", payload );
 				assertThat( result.statusCode() ).as( "status code" ).isEqualTo( 200 );


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4836

Since the property was added in HSEARCH-4683 (6.2.0.Alpha2)  I guess we can just move the property without keeping the "old" one. 
