### PR TITLE
HSEARCH-4801 Update build dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -368,7 +368,7 @@
 
         <version.assembly.plugin>3.4.2</version.assembly.plugin>
         <version.buildhelper.plugin>3.3.0</version.buildhelper.plugin>
-        <version.checkstyle.plugin>3.2.2</version.checkstyle.plugin>
+        <version.checkstyle.plugin>3.3.0</version.checkstyle.plugin>
         <version.bundle.plugin>5.1.9</version.bundle.plugin>
         <version.clean.plugin>3.2.0</version.clean.plugin>
         <!-- Needing 3.6.2 at least because of MCOMPILER-294 -->

--- a/pom.xml
+++ b/pom.xml
@@ -413,7 +413,7 @@
 
         <!-- Asciidoctor -->
 
-        <version.asciidoctor.plugin>2.2.3</version.asciidoctor.plugin>
+        <version.asciidoctor.plugin>2.2.4</version.asciidoctor.plugin>
         <version.org.hibernate.infra.hibernate-asciidoctor-theme>1.0.6.Final</version.org.hibernate.infra.hibernate-asciidoctor-theme>
         <version.org.jruby>9.3.2.0</version.org.jruby>
         <version.org.asciidoctor.asciidoctorj>2.5.6</version.org.asciidoctor.asciidoctorj>

--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,7 @@
         <version.clean.plugin>3.2.0</version.clean.plugin>
         <!-- Needing 3.6.2 at least because of MCOMPILER-294 -->
         <version.compiler.plugin>3.10.1</version.compiler.plugin>
-        <version.dependency.plugin>3.5.0</version.dependency.plugin>
+        <version.dependency.plugin>3.6.0</version.dependency.plugin>
         <!-- Check dependencies for security vulnerabilities -->
         <version.dependency-check.plugin>7.2.1</version.dependency-check.plugin>
         <version.deploy.plugin>3.1.1</version.deploy.plugin>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4801

follows up on https://github.com/hibernate/hibernate-search/pull/3510, https://github.com/hibernate/hibernate-search/pull/3498, https://github.com/hibernate/hibernate-search/pull/3482, https://github.com/hibernate/hibernate-search/pull/3473, https://github.com/hibernate/hibernate-search/pull/3465, https://github.com/hibernate/hibernate-search/pull/3456, https://github.com/hibernate/hibernate-search/pull/3446, https://github.com/hibernate/hibernate-search/pull/3441, https://github.com/hibernate/hibernate-search/pull/3435, https://github.com/hibernate/hibernate-search/pull/3428, https://github.com/hibernate/hibernate-search/pull/3419