### PR TITLE
DRAFT: HSEARCH-1182  experiments

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
@@ -548,4 +548,9 @@ public interface Log extends BasicLogger {
 	SearchException invalidTypeForEntityProjection(String name, @FormatWith(ClassFormatter.class) Class<?> entityType,
 			@FormatWith(ClassFormatter.class) Class<?> requestedEntityType);
 
+	@Message(id = ID_OFFSET + 119,
+			value = "Include/exclude paths of an indexed embedded are mutually exclusive. " +
+					"Use either `includePaths` or `excludePaths` leaving the other one empty. " +
+					"Included paths are: '%1$s', excluded paths are: '%2$s'.")
+	SearchException cannotIncludeAndExcludePathsWithinSameIndexedEmbedded(Set<String> includePaths, Set<String> excludePaths);
 }

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/impl/IndexSchemaFilter.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/impl/IndexSchemaFilter.java
@@ -119,8 +119,9 @@ class IndexSchemaFilter {
 	 */
 	private boolean isPathIncludedInternal(int relativeDepth, String relativePath,
 			boolean markAsEncountered, boolean includedByChild) {
-		boolean includedByThis = depthFilter.isEveryPathIncludedAtDepth( relativeDepth )
-				|| pathFilter.isExplicitlyIncluded( relativePath );
+		boolean includedByThis = ( depthFilter.isEveryPathIncludedAtDepth( relativeDepth )
+				|| pathFilter.isExplicitlyIncluded( relativePath ) )
+				&& !pathFilter.isExplicitlyExcluded( relativePath );
 
 		boolean includedByParent = true;
 		/*
@@ -128,7 +129,7 @@ class IndexSchemaFilter {
 		 * by reducing the includeDepth in particular,
 		 * but it cannot include paths that are filtered out by a child.
 		 */
-		if ( parent != null ) {
+		if ( includedByThis && parent != null ) {
 			includedByParent = parent.isPathIncludedInternal(
 					relativeDepth + 1,
 					definition.relativePrefix() + relativePath,
@@ -227,7 +228,7 @@ class IndexSchemaFilter {
 		DepthFilter newDepthFilter = DepthFilter.of( definition.includeDepth() );
 
 		// The new path filter according to the given includedPaths
-		PathFilter newPathFilter = PathFilter.of( definition.includePaths() );
+		PathFilter newPathFilter = PathFilter.of( definition.includePaths(), definition.excludePaths() );
 
 		return new IndexSchemaFilter(
 				this, definition, pathTracker,

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/impl/PathFilter.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/impl/PathFilter.java
@@ -10,54 +10,106 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-class PathFilter {
-
-	private static final PathFilter UNCONSTRAINED = new PathFilter( Collections.emptySet() );
+abstract class PathFilter {
 
 	static PathFilter unconstrained() {
-		return UNCONSTRAINED;
+		return Unconstrained.INSTANCE;
 	}
 
-	static PathFilter of(Set<String> paths) {
-		if ( paths == null || paths.isEmpty() ) {
+	static PathFilter of(Set<String> includedPaths, Set<String> excludedPaths) {
+		if ( includedPaths == null || includedPaths.isEmpty() ) {
+			if ( excludedPaths != null && !excludedPaths.isEmpty() ) {
+				return new ExcludePathFilter( excludedPaths );
+			}
 			return unconstrained();
 		}
 
 		// The included paths in the filter
-		Set<String> includedPaths = new HashSet<>();
+		Set<String> actualIncludedPaths = new HashSet<>();
 
-		for ( String path : paths ) {
-			includedPaths.add( path );
+		for ( String path : includedPaths ) {
+			actualIncludedPaths.add( path );
 			// Also add paths leading to this path (so that object nodes are not excluded)
-			addSubPathsFromRoot( includedPaths, path );
+			addSubPathsFromRoot( actualIncludedPaths, path );
 		}
 
-		return new PathFilter( includedPaths );
+		return new IncludePathFilter( actualIncludedPaths );
 	}
 
 	/**
 	 * Paths to be included even when the default behavior is to exclude paths.
 	 */
-	private final Set<String> includedPaths;
+	protected final Set<String> paths;
 
-	private PathFilter(Set<String> includedPaths) {
-		this.includedPaths = includedPaths;
+	private PathFilter(Set<String> paths) {
+		this.paths = paths;
 	}
 
 	@Override
 	public String toString() {
 		return getClass().getSimpleName() + "["
-				+ "includedPaths=" + includedPaths
+				+ "paths=" + paths
 				+ "]";
 	}
 
 	boolean isExplicitlyIncluded(String relativePath) {
-		return includedPaths.contains( relativePath );
+		return false;
+	}
+	boolean isExplicitlyExcluded(String relativePath) {
+		return false;
 	}
 
-	boolean isAnyPathExplicitlyIncluded() {
-		return !includedPaths.isEmpty();
+	abstract boolean isAnyPathExplicitlyIncluded();
+
+	private static class IncludePathFilter extends PathFilter {
+		private IncludePathFilter(Set<String> paths) {
+			super( paths );
+		}
+
+		@Override
+		boolean isExplicitlyIncluded(String relativePath) {
+			return paths.contains( relativePath );
+		}
+
+		@Override
+		boolean isAnyPathExplicitlyIncluded() {
+			return true;
+		}
 	}
+
+	private static class ExcludePathFilter extends PathFilter {
+		private ExcludePathFilter(Set<String> paths) {
+			super( paths );
+		}
+
+		@Override
+		boolean isExplicitlyExcluded(String relativePath) {
+			return paths.contains( relativePath );
+		}
+
+		@Override
+		boolean isAnyPathExplicitlyIncluded() {
+			return false;
+		}
+	}
+
+	private static class Unconstrained extends PathFilter {
+		private static final PathFilter INSTANCE = new Unconstrained();
+		private Unconstrained() {
+			super( Collections.emptySet() );
+		}
+
+		@Override
+		boolean isExplicitlyIncluded(String relativePath) {
+			return false;
+		}
+
+		@Override
+		boolean isAnyPathExplicitlyIncluded() {
+			return false;
+		}
+	}
+
 
 	private static void addSubPathsFromRoot(Set<String> collector, String path) {
 		int afterPreviousDotIndex = 0;

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/spi/IndexedEmbeddedDefinition.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/spi/IndexedEmbeddedDefinition.java
@@ -6,20 +6,26 @@
  */
 package org.hibernate.search.engine.mapper.mapping.building.spi;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 
 import org.hibernate.search.engine.backend.types.ObjectStructure;
+import org.hibernate.search.engine.logging.impl.Log;
 import org.hibernate.search.engine.mapper.model.spi.MappableTypeModel;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 public final class IndexedEmbeddedDefinition {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final MappableTypeModel definingTypeModel;
 	private final String relativePrefix;
 	private final ObjectStructure structure;
 	private final Set<String> includePaths;
+	private final Set<String> excludePaths;
 	private final Integer includeDepth;
 
 	/**
@@ -28,20 +34,35 @@ public final class IndexedEmbeddedDefinition {
 	 * @param structure The structure of all object fields created as part of the {@code relativePrefix}.
 	 * @param includeDepth The maximum depth beyond which all created fields will be ignored. {@code null} for no limit.
 	 * @param includePaths The exhaustive list of paths of fields that are to be included. {@code null} for no limit.
+	 * Cannot be used with nonempty {@code excludePaths}.
+	 * @param excludePaths The list of paths of fields that are to be excluded. {@code null} for no limit.
+	 * Cannot be used with nonempty {@code includePaths}.
 	 */
 	public IndexedEmbeddedDefinition(MappableTypeModel definingTypeModel, String relativePrefix,
 			ObjectStructure structure, Integer includeDepth,
-			Set<String> includePaths) {
+			Set<String> includePaths, Set<String> excludePaths) {
 		this.definingTypeModel = definingTypeModel;
 		this.relativePrefix = relativePrefix;
 		this.structure = structure;
 		this.includePaths = includePaths == null ? Collections.emptySet() : new LinkedHashSet<>( includePaths );
-		if ( includeDepth == null && !this.includePaths.isEmpty() ) {
+		this.excludePaths = excludePaths == null ? Collections.emptySet() : new LinkedHashSet<>( excludePaths );
+		if ( !this.includePaths.isEmpty() && !this.excludePaths.isEmpty() ) {
+			throw log.cannotIncludeAndExcludePathsWithinSameIndexedEmbedded(
+					includePaths,
+					excludePaths
+			);
+		}
+		if ( includeDepth == null && !( this.includePaths.isEmpty() && this.excludePaths.isEmpty() ) ) {
 			/*
-			 * If no max depth was provided and included paths were provided,
+			 * If no max depth was provided and
+			 * a)  included paths were provided,
 			 * the remaining composition depth is implicitly set to 0,
 			 * meaning no composition is allowed and paths are excluded unless
 			 * explicitly listed in "includePaths".
+			 * b)  excluded paths were provided,
+			 * the remaining composition depth is implicitly set to 0,
+			 * meaning no composition is allowed and paths are included unless
+			 * explicitly listed in "excludePaths".
 			 */
 			this.includeDepth = 0;
 		}
@@ -62,12 +83,13 @@ public final class IndexedEmbeddedDefinition {
 		return definingTypeModel.equals( that.definingTypeModel ) &&
 				relativePrefix.equals( that.relativePrefix ) &&
 				Objects.equals( includeDepth, that.includeDepth ) &&
-				includePaths.equals( that.includePaths );
+				includePaths.equals( that.includePaths ) &&
+				excludePaths.equals( that.excludePaths );
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash( definingTypeModel, relativePrefix, includeDepth, includePaths );
+		return Objects.hash( definingTypeModel, relativePrefix, includeDepth, includePaths, excludePaths );
 	}
 
 	public MappableTypeModel definingTypeModel() {
@@ -84,6 +106,10 @@ public final class IndexedEmbeddedDefinition {
 
 	public Set<String> includePaths() {
 		return includePaths;
+	}
+
+	public Set<String> excludePaths() {
+		return excludePaths;
 	}
 
 	public Integer includeDepth() {

--- a/engine/src/test/java/org/hibernate/search/engine/mapper/mapping/building/impl/ConfiguredIndexSchemaManagerNestingContextTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/mapper/mapping/building/impl/ConfiguredIndexSchemaManagerNestingContextTest.java
@@ -99,7 +99,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"level1", rootContext, typeModel1Mock, "level1.prefix1_",
-				null, null
+				null, null, null
 		);
 		checkFooBarIncluded( "prefix1_", level1Context );
 
@@ -113,7 +113,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"prefix1_level2", level1Context, typeModel2Mock, "level2.prefix2_",
-				null, null
+				null, null, null
 		);
 		checkFooBarIncluded( "prefix2_", level2Context );
 	}
@@ -124,14 +124,14 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"level1", rootContext, typeModel1Mock, "level1.prefix1_",
-				null, null
+				null, null, null
 		);
 		checkFooBarIncluded( "prefix1_", level1Context );
 
 		assertThatThrownBy( () -> {
 				IndexedEmbeddedDefinition level1Definition = new IndexedEmbeddedDefinition(
 						typeModel1Mock, "level1.prefix1_", ObjectStructure.DEFAULT,
-						null, null
+						null, null, null
 				);
 				level1Context.addIndexedEmbeddedIfIncluded(
 						level1Definition, new IndexedEmbeddedPathTracker( level1Definition ),
@@ -151,18 +151,18 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"level1", rootContext, typeModel1Mock, "level1.prefix1_",
-				null, null
+				null, null, null
 		);
 
 		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"prefix1_level2", level1Context, typeModel1Mock, "level2.prefix2_",
-				null, null
+				null, null, null
 		);
 
 		assertThatThrownBy( () -> {
 			IndexedEmbeddedDefinition level2Definition = new IndexedEmbeddedDefinition(
 					typeModel1Mock, "level1.prefix1_", ObjectStructure.DEFAULT,
-					null, null
+					null, null, null
 			);
 			level2Context.addIndexedEmbeddedIfIncluded(
 					level2Definition, new IndexedEmbeddedPathTracker( level2Definition ),
@@ -191,7 +191,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 				.thenReturn( expectedReturn );
 		IndexedEmbeddedDefinition definition = new IndexedEmbeddedDefinition(
 				typeModel1Mock, "level1.level2.level3.prefix1_", ObjectStructure.DEFAULT,
-				null, null
+				null, null, null
 		);
 		actualReturn = rootContext.addIndexedEmbeddedIfIncluded(
 				definition, new IndexedEmbeddedPathTracker( definition ),
@@ -224,7 +224,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"level1", rootContext, typeModel1Mock, "level1.",
-				null, includePaths
+				null, includePaths, null
 		);
 		checkFooBarExcluded( "", level1Context );
 		checkFooBarIndexedEmbeddedExcluded( level1Context, typeModel2Mock );
@@ -251,7 +251,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, typeModel2Mock, "level2.",
-				null, null
+				null, null, null
 		);
 		checkFooBarExcluded( "", level2Context );
 		checkFooBarIndexedEmbeddedExcluded( level2Context, typeModel3Mock );
@@ -266,7 +266,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, typeModel2Mock, "level2.prefix2_",
-				null, null
+				null, null, null
 		);
 		checkFooBarExcluded( "prefix2_", level2Context );
 		checkFooBarIndexedEmbeddedExcluded( level2Context, typeModel3Mock );
@@ -284,7 +284,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, typeModel2Mock, "level2.",
-				null, includePaths
+				null, includePaths, null
 		);
 		checkFooBarExcluded( "", level2Context );
 		checkFooBarIndexedEmbeddedExcluded( level2Context, typeModel3Mock );
@@ -312,7 +312,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		includePaths.add( "level2IndexedEmbedded.notEncountered" );
 		includePaths.add( "level2IndexedEmbedded.excludedBecauseOfLevel2" );
 		IndexedEmbeddedDefinition level1Definition = new IndexedEmbeddedDefinition(
-				typeModel1Mock, "level1.", ObjectStructure.DEFAULT, null, includePaths
+				typeModel1Mock, "level1.", ObjectStructure.DEFAULT, null, includePaths, null
 		);
 		IndexedEmbeddedPathTracker level1PathTracker = new IndexedEmbeddedPathTracker( level1Definition );
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
@@ -402,7 +402,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		includePaths.add( "excludedBecauseOfLevel1" );
 		IndexedEmbeddedDefinition level2Definition = new IndexedEmbeddedDefinition(
 				typeModel2Mock, "level2IndexedEmbedded.", ObjectStructure.DEFAULT,
-				null, includePaths
+				null, includePaths, null
 		);
 		IndexedEmbeddedPathTracker level2PathTracker = new IndexedEmbeddedPathTracker( level2Definition );
 		ConfiguredIndexSchemaNestingContext level2IndexedEmbeddedContext = checkSimpleIndexedEmbeddedIncluded(
@@ -513,13 +513,13 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		// First level of @IndexedEmbedded: no filter
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"professionnelGC", rootContext, typeModel1Mock, "professionnelGC.",
-				null, null
+				null, null, null
 		);
 
 		// Second level of @IndexedEmbedded: includePaths filter
 		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"groupe", level1Context, typeModel1Mock, "groupe.",
-				null, CollectionHelper.asSet( "raisonSociale" )
+				null, CollectionHelper.asSet( "raisonSociale" ), null
 		);
 
 		checkLeafIncluded( "raisonSociale", level2Context, "raisonSociale" );
@@ -535,7 +535,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		checkSimpleIndexedEmbeddedExcluded(
 				rootContext, typeModel1Mock,
-				"level1.", 0, null
+				"level1.", 0, null, null
 		);
 	}
 
@@ -549,7 +549,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"level1", rootContext, typeModel1Mock,
-				"level1.", 1, null
+				"level1.", 1, null, null
 		);
 		checkFooBarIncluded( "", level1Context );
 		checkFooBarIndexedEmbeddedExcluded( level1Context, typeModel2Mock );
@@ -574,7 +574,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"level1", rootContext, typeModel1Mock,
-				"level1.", 3, null
+				"level1.", 3, null, null
 		);
 		checkFooBarIncluded( "", level1Context );
 
@@ -596,7 +596,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, typeModel2Mock,
-				"level2.", null, null
+				"level2.", null, null, null
 		);
 		checkFooBarIncluded( "", level2Context );
 		level3NonIndexedEmbeddedContext =
@@ -608,7 +608,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level3Context = checkSimpleIndexedEmbeddedIncluded(
 				"level3", level2Context, typeModel3Mock,
-				"level3.", null, null
+				"level3.", null, null, null
 		);
 		checkFooBarIncluded( "", level3Context );
 		level4NonIndexedEmbeddedContext =
@@ -617,20 +617,20 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		checkSimpleIndexedEmbeddedExcluded(
 				level3Context, typeModel4Mock,
-				"level4.", null, null
+				"level4.", null, null, null
 		);
 
 		// Check IndexedEmbedded composition with a depth override
 
 		level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, typeModel2Mock,
-				"level2.", 1, null
+				"level2.", 1, null, null
 		);
 		checkFooBarIncluded( "", level2Context );
 
 		checkSimpleIndexedEmbeddedExcluded(
 				level2Context, typeModel3Mock,
-				"level3.", null, null
+				"level3.", null, null, null
 		);
 	}
 
@@ -645,7 +645,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"level1", rootContext, typeModel1Mock, "level1.",
-				1, includePaths
+				1, includePaths, null
 		);
 		checkFooBarIncluded( "", level1Context );
 		checkFooBarIndexedEmbeddedExcluded( level1Context, typeModel2Mock );
@@ -661,7 +661,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, typeModel2Mock, "level2.",
-				null, null
+				null, null, null
 		);
 		checkFooBarExcluded( "", level2Context );
 		checkFooBarIndexedEmbeddedExcluded( level2Context, typeModel3Mock );
@@ -676,7 +676,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, typeModel2Mock, "level2.prefix2_",
-				null, null
+				null, null, null
 		);
 		checkFooBarExcluded( "prefix2_", level2Context );
 		checkFooBarIndexedEmbeddedExcluded( level2Context, typeModel3Mock );
@@ -694,7 +694,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, typeModel2Mock, "level2.",
-				null, includePaths
+				null, includePaths, null
 		);
 		checkFooBarExcluded( "", level2Context );
 		checkFooBarIndexedEmbeddedExcluded( level2Context, typeModel3Mock );
@@ -719,7 +719,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		includePaths.add( "level2.level3.included" );
 		includePaths.add( "level2.level3.notEncountered" );
 		IndexedEmbeddedDefinition level1Definition = new IndexedEmbeddedDefinition(
-				typeModel1Mock, "level1.", ObjectStructure.DEFAULT, 1, includePaths
+				typeModel1Mock, "level1.", ObjectStructure.DEFAULT, 1, includePaths, null
 		);
 		IndexedEmbeddedPathTracker level1PathTracker = new IndexedEmbeddedPathTracker( level1Definition );
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
@@ -755,14 +755,14 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		// Encounter a nested indexedEmbedded
 		IndexedEmbeddedDefinition level2Definition = new IndexedEmbeddedDefinition(
-				typeModel2Mock, "level2.", ObjectStructure.DEFAULT, null, null
+				typeModel2Mock, "level2.", ObjectStructure.DEFAULT, null, null, null
 		);
 		IndexedEmbeddedPathTracker level2PathTracker = new IndexedEmbeddedPathTracker( level2Definition );
 		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, level2Definition, level2PathTracker
 		);
 		IndexedEmbeddedDefinition level3Definition = new IndexedEmbeddedDefinition(
-				typeModel2Mock, "level3.", ObjectStructure.DEFAULT, null, null
+				typeModel2Mock, "level3.", ObjectStructure.DEFAULT, null, null, null
 		);
 		IndexedEmbeddedPathTracker level3PathTracker = new IndexedEmbeddedPathTracker( level3Definition );
 		ConfiguredIndexSchemaNestingContext level3Context = checkSimpleIndexedEmbeddedIncluded(
@@ -817,7 +817,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		includePaths.add( "level2.level3" );
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"level1", rootContext, typeModel1Mock, "level1.",
-				null, includePaths
+				null, includePaths, null
 		);
 		checkFooBarExcluded( "", level1Context );
 		checkFooBarIndexedEmbeddedExcluded( level1Context, typeModel2Mock );
@@ -828,7 +828,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		includePaths.add( "level3-alt.level4" );
 		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, typeModel2Mock, "level2.",
-				null, includePaths
+				null, includePaths, null
 		);
 		checkFooBarExcluded( "", level2Context );
 		checkFooBarIndexedEmbeddedExcluded( level2Context, typeModel3Mock );
@@ -841,7 +841,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		includePaths.add( "level3-alt.level4" );
 		checkSimpleIndexedEmbeddedExcluded(
 				level1Context, typeModel2Mock, "level2.",
-				null, includePaths
+				null, includePaths, null
 		);
 
 		IndexSchemaNestingContext level3Context =
@@ -858,7 +858,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		includePaths.add( "level2.level3" );
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"level1", rootContext, typeModel1Mock, "level1.",
-				null, includePaths
+				null, includePaths, null
 		);
 		checkFooBarExcluded( "", level1Context );
 		checkFooBarIndexedEmbeddedExcluded( level1Context, typeModel2Mock );
@@ -868,7 +868,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		includePaths.add( "level3-alt.level4" );
 		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, typeModel2Mock, "level2.",
-				1, includePaths
+				1, includePaths, null
 		);
 		checkFooBarExcluded( "", level2Context );
 		checkFooBarIndexedEmbeddedExcluded( level2Context, typeModel3Mock );
@@ -893,13 +893,13 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		includePaths.add( "nested.nested.text" );
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"level1", rootContext, typeModel1Mock, "level1.",
-				2, includePaths
+				2, includePaths, null
 		);
 
 		// Same includePaths as above
 		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"nested", level1Context, typeModel2Mock, "nested.",
-				2, includePaths
+				2, includePaths, null
 		);
 		checkFooBarIncluded( "", level2Context );
 		checkFooBarIndexedEmbeddedExcluded( level2Context, typeModel3Mock );
@@ -910,7 +910,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		// Same includePaths as above
 		ConfiguredIndexSchemaNestingContext level3Context = checkSimpleIndexedEmbeddedIncluded(
 				"nested", level2Context, typeModel3Mock, "nested.",
-				2, includePaths
+				2, includePaths, null
 		);
 		checkFooBarExcluded( "", level3Context );
 		checkFooBarIndexedEmbeddedExcluded( level3Context, typeModel3Mock );
@@ -921,8 +921,94 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		// Same includePaths as above
 		checkSimpleIndexedEmbeddedExcluded(
 				level3Context, typeModel4Mock, "nested.",
-				2, includePaths
+				2, includePaths, null
 		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-1182")
+	public void indexedEmbedded_excludePaths() {
+		ConfiguredIndexSchemaNestingContext rootContext = ConfiguredIndexSchemaNestingContext.root();
+
+		Set<String> excludePaths = new HashSet<>();
+
+		excludePaths.add( "foo" );
+		excludePaths.add( "bar" );
+		excludePaths.add( "foo.bar" );
+
+		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
+				"level1", rootContext, typeModel1Mock, "level1.",
+				null, null, excludePaths
+		);
+		checkFooBarExcluded( "", level1Context );
+		checkFooBarIndexedEmbeddedExcluded( level1Context, typeModel2Mock );
+		checkLeafExcluded( "level3", level1Context, "level3" );
+		checkCompositeExcluded( "level3", level1Context, "level3" );
+		checkLeafIncluded( "level2", level1Context, "level2" );
+		// Names including dots and matching the filter will be accepted
+		checkLeafIncluded( "level2.level3", level1Context, "level2.level3" );
+		checkCompositeIncluded( "level2.level3", level1Context, "level2.level3" );
+
+		// Check non-IndexedEmbedded nesting
+
+		IndexSchemaNestingContext level2NonIndexedEmbeddedContext =
+				checkCompositeIncluded( "level2", level1Context, "level2" );
+		checkFooBarExcluded( "", level2NonIndexedEmbeddedContext );
+		checkLeafIncluded( "level3", level2NonIndexedEmbeddedContext, "level3" );
+		checkLeafIncluded( "prefix2_level3", level2NonIndexedEmbeddedContext, "prefix2_level3" );
+		checkCompositeIncluded( "level3", level2NonIndexedEmbeddedContext, "level3" );
+		checkCompositeIncluded( "prefix2_level3", level2NonIndexedEmbeddedContext, "prefix2_level3" );
+		checkLeafExcluded( "level3.foo", level2NonIndexedEmbeddedContext, "level3.foo" );
+		checkCompositeExcluded( "level3.foo", level2NonIndexedEmbeddedContext, "level3.foo" );
+
+		// Check IndexedEmbedded composition without a prefix
+
+		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
+				"level2", level1Context, typeModel2Mock, "level2.",
+				null, null, null
+		);
+		checkFooBarExcluded( "", level2Context );
+		checkFooBarIndexedEmbeddedExcluded( level2Context, typeModel3Mock );
+		checkLeafIncluded( "level3", level2Context, "level3" );
+		checkLeafIncluded( "prefix2_level3", level2Context, "prefix2_level3" );
+		checkCompositeIncluded( "level3", level2Context, "level3" );
+		checkCompositeIncluded( "prefix2_level3", level2Context, "prefix2_level3" );
+		checkLeafExcluded( "level3.foo", level2Context, "level3.foo" );
+		checkCompositeExcluded( "level3.foo", level2Context, "level3.foo" );
+
+		// Check IndexedEmbedded composition with a prefix
+
+		level2Context = checkSimpleIndexedEmbeddedIncluded(
+				"level2", level1Context, typeModel2Mock, "level2.prefix2_",
+				null, null, null
+		);
+		checkFooBarExcluded( "prefix2_", level2Context );
+		checkFooBarIndexedEmbeddedExcluded( level2Context, typeModel3Mock );
+		checkLeafIncluded( "prefix2_level3", level2Context, "level3" );
+		checkCompositeIncluded( "prefix2_level3", level2Context, "level3" );
+		checkLeafExcluded( "prefix2_prefix2_level3", level2Context, "prefix2_level3" );
+		checkCompositeExcluded( "prefix2_prefix2_level3", level2Context, "prefix2_level3" );
+		checkLeafExcluded( "prefix2_level3.foo", level2Context, "level3.foo" );
+		checkCompositeExcluded( "prefix2_level3.foo", level2Context, "level3.foo" );
+
+		// Check IndexedEmbedded composition with path filter composition
+
+		excludePaths.clear();
+		excludePaths.add( "prefix2_level3" );
+
+		level2Context = checkSimpleIndexedEmbeddedIncluded(
+				"level2", level1Context, typeModel2Mock, "level2.",
+				null, excludePaths, null
+		);
+		checkFooBarExcluded( "", level2Context );
+		checkFooBarIndexedEmbeddedExcluded( level2Context, typeModel3Mock );
+		checkLeafIncluded( "prefix2_level3", level2Context, "prefix2_level3" );
+		checkCompositeIncluded( "prefix2_level3", level2Context, "prefix2_level3" );
+		checkLeafExcluded( "prefix2_level3.foo", level2Context, "prefix2_level3.foo" );
+		checkCompositeExcluded( "prefix2_level3.foo", level2Context, "prefix2_level3.foo" );
+		// Excluded due to additional filters: this right here checks HSEARCH-2552 is fixed
+		checkLeafExcluded( "level3", level2Context, "level3" );
+		checkCompositeExcluded( "level3", level2Context, "level3" );
 	}
 
 	private void checkLeafIncluded(String expectedPrefixedName, IndexSchemaNestingContext context,
@@ -1011,10 +1097,10 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 	private ConfiguredIndexSchemaNestingContext checkSimpleIndexedEmbeddedIncluded(String expectedObjectName,
 			ConfiguredIndexSchemaNestingContext context, MappableTypeModel typeModel,
-			String relativePrefix, Integer depth, Set<String> includePaths) {
+			String relativePrefix, Integer depth, Set<String> includePaths, Set<String> excludePaths) {
 		IndexedEmbeddedDefinition definition = new IndexedEmbeddedDefinition(
 				typeModel, relativePrefix, ObjectStructure.DEFAULT,
-				depth, includePaths
+				depth, includePaths, excludePaths
 		);
 		return checkSimpleIndexedEmbeddedIncluded(
 				expectedObjectName, context, definition, new IndexedEmbeddedPathTracker( definition )
@@ -1044,10 +1130,10 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 	}
 
 	private void checkSimpleIndexedEmbeddedExcluded(ConfiguredIndexSchemaNestingContext context, MappableTypeModel typeModel,
-			String relativePrefix, Integer depth, Set<String> includePaths) {
+			String relativePrefix, Integer depth, Set<String> includePaths, Set<String> excludePaths) {
 		IndexedEmbeddedDefinition definition = new IndexedEmbeddedDefinition(
 				typeModel, relativePrefix, ObjectStructure.DEFAULT,
-				depth, includePaths
+				depth, includePaths, excludePaths
 		);
 		checkSimpleIndexedEmbeddedExcluded(
 				context, definition, new IndexedEmbeddedPathTracker( definition )
@@ -1095,22 +1181,22 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 	private void checkFooBarIndexedEmbeddedExcluded(ConfiguredIndexSchemaNestingContext context, MappableTypeModel typeModel) {
 		checkSimpleIndexedEmbeddedExcluded(
-				context, typeModel, "foo.", null, null
+				context, typeModel, "foo.", null, null, null
 		);
 		checkSimpleIndexedEmbeddedExcluded(
-				context, typeModel, "prefix1_", null, null
+				context, typeModel, "prefix1_", null, null, null
 		);
 		checkSimpleIndexedEmbeddedExcluded(
-				context, typeModel, "foo.prefix1_", null, null
+				context, typeModel, "foo.prefix1_", null, null, null
 		);
 		checkSimpleIndexedEmbeddedExcluded(
-				context, typeModel, "foo.bar.prefix1_", null, null
+				context, typeModel, "foo.bar.prefix1_", null, null, null
 		);
 		Set<String> includePaths = new HashSet<>();
 		includePaths.add( "foo" );
 		includePaths.add( "bar" );
 		checkSimpleIndexedEmbeddedExcluded(
-				context, typeModel, "foo", 3, includePaths
+				context, typeModel, "foo", 3, includePaths, null
 		);
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementDynamicFieldNameIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementDynamicFieldNameIT.java
@@ -265,7 +265,7 @@ public class DocumentElementDynamicFieldNameIT<F> {
 			IndexedEmbeddedDefinition indexedEmbeddedDefinition = new IndexedEmbeddedDefinition(
 					new StubTypeModel( "embedded" ),
 					"excludingObject.", ObjectStructure.FLATTENED,
-					null, Collections.singleton( "pathThatDoesNotMatchAnything" )
+					null, Collections.singleton( "pathThatDoesNotMatchAnything" ), Collections.emptySet()
 			);
 			// Ignore the result, we'll just reference "excludingObject" by its name
 			ctx.addIndexedEmbeddedIfIncluded( indexedEmbeddedDefinition, true ).get();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementFieldReferenceIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementFieldReferenceIT.java
@@ -253,7 +253,7 @@ public class DocumentElementFieldReferenceIT<F> {
 			IndexedEmbeddedDefinition indexedEmbeddedDefinition = new IndexedEmbeddedDefinition(
 					new StubTypeModel( "embedded" ),
 					"excludingObject.", ObjectStructure.FLATTENED,
-					null, Collections.singleton( "pathThatDoesNotMatchAnything" )
+					null, Collections.singleton( "pathThatDoesNotMatchAnything" ), Collections.emptySet()
 			);
 			IndexedEmbeddedBindingContext excludingEmbeddedContext =
 					ctx.addIndexedEmbeddedIfIncluded( indexedEmbeddedDefinition, true ).get();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementStaticFieldNameIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementStaticFieldNameIT.java
@@ -268,7 +268,7 @@ public class DocumentElementStaticFieldNameIT<F> {
 			IndexedEmbeddedDefinition indexedEmbeddedDefinition = new IndexedEmbeddedDefinition(
 					new StubTypeModel( "embedded" ),
 					"excludingObject.", ObjectStructure.FLATTENED,
-					null, Collections.singleton( "pathThatDoesNotMatchAnything" )
+					null, Collections.singleton( "pathThatDoesNotMatchAnything" ), Collections.emptySet()
 			);
 			IndexedEmbeddedBindingContext excludingEmbeddedContext =
 					ctx.addIndexedEmbeddedIfIncluded( indexedEmbeddedDefinition, true ).get();

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/smoke/ExcludePathsIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/smoke/ExcludePathsIT.java
@@ -1,0 +1,291 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.smoke;
+
+import java.lang.invoke.MethodHandles;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.search.integrationtest.mapper.pojo.smoke.bridge.CustomPropertyBinding;
+import org.hibernate.search.integrationtest.mapper.pojo.smoke.bridge.CustomTypeBinding;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.AssociationInverseSide;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyValue;
+import org.hibernate.search.mapper.pojo.standalone.mapping.SearchMapping;
+import org.hibernate.search.mapper.pojo.standalone.session.SearchSession;
+import org.hibernate.search.util.common.impl.CollectionHelper;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.pojo.standalone.StandalonePojoMappingSetupHelper;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+
+public class ExcludePathsIT {
+
+	@Rule
+	public BackendMock backendMock = new BackendMock();
+
+	@Rule
+	public StandalonePojoMappingSetupHelper setupHelper = StandalonePojoMappingSetupHelper.withBackendMock(
+			MethodHandles.lookup(), backendMock );
+
+	private SearchMapping mapping;
+
+	@Before
+	public void setup() {
+		backendMock.expectSchema( IndexedEntity.INDEX, b -> b
+				.objectField( "customBridgeOnClass", b2 -> b2
+						.field( "date", LocalDate.class )
+						.field( "text", String.class )
+				)
+				.objectField( "customBridgeOnProperty", b2 -> b2
+						.field( "date", LocalDate.class )
+						.field( "text", String.class )
+				)
+				.objectField( "myEmbedded", b2 -> b2
+						.objectField( "customBridgeOnClass", b3 -> b3
+								.field( "date", LocalDate.class )
+						)
+						.objectField( "customBridgeOnProperty", b3 -> b3
+								.field( "date", LocalDate.class )
+								.field( "text", String.class )
+						)
+						.field( "myLocalDateField", LocalDate.class )
+						.field( "myTextField", String.class )
+						.objectField( "myEmbedded", b3 -> b3
+								.objectField( "customBridgeOnClass", b4 -> b4
+										.field( "date", LocalDate.class )
+								)
+								.objectField( "customBridgeOnProperty", b4 -> b4
+										.field( "date", LocalDate.class )
+										.field( "text", String.class )
+								)
+								.field( "myLocalDateField", LocalDate.class )
+								.field( "myTextField", String.class )
+						)
+				)
+				.field( "myTextField", String.class )
+				.field( "myLocalDateField", LocalDate.class )
+		);
+
+		mapping = setupHelper.start()
+				.expectCustomBeans()
+				.withConfiguration( builder -> {
+					builder.addEntityTypes( CollectionHelper.asSet(
+							IndexedEntity.class
+					) );
+					builder.annotationMapping().add( IndexedEntity.class );
+				} )
+				.setup();
+
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void index() {
+		try ( SearchSession session = mapping.createSession() ) {
+			IndexedEntity entity1 = new IndexedEntity();
+			entity1.setId( 1 );
+			entity1.setText( "this is text (1)" );
+			entity1.setLocalDate( LocalDate.of( 2017, 11, 1 ) );
+			IndexedEntity entity2 = new IndexedEntity();
+			entity2.setId( 2 );
+			entity2.setText( "some more text (2)" );
+			entity2.setLocalDate( LocalDate.of( 2017, 11, 2 ) );
+			IndexedEntity entity3 = new IndexedEntity();
+			entity3.setId( 3 );
+			entity3.setText( "some more text (3)" );
+			entity3.setLocalDate( LocalDate.of( 2017, 11, 3 ) );
+			IndexedEntity entity6 = new IndexedEntity();
+			entity6.setId( 6 );
+			entity6.setText( "some more text (6)" );
+			entity6.setLocalDate( LocalDate.of( 2017, 11, 6 ) );
+
+			entity1.setEmbedded( entity2 );
+			entity2.getEmbeddingAsSingle().add( entity1 );
+
+			entity2.setEmbedded( entity3 );
+			entity3.getEmbeddingAsSingle().add( entity2 );
+
+			entity3.setEmbedded( entity2 );
+			entity2.getEmbeddingAsSingle().add( entity3 );
+
+
+			Map<String, List<IndexedEntity>> embeddedMap = new LinkedHashMap<>();
+			embeddedMap.computeIfAbsent( "entity3", ignored -> new ArrayList<>() ).add( entity3 );
+			embeddedMap.computeIfAbsent( "entity2", ignored -> new ArrayList<>() ).add( entity2 );
+			embeddedMap.computeIfAbsent( "entity2", ignored -> new ArrayList<>() ).add( entity3 );
+
+			session.indexingPlan().add( entity1 );
+			session.indexingPlan().add( entity2 );
+			session.indexingPlan().delete( entity1 );
+			session.indexingPlan().add( entity3 );
+			session.indexingPlan().add( entity6 );
+
+			backendMock.expectWorks( IndexedEntity.INDEX )
+					.add( "2", b -> b
+							.field( "myLocalDateField", entity2.getLocalDate() )
+							.field( "myTextField", entity2.getText() )
+							.objectField( "customBridgeOnClass", b2 -> b2
+									.field( "text", entity2.getText() )
+									.field( "date", entity2.getLocalDate() )
+							)
+							.objectField( "customBridgeOnProperty", b2 -> b2
+									.field( "text", entity2.getEmbedded().getText() )
+									.field( "date", entity2.getEmbedded().getLocalDate() )
+							)
+							.objectField( "myEmbedded", b2 -> b2
+									.field( "myTextField", entity2.getEmbedded().getText() )
+									.field( "myLocalDateField", entity2.getEmbedded().getLocalDate() )
+									.objectField( "customBridgeOnClass", b3 -> b3
+											.field( "date", entity2.getEmbedded().getLocalDate() )
+									)
+									.objectField( "customBridgeOnProperty", b3 -> b3
+											.field( "text", entity2.getEmbedded().getEmbedded().getText() )
+											.field( "date", entity2.getEmbedded().getEmbedded().getLocalDate() )
+									)
+									.objectField( "myEmbedded", b3 -> b3
+											.field( "myTextField", entity2.getEmbedded().getEmbedded().getText() )
+											.field( "myLocalDateField", entity2.getEmbedded().getEmbedded().getLocalDate() )
+											.objectField( "customBridgeOnClass", b4 -> b4
+													.field( "date", entity2.getEmbedded().getEmbedded().getLocalDate() )
+											)
+											.objectField( "customBridgeOnProperty", b4 -> b4
+													.field( "text", entity2.getEmbedded().getEmbedded().getEmbedded().getText() )
+													.field( "date", entity2.getEmbedded().getEmbedded().getEmbedded().getLocalDate() )
+											)
+									)
+							)
+					)
+					.add( "3", b -> b
+							.field( "myLocalDateField", entity3.getLocalDate() )
+							.field( "myTextField", entity3.getText() )
+							.objectField( "customBridgeOnClass", b2 -> b2
+									.field( "text", entity3.getText() )
+									.field( "date", entity3.getLocalDate() )
+							)
+							.objectField( "customBridgeOnProperty", b2 -> b2
+									.field( "text", entity3.getEmbedded().getText() )
+									.field( "date", entity3.getEmbedded().getLocalDate() )
+							)
+							.objectField( "myEmbedded", b2 -> b2
+									.field( "myTextField", entity3.getEmbedded().getText() )
+									.field( "myLocalDateField", entity3.getEmbedded().getLocalDate() )
+									.objectField( "customBridgeOnClass", b3 -> b3
+											.field( "date", entity3.getEmbedded().getLocalDate() )
+									)
+									.objectField( "customBridgeOnProperty", b3 -> b3
+											.field( "text", entity3.getEmbedded().getEmbedded().getText() )
+											.field( "date", entity3.getEmbedded().getEmbedded().getLocalDate() )
+									)
+									.objectField( "myEmbedded", b3 -> b3
+											.field( "myTextField", entity3.getEmbedded().getEmbedded().getText() )
+											.field( "myLocalDateField", entity3.getEmbedded().getEmbedded().getLocalDate() )
+											.objectField( "customBridgeOnClass", b4 -> b4
+													.field( "date", entity3.getEmbedded().getEmbedded().getLocalDate() )
+											)
+											.objectField( "customBridgeOnProperty", b4 -> b4
+													.field( "text", entity3.getEmbedded().getEmbedded().getEmbedded().getText() )
+													.field( "date", entity3.getEmbedded().getEmbedded().getEmbedded().getLocalDate() )
+											)
+									)
+							)
+					)
+					.add( "6", b -> b
+							.field( "myLocalDateField", entity6.getLocalDate() )
+							.field( "myTextField", entity6.getText() )
+							.objectField( "customBridgeOnClass", b2 -> b2
+									.field( "text", entity6.getText() )
+									.field( "date", entity6.getLocalDate() )
+							)
+					);
+		}
+	}
+
+	public static class ParentIndexedEntity {
+
+		private LocalDate localDate;
+
+		private IndexedEntity embedded;
+
+		@GenericField(name = "myLocalDateField")
+		public LocalDate getLocalDate() {
+			return localDate;
+		}
+
+		public void setLocalDate(LocalDate localDate) {
+			this.localDate = localDate;
+		}
+
+		@CustomPropertyBinding(objectName = "customBridgeOnProperty")
+		@AssociationInverseSide(
+				inversePath = @ObjectPath(
+						@PropertyValue(propertyName = "embeddingAsSingle")
+				)
+		)
+		public IndexedEntity getEmbedded() {
+			return embedded;
+		}
+
+		public void setEmbedded(IndexedEntity embedded) {
+			this.embedded = embedded;
+		}
+	}
+
+	@Indexed(index = IndexedEntity.INDEX)
+	@CustomTypeBinding(objectName = "customBridgeOnClass")
+	public static final class IndexedEntity extends ParentIndexedEntity {
+
+		public static final String INDEX = "IndexedEntity";
+
+		private Integer id;
+
+		private String text;
+
+		private List<ParentIndexedEntity> embeddingAsSingle = new ArrayList<>();
+
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		@GenericField(name = "myTextField")
+		public String getText() {
+			return text;
+		}
+
+		public void setText(String text) {
+			this.text = text;
+		}
+
+		@Override
+		@IndexedEmbedded(name = "myEmbedded", includeDepth = 2,
+				excludePaths = { "customBridgeOnClass.text", "myEmbedded.customBridgeOnClass.text" })
+		public IndexedEntity getEmbedded() {
+			return super.getEmbedded();
+		}
+
+		public List<ParentIndexedEntity> getEmbeddingAsSingle() {
+			return embeddingAsSingle;
+		}
+
+	}
+
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/IdentityMappingCollectorValueNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/IdentityMappingCollectorValueNode.java
@@ -41,7 +41,7 @@ class IdentityMappingCollectorValueNode extends AbstractIdentityMappingCollector
 	@Override
 	public void indexedEmbedded(PojoRawTypeModel<?> definingTypeModel, String relativePrefix,
 			ObjectStructure structure,
-			Integer includeDepth, Set<String> includePaths, boolean includeEmbeddedObjectId,
+			Integer includeDepth, Set<String> includePaths, Set<String> excludePaths, boolean includeEmbeddedObjectId,
 			Class<?> targetType) {
 		// No-op, we're just collecting the identity mapping.
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/spi/PojoIndexMappingCollectorValueNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/spi/PojoIndexMappingCollectorValueNode.java
@@ -20,6 +20,6 @@ public interface PojoIndexMappingCollectorValueNode extends PojoMappingCollector
 			String relativeFieldName, FieldModelContributor fieldModelContributor);
 
 	void indexedEmbedded(PojoRawTypeModel<?> definingTypeModel, String relativePrefix, ObjectStructure structure,
-			Integer includeDepth, Set<String> includePaths, boolean includeEmbeddedObjectId, Class<?> targetType);
+			Integer includeDepth, Set<String> includePaths, Set<String> excludePaths, boolean includeEmbeddedObjectId, Class<?> targetType);
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/IndexedEmbedded.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/IndexedEmbedded.java
@@ -19,6 +19,7 @@ import org.hibernate.search.mapper.pojo.extractor.mapping.annotation.ContainerEx
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMapping;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessorRef;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.impl.IndexedEmbeddedProcessor;
+import org.hibernate.search.util.common.annotation.Incubating;
 import org.hibernate.search.util.common.annotation.Search5DeprecatedAPI;
 
 /**
@@ -134,6 +135,9 @@ public @interface IndexedEmbedded {
 	 * i.e. they must not include the {@link #name()}.
 	 */
 	String[] includePaths() default {};
+
+	@Incubating
+	String[] excludePaths() default {};
 
 	/**
 	 * The number of levels of indexed-embedded that will have all their fields included by default.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/IndexedEmbeddedProcessor.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/IndexedEmbeddedProcessor.java
@@ -30,14 +30,7 @@ public class IndexedEmbeddedProcessor implements PropertyMappingAnnotationProces
 		Integer cleanedUpIncludeDepth = context.toNullIfDefault( annotation.includeDepth(), -1 );
 
 		String[] includePathsArray = annotation.includePaths();
-		Set<String> cleanedUpIncludePaths;
-		if ( includePathsArray.length > 0 ) {
-			cleanedUpIncludePaths = new HashSet<>();
-			Collections.addAll( cleanedUpIncludePaths, includePathsArray );
-		}
-		else {
-			cleanedUpIncludePaths = Collections.emptySet();
-		}
+		String[] excludePathsArray = annotation.excludePaths();
 
 		ContainerExtractorPath extractorPath = context.toContainerExtractorPath( annotation.extraction() );
 
@@ -50,8 +43,21 @@ public class IndexedEmbeddedProcessor implements PropertyMappingAnnotationProces
 				.prefix( cleanedUpPrefix )
 				.structure( structure )
 				.includeDepth( cleanedUpIncludeDepth )
-				.includePaths( cleanedUpIncludePaths )
+				.includePaths( cleanUpPaths( includePathsArray ) )
+				.excludePaths( cleanUpPaths( excludePathsArray ) )
 				.includeEmbeddedObjectId( annotation.includeEmbeddedObjectId() )
 				.targetType( cleanedUpTargetType );
+	}
+
+	private Set<String> cleanUpPaths(String[] pathsArray) {
+		Set<String> paths;
+		if ( pathsArray.length > 0 ) {
+			paths = new HashSet<>();
+			Collections.addAll( paths, pathsArray );
+		}
+		else {
+			paths = Collections.emptySet();
+		}
+		return paths;
 	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/PropertyMappingIndexedEmbeddedStep.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/PropertyMappingIndexedEmbeddedStep.java
@@ -53,6 +53,8 @@ public interface PropertyMappingIndexedEmbeddedStep extends PropertyMappingStep 
 	 */
 	PropertyMappingIndexedEmbeddedStep includePaths(Collection<String> paths);
 
+	PropertyMappingIndexedEmbeddedStep excludePaths(Collection<String> paths);
+
 	/**
 	 * @param include Whether the identifier of embedded objects should be included as an index field.
 	 * @return {@code this}, for method chaining.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyMappingIndexedEmbeddedStepImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyMappingIndexedEmbeddedStepImpl.java
@@ -39,6 +39,7 @@ class PropertyMappingIndexedEmbeddedStepImpl extends DelegatingPropertyMappingSt
 
 	private Integer includeDepth;
 	private final Set<String> includePaths = new HashSet<>();
+	private final Set<String> excludePaths = new HashSet<>();
 	private boolean includeEmbeddedObjectId = false;
 
 	private Class<?> targetType;
@@ -65,8 +66,8 @@ class PropertyMappingIndexedEmbeddedStepImpl extends DelegatingPropertyMappingSt
 			actualPrefix = prefix;
 		}
 		collector.value( extractorPath ).indexedEmbedded(
-				definingTypeModel, actualPrefix, structure, includeDepth, includePaths, includeEmbeddedObjectId,
-				targetType
+				definingTypeModel, actualPrefix, structure, includeDepth, includePaths, excludePaths,
+				includeEmbeddedObjectId, targetType
 		);
 	}
 
@@ -96,6 +97,12 @@ class PropertyMappingIndexedEmbeddedStepImpl extends DelegatingPropertyMappingSt
 	@Override
 	public PropertyMappingIndexedEmbeddedStep includePaths(Collection<String> paths) {
 		this.includePaths.addAll( paths );
+		return this;
+	}
+
+	@Override
+	public PropertyMappingIndexedEmbeddedStep excludePaths(Collection<String> paths) {
+		this.excludePaths.addAll( paths );
 		return this;
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexingProcessorValueNodeBuilderDelegate.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexingProcessorValueNodeBuilderDelegate.java
@@ -88,7 +88,7 @@ class PojoIndexingProcessorValueNodeBuilderDelegate<P, V> extends AbstractPojoPr
 	@Override
 	public void indexedEmbedded(PojoRawTypeModel<?> definingTypeModel, String relativePrefix,
 			ObjectStructure structure,
-			Integer includeDepth, Set<String> includePaths, boolean includeEmbeddedObjectId,
+			Integer includeDepth, Set<String> includePaths, Set<String> excludePaths, boolean includeEmbeddedObjectId,
 			Class<?> targetType) {
 		String defaultedRelativePrefix = relativePrefix;
 		if ( defaultedRelativePrefix == null ) {
@@ -97,7 +97,7 @@ class PojoIndexingProcessorValueNodeBuilderDelegate<P, V> extends AbstractPojoPr
 
 		IndexedEmbeddedDefinition definition = new IndexedEmbeddedDefinition(
 				definingTypeModel, defaultedRelativePrefix, structure,
-				includeDepth, includePaths
+				includeDepth, includePaths, excludePaths
 		);
 
 		Optional<IndexedEmbeddedBindingContext> nestedBindingContextOptional =


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-1182

This is just to get some initial feedback. `ExcludePathsIT` is the test I've been experimenting with. 
The general idea is that a user can apply either include or exclude paths. The filtering part happens in `IndexSchemaFilter#isPathIncludedInternal` by just adding a check if the path wasn't explicitly excluded. Everything else in here is just "noise" to get the info from an annotation to the filter 😃. Is this going in the right direction?