### PR TITLE
HSEARCH-4839 Follow-up: Make sure to rebuild everything when running a Lucene upgrade job

### DIFF
--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -38,11 +38,10 @@ Map settings() {
 			]
 		case 'lucene9':
 			return [
-					updateProperties: ['version.org.apache.lucene'],
-					onlyRunTestDependingOn: ['hibernate-search-backend-lucene'],
-					// Need to rebuild this module in order to get Lucene upgrade changes built and used in tests.
-					// No need to rebuild modules on which this one depends since those should stay unchanged.
-					additionalMavenArgs: '-pl :hibernate-search-backend-lucene'
+					updateProperties: ['version.org.apache.lucene']
+					// In this case we'll rebuild and test everything. Since we have some JDK 11 changes as well as
+					// some driver updates. These changes spans across multiple modules and we would either need to
+					// closely monitor which ones are affected and add them to the build, or ... build everything.
 			]
 		default:
 			return [:]


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4839

Just having the Lucene backend rebuilt is not enough since there are also changes in some test utils as well as changes in the batch module caused by the driver upgrade... It looks like it would be just safer to rebuild the entire project like we do for the orm6-in-main-code