### PR TITLE
HSEARCH-4801 Update build dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -369,7 +369,7 @@
         <version.assembly.plugin>3.4.2</version.assembly.plugin>
         <version.buildhelper.plugin>3.3.0</version.buildhelper.plugin>
         <version.checkstyle.plugin>3.2.2</version.checkstyle.plugin>
-        <version.bundle.plugin>5.1.8</version.bundle.plugin>
+        <version.bundle.plugin>5.1.9</version.bundle.plugin>
         <version.clean.plugin>3.2.0</version.clean.plugin>
         <!-- Needing 3.6.2 at least because of MCOMPILER-294 -->
         <version.compiler.plugin>3.10.1</version.compiler.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -396,7 +396,7 @@
         <version.resources.plugin>3.3.1</version.resources.plugin>
         <version.shade.plugin>3.4.1</version.shade.plugin>
         <version.site.plugin>3.12.1</version.site.plugin>
-        <version.source.plugin>3.2.1</version.source.plugin>
+        <version.source.plugin>3.3.0</version.source.plugin>
         <!-- Surefire versions are a minefield of bugs: be careful with upgrades -->
         <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
         <version.surefire.plugin.java-version.asm>9.5</version.surefire.plugin.java-version.asm>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4801

follows up on https://github.com/hibernate/hibernate-search/pull/3498, https://github.com/hibernate/hibernate-search/pull/3482, https://github.com/hibernate/hibernate-search/pull/3473, https://github.com/hibernate/hibernate-search/pull/3465, https://github.com/hibernate/hibernate-search/pull/3456, https://github.com/hibernate/hibernate-search/pull/3446, https://github.com/hibernate/hibernate-search/pull/3441, https://github.com/hibernate/hibernate-search/pull/3435, https://github.com/hibernate/hibernate-search/pull/3428, https://github.com/hibernate/hibernate-search/pull/3419