### PR TITLE
HSEARCH-1182 Add `excludePaths` to IndexedEmbedded

### DIFF
--- a/documentation/src/main/asciidoc/reference/mapping-indexedembedded.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapping-indexedembedded.asciidoc
@@ -257,7 +257,7 @@ which Hibernate Search will detect and reject with an exception.
 
 To address these problems, it is possible to filter the fields to embed,
 to only include those that are actually useful.
-Two filtering attributes are available on `@IndexedEmbedded` and may be combined:
+Available filtering attributes on `@IndexedEmbedded` are:
 
 `includePaths`::
 The paths of index fields from the indexed-embedded element that should be embedded.
@@ -267,24 +267,39 @@ i.e. they must not include its <<mapping-indexedembedded-name,name>>
 or <<mapping-indexedembedded-prefix,prefix>>.
 +
 This takes precedence over `includeDepth` (see below).
++
+Cannot be used in combination with `excludePaths` in the same `@IndexedEmbedded`.
+`excludePaths`::
+The paths of index fields from the indexed-embedded element that must *not* be embedded.
++
+Provided paths must be relative to the indexed-embedded element,
+i.e. they must not include its <<mapping-indexedembedded-name,name>>
+or <<mapping-indexedembedded-prefix,prefix>>.
++
+This takes precedence over `includeDepth` (see below).
++
+Cannot be used in combination with `includePaths` in the same `@IndexedEmbedded`.
 `includeDepth`::
 The number of levels of indexed-embedded that will have all their fields included by default.
 +
 `includeDepth` is the number of `@IndexedEmbedded` that will be traversed
 and for which all fields of the indexed-embedded element will be included,
-even if these fields are not included explicitly through `includePaths`:
+even if these fields are not included explicitly through `includePaths`,
+unless these fields are excluded explicitly through `excludePaths`:
 +
  * `includeDepth=0` means that fields of the indexed-embedded element are *not* included,
 nor is any field of nested indexed-embedded elements,
 unless these fields are included explicitly through `includePaths`.
  * `includeDepth=1` means that fields of the indexed-embedded element *are* included,
+unless these fields are excluded explicitly through `excludePaths`,
 but *not* fields of nested indexed-embedded elements,
 unless these fields are included explicitly through `includePaths`.
  * And so on.
 +
 The default value depends on the value of the `includePaths` attribute:
-if `includePaths` is empty, the default is `Integer.MAX_VALUE` (include all fields at every level)
-if `includePaths` is *not* empty, the default is `0`
++
+* if `includePaths` is empty, the default is `Integer.MAX_VALUE` (include all fields at every level)
+* if `includePaths` is *not* empty, the default is `0`
 (only include fields included explicitly).
 
 [NOTE]
@@ -298,8 +313,16 @@ constraints only need to match the nearest static parent of a dynamic field
 in order for that field to be included.
 ====
 
-Below are two examples: one leveraging `includePaths` only,
-and one leveraging `includePaths` and `includeDepth`.
+[NOTE]
+.Mixing `includePaths` and `excludePaths` at different nesting levels
+====
+In general, it is possible to use `includePaths` and `excludePaths` at different levels of nested `@IndexedEmbedded`.
+When doing so, keep in mind that the filter at each level can only reference reachable paths,
+i.e. a filter cannot reference a path that was excluded by a nested `@IndexedEmbedded` (implicitly or explicitly).
+====
+
+Below are three examples: one leveraging `includePaths` only,
+one leveraging `excludePaths`, and one leveraging `includePaths` and `includeDepth`
 
 [[indexedembedded-includePath]]
 .Filtering indexed-embedded fields with `includePaths`
@@ -322,6 +345,29 @@ and *not* explicitly included either because `includePaths` on `parents` does no
 [source, JAVA, indent=0, subs="+callouts"]
 ----
 include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexedembedded/includepaths/Human.java[tags=include;!getters-setters]
+----
+====
+
+[[indexedembedded-excludePath]]
+.Filtering indexed-embedded fields with `excludePaths`
+====
+This mapping will result in the same schema as in the <<indexedembedded-includePath>> example, but through using the `excludePaths` instead.
+Following fields in the `Human` index will be declared:
+
+* `name`
+* `nickname`
+* `parents.name`: implicitly included because `includeDepth` on `parents` defaults to `Integer.MAX_VALUE`.
+* `parents.nickname`: implicitly included because `includeDepth` on `parents` defaults to `Integer.MAX_VALUE`.
+* `parents.parents.name`: implicitly included because `includeDepth` on `parents` defaults to `Integer.MAX_VALUE`.
+
+The following fields in particular are excluded:
+
+* `parents.parents.nickname`: *not* included because `excludePaths` explicitly excludes `parents.nickname`.
+* `parents.parents.parents`/`parents.parents.parents.<any-field>`: *not* included because `excludePaths` explicitly excludes `parents.parents` stopping any further traversing.
+
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexedembedded/excludepaths/Human.java[tags=include;!getters-setters]
 ----
 ====
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/excludepaths/Human.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/excludepaths/Human.java
@@ -1,0 +1,88 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.mapper.orm.indexedembedded.excludepaths;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+
+// tag::include[]
+@Entity
+@Indexed
+public class Human {
+
+	@Id
+	private Integer id;
+
+	@FullTextField(analyzer = "name")
+	private String name;
+
+	@FullTextField(analyzer = "name")
+	private String nickname;
+
+	@ManyToMany
+	@IndexedEmbedded(excludePaths = { "parents.nickname", "parents.parents" })
+	private List<Human> parents = new ArrayList<>();
+
+	@ManyToMany(mappedBy = "parents")
+	private List<Human> children = new ArrayList<>();
+
+	public Human() {
+	}
+
+	// Getters and setters
+	// ...
+
+	// tag::getters-setters[]
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getNickname() {
+		return nickname;
+	}
+
+	public void setNickname(String nickname) {
+		this.nickname = nickname;
+	}
+
+	public List<Human> getParents() {
+		return parents;
+	}
+
+	public void setParents(List<Human> parents) {
+		this.parents = parents;
+	}
+
+	public List<Human> getChildren() {
+		return children;
+	}
+
+	public void setChildren(List<Human> children) {
+		this.children = children;
+	}
+	// end::getters-setters[]
+}
+// end::include[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/excludepaths/IndexedEmbeddedExcludePathsIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedembedded/excludepaths/IndexedEmbeddedExcludePathsIT.java
@@ -1,0 +1,110 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.mapper.orm.indexedembedded.excludepaths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
+
+import java.util.List;
+import javax.persistence.EntityManagerFactory;
+
+import org.hibernate.search.documentation.testsupport.BackendConfigurations;
+import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.mapping.SearchMapping;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.hibernate.search.util.common.SearchException;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class IndexedEmbeddedExcludePathsIT {
+
+	@Rule
+	public DocumentationSetupHelper setupHelper = DocumentationSetupHelper.withSingleBackend( BackendConfigurations.simple() );
+
+	private EntityManagerFactory entityManagerFactory;
+
+	@Before
+	public void setup() {
+		entityManagerFactory = setupHelper.start().setup( Human.class );
+	}
+
+	@Test
+	public void smoke() {
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
+			Human human1 = new Human();
+			human1.setId( 1 );
+			human1.setName( "George Bush Senior" );
+			human1.setNickname( "The Ancient" );
+
+			Human human2 = new Human();
+			human2.setId( 2 );
+			human2.setName( "George Bush Junior" );
+			human2.setNickname( "The Old" );
+			human1.getChildren().add( human2 );
+			human2.getParents().add( human1 );
+
+			Human human3 = new Human();
+			human3.setId( 3 );
+			human3.setName( "George Bush The Third" );
+			human3.setNickname( "The Young" );
+			human2.getChildren().add( human3 );
+			human3.getParents().add( human2 );
+
+			Human human4 = new Human();
+			human4.setId( 4 );
+			human4.setName( "George Bush The Fourth" );
+			human4.setNickname( "The Babe" );
+			human3.getChildren().add( human4 );
+			human4.getParents().add( human3 );
+
+			entityManager.persist( human1 );
+			entityManager.persist( human2 );
+			entityManager.persist( human3 );
+			entityManager.persist( human4 );
+		} );
+
+		with( entityManagerFactory ).runInTransaction( entityManager -> {
+			SearchSession searchSession = Search.session( entityManager );
+
+			List<Human> result = searchSession.search( Human.class )
+					.where( f -> f.and(
+							f.match().field( "name" ).matching( "fourth" ),
+							f.match().field( "nickname" ).matching( "babe" ),
+							f.match().field( "parents.name" ).matching( "third" ),
+							f.match().field( "parents.nickname" ).matching( "young" ),
+							f.match().field( "parents.parents.name" ).matching( "junior" )
+					) )
+					.fetchHits( 20 );
+			assertThat( result ).hasSize( 1 );
+		} );
+
+		SearchMapping searchMapping = Search.mapping( entityManagerFactory );
+
+		assertThatThrownBy(
+				() -> {
+					searchMapping.scope( Human.class ).predicate()
+							.match().field( "parents.parents.nickname" );
+				}
+		)
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Unknown field" );
+		assertThatThrownBy(
+				() -> {
+					searchMapping.scope( Human.class ).predicate()
+							.match().field( "parents.parents.parents.name" );
+				}
+		)
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Unknown field" );
+
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
@@ -208,7 +208,7 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET + 46, value = "Cyclic @IndexedEmbedded recursion starting from type '%2$s'."
 			+ " Path starting from that type and ending with a cycle: '%1$s'."
 			+ " A type cannot declare an unrestricted @IndexedEmbedded to itself, even indirectly."
-			+ " To break the cycle, you should consider adding filters to your @IndexedEmbedded: includePaths, includeDepth, ...")
+			+ " To break the cycle, you should consider adding filters to your @IndexedEmbedded: includePaths, includeDepth, excludePaths, ...")
 	SearchException indexedEmbeddedCyclicRecursion(String cyclicRecursionPath,
 			@FormatWith(MappableTypeModelFormatter.class) MappableTypeModel parentTypeModel);
 
@@ -548,4 +548,10 @@ public interface Log extends BasicLogger {
 	SearchException invalidTypeForEntityProjection(String name, @FormatWith(ClassFormatter.class) Class<?> entityType,
 			@FormatWith(ClassFormatter.class) Class<?> requestedEntityType);
 
+	@Message(id = ID_OFFSET + 119,
+			value = "'includePaths' and 'excludePaths' cannot be used together in an @IndexedEmbedded. "
+					+ "Use either `includePaths` or `excludePaths` leaving the other one empty. "
+					+ "Included paths are: '%1$s', excluded paths are: '%2$s'.")
+	SearchException cannotIncludeAndExcludePathsWithinSameIndexedEmbedded(Set<String> includePaths,
+			Set<String> excludePaths);
 }

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/impl/ConfiguredIndexSchemaNestingContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/impl/ConfiguredIndexSchemaNestingContext.java
@@ -87,7 +87,7 @@ class ConfiguredIndexSchemaNestingContext implements IndexSchemaNestingContext {
 			int nextDotIndex = prefixToParse.indexOf( '.', afterPreviousDotIndex );
 			while ( nextDotIndex >= 0 ) {
 				// Make sure to mark the paths as encountered in the filter
-				String objectNameRelativeToFilter = prefixToParse.substring( 0, nextDotIndex );
+				String objectNameRelativeToFilter = prefixToParse.substring( unconsumedPrefix.length(), nextDotIndex );
 
 				// we don't want to proceed if a subpath is already excluded:
 				if ( !filter.isPathIncluded( objectNameRelativeToFilter ) ) {

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/spi/IndexedEmbeddedDefinition.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/spi/IndexedEmbeddedDefinition.java
@@ -6,20 +6,26 @@
  */
 package org.hibernate.search.engine.mapper.mapping.building.spi;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 
 import org.hibernate.search.engine.backend.types.ObjectStructure;
+import org.hibernate.search.engine.logging.impl.Log;
 import org.hibernate.search.engine.mapper.model.spi.MappableTypeModel;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 public final class IndexedEmbeddedDefinition {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final MappableTypeModel definingTypeModel;
 	private final String relativePrefix;
 	private final ObjectStructure structure;
 	private final Set<String> includePaths;
+	private final Set<String> excludePaths;
 	private final Integer includeDepth;
 
 	/**
@@ -28,22 +34,37 @@ public final class IndexedEmbeddedDefinition {
 	 * @param structure The structure of all object fields created as part of the {@code relativePrefix}.
 	 * @param includeDepth The maximum depth beyond which all created fields will be ignored. {@code null} for no limit.
 	 * @param includePaths The exhaustive list of paths of fields that are to be included. {@code null} for no limit.
+	 * Cannot be used with nonempty {@code excludePaths}.
+	 * @param excludePaths The list of paths of fields that are to be excluded. {@code null} for no limit.
+	 * Cannot be used with nonempty {@code includePaths}.
 	 */
 	public IndexedEmbeddedDefinition(MappableTypeModel definingTypeModel, String relativePrefix,
 			ObjectStructure structure, Integer includeDepth,
-			Set<String> includePaths) {
+			Set<String> includePaths, Set<String> excludePaths) {
 		this.definingTypeModel = definingTypeModel;
 		this.relativePrefix = relativePrefix;
 		this.structure = structure;
 		this.includePaths = includePaths == null ? Collections.emptySet() : new LinkedHashSet<>( includePaths );
-		if ( includeDepth == null && !this.includePaths.isEmpty() ) {
+		this.excludePaths = excludePaths == null ? Collections.emptySet() : new LinkedHashSet<>( excludePaths );
+		if ( !this.includePaths.isEmpty() && !this.excludePaths.isEmpty() ) {
+			throw log.cannotIncludeAndExcludePathsWithinSameIndexedEmbedded(
+					includePaths,
+					excludePaths
+			);
+		}
+		if ( includeDepth == null && !( this.includePaths.isEmpty() && this.excludePaths.isEmpty() ) ) {
 			/*
-			 * If no max depth was provided and included paths were provided,
+			 * If no max depth was provided and
+			 * a)  included paths were provided,
 			 * the remaining composition depth is implicitly set to 0,
 			 * meaning no composition is allowed and paths are excluded unless
 			 * explicitly listed in "includePaths".
+			 * b)  excluded paths were provided,
+			 * the remaining composition depth is implicitly set to Integer.MAX_VALUE,
+			 * meaning no composition is allowed and paths are included unless
+			 * explicitly listed in "excludePaths".
 			 */
-			this.includeDepth = 0;
+			this.includeDepth = this.includePaths.isEmpty() ? Integer.MAX_VALUE : 0;
 		}
 		else {
 			this.includeDepth = includeDepth;
@@ -62,12 +83,13 @@ public final class IndexedEmbeddedDefinition {
 		return definingTypeModel.equals( that.definingTypeModel ) &&
 				relativePrefix.equals( that.relativePrefix ) &&
 				Objects.equals( includeDepth, that.includeDepth ) &&
-				includePaths.equals( that.includePaths );
+				includePaths.equals( that.includePaths ) &&
+				excludePaths.equals( that.excludePaths );
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash( definingTypeModel, relativePrefix, includeDepth, includePaths );
+		return Objects.hash( definingTypeModel, relativePrefix, includeDepth, includePaths, excludePaths );
 	}
 
 	public MappableTypeModel definingTypeModel() {
@@ -84,6 +106,10 @@ public final class IndexedEmbeddedDefinition {
 
 	public Set<String> includePaths() {
 		return includePaths;
+	}
+
+	public Set<String> excludePaths() {
+		return excludePaths;
 	}
 
 	public Integer includeDepth() {

--- a/engine/src/test/java/org/hibernate/search/engine/mapper/mapping/building/impl/ConfiguredIndexSchemaManagerNestingContextTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/mapper/mapping/building/impl/ConfiguredIndexSchemaManagerNestingContextTest.java
@@ -8,6 +8,7 @@ package org.hibernate.search.engine.mapper.mapping.building.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hibernate.search.util.common.impl.CollectionHelper.asSet;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
@@ -30,7 +31,6 @@ import org.hibernate.search.engine.mapper.mapping.building.spi.IndexedEmbeddedDe
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexedEmbeddedPathTracker;
 import org.hibernate.search.engine.mapper.model.spi.MappableTypeModel;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.common.impl.CollectionHelper;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
@@ -99,7 +99,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"level1", rootContext, typeModel1Mock, "level1.prefix1_",
-				null, null
+				null, null, null
 		);
 		checkFooBarIncluded( "prefix1_", level1Context );
 
@@ -113,7 +113,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"prefix1_level2", level1Context, typeModel2Mock, "level2.prefix2_",
-				null, null
+				null, null, null
 		);
 		checkFooBarIncluded( "prefix2_", level2Context );
 	}
@@ -124,14 +124,14 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"level1", rootContext, typeModel1Mock, "level1.prefix1_",
-				null, null
+				null, null, null
 		);
 		checkFooBarIncluded( "prefix1_", level1Context );
 
 		assertThatThrownBy( () -> {
 				IndexedEmbeddedDefinition level1Definition = new IndexedEmbeddedDefinition(
 						typeModel1Mock, "level1.prefix1_", ObjectStructure.DEFAULT,
-						null, null
+						null, null, null
 				);
 				level1Context.addIndexedEmbeddedIfIncluded(
 						level1Definition, new IndexedEmbeddedPathTracker( level1Definition ),
@@ -151,18 +151,18 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"level1", rootContext, typeModel1Mock, "level1.prefix1_",
-				null, null
+				null, null, null
 		);
 
 		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"prefix1_level2", level1Context, typeModel1Mock, "level2.prefix2_",
-				null, null
+				null, null, null
 		);
 
 		assertThatThrownBy( () -> {
 			IndexedEmbeddedDefinition level2Definition = new IndexedEmbeddedDefinition(
 					typeModel1Mock, "level1.prefix1_", ObjectStructure.DEFAULT,
-					null, null
+					null, null, null
 			);
 			level2Context.addIndexedEmbeddedIfIncluded(
 					level2Definition, new IndexedEmbeddedPathTracker( level2Definition ),
@@ -191,7 +191,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 				.thenReturn( expectedReturn );
 		IndexedEmbeddedDefinition definition = new IndexedEmbeddedDefinition(
 				typeModel1Mock, "level1.level2.level3.prefix1_", ObjectStructure.DEFAULT,
-				null, null
+				null, null, null
 		);
 		actualReturn = rootContext.addIndexedEmbeddedIfIncluded(
 				definition, new IndexedEmbeddedPathTracker( definition ),
@@ -224,7 +224,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"level1", rootContext, typeModel1Mock, "level1.",
-				null, includePaths
+				null, includePaths, null
 		);
 		checkFooBarExcluded( "", level1Context );
 		checkFooBarIndexedEmbeddedExcluded( level1Context, typeModel2Mock );
@@ -251,7 +251,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, typeModel2Mock, "level2.",
-				null, null
+				null, null, null
 		);
 		checkFooBarExcluded( "", level2Context );
 		checkFooBarIndexedEmbeddedExcluded( level2Context, typeModel3Mock );
@@ -266,7 +266,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, typeModel2Mock, "level2.prefix2_",
-				null, null
+				null, null, null
 		);
 		checkFooBarExcluded( "prefix2_", level2Context );
 		checkFooBarIndexedEmbeddedExcluded( level2Context, typeModel3Mock );
@@ -284,7 +284,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, typeModel2Mock, "level2.",
-				null, includePaths
+				null, includePaths, null
 		);
 		checkFooBarExcluded( "", level2Context );
 		checkFooBarIndexedEmbeddedExcluded( level2Context, typeModel3Mock );
@@ -312,7 +312,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		includePaths.add( "level2IndexedEmbedded.notEncountered" );
 		includePaths.add( "level2IndexedEmbedded.excludedBecauseOfLevel2" );
 		IndexedEmbeddedDefinition level1Definition = new IndexedEmbeddedDefinition(
-				typeModel1Mock, "level1.", ObjectStructure.DEFAULT, null, includePaths
+				typeModel1Mock, "level1.", ObjectStructure.DEFAULT, null, includePaths, null
 		);
 		IndexedEmbeddedPathTracker level1PathTracker = new IndexedEmbeddedPathTracker( level1Definition );
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
@@ -322,6 +322,8 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		// Initially no path was encountered so all includePaths are useless
 		assertThat( level1PathTracker.encounteredFieldPaths() )
 				.isEmpty();
+		// We have no exclude paths so it should be empty all the time:
+		assertThat( level1PathTracker.uselessExcludePaths() ).isEmpty();
 		assertThat( level1PathTracker.uselessIncludePaths() )
 				.containsOnly(
 						"included",
@@ -342,6 +344,8 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 						"included", // Added
 						"excludedBecauseOfLevel1" // Added
 				);
+		// We have no exclude paths so it should be empty all the time:
+		assertThat( level1PathTracker.uselessExcludePaths() ).isEmpty();
 		assertThat( level1PathTracker.uselessIncludePaths() )
 				.containsOnly(
 						// "included" removed
@@ -363,6 +367,8 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 						"excludedBecauseOfLevel1",
 						"level2NonIndexedEmbedded" // Added
 				);
+		// We have no exclude paths so it should be empty all the time:
+		assertThat( level1PathTracker.uselessExcludePaths() ).isEmpty();
 		assertThat( level1PathTracker.uselessIncludePaths() )
 				.containsOnly(
 						"notEncountered",
@@ -385,6 +391,8 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 						"level2NonIndexedEmbedded.included", // Added
 						"level2NonIndexedEmbedded.excludedBecauseOfLevel1" // Added
 				);
+		// We have no exclude paths so it should be empty all the time:
+		assertThat( level1PathTracker.uselessExcludePaths() ).isEmpty();
 		assertThat( level1PathTracker.uselessIncludePaths() )
 				.containsOnly(
 						"notEncountered",
@@ -402,7 +410,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		includePaths.add( "excludedBecauseOfLevel1" );
 		IndexedEmbeddedDefinition level2Definition = new IndexedEmbeddedDefinition(
 				typeModel2Mock, "level2IndexedEmbedded.", ObjectStructure.DEFAULT,
-				null, includePaths
+				null, includePaths, null
 		);
 		IndexedEmbeddedPathTracker level2PathTracker = new IndexedEmbeddedPathTracker( level2Definition );
 		ConfiguredIndexSchemaNestingContext level2IndexedEmbeddedContext = checkSimpleIndexedEmbeddedIncluded(
@@ -426,6 +434,8 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 						"notEncountered",
 						"excludedBecauseOfLevel1"
 				);
+		// We have no exclude paths so it should be empty all the time:
+		assertThat( level1PathTracker.uselessExcludePaths() ).isEmpty();
 		assertThat( level1PathTracker.uselessIncludePaths() )
 				.containsOnly(
 						// No change expected
@@ -461,6 +471,8 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 						"notEncountered"
 						// "excludedBecauseOfLevel1" removed
 				);
+		// We have no exclude paths so it should be empty all the time:
+		assertThat( level1PathTracker.uselessExcludePaths() ).isEmpty();
 		assertThat( level1PathTracker.uselessIncludePaths() )
 				.containsOnly(
 						"notEncountered",
@@ -487,14 +499,16 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 						"level2NonIndexedEmbedded.excludedBecauseOfLevel1",
 						"level2IndexedEmbedded",
 						"level2IndexedEmbedded.included",
-						"level2IndexedEmbedded.excludedBecauseOfLevel1",
-						"level2IndexedEmbedded.excludedBecauseOfLevel2" // Added
+						"level2IndexedEmbedded.excludedBecauseOfLevel1"
+						//"level2IndexedEmbedded.excludedBecauseOfLevel2" // should not be added since it is excluded at lvl2, hence it wasn't encountered at lvl1.
 				);
 		assertThat( level2PathTracker.uselessIncludePaths() )
 				.containsOnly(
 						// No change expected
 						"notEncountered"
 				);
+		// We have no exclude paths so it should be empty all the time:
+		assertThat( level1PathTracker.uselessExcludePaths() ).isEmpty();
 		assertThat( level1PathTracker.uselessIncludePaths() )
 				.containsOnly(
 						"notEncountered",
@@ -505,6 +519,394 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 				);
 	}
 
+	/*
+	 * Test is using the following pseudo model ( all IndexedEmbedded has "notEncountered" excludes ):
+	 *
+	 * public static class Indexed {
+	 * 		String exclude;
+	 * 		String include;
+	 * 		@IndexedEmbedded( exclude Level1( exclude, level2.exclude, level2.level3.exclude ))
+	 * 		Level1 level1;
+	 * 		Level1 level1NotIndexed;
+	 * 	}
+	 *
+	 * 	public static class Level1 {
+	 * 		String exclude;
+	 * 		String include;
+	 * 		@IndexedEmbedded( exclude Level2(String exclude) )
+	 * 		Level2 level2;
+	 * 	}
+	 *
+	 * 	public static class Level2 {
+	 * 		String exclude;
+	 * 		String include;
+	 * 		String excludedInLevel1Embedded;
+	 * 		@IndexedEmbedded
+	 * 		Level3 level3;
+	 * 		Level3 level3NotAnnotated;
+	 * 	}
+	 *
+	 * 	public static class Level3 {
+	 * 		String exclude;
+	 * 		String include;
+	 * 	}
+	 */
+
+	@Test
+	public void indexedEmbedded_excludePaths_tracking() {
+		ConfiguredIndexSchemaNestingContext rootContext = ConfiguredIndexSchemaNestingContext.root();
+
+		Set<String> excludePaths = new HashSet<>();
+		excludePaths.add( "exclude" );
+		excludePaths.add( "notEncountered" );
+		excludePaths.add( "level2.exclude" );
+		excludePaths.add( "level2.notEncountered" );
+		excludePaths.add( "level2.level3.exclude" );
+		excludePaths.add( "level2.level3.notEncountered" );
+
+		IndexedEmbeddedDefinition level1Definition = new IndexedEmbeddedDefinition(
+				typeModel1Mock, "level1.", ObjectStructure.DEFAULT, null, null, excludePaths
+		);
+		IndexedEmbeddedPathTracker level1PathTracker = new IndexedEmbeddedPathTracker( level1Definition );
+		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
+				"level1", rootContext,
+				level1Definition, level1PathTracker
+		);
+		// Initially no path was encountered so all excludePaths are useless and there's no include paths so no useless included paths as a result
+		assertThat( level1PathTracker.encounteredFieldPaths() ).isEmpty();
+		assertThat( level1PathTracker.uselessIncludePaths() ).isEmpty();
+		assertThat( level1PathTracker.uselessExcludePaths() ).containsOnlyOnceElementsOf( excludePaths );
+
+
+		// Encounter "excluded" and "included"
+		checkLeafExcluded( "exclude", level1Context, "exclude" );
+		checkLeafIncluded( "include", level1Context, "include" );
+		assertThat( level1PathTracker.encounteredFieldPaths() )
+				.containsOnly(
+						"exclude", // Added
+						"include" // Added
+				);
+		// We have no include paths so it should be empty all the time:
+		assertThat( level1PathTracker.uselessIncludePaths() ).isEmpty();
+		assertThat( level1PathTracker.uselessExcludePaths() )
+				.containsOnly(
+						// "exclude", // removed
+						"notEncountered",
+						"level2.exclude",
+						"level2.notEncountered",
+						"level2.level3.exclude",
+						"level2.level3.notEncountered"
+				);
+
+		IndexedEmbeddedDefinition level2Definition = new IndexedEmbeddedDefinition(
+				typeModel2Mock, "level2.", ObjectStructure.DEFAULT,
+				null, null, asSet( "excludedInLevel1Embedded", "notEncountered" )
+		);
+		IndexedEmbeddedPathTracker level2PathTracker = new IndexedEmbeddedPathTracker( level2Definition );
+		ConfiguredIndexSchemaNestingContext level2IndexedEmbeddedContext = checkSimpleIndexedEmbeddedIncluded(
+				"level2", level1Context,
+				level2Definition, level2PathTracker
+		);
+		assertThat( level2PathTracker.encounteredFieldPaths() ).isEmpty();
+		assertThat( level1PathTracker.encounteredFieldPaths() )
+				.containsOnly(
+						"exclude",
+						"include",
+						"level2" // Added
+				);
+		assertThat( level2PathTracker.uselessIncludePaths() ).isEmpty();
+		assertThat( level2PathTracker.uselessExcludePaths() )
+				.containsOnly(
+						"notEncountered",
+						"excludedInLevel1Embedded"
+				);
+
+		// go through level2 properties:
+		checkLeafIncluded( "include", level2IndexedEmbeddedContext, "include" );
+		checkLeafExcluded( "exclude", level2IndexedEmbeddedContext, "exclude" );
+		checkLeafExcluded( "excludedInLevel1Embedded", level2IndexedEmbeddedContext, "excludedInLevel1Embedded" );
+
+		assertThat( level2PathTracker.encounteredFieldPaths() )
+				.containsOnly(
+						"include", // Added
+						"exclude", // Added
+						"excludedInLevel1Embedded" // Added
+				);
+		assertThat( level1PathTracker.encounteredFieldPaths() )
+				.containsOnly(
+						"exclude",
+						"include",
+						"level2",
+						"level2.include", // Added
+						"level2.exclude" // Added
+						// "level2.excludedInLevel1Embedded" // Should not be added since it was excluded at lvl2 tracking.
+				);
+		assertThat( level2PathTracker.uselessIncludePaths() ).isEmpty();
+		assertThat( level2PathTracker.uselessExcludePaths() )
+				.containsOnly(
+						"notEncountered"
+						// "excludedInLevel1Embedded" // Removed
+				);
+		assertThat( level1PathTracker.uselessIncludePaths() ).isEmpty();
+		assertThat( level1PathTracker.uselessExcludePaths() )
+				.containsOnly(
+						// "exclude", // removed
+						"notEncountered",
+						// "level2.exclude", // removed
+						"level2.notEncountered",
+						"level2.level3.exclude",
+						"level2.level3.notEncountered"
+				);
+
+
+		IndexedEmbeddedDefinition level3Definition = new IndexedEmbeddedDefinition(
+				typeModel3Mock, "level3.", ObjectStructure.DEFAULT,
+				null, null, asSet( "notEncountered" )
+		);
+		IndexedEmbeddedPathTracker level3PathTracker = new IndexedEmbeddedPathTracker( level3Definition );
+		ConfiguredIndexSchemaNestingContext level3IndexedEmbeddedContext = checkSimpleIndexedEmbeddedIncluded(
+				"level3", level2IndexedEmbeddedContext,
+				level3Definition, level3PathTracker
+		);
+		assertThat( level3PathTracker.encounteredFieldPaths() ).isEmpty();
+		assertThat( level2PathTracker.encounteredFieldPaths() ).containsOnly(
+				"include",
+				"exclude",
+				"excludedInLevel1Embedded",
+				"level3" // Added
+		);
+		assertThat( level1PathTracker.encounteredFieldPaths() )
+				.containsOnly(
+						"exclude",
+						"include",
+						"level2",
+						"level2.include",
+						"level2.exclude",
+						"level2.level3"
+				);
+		assertThat( level2PathTracker.uselessIncludePaths() ).isEmpty();
+		assertThat( level2PathTracker.uselessExcludePaths() )
+				.containsOnly(
+						"notEncountered"
+				);
+		assertThat( level1PathTracker.uselessIncludePaths() ).isEmpty();
+		assertThat( level1PathTracker.uselessExcludePaths() )
+				.containsOnly(
+						"notEncountered",
+						"level2.notEncountered",
+						"level2.level3.exclude",
+						"level2.level3.notEncountered"
+				);
+
+		checkLeafIncluded( "include", level3IndexedEmbeddedContext, "include" );
+		checkLeafExcluded( "exclude", level3IndexedEmbeddedContext, "exclude" );
+
+		assertThat( level3PathTracker.encounteredFieldPaths() ).containsOnly(
+				"include", // Added
+				"exclude" // Added
+		);
+		assertThat( level2PathTracker.encounteredFieldPaths() ).containsOnly(
+				"include",
+				"exclude",
+				"excludedInLevel1Embedded",
+				"level3",
+				"level3.include", // Added
+				"level3.exclude" // Added
+		);
+		assertThat( level1PathTracker.encounteredFieldPaths() )
+				.containsOnly(
+						"exclude",
+						"include",
+						"level2",
+						"level2.include",
+						"level2.exclude",
+						"level2.level3",
+						"level2.level3.include", // Added
+						"level2.level3.exclude" // Added
+				);
+		assertThat( level2PathTracker.uselessIncludePaths() ).isEmpty();
+		assertThat( level2PathTracker.uselessExcludePaths() )
+				.containsOnly(
+						"notEncountered"
+				);
+		assertThat( level1PathTracker.uselessIncludePaths() ).isEmpty();
+		assertThat( level1PathTracker.uselessExcludePaths() )
+				.containsOnly(
+						"notEncountered",
+						"level2.notEncountered",
+						// "level2.level3.exclude", // removed
+						"level2.level3.notEncountered"
+				);
+	}
+
+	/*
+	 * Test is using the following pseudo model:
+	 *
+	 * public static class Indexed {
+	 * 		String exclude;
+	 * 		String include;
+	 * 		@IndexedEmbedded( depth = 1 exclude = level2.exclude))
+	 * 		Level1 level1;
+	 * 		Level1 level1NotIndexed;
+	 * 	}
+	 *
+	 * 	public static class Level1 {
+	 * 		String exclude;
+	 * 		String include;
+	 * 		@IndexedEmbedded
+	 * 		Level2 level2;
+	 * 	}
+	 *
+	 * 	public static class Level2 {
+	 * 		String exclude;
+	 * 		String include;
+	 * 		String excludedInLevel1Embedded;
+	 * 		@IndexedEmbedded
+	 * 		Level3 level3;
+	 * 		Level3 level3NotAnnotated;
+	 * 	}
+	 *
+	 * 	public static class Level3 {
+	 * 		String exclude;
+	 * 		String include;
+	 * 	}
+	 */
+
+	@Test
+	public void indexedEmbedded_excludePaths_depth1_exclude_level2() {
+		ConfiguredIndexSchemaNestingContext rootContext = ConfiguredIndexSchemaNestingContext.root();
+
+		Set<String> excludePaths = new HashSet<>();
+		excludePaths.add( "level2.exclude" );
+
+		IndexedEmbeddedDefinition level1Definition = new IndexedEmbeddedDefinition(
+				typeModel1Mock, "level1.", ObjectStructure.DEFAULT, 1, null, excludePaths
+		);
+		IndexedEmbeddedPathTracker level1PathTracker = new IndexedEmbeddedPathTracker( level1Definition );
+		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
+				"level1", rootContext,
+				level1Definition, level1PathTracker
+		);
+		// Initially no path was encountered so all excludePaths are useless and there's no include paths so no useless included paths as a result
+		assertThat( level1PathTracker.encounteredFieldPaths() ).isEmpty();
+		assertThat( level1PathTracker.uselessIncludePaths() ).isEmpty();
+		assertThat( level1PathTracker.uselessExcludePaths() ).containsOnlyOnceElementsOf( excludePaths );
+
+
+		// Encounter "excluded" and "included"
+		checkLeafIncluded( "exclude", level1Context, "exclude" );
+		checkLeafIncluded( "include", level1Context, "include" );
+
+		// We have no include paths so it should be empty all the time:
+		assertThat( level1PathTracker.uselessIncludePaths() ).isEmpty();
+		assertThat( level1PathTracker.uselessExcludePaths() )
+				.containsOnly(
+						"level2.exclude" // so far it is useless
+				);
+
+		IndexedEmbeddedDefinition level2Definition = new IndexedEmbeddedDefinition(
+				typeModel2Mock, "level2.", ObjectStructure.DEFAULT,
+				null, null, null
+		);
+		IndexedEmbeddedPathTracker level2PathTracker = new IndexedEmbeddedPathTracker( level2Definition );
+		checkSimpleIndexedEmbeddedExcluded(
+				level1Context,
+				level2Definition, level2PathTracker
+		);
+
+		assertThat( level1PathTracker.uselessExcludePaths() )
+				.containsOnly(
+						"level2.exclude" // it is still useless
+				);
+
+		assertThat( level2PathTracker.uselessExcludePaths() ).isEmpty();
+	}
+
+	/*
+	 * Test is using the following pseudo model:
+	 *
+	 * public static class Indexed {
+	 * 		String exclude;
+	 * 		String include;
+	 * 		@IndexedEmbedded( exclude = level2.exclude ))
+	 * 		Level1 level1;
+	 * 		Level1 level1NotIndexed;
+	 * 	}
+	 *
+	 * 	public static class Level1 {
+	 * 		String exclude;
+	 * 		String include;
+	 * 		@IndexedEmbedded( exclude = exclude ))
+	 * 		Level2 level2;
+	 * 	}
+	 *
+	 * 	public static class Level2 {
+	 * 		String exclude;
+	 * 		String include;
+	 * 		String excludedInLevel1Embedded;
+	 * 		@IndexedEmbedded
+	 * 		Level3 level3;
+	 * 		Level3 level3NotAnnotated;
+	 * 	}
+	 *
+	 * 	public static class Level3 {
+	 * 		String exclude;
+	 * 		String include;
+	 * 	}
+	 */
+
+	@Test
+	public void indexedEmbedded_excludePaths_same_field_different_levels() {
+		ConfiguredIndexSchemaNestingContext rootContext = ConfiguredIndexSchemaNestingContext.root();
+
+		Set<String> excludePaths = new HashSet<>();
+		excludePaths.add( "level2.exclude" );
+
+		IndexedEmbeddedDefinition level1Definition = new IndexedEmbeddedDefinition(
+				typeModel1Mock, "level1.", ObjectStructure.DEFAULT, null, null, excludePaths
+		);
+		IndexedEmbeddedPathTracker level1PathTracker = new IndexedEmbeddedPathTracker( level1Definition );
+		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
+				"level1", rootContext,
+				level1Definition, level1PathTracker
+		);
+		// Initially no path was encountered so all excludePaths are useless and there's no include paths so no useless included paths as a result
+		assertThat( level1PathTracker.encounteredFieldPaths() ).isEmpty();
+		assertThat( level1PathTracker.uselessIncludePaths() ).isEmpty();
+		assertThat( level1PathTracker.uselessExcludePaths() ).containsOnlyOnceElementsOf( excludePaths );
+
+
+		// Encounter "excluded" and "included"
+		checkLeafIncluded( "exclude", level1Context, "exclude" );
+		checkLeafIncluded( "include", level1Context, "include" );
+
+		// We have no include paths so it should be empty all the time:
+		assertThat( level1PathTracker.uselessIncludePaths() ).isEmpty();
+		assertThat( level1PathTracker.uselessExcludePaths() )
+				.containsOnly(
+						"level2.exclude" // so far it is useless
+				);
+
+		IndexedEmbeddedDefinition level2Definition = new IndexedEmbeddedDefinition(
+				typeModel2Mock, "level2.", ObjectStructure.DEFAULT,
+				null, null, asSet( "exclude" )
+		);
+		IndexedEmbeddedPathTracker level2PathTracker = new IndexedEmbeddedPathTracker( level2Definition );
+		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
+				"level2", level1Context,
+				level2Definition, level2PathTracker
+		);
+
+		checkLeafExcluded( "exclude", level2Context, "exclude" );
+		checkLeafIncluded( "include", level2Context, "include" );
+
+		assertThat( level1PathTracker.uselessExcludePaths() ).containsOnly(
+				"level2.exclude" // added since we have an exclude filter at lvl2 already...
+		);
+
+		assertThat( level2PathTracker.uselessExcludePaths() ).isEmpty();
+	}
+
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-2194")
 	public void indexedEmbedded_noFilterThenIncludePaths() {
@@ -513,13 +915,13 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		// First level of @IndexedEmbedded: no filter
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"professionnelGC", rootContext, typeModel1Mock, "professionnelGC.",
-				null, null
+				null, null, null
 		);
 
 		// Second level of @IndexedEmbedded: includePaths filter
 		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"groupe", level1Context, typeModel1Mock, "groupe.",
-				null, CollectionHelper.asSet( "raisonSociale" )
+				null, asSet( "raisonSociale" ), null
 		);
 
 		checkLeafIncluded( "raisonSociale", level2Context, "raisonSociale" );
@@ -535,7 +937,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		checkSimpleIndexedEmbeddedExcluded(
 				rootContext, typeModel1Mock,
-				"level1.", 0, null
+				"level1.", 0, null, null
 		);
 	}
 
@@ -544,12 +946,13 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		ConfiguredIndexSchemaNestingContext rootContext = ConfiguredIndexSchemaNestingContext.root();
 
 		// Depth == 1 => implicitly include all fields at the first level,
+		// unless a field is explicitly excluded,
 		// but only include nested indexed-embeddeds and their fields if they are explicitly included.
-		// (which they won't, because we don't use includePaths here).
+		// (which they won't, because we don't use includePaths/excludePaths here).
 
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"level1", rootContext, typeModel1Mock,
-				"level1.", 1, null
+				"level1.", 1, null, null
 		);
 		checkFooBarIncluded( "", level1Context );
 		checkFooBarIndexedEmbeddedExcluded( level1Context, typeModel2Mock );
@@ -574,7 +977,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"level1", rootContext, typeModel1Mock,
-				"level1.", 3, null
+				"level1.", 3, null, null
 		);
 		checkFooBarIncluded( "", level1Context );
 
@@ -596,7 +999,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, typeModel2Mock,
-				"level2.", null, null
+				"level2.", null, null, null
 		);
 		checkFooBarIncluded( "", level2Context );
 		level3NonIndexedEmbeddedContext =
@@ -608,7 +1011,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level3Context = checkSimpleIndexedEmbeddedIncluded(
 				"level3", level2Context, typeModel3Mock,
-				"level3.", null, null
+				"level3.", null, null, null
 		);
 		checkFooBarIncluded( "", level3Context );
 		level4NonIndexedEmbeddedContext =
@@ -617,20 +1020,20 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		checkSimpleIndexedEmbeddedExcluded(
 				level3Context, typeModel4Mock,
-				"level4.", null, null
+				"level4.", null, null, null
 		);
 
 		// Check IndexedEmbedded composition with a depth override
 
 		level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, typeModel2Mock,
-				"level2.", 1, null
+				"level2.", 1, null, null
 		);
 		checkFooBarIncluded( "", level2Context );
 
 		checkSimpleIndexedEmbeddedExcluded(
 				level2Context, typeModel3Mock,
-				"level3.", null, null
+				"level3.", null, null, null
 		);
 	}
 
@@ -645,7 +1048,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"level1", rootContext, typeModel1Mock, "level1.",
-				1, includePaths
+				1, includePaths, null
 		);
 		checkFooBarIncluded( "", level1Context );
 		checkFooBarIndexedEmbeddedExcluded( level1Context, typeModel2Mock );
@@ -661,7 +1064,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, typeModel2Mock, "level2.",
-				null, null
+				null, null, null
 		);
 		checkFooBarExcluded( "", level2Context );
 		checkFooBarIndexedEmbeddedExcluded( level2Context, typeModel3Mock );
@@ -676,7 +1079,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, typeModel2Mock, "level2.prefix2_",
-				null, null
+				null, null, null
 		);
 		checkFooBarExcluded( "prefix2_", level2Context );
 		checkFooBarIndexedEmbeddedExcluded( level2Context, typeModel3Mock );
@@ -694,7 +1097,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, typeModel2Mock, "level2.",
-				null, includePaths
+				null, includePaths, null
 		);
 		checkFooBarExcluded( "", level2Context );
 		checkFooBarIndexedEmbeddedExcluded( level2Context, typeModel3Mock );
@@ -719,7 +1122,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		includePaths.add( "level2.level3.included" );
 		includePaths.add( "level2.level3.notEncountered" );
 		IndexedEmbeddedDefinition level1Definition = new IndexedEmbeddedDefinition(
-				typeModel1Mock, "level1.", ObjectStructure.DEFAULT, 1, includePaths
+				typeModel1Mock, "level1.", ObjectStructure.DEFAULT, 1, includePaths, null
 		);
 		IndexedEmbeddedPathTracker level1PathTracker = new IndexedEmbeddedPathTracker( level1Definition );
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
@@ -755,14 +1158,14 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 		// Encounter a nested indexedEmbedded
 		IndexedEmbeddedDefinition level2Definition = new IndexedEmbeddedDefinition(
-				typeModel2Mock, "level2.", ObjectStructure.DEFAULT, null, null
+				typeModel2Mock, "level2.", ObjectStructure.DEFAULT, null, null, null
 		);
 		IndexedEmbeddedPathTracker level2PathTracker = new IndexedEmbeddedPathTracker( level2Definition );
 		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, level2Definition, level2PathTracker
 		);
 		IndexedEmbeddedDefinition level3Definition = new IndexedEmbeddedDefinition(
-				typeModel2Mock, "level3.", ObjectStructure.DEFAULT, null, null
+				typeModel2Mock, "level3.", ObjectStructure.DEFAULT, null, null, null
 		);
 		IndexedEmbeddedPathTracker level3PathTracker = new IndexedEmbeddedPathTracker( level3Definition );
 		ConfiguredIndexSchemaNestingContext level3Context = checkSimpleIndexedEmbeddedIncluded(
@@ -817,7 +1220,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		includePaths.add( "level2.level3" );
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"level1", rootContext, typeModel1Mock, "level1.",
-				null, includePaths
+				null, includePaths, null
 		);
 		checkFooBarExcluded( "", level1Context );
 		checkFooBarIndexedEmbeddedExcluded( level1Context, typeModel2Mock );
@@ -828,7 +1231,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		includePaths.add( "level3-alt.level4" );
 		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, typeModel2Mock, "level2.",
-				null, includePaths
+				null, includePaths, null
 		);
 		checkFooBarExcluded( "", level2Context );
 		checkFooBarIndexedEmbeddedExcluded( level2Context, typeModel3Mock );
@@ -841,7 +1244,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		includePaths.add( "level3-alt.level4" );
 		checkSimpleIndexedEmbeddedExcluded(
 				level1Context, typeModel2Mock, "level2.",
-				null, includePaths
+				null, includePaths, null
 		);
 
 		IndexSchemaNestingContext level3Context =
@@ -858,7 +1261,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		includePaths.add( "level2.level3" );
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"level1", rootContext, typeModel1Mock, "level1.",
-				null, includePaths
+				null, includePaths, null
 		);
 		checkFooBarExcluded( "", level1Context );
 		checkFooBarIndexedEmbeddedExcluded( level1Context, typeModel2Mock );
@@ -868,7 +1271,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		includePaths.add( "level3-alt.level4" );
 		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"level2", level1Context, typeModel2Mock, "level2.",
-				1, includePaths
+				1, includePaths, null
 		);
 		checkFooBarExcluded( "", level2Context );
 		checkFooBarIndexedEmbeddedExcluded( level2Context, typeModel3Mock );
@@ -893,13 +1296,13 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		includePaths.add( "nested.nested.text" );
 		ConfiguredIndexSchemaNestingContext level1Context = checkSimpleIndexedEmbeddedIncluded(
 				"level1", rootContext, typeModel1Mock, "level1.",
-				2, includePaths
+				2, includePaths, null
 		);
 
 		// Same includePaths as above
 		ConfiguredIndexSchemaNestingContext level2Context = checkSimpleIndexedEmbeddedIncluded(
 				"nested", level1Context, typeModel2Mock, "nested.",
-				2, includePaths
+				2, includePaths, null
 		);
 		checkFooBarIncluded( "", level2Context );
 		checkFooBarIndexedEmbeddedExcluded( level2Context, typeModel3Mock );
@@ -910,7 +1313,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		// Same includePaths as above
 		ConfiguredIndexSchemaNestingContext level3Context = checkSimpleIndexedEmbeddedIncluded(
 				"nested", level2Context, typeModel3Mock, "nested.",
-				2, includePaths
+				2, includePaths, null
 		);
 		checkFooBarExcluded( "", level3Context );
 		checkFooBarIndexedEmbeddedExcluded( level3Context, typeModel3Mock );
@@ -921,7 +1324,7 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 		// Same includePaths as above
 		checkSimpleIndexedEmbeddedExcluded(
 				level3Context, typeModel4Mock, "nested.",
-				2, includePaths
+				2, includePaths, null
 		);
 	}
 
@@ -1011,10 +1414,10 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 	private ConfiguredIndexSchemaNestingContext checkSimpleIndexedEmbeddedIncluded(String expectedObjectName,
 			ConfiguredIndexSchemaNestingContext context, MappableTypeModel typeModel,
-			String relativePrefix, Integer depth, Set<String> includePaths) {
+			String relativePrefix, Integer depth, Set<String> includePaths, Set<String> excludePaths) {
 		IndexedEmbeddedDefinition definition = new IndexedEmbeddedDefinition(
 				typeModel, relativePrefix, ObjectStructure.DEFAULT,
-				depth, includePaths
+				depth, includePaths, excludePaths
 		);
 		return checkSimpleIndexedEmbeddedIncluded(
 				expectedObjectName, context, definition, new IndexedEmbeddedPathTracker( definition )
@@ -1044,10 +1447,10 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 	}
 
 	private void checkSimpleIndexedEmbeddedExcluded(ConfiguredIndexSchemaNestingContext context, MappableTypeModel typeModel,
-			String relativePrefix, Integer depth, Set<String> includePaths) {
+			String relativePrefix, Integer depth, Set<String> includePaths, Set<String> excludePaths) {
 		IndexedEmbeddedDefinition definition = new IndexedEmbeddedDefinition(
 				typeModel, relativePrefix, ObjectStructure.DEFAULT,
-				depth, includePaths
+				depth, includePaths, excludePaths
 		);
 		checkSimpleIndexedEmbeddedExcluded(
 				context, definition, new IndexedEmbeddedPathTracker( definition )
@@ -1095,22 +1498,22 @@ public class ConfiguredIndexSchemaManagerNestingContextTest {
 
 	private void checkFooBarIndexedEmbeddedExcluded(ConfiguredIndexSchemaNestingContext context, MappableTypeModel typeModel) {
 		checkSimpleIndexedEmbeddedExcluded(
-				context, typeModel, "foo.", null, null
+				context, typeModel, "foo.", null, null, null
 		);
 		checkSimpleIndexedEmbeddedExcluded(
-				context, typeModel, "prefix1_", null, null
+				context, typeModel, "prefix1_", null, null, null
 		);
 		checkSimpleIndexedEmbeddedExcluded(
-				context, typeModel, "foo.prefix1_", null, null
+				context, typeModel, "foo.prefix1_", null, null, null
 		);
 		checkSimpleIndexedEmbeddedExcluded(
-				context, typeModel, "foo.bar.prefix1_", null, null
+				context, typeModel, "foo.bar.prefix1_", null, null, null
 		);
 		Set<String> includePaths = new HashSet<>();
 		includePaths.add( "foo" );
 		includePaths.add( "bar" );
 		checkSimpleIndexedEmbeddedExcluded(
-				context, typeModel, "foo", 3, includePaths
+				context, typeModel, "foo", 3, includePaths, null
 		);
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementDynamicFieldNameIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementDynamicFieldNameIT.java
@@ -265,7 +265,7 @@ public class DocumentElementDynamicFieldNameIT<F> {
 			IndexedEmbeddedDefinition indexedEmbeddedDefinition = new IndexedEmbeddedDefinition(
 					new StubTypeModel( "embedded" ),
 					"excludingObject.", ObjectStructure.FLATTENED,
-					null, Collections.singleton( "pathThatDoesNotMatchAnything" )
+					null, Collections.singleton( "pathThatDoesNotMatchAnything" ), Collections.emptySet()
 			);
 			// Ignore the result, we'll just reference "excludingObject" by its name
 			ctx.addIndexedEmbeddedIfIncluded( indexedEmbeddedDefinition, true ).get();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementFieldReferenceIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementFieldReferenceIT.java
@@ -253,7 +253,7 @@ public class DocumentElementFieldReferenceIT<F> {
 			IndexedEmbeddedDefinition indexedEmbeddedDefinition = new IndexedEmbeddedDefinition(
 					new StubTypeModel( "embedded" ),
 					"excludingObject.", ObjectStructure.FLATTENED,
-					null, Collections.singleton( "pathThatDoesNotMatchAnything" )
+					null, Collections.singleton( "pathThatDoesNotMatchAnything" ), Collections.emptySet()
 			);
 			IndexedEmbeddedBindingContext excludingEmbeddedContext =
 					ctx.addIndexedEmbeddedIfIncluded( indexedEmbeddedDefinition, true ).get();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementStaticFieldNameIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementStaticFieldNameIT.java
@@ -268,7 +268,7 @@ public class DocumentElementStaticFieldNameIT<F> {
 			IndexedEmbeddedDefinition indexedEmbeddedDefinition = new IndexedEmbeddedDefinition(
 					new StubTypeModel( "embedded" ),
 					"excludingObject.", ObjectStructure.FLATTENED,
-					null, Collections.singleton( "pathThatDoesNotMatchAnything" )
+					null, Collections.singleton( "pathThatDoesNotMatchAnything" ), Collections.emptySet()
 			);
 			IndexedEmbeddedBindingContext excludingEmbeddedContext =
 					ctx.addIndexedEmbeddedIfIncluded( indexedEmbeddedDefinition, true ).get();

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/validation/TestInvalidPaths.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/validation/TestInvalidPaths.java
@@ -56,7 +56,7 @@ public class TestInvalidPaths {
 					.hasMessageContainingAll(
 							"type '" + DeepPathWithLeadingPrefixCase.class.getName() + "'",
 							"Non-matching includePaths filters: [b.c.dne]",
-							"Encountered field paths: [notJustAb, b.c, b.c.indexed]"
+							"Encountered field paths: [b, b.c, b.c.indexed]"
 					);
 		}
 	}

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/validation/TestInvalidPaths.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/validation/TestInvalidPaths.java
@@ -56,7 +56,7 @@ public class TestInvalidPaths {
 					.hasMessageContainingAll(
 							"type '" + DeepPathWithLeadingPrefixCase.class.getName() + "'",
 							"Non-matching includePaths filters: [b.c.dne]",
-							"Encountered field paths: [notJustAb, b.c, b.c.indexed, b.c.notIndexed]"
+							"Encountered field paths: [notJustAb, b.c, b.c.indexed]"
 					);
 		}
 	}

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/validation/TestInvalidPaths.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/path/validation/TestInvalidPaths.java
@@ -56,7 +56,7 @@ public class TestInvalidPaths {
 					.hasMessageContainingAll(
 							"type '" + DeepPathWithLeadingPrefixCase.class.getName() + "'",
 							"Non-matching includePaths filters: [b.c.dne]",
-							"Encountered field paths: [b, b.c, b.c.indexed]"
+							"Encountered field paths: [b, b.c, b.c.indexed, prefixedc.indexed]"
 					);
 		}
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/IdentityMappingCollectorValueNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/IdentityMappingCollectorValueNode.java
@@ -41,7 +41,7 @@ class IdentityMappingCollectorValueNode extends AbstractIdentityMappingCollector
 	@Override
 	public void indexedEmbedded(PojoRawTypeModel<?> definingTypeModel, String relativePrefix,
 			ObjectStructure structure,
-			Integer includeDepth, Set<String> includePaths, boolean includeEmbeddedObjectId,
+			Integer includeDepth, Set<String> includePaths, Set<String> excludePaths, boolean includeEmbeddedObjectId,
 			Class<?> targetType) {
 		// No-op, we're just collecting the identity mapping.
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
@@ -870,4 +870,13 @@ public interface Log extends BasicLogger {
 	SearchException invalidParameterTypeForHighlightProjectionInProjectionConstructor(
 			@FormatWith(ClassFormatter.class) Class<?> rawClass);
 
+	@Message(id = ID_OFFSET + 142,
+			value = "An @IndexedEmbedded defines excludePaths filters that do not match anything."
+					+ " Non-matching excludePaths filters: %1$s."
+					+ " Encountered field paths: %2$s."
+					+ " Check the filters for typos, or remove them if they are not useful."
+	)
+	SearchException uselessExcludePathFilters(Set<String> nonMatchingExcludePaths, Set<String> encounteredFieldPaths,
+			@Param EventContext eventContext);
+
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoMapper.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoMapper.java
@@ -380,6 +380,16 @@ public class PojoMapper<MPBS extends MappingPartialBuildState> implements Mapper
 						EventContexts.fromType( entry.getKey().definingTypeModel() )
 				) );
 			}
+
+			Set<String> uselessExcludePaths = pathTracker.uselessExcludePaths();
+			// this would mean that we have a path in excludes that is unavailable
+			if ( !uselessExcludePaths.isEmpty() ) {
+				Set<String> encounteredFieldPaths = pathTracker.encounteredFieldPaths();
+				failureCollector.add( log.uselessExcludePathFilters(
+						uselessExcludePaths, encounteredFieldPaths,
+						EventContexts.fromType( entry.getKey().definingTypeModel() )
+				) );
+			}
 		}
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/spi/PojoIndexMappingCollectorValueNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/spi/PojoIndexMappingCollectorValueNode.java
@@ -20,6 +20,6 @@ public interface PojoIndexMappingCollectorValueNode extends PojoMappingCollector
 			String relativeFieldName, FieldModelContributor fieldModelContributor);
 
 	void indexedEmbedded(PojoRawTypeModel<?> definingTypeModel, String relativePrefix, ObjectStructure structure,
-			Integer includeDepth, Set<String> includePaths, boolean includeEmbeddedObjectId, Class<?> targetType);
+			Integer includeDepth, Set<String> includePaths, Set<String> excludePaths, boolean includeEmbeddedObjectId, Class<?> targetType);
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/IndexedEmbedded.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/IndexedEmbedded.java
@@ -19,6 +19,7 @@ import org.hibernate.search.mapper.pojo.extractor.mapping.annotation.ContainerEx
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMapping;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessorRef;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.impl.IndexedEmbeddedProcessor;
+import org.hibernate.search.util.common.annotation.Incubating;
 import org.hibernate.search.util.common.annotation.Search5DeprecatedAPI;
 
 /**
@@ -126,8 +127,10 @@ public @interface IndexedEmbedded {
 	 * <p>
 	 * This takes precedence over {@link #includeDepth()}.
 	 * <p>
-	 * By default, if neither {@code includePaths} nor {@link #includeDepth()} is defined,
+	 * By default, if none of {@code includePaths}, {@code excludePaths} or {@link #includeDepth()} are defined,
 	 * all index fields are included.
+	 * <p>
+	 * Cannot be used when {@link #excludePaths()} contains any paths.
 	 *
 	 * @return The paths of index fields to include explicitly.
 	 * Provided paths must be relative to the indexed-embedded element,
@@ -135,25 +138,45 @@ public @interface IndexedEmbedded {
 	 */
 	String[] includePaths() default {};
 
+	@Incubating
+	/**
+	 * The paths of index fields from the indexed-embedded element that should not be embedded.
+	 * <p>
+	 * This takes precedence over {@link #includeDepth()}.
+	 * <p>
+	 * By default, if none of {@code includePaths}, {@code excludePaths} or {@link #includeDepth()} are defined,
+	 * all index fields are included.
+	 * <p>
+	 * Cannot be used when {@link #includePaths()} contains any paths.
+	 *
+	 * @return The paths of index fields to exclude explicitly.
+	 * Provided paths must be relative to the indexed-embedded element,
+	 * i.e. they must not include the {@link #name()}.
+	 */
+	String[] excludePaths() default {};
+
 	/**
 	 * The number of levels of indexed-embedded that will have all their fields included by default.
 	 * <p>
 	 * {@code includeDepth} is the number of `@IndexedEmbedded` that will be traversed
 	 * and for which all fields of the indexed-embedded element will be included,
-	 * even if these fields are not included explicitly through {@code includePaths}:
+	 * even if these fields are not included explicitly through {@code includePaths},
+	 * unless these fields are excluded explicitly through {@code excludePaths}:
 	 * <ul>
 	 * <li>{@code includeDepth=0} means fields of the indexed-embedded element are <strong>not</strong> included,
 	 * nor is any field of nested indexed-embedded elements,
 	 * unless these fields are included explicitly through {@link #includePaths()}.
 	 * <li>{@code includeDepth=1} means fields of the indexed-embedded element <strong>are</strong> included,
+	 * unless these fields are explicitly excluded through {@code excludePaths},
 	 * but <strong>not</strong> fields of nested indexed-embedded elements,
 	 * unless these fields are included explicitly through {@link #includePaths()}.
 	 * <li>And so on.
 	 * </ul>
-	 * The default value depends on the value of the {@link #includePaths()} attribute:
-	 * if {@link #includePaths()} is empty, the default is {@code Integer.MAX_VALUE} (include all fields at every level)
-	 * if {@link #includePaths()} is <strong>not</strong> empty, the default is {@code 0}
-	 * (only include fields included explicitly).
+	 * The default value depends on the value of {@link #includePaths()}/{@link #excludePaths()} attributes:
+	 * <ul>
+	 * <li>if {@link #includePaths()} is empty, the default is {@code Integer.MAX_VALUE} (include all fields at every level)</li>
+	 * <li>if {@link #includePaths()} is <strong>not</strong> empty, the default is {@code 0} (only include fields included explicitly).</li>
+	 * </ul>
 	 *
 	 * @return The number of levels of indexed-embedded that will have all their fields included by default.
 	 */

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/IndexedEmbeddedProcessor.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/IndexedEmbeddedProcessor.java
@@ -30,14 +30,7 @@ public class IndexedEmbeddedProcessor implements PropertyMappingAnnotationProces
 		Integer cleanedUpIncludeDepth = context.toNullIfDefault( annotation.includeDepth(), -1 );
 
 		String[] includePathsArray = annotation.includePaths();
-		Set<String> cleanedUpIncludePaths;
-		if ( includePathsArray.length > 0 ) {
-			cleanedUpIncludePaths = new HashSet<>();
-			Collections.addAll( cleanedUpIncludePaths, includePathsArray );
-		}
-		else {
-			cleanedUpIncludePaths = Collections.emptySet();
-		}
+		String[] excludePathsArray = annotation.excludePaths();
 
 		ContainerExtractorPath extractorPath = context.toContainerExtractorPath( annotation.extraction() );
 
@@ -50,8 +43,21 @@ public class IndexedEmbeddedProcessor implements PropertyMappingAnnotationProces
 				.prefix( cleanedUpPrefix )
 				.structure( structure )
 				.includeDepth( cleanedUpIncludeDepth )
-				.includePaths( cleanedUpIncludePaths )
+				.includePaths( cleanUpPaths( includePathsArray ) )
+				.excludePaths( cleanUpPaths( excludePathsArray ) )
 				.includeEmbeddedObjectId( annotation.includeEmbeddedObjectId() )
 				.targetType( cleanedUpTargetType );
+	}
+
+	private Set<String> cleanUpPaths(String[] pathsArray) {
+		Set<String> paths;
+		if ( pathsArray.length > 0 ) {
+			paths = new HashSet<>();
+			Collections.addAll( paths, pathsArray );
+		}
+		else {
+			paths = Collections.emptySet();
+		}
+		return paths;
 	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/PropertyMappingIndexedEmbeddedStep.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/PropertyMappingIndexedEmbeddedStep.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.mapper.pojo.extractor.mapping.programmatic.ContainerExtractorPath;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.util.common.annotation.Incubating;
 import org.hibernate.search.util.common.annotation.Search5DeprecatedAPI;
 
 /**
@@ -52,6 +53,26 @@ public interface PropertyMappingIndexedEmbeddedStep extends PropertyMappingStep 
 	 * @see IndexedEmbedded#includePaths()
 	 */
 	PropertyMappingIndexedEmbeddedStep includePaths(Collection<String> paths);
+
+	/**
+	 * @param paths The paths of index fields to exclude.
+	 * @return {@code this}, for method chaining.
+	 *
+	 * @see IndexedEmbedded#excludePaths()
+	 */
+	@Incubating
+	default PropertyMappingIndexedEmbeddedStep excludePaths(String... paths) {
+		return excludePaths( Arrays.asList( paths ) );
+	}
+
+	/**
+	 * @param paths The paths of index fields to exclude.
+	 * @return {@code this}, for method chaining.
+	 *
+	 * @see IndexedEmbedded#excludePaths()
+	 */
+	@Incubating
+	PropertyMappingIndexedEmbeddedStep excludePaths(Collection<String> paths);
 
 	/**
 	 * @param include Whether the identifier of embedded objects should be included as an index field.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyMappingIndexedEmbeddedStepImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyMappingIndexedEmbeddedStepImpl.java
@@ -39,6 +39,7 @@ class PropertyMappingIndexedEmbeddedStepImpl extends DelegatingPropertyMappingSt
 
 	private Integer includeDepth;
 	private final Set<String> includePaths = new HashSet<>();
+	private final Set<String> excludePaths = new HashSet<>();
 	private boolean includeEmbeddedObjectId = false;
 
 	private Class<?> targetType;
@@ -65,8 +66,8 @@ class PropertyMappingIndexedEmbeddedStepImpl extends DelegatingPropertyMappingSt
 			actualPrefix = prefix;
 		}
 		collector.value( extractorPath ).indexedEmbedded(
-				definingTypeModel, actualPrefix, structure, includeDepth, includePaths, includeEmbeddedObjectId,
-				targetType
+				definingTypeModel, actualPrefix, structure, includeDepth, includePaths, excludePaths,
+				includeEmbeddedObjectId, targetType
 		);
 	}
 
@@ -96,6 +97,12 @@ class PropertyMappingIndexedEmbeddedStepImpl extends DelegatingPropertyMappingSt
 	@Override
 	public PropertyMappingIndexedEmbeddedStep includePaths(Collection<String> paths) {
 		this.includePaths.addAll( paths );
+		return this;
+	}
+
+	@Override
+	public PropertyMappingIndexedEmbeddedStep excludePaths(Collection<String> paths) {
+		this.excludePaths.addAll( paths );
 		return this;
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexingProcessorValueNodeBuilderDelegate.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexingProcessorValueNodeBuilderDelegate.java
@@ -88,7 +88,7 @@ class PojoIndexingProcessorValueNodeBuilderDelegate<P, V> extends AbstractPojoPr
 	@Override
 	public void indexedEmbedded(PojoRawTypeModel<?> definingTypeModel, String relativePrefix,
 			ObjectStructure structure,
-			Integer includeDepth, Set<String> includePaths, boolean includeEmbeddedObjectId,
+			Integer includeDepth, Set<String> includePaths, Set<String> excludePaths, boolean includeEmbeddedObjectId,
 			Class<?> targetType) {
 		String defaultedRelativePrefix = relativePrefix;
 		if ( defaultedRelativePrefix == null ) {
@@ -97,7 +97,7 @@ class PojoIndexingProcessorValueNodeBuilderDelegate<P, V> extends AbstractPojoPr
 
 		IndexedEmbeddedDefinition definition = new IndexedEmbeddedDefinition(
 				definingTypeModel, defaultedRelativePrefix, structure,
-				includeDepth, includePaths
+				includeDepth, includePaths, excludePaths
 		);
 
 		Optional<IndexedEmbeddedBindingContext> nestedBindingContextOptional =


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-1182

Not going into recursion in `isPathIncludedInternal` when `!includedByThis` is messing up the path tracking, so I removed the change and added a note there so someone wouldn't try it in the future 😄 