### PR TITLE
HSEARCH-4839 Follow-up: Make sure to rebuild the Lucene backend when running an upgrade job

### DIFF
--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -39,7 +39,10 @@ Map settings() {
 		case 'lucene9':
 			return [
 					updateProperties: ['version.org.apache.lucene'],
-					onlyRunTestDependingOn: ['hibernate-search-backend-lucene']
+					onlyRunTestDependingOn: ['hibernate-search-backend-lucene'],
+					// Need to rebuild this module in order to get Lucene upgrade changes built and used in tests.
+					// No need to rebuild modules on which this one depends since those should stay unchanged.
+					additionalMavenArgs: '-pl :hibernate-search-backend-lucene'
 			]
 		default:
 			return [:]


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4839

follows up on https://github.com/hibernate/hibernate-search/pull/3495