### PR TITLE
HSEARCH-4845 Use a different field for retrieving a root object id in the Lucene backend

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneRootDocumentBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneRootDocumentBuilder.java
@@ -42,7 +42,8 @@ public class LuceneRootDocumentBuilder extends AbstractLuceneDocumentElementBuil
 		// We own the document content, so we finalize it ourselves.
 		Document document = documentContent.finalizeDocument( multiTenancyStrategy, tenantId, routingKey );
 		document.add( MetadataFields.searchableMetadataField( MetadataFields.typeFieldName(), MetadataFields.TYPE_MAIN_DOCUMENT ) );
-		document.add( MetadataFields.searchableRetrievableMetadataField( MetadataFields.idFieldName(), id ) );
+		document.add( MetadataFields.searchableMetadataField( MetadataFields.idFieldName(), id ) );
+		document.add( MetadataFields.retrievableMetadataField( MetadataFields.idDocValueFieldName(), id ) );
 
 		// In the list of documents, a child must appear before its parent,
 		// so we let children contribute their document first.

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/collector/impl/DocumentReferenceValues.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/collector/impl/DocumentReferenceValues.java
@@ -33,14 +33,14 @@ public abstract class DocumentReferenceValues<R> implements Values<R> {
 	private String currentLeafMappedTypeName;
 	private BinaryDocValues currentLeafIdDocValues;
 
-	public DocumentReferenceValues(CollectorExecutionContext executionContext) {
+	protected DocumentReferenceValues(CollectorExecutionContext executionContext) {
 		this.metadataResolver = executionContext.getMetadataResolver();
 	}
 
 	@Override
 	public final void context(LeafReaderContext context) throws IOException {
 		this.currentLeafMappedTypeName = metadataResolver.resolveMappedTypeName( context );
-		this.currentLeafIdDocValues = DocValues.getBinary( context.reader(), MetadataFields.idFieldName() );
+		this.currentLeafIdDocValues = DocValues.getBinary( context.reader(), MetadataFields.idDocValueFieldName() );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/collector/impl/IdentifierValues.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/collector/impl/IdentifierValues.java
@@ -20,7 +20,7 @@ public final class IdentifierValues implements Values<String> {
 
 	@Override
 	public void context(LeafReaderContext context) throws IOException {
-		this.currentLeafIdDocValues = DocValues.getBinary( context.reader(), MetadataFields.idFieldName() );
+		this.currentLeafIdDocValues = DocValues.getBinary( context.reader(), MetadataFields.idDocValueFieldName() );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/common/impl/MetadataFields.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/common/impl/MetadataFields.java
@@ -16,7 +16,7 @@ import org.apache.lucene.util.BytesRef;
 public class MetadataFields {
 
 	private static final FieldType METADATA_FIELD_TYPE_WITH_INDEX;
-	private static final FieldType METADATA_FIELD_TYPE_WITH_INDEX_WITH_DOCVALUES;
+	private static final FieldType METADATA_FIELD_TYPE_WITH_DOCVALUES;
 	static {
 		METADATA_FIELD_TYPE_WITH_INDEX = new FieldType();
 		METADATA_FIELD_TYPE_WITH_INDEX.setTokenized( false );
@@ -24,17 +24,19 @@ public class MetadataFields {
 		METADATA_FIELD_TYPE_WITH_INDEX.setIndexOptions( IndexOptions.DOCS );
 		METADATA_FIELD_TYPE_WITH_INDEX.freeze();
 
-		METADATA_FIELD_TYPE_WITH_INDEX_WITH_DOCVALUES = new FieldType();
-		METADATA_FIELD_TYPE_WITH_INDEX_WITH_DOCVALUES.setTokenized( false );
-		METADATA_FIELD_TYPE_WITH_INDEX_WITH_DOCVALUES.setOmitNorms( true );
-		METADATA_FIELD_TYPE_WITH_INDEX_WITH_DOCVALUES.setIndexOptions( IndexOptions.DOCS );
-		METADATA_FIELD_TYPE_WITH_INDEX_WITH_DOCVALUES.setDocValuesType( DocValuesType.BINARY );
-		METADATA_FIELD_TYPE_WITH_INDEX_WITH_DOCVALUES.freeze();
+		METADATA_FIELD_TYPE_WITH_DOCVALUES = new FieldType();
+		METADATA_FIELD_TYPE_WITH_DOCVALUES.setTokenized( false );
+		METADATA_FIELD_TYPE_WITH_DOCVALUES.setOmitNorms( true );
+		METADATA_FIELD_TYPE_WITH_DOCVALUES.setIndexOptions( IndexOptions.NONE );
+		METADATA_FIELD_TYPE_WITH_DOCVALUES.setDocValuesType( DocValuesType.BINARY );
+		METADATA_FIELD_TYPE_WITH_DOCVALUES.freeze();
 	}
 
 	private static final String INTERNAL_FIELD_PREFIX = "__HSEARCH_";
 
 	private static final String ID_FIELD_NAME = internalFieldName( "id" );
+
+	private static final String ID_DOCVALUE_FIELD_NAME = internalFieldName( "id_docvalue" );
 
 	private static final String ROUTING_KEY_FIELD_NAME = internalFieldName( "routing_key" );
 
@@ -64,12 +66,16 @@ public class MetadataFields {
 		return new Field( name, value, METADATA_FIELD_TYPE_WITH_INDEX );
 	}
 
-	public static IndexableField searchableRetrievableMetadataField(String name, String value) {
-		return new Field( name, new BytesRef( value ), METADATA_FIELD_TYPE_WITH_INDEX_WITH_DOCVALUES );
+	public static IndexableField retrievableMetadataField(String name, String value) {
+		return new Field( name, new BytesRef( value ), METADATA_FIELD_TYPE_WITH_DOCVALUES );
 	}
 
 	public static String idFieldName() {
 		return ID_FIELD_NAME;
+	}
+
+	public static String idDocValueFieldName() {
+		return ID_DOCVALUE_FIELD_NAME;
 	}
 
 	public static String routingKeyFieldName() {

--- a/documentation/src/main/asciidoc/migration/index.asciidoc
+++ b/documentation/src/main/asciidoc/migration/index.asciidoc
@@ -43,8 +43,12 @@ Hibernate Search's requirements did not change in version {hibernateSearchVersio
 [[data-format]]
 == Data format and schema changes
 
-Indexes created with Hibernate Search {hibernateSearchPreviousStableVersionShort}
+Elasticsearch indexes created with Hibernate Search {hibernateSearchPreviousStableVersionShort}
 can be read from and written to with Hibernate Search {hibernateSearchVersion}.
+
+Reading and writing to Lucene indexes created with Hibernate Search {hibernateSearchPreviousStableVersionShort}
+using Hibernate Search {hibernateSearchVersion} may lead to exceptions, since there were incompatible changes applied to internal fields.
+You must recreate your Lucene indexes and reindex your database. The easiest way to do so is to use link:{hibernateSearchDocUrl}#indexing-massindexer[the `MassIndexer`] with link:{hibernateSearchDocUrl}#indexing-massindexer-parameters-drop-and-create-schema[`dropAndCreateSchemaOnStart(true)`].
 
 If your Hibernate Search mapping includes `GeoPoint` fields that are using the default value for the `projectable` option,
 and are using either the default value or `Sortable.NO` for the `sortable` option, Elasticsearch schema validation
@@ -52,7 +56,7 @@ will fail on startup because of missing docvalues on those fields.
 To address that, either:
 
 * Revert to the previous defaults by adding `projectable = Projectable.NO` to the mapping annotation of relevant `GeoPoint` fields.
-* Or recreate your Elasticsearch indexes and reindex your database. The easiest way to do so is to use link:{hibernateSearchDocUrl}#indexing-massindexer[the the `MassIndexer`] with link:{hibernateSearchDocUrl}#indexing-massindexer-parameters-drop-and-create-schema[`dropAndCreateSchemaOnStart(true)`].
+* Or recreate your Elasticsearch indexes and reindex your database. The easiest way to do so is to use link:{hibernateSearchDocUrl}#indexing-massindexer[the `MassIndexer`] with link:{hibernateSearchDocUrl}#indexing-massindexer-parameters-drop-and-create-schema[`dropAndCreateSchemaOnStart(true)`].
 
 [[outboxpolling]]
 === Outbox polling system tables


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4845

I went with "recommendation" instead of "instruction" to recreate indexes for the Lucene backend since users not using ID or document reference projections will probably be ok with their indexes as is.