### PR TITLE
HSEARCH-4853 On JDK 21-ea+21, projection constructor relying on cannical record constructor result in all-null records

### DIFF
--- a/integrationtest/mapper/pojo-base/src/test/java17/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorRecordIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java17/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorRecordIT.java
@@ -22,6 +22,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ProjectionConstructor;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.common.rule.StubSearchWorkBehavior;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -70,6 +71,7 @@ public class ProjectionConstructorRecordIT {
 	}
 
 	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4853")
 	public void constructorLevelAnnotation_canonical() {
 		@Indexed(index = INDEX_NAME)
 		class IndexedEntity {

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/hcann/spi/AbstractPojoHCAnnRawTypeModel.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/hcann/spi/AbstractPojoHCAnnRawTypeModel.java
@@ -76,9 +76,8 @@ public abstract class AbstractPojoHCAnnRawTypeModel<T, I extends AbstractPojoHCA
 				.collect( Collectors.toList() );
 	}
 
-	@SuppressWarnings("unchecked")
 	Class<T> javaClass() {
-		return (Class<T>) introspector.toClass( xClass );
+		return typeIdentifier.javaClass();
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/hcann/spi/AbstractPojoHCAnnRawTypeModel.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/hcann/spi/AbstractPojoHCAnnRawTypeModel.java
@@ -70,14 +70,14 @@ public abstract class AbstractPojoHCAnnRawTypeModel<T, I extends AbstractPojoHCA
 	@Override
 	@SuppressWarnings("unchecked")
 	protected List<PojoConstructorModel<T>> createDeclaredConstructors() {
-		return Arrays.stream( toClass().getDeclaredConstructors() )
+		return Arrays.stream( javaClass().getDeclaredConstructors() )
 				.<PojoConstructorModel<T>>map( constructor -> new PojoHCAnnConstructorModel<>(
 						introspector, this, (Constructor<T>) constructor ) )
 				.collect( Collectors.toList() );
 	}
 
 	@SuppressWarnings("unchecked")
-	private Class<T> toClass() {
+	Class<T> javaClass() {
 		return (Class<T>) introspector.toClass( xClass );
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/hcann/spi/PojoHCAnnMethodParameterModel.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/hcann/spi/PojoHCAnnMethodParameterModel.java
@@ -8,6 +8,7 @@ package org.hibernate.search.mapper.pojo.model.hcann.spi;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
 import java.util.Optional;
 
@@ -66,7 +67,11 @@ public final class PojoHCAnnMethodParameterModel<T> implements PojoMethodParamet
 	}
 
 	@Override
-	public boolean isImplicit() {
-		return parameter.isImplicit();
+	public boolean isEnclosingInstance() {
+		// HSEARCH-4853: we can't simply use `Parameter#isImplicit()` because, starting with JDK 21-ea+21,
+		// this returns `true` for parameters of canonical constructors of record types.
+		return index == 0
+				&& constructorModel.declaringTypeModel.javaClass().getEnclosingClass() != null
+				&& !Modifier.isStatic( constructorModel.declaringTypeModel.javaClass().getModifiers() );
 	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/spi/PojoMethodParameterModel.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/spi/PojoMethodParameterModel.java
@@ -18,7 +18,11 @@ public interface PojoMethodParameterModel<T> {
 
 	PojoTypeModel<T> typeModel();
 
-	boolean isImplicit();
+	/**
+	 * @return {@code true} if this parameter is expected to receive an "enclosing instance",
+	 * e.g. an instance of the enclosing class in the case of Java inner classes or method-local classes.
+	 */
+	boolean isEnclosingInstance();
 
 	/**
 	 * @return {@code true} if {@code obj} is a {@link MappableTypeModel} referencing the exact same type

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/search/definition/impl/PojoConstructorProjectionDefinition.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/search/definition/impl/PojoConstructorProjectionDefinition.java
@@ -190,9 +190,11 @@ public final class PojoConstructorProjectionDefinition<T>
 		}
 
 		InnerProjectionDefinition inferInnerProjection() {
-			if ( parameter.isImplicit() ) {
-				// Inner class: the constructor has an implicit parameter for the instance of the surrounding class.
-				// Let's ignore that, because there isn't much we can do about it anyway.
+			if ( parameter.isEnclosingInstance() ) {
+				// Let's ignore this parameter, because we are not able to provide an enclosing instance,
+				// and it's often useful to be able to declare a method-local type for projections
+				// (those types have a "enclosing instance" parameter in their constructor
+				// even if they don't use it).
 				return NullInnerProjectionDefinition.INSTANCE;
 			}
 			PojoTypeModel<P> parameterType = parameter.typeModel();

--- a/pom.xml
+++ b/pom.xml
@@ -2841,6 +2841,23 @@
                     <scope>provided</scope>
                 </dependency>
             </dependencies>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <configuration>
+                                <!-- Intellij IDEA only understands the main configuration,
+                                     so we need to do this in order for (most) @ProjectionConstructor tests to work fine. -->
+                                <compilerArgs combine.self="append">
+                                    <compilerArg>-parameters</compilerArg>
+                                </compilerArgs>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
         </profile>
 
         <profile>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4853
