### PR TITLE
HSEARCH-4848 Fix unpredictable order of some associations in automatic reindexing tests

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetomany/AutomaticIndexingOneToManyCollectionBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetomany/AutomaticIndexingOneToManyCollectionBaseIT.java
@@ -160,6 +160,7 @@ public class AutomaticIndexingOneToManyCollectionBaseIT
 		 * TODO use mappedBy when the above gets fixed in Hibernate ORM
 		 */
 		@OneToMany
+		@OrderColumn(name = "idx")
 		@JoinTable(name = "i_containedECAssocIdxEmb",
 				joinColumns = @JoinColumn(name = "containing"),
 				inverseJoinColumns = @JoinColumn(name = "contained"))
@@ -175,6 +176,7 @@ public class AutomaticIndexingOneToManyCollectionBaseIT
 		 * TODO use mappedBy when the above gets fixed in Hibernate ORM
 		 */
 		@OneToMany
+		@OrderColumn(name = "idx")
 		@JoinTable(name = "i_containedECAssocNonIdxEmb",
 				joinColumns = @JoinColumn(name = "containing"),
 				inverseJoinColumns = @JoinColumn(name = "contained"))

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetomany/AutomaticIndexingOneToManyListBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetomany/AutomaticIndexingOneToManyListBaseIT.java
@@ -397,10 +397,12 @@ public class AutomaticIndexingOneToManyListBaseIT
 	public static class ContainingEmbeddable {
 
 		@OneToMany(mappedBy = "embeddedAssociations.containingAsIndexedEmbedded")
+		@OrderBy("id asc") // Make sure the iteration order is predictable
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField", "containedDerivedField" })
 		private List<ContainedEntity> containedIndexedEmbedded = new ArrayList<>();
 
 		@OneToMany(mappedBy = "embeddedAssociations.containingAsNonIndexedEmbedded")
+		@OrderBy("id asc") // Make sure the iteration order is predictable
 		private List<ContainedEntity> containedNonIndexedEmbedded = new ArrayList<>();
 
 		public List<ContainedEntity> getContainedIndexedEmbedded() {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4848
