### PR TITLE
HSEARCH-4854 Work around build errors caused by the Maven Pipeline Integration Plugin on Jenkins CI

### DIFF
--- a/integrationtest/jsr352/pom.xml
+++ b/integrationtest/jsr352/pom.xml
@@ -176,7 +176,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <reportsDirectory>target/failsafe-reports/lucene</reportsDirectory>
+                            <reportsDirectory>${project.build.directory}/failsafe-reports/lucene</reportsDirectory>
                             <systemPropertyVariables>
                                 <org.hibernate.search.jsr352.persistence_unit>lucene_pu</org.hibernate.search.jsr352.persistence_unit>
                             </systemPropertyVariables>
@@ -188,7 +188,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
-                            <reportsDirectory>target/failsafe-reports/elasticsearch</reportsDirectory>
+                            <reportsDirectory>${project.build.directory}/failsafe-reports/elasticsearch</reportsDirectory>
                             <systemPropertyVariables>
                                 <org.hibernate.search.jsr352.persistence_unit>elasticsearch_pu</org.hibernate.search.jsr352.persistence_unit>
                             </systemPropertyVariables>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4854

If CI passes for this PR, I think we can consider the workaround is effective.