### PR TITLE
HSEARCH-4149 Follow-up: Remove duplicate sentence in documentation

### DIFF
--- a/documentation/src/main/asciidoc/reference/search-dsl-sort.asciidoc
+++ b/documentation/src/main/asciidoc/reference/search-dsl-sort.asciidoc
@@ -380,7 +380,6 @@ The behavior for missing values can be controlled explicitly through the `.missi
 it puts documents with no value in the first position when using ascending order or in the last position when using descending order.
 * `.missing().highest()` interprets missing values as the highest value:
 it puts documents with no value in the last position when using ascending order or in the first position when using descending order.
-The documents with no value will go first if descending order is used.
 * `.missing().use(...)` uses the given value as a default for documents with no value.
 
 [NOTE]


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4149

This was probably caused by some mixup while addressing review comments.