### PR TITLE
HSEARCH-2192 Follow-up: Exclude the score order test for some ES versions

### DIFF
--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -299,4 +299,15 @@ class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 		// https://github.com/elastic/elasticsearch/issues/94550
 		return false;
 	}
+
+	@Override
+	public boolean supportsHighlighterPlainOrderByScoreMultivaluedField() {
+		// A plain highlighter implementation in ES had a bug
+		// https://github.com/elastic/elasticsearch/issues/87210
+		// that is now fixed with https://github.com/elastic/elasticsearch/pull/87414
+		return isActualVersion(
+				esVersion -> !esVersion.isBetween( "7.15", "8.3" ),
+				osVersion -> true
+		);
+	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/highlight/AbstractHighlighterIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/highlight/AbstractHighlighterIT.java
@@ -702,6 +702,10 @@ public abstract class AbstractHighlighterIT {
 				"We ignore this test for the highlighters that do not support multi fragments as separate items since there's nothing to sort.",
 				supportsMultipleFragmentsAsSeparateItems()
 		);
+		assumeTrue(
+				"Some versions of the backend have a bug that prevents them from correctly sorting the results.",
+				supportsOrderByScoreMultivaluedField()
+		);
 		StubMappingScope scope = index.createScope();
 
 		SearchQuery<List<String>> highlights = scope.query().select(
@@ -725,6 +729,10 @@ public abstract class AbstractHighlighterIT {
 						"The quick brown fox jumps right over the little lazy <em>dog</em>"
 				)
 		);
+	}
+
+	protected boolean supportsOrderByScoreMultivaluedField() {
+		return true;
 	}
 
 	@Test

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/highlight/HighlighterPlainIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/highlight/HighlighterPlainIT.java
@@ -15,6 +15,7 @@ import org.hibernate.search.engine.search.highlighter.dsl.HighlighterFragmenter;
 import org.hibernate.search.engine.search.highlighter.dsl.HighlighterPlainOptionsStep;
 import org.hibernate.search.engine.search.highlighter.dsl.SearchHighlighterFactory;
 import org.hibernate.search.engine.search.query.SearchQuery;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 
 import org.junit.Test;
@@ -31,10 +32,16 @@ public class HighlighterPlainIT extends AbstractHighlighterIT {
 		return Arrays.asList( "Lorem <em>ipsum</em> dolor", " <em>ipsum</em> ultricies" );
 	}
 
+	@Override
 	protected List<String> numberOfFragmentsResult() {
 		return Arrays.asList(
 				"Lorem <em>ipsum</em> dolor sit amet, consectetur adipiscing elit. Proin nec <em>ipsum</em> ultricies, blandit velit"
 		);
+	}
+
+	@Override
+	protected boolean supportsOrderByScoreMultivaluedField() {
+		return TckConfiguration.get().getBackendFeatures().supportsHighlighterPlainOrderByScoreMultivaluedField();
 	}
 
 	@Test

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
@@ -142,4 +142,8 @@ public abstract class TckBackendFeatures {
 	public boolean supportsHighlighterFastVectorNoMatchSizeOnMultivaluedFields() {
 		return true;
 	}
+
+	public boolean supportsHighlighterPlainOrderByScoreMultivaluedField() {
+		return true;
+	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2192

follows up on https://github.com/hibernate/hibernate-search/pull/3490