### PR TITLE
Add .mailmap to the root of the repository

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,27 @@
+Fabio Massimo Ercoli <fabiomassimo.ercoli@gmail.com>
+Gustavo Fernandes <gustavonalle@gmail.com>
+Hibernate-CI <ci@hibernate.org>
+Hibernate-CI <ci@hibernate.org> <jenkins@ip-172-30-1-188.ec2.internal>
+Hibernate-CI <ci@hibernate.org> <jenkins@ip-172-30-1-170.ec2.internal>
+Hibernate-CI <ci@hibernate.org> <jenkins@ip-172-30-1-84.ec2.internal>
+Hibernate-CI <ci@hibernate.org> <jenkins@ip-172-30-1-162.ec2.internal>
+Hibernate-CI <ci@hibernate.org> <jenkins@ip-172-30-1-238.ec2.internal>
+Hibernate-CI <ci@hibernate.org> <jenkins@ip-172-30-1-31.ec2.internal>
+Hibernate-CI <ci@hibernate.org> <jenkins@ip-172-30-1-223.ec2.internal>
+Hibernate-CI <ci@hibernate.org> <jenkins@ip-172-30-1-226.ec2.internal>
+Hibernate-CI <ci@hibernate.org> <jenkins@ip-172-30-1-66.ec2.internal>
+Hibernate-CI <ci@hibernate.org> <jenkins@ip-172-30-1-117.ec2.internal>
+Hibernate-CI <ci@hibernate.org> <jenkins@ip-172-30-1-145.ec2.internal>
+Hibernate-CI <ci@hibernate.org> <jenkins@ip-172-30-1-79.ec2.internal>
+Hibernate-CI <ci@hibernate.org> <jenkins@ip-172-30-1-244.ec2.internal>
+Hibernate-CI <ci@hibernate.org> <jenkins@ip-172-30-1-126.ec2.internal>
+Hibernate-CI <ci@hibernate.org> <jenkins@ip-172-30-1-27.ec2.internal>
+Hibernate-CI <ci@hibernate.org> <jenkins@ip-172-30-1-159.ec2.internal>
+Hibernate-CI <ci@hibernate.org> <jenkins@ip-172-30-1-169.ec2.internal>
+Hibernate-CI <ci@hibernate.org> <jenkins@ip-172-30-1-106.ec2.internal>
+Mincong HUANG <mincong.h@gmail.com>
+rnveach <ricky@ricky-VirtualBox>
+Sanne Grinovero <sanne.grinovero@gmail.com>
+Sanne Grinovero <sanne@hibernate.org>
+Waldemar Kłaczyński <waldek@azzumi.pl>
+Yoann Rodière <yoann@hibernate.org> <yrodiere@redhat.com>


### PR DESCRIPTION
So that:

1. `git log` and similar commands stop displaying "Jenkins user <some random email>" for release commits from back when Jenkins was incorrectly configured, and just display "Hibernate-CI <ci@hibernate.org>" instead.
2. `git shortlog` correctly groups together commits of people who committed with multiple names (e.g. Sanne Grinovero vs. Sanne.Grinovero).

See https://git-scm.com/docs/gitmailmap