### PR TITLE
HSEARCH-4616 Rename automatic indexing to something more explicit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,7 +199,7 @@ and transform it to use Jakarta EE instead of Java EE.
 and do the work of converting between user entities and documents to be indexed.
   * `pojo-base`: Contains base classes and APIs that are re-used in other POJO-based mapper.
   * `orm`: A mapper for [Hibernate ORM](http://hibernate.org/orm/) entities.
-  * `orm-coordination-outbox-polling`: An implementation of coordination of automatic indexing between nodes
+  * `orm-coordination-outbox-polling`: An implementation of indexing coordination between nodes
   in the orm mapper (see above) using an outbox, i.e. an event table in the database. 
   * `pojo-standalone`: A mapper for POJOs in standalone mode, i.e. without Hibernate ORM.
     Currently incubating, i.e. backwards-incompatible changes in APIs may happen.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ either through annotations or a programmatic API.
 * [**On-demand mass indexing**](https://docs.jboss.org/hibernate/stable/search/reference/en-US/html_single/#mapper-orm-indexing-massindexer)
 of all entities in the database,
 to initialize the indexes with pre-existing data.
-* [**On-the-fly automatic indexing**](https://docs.jboss.org/hibernate/stable/search/reference/en-US/html_single/#mapper-orm-indexing-automatic)
+* [**On-the-fly listener-triggered indexing**](https://docs.jboss.org/hibernate/stable/search/reference/en-US/html_single/#listener-triggered-indexing)
 of entities modified through a Hibernate ORM session,
 to always keep the indexes up-to-date.
 * [**A Search DSL**](https://docs.jboss.org/hibernate/stable/search/reference/en-US/html_single/#search-dsl)
@@ -89,7 +89,7 @@ MassIndexer indexer = searchSession.massIndexer( Book.class );
 indexer.startAndWait();
 ```
 
-Automatic indexing does not require any change to code based on JPA or Hibernate ORM:
+Listener-triggered indexing does not require any change to code based on JPA or Hibernate ORM:
 
 ```java
 Author author = new Author();

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/cfg/LuceneIndexSettings.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/cfg/LuceneIndexSettings.java
@@ -108,7 +108,7 @@ public final class LuceneIndexSettings {
 	 * </ul>
 	 * <p>
 	 * Note that individual write operations may trigger a forced commit
-	 * (for example with the {@code write-sync} and {@code sync} automatic indexing synchronization strategies in the ORM mapper),
+	 * (for example with the {@code write-sync} and {@code sync} indexing plan synchronization strategies in the ORM mapper),
 	 * in which case you will only benefit from a non-zero commit interval during intensive indexing (mass indexer, ...).
 	 * <p>
 	 * Note that committing is <strong>not</strong> necessary to make changes visible to search queries:
@@ -136,7 +136,7 @@ public final class LuceneIndexSettings {
 	 * </ul>
 	 * <p>
 	 * Note that individual write operations may trigger a forced refresh
-	 * (for example with the {@code read-sync} and {@code sync} automatic indexing synchronization strategies in the ORM mapper),
+	 * (for example with the {@code read-sync} and {@code sync} indexing plan synchronization strategies in the ORM mapper),
 	 * in which case you will only benefit from a non-zero refresh interval during intensive indexing (mass indexer, ...).
 	 * <p>
 	 * Expects a positive Integer value in milliseconds, such as {@code 1000},

--- a/documentation/src/main/asciidoc/migration/index.adoc
+++ b/documentation/src/main/asciidoc/migration/index.adoc
@@ -316,6 +316,9 @@ This affects the following configuration properties:
 Additionally, some configuration properties have been deprecated:
 
 * `hibernate.search.automatic_indexing.synchronization.strategy` is now deprecated in favor of `hibernate.search.indexing.plan.synchronization.strategy`.
+* `hibernate.search.automatic_indexing.enabled` is now deprecated in favor of `hibernate.search.indexing.listeners.enabled`.
+* `hibernate.search.automatic_indexing.enable_dirty_check` is now deprecated with no alternative to replace it.
+A dirty check will always be performed when considering triggering the reindexing.
 
 [[api]]
 == API changes

--- a/documentation/src/main/asciidoc/public/components/_coordination-comparison-note.adoc
+++ b/documentation/src/main/asciidoc/public/components/_coordination-comparison-note.adoc
@@ -9,6 +9,6 @@ and a summary of the differences between each architecture,
 see <<architecture-examples>>.
 
 For a summary of the differences between coordination strategies
-specifically in the context of automatic indexing,
-see <<indexing-automatic-concepts>>.
+specifically in the context of listener-triggered indexing,
+see <<listener-triggered-indexing-concepts>>.
 ====

--- a/documentation/src/main/asciidoc/public/getting-started/orm/index.adoc
+++ b/documentation/src/main/asciidoc/public/getting-started/orm/index.adoc
@@ -209,7 +209,7 @@ Here, the `Author` class defines a single indexed field, `name`.
 Thus adding `@IndexedEmbedded` to the `authors` property of `Book`
 will add a single field named `authors.name` to the `Book` index.
 This field will be populated automatically based on the content of the `authors` property,
-and the books will be re-indexed automatically whenever the `name` property of their author changes.
+and the books will be re-indexed whenever Hibernate Search xref:{reference-documentation-location}#architecture-hsearch-indexing[detects that the `name` property of their author changes].
 See xref:{reference-documentation-location}#mapping-indexedembedded[Mapping associated elements with `@IndexedEmbedded`] for more information.
 <7> Entities that are only `@IndexedEmbedded` in other entities,
 but do not require to be searchable by themselves, do not need to be annotated with `@Indexed`.

--- a/documentation/src/main/asciidoc/public/getting-started/standalone/index.adoc
+++ b/documentation/src/main/asciidoc/public/getting-started/standalone/index.adoc
@@ -210,7 +210,7 @@ Here, the `Author` class defines a single indexed field, `name`.
 Thus adding `@IndexedEmbedded` to the `authors` property of `Book`
 will add a single field named `authors.name` to the `Book` index.
 This field will be populated automatically based on the content of the `authors` property,
-and the books will be re-indexed automatically whenever the `name` property of their author changes.
+and the books will be re-indexed whenever Hibernate Search xref:{reference-documentation-location}#architecture-hsearch-indexing[detects that the `name` property of their author changes].
 See xref:{reference-documentation-location}#mapping-indexedembedded[Mapping associated elements with `@IndexedEmbedded`] for more information.
 <7> Entities that are only `@IndexedEmbedded` in other entities,
 but do not require to be searchable by themselves, do not need to be annotated with `@Indexed`.

--- a/documentation/src/main/asciidoc/public/reference/_architecture.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_architecture.adoc
@@ -27,7 +27,7 @@ The backend is configured partly by the mapper,
 which tells the backend which indexes must exist and what fields they must have,
 and partly through configuration properties.
 
-The mapper and backend work together to provide three main features:
+The mapper and the backend work together to provide three main features:
 
 Mass indexing::
 This is how Hibernate Search rebuilds indexes from zero based on the content of a database.
@@ -39,19 +39,36 @@ The backend puts the document in an internal queue, and will index documents in 
 notifying the mapper when it's done.
 +
 See <<indexing-massindexer>> for details.
-Automatic indexing::
-This is how Hibernate Search keeps indexes in sync with a database with the <<mapper-orm,Hibernate ORM integration>>.
+[[architecture-hsearch-indexing]]Explicit and listener-triggered indexing::
+Both concepts, explicit and listener-triggered indexing, rely on indexing plans (`SearchIndexingPlan`).
+The difference between the two is in who should build these indexing plans or in other words --
+who should inform them of any changes that are expected to be reflected in the index.
++
+A search indexing plan can not only check if the changes applied to an entity require reindexing of that entity,
+but it also can detect if those changes must trigger any operations on other indexes that are dependent on the entity being added to the plan.
++
+Explicit indexing refers to a scenario when indexing operations are manually added to a search indexing plan (`SearchIndexingPlan`) by a user.
+It is available for both <<mapper-orm>> and <<mapper-pojo-standalone>>.
++
+See <<indexing-plan>> for more details on the search indexing plan.
++
+Listener-triggered indexing is a way of detecting entity changes without a user explicitly telling Hibernate Search about them.
+It is possible to do so with the <<mapper-orm,Hibernate ORM integration>> where change entity events are reported to
+Hibernate Search, which can then construct the search indexing plan on its own.
+This allows to keep indexes in sync with a database when the <<mapper-orm,Hibernate ORM integration>> is used and entity changes
+are made through Hibernate ORM means. See <<listener-triggered-indexing-possible-limitations,possible limitations>> of listener-triggered indexing.
 +
 When an entity changes, the mapper detects the change and stores the information in an indexing plan.
-Upon transaction commit, these changes processed (either in the same thread or in a background process,
+Upon transaction commit, these changes are processed (either in the same thread or in a background process,
 depending on the <<coordination,coordination strategy>>),
 and documents are generated, then sent to the backend for indexing.
 The backend puts the documents in an internal queue, and will index documents in batches, in background processes,
 notifying the mapper when it's done.
 +
-See <<indexing-automatic>> for details.
+NOTE: Listener-triggered indexing only makes sense in the context of <<mapper-orm>> and
+there is <<mapper-pojo-standalone-indexing-listener-triggered,no similar option available for the Standalone POJO Mapper>>.
 +
-NOTE: Automatic indexing is <<mapper-pojo-standalone-indexing-automatic,not available for the Standalone POJO Mapper>>.
+See <<listener-triggered-indexing>> for details.
 Searching::
 This is how Hibernate Search provides ways to query an index.
 +
@@ -116,8 +133,8 @@ See <<search-dsl>> for details.
 2+|None
 |<<coordination-outbox-polling-schema,Extra tables>>
 
-.2+|Limitations
-3+|Automatic indexing ignores: <<limitations-changes-in-session,JPQL/SQL queries>>, <<limitations-changes-asymmetric-association-updates,asymmetric association updates>>
+.2+|[[listener-triggered-indexing-possible-limitations]]Limitations
+3+|Listener-triggered indexing ignores: <<limitations-changes-in-session,JPQL/SQL queries>>, <<limitations-changes-asymmetric-association-updates,asymmetric association updates>>
 2+d|Out-of-sync indexes in rare situations: <<limitations-parallel-embedded-update,concurrent `@IndexedEmbedded`>>, <<limitations-backend-indexing-error,backend I/O errors>>
 |No other known limitation
 |===

--- a/documentation/src/main/asciidoc/public/reference/_architecture.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_architecture.adoc
@@ -40,33 +40,28 @@ notifying the mapper when it's done.
 +
 See <<indexing-massindexer>> for details.
 [[architecture-hsearch-indexing]]Explicit and listener-triggered indexing::
-Both concepts, explicit and listener-triggered indexing, rely on indexing plans (`SearchIndexingPlan`).
-The difference between the two is in who should build these indexing plans or in other words --
-who should inform them of any changes that are expected to be reflected in the index.
+Explicit and listener-triggered indexing rely on indexing plans (`SearchIndexingPlan`)
+to index specific entities as a result of limited changes.
 +
-A search indexing plan can not only check if the changes applied to an entity require reindexing of that entity,
-but it also can detect if those changes must trigger any operations on other indexes that are dependent on the entity being added to the plan.
+With <<manual-index-changes,explicit indexing>>,
+the caller explicitly passes information about changes on entities to an <<indexing-plan,indexing plan>>;
+with <<listener-triggered-indexing,listener-triggered indexing>>,
+entity changes are detected transparently by <<mapper-orm,the Hibernate ORM integration>>
+(with <<listener-triggered-indexing-possible-limitations,a few exceptions>>)
+and added to the indexing plan automatically.
 +
-Explicit indexing refers to a scenario when indexing operations are manually added to a search indexing plan (`SearchIndexingPlan`) by a user.
-It is available for both <<mapper-orm>> and <<mapper-pojo-standalone>>.
+NOTE: Listener-triggered indexing only makes sense in the context of <<mapper-orm,the Hibernate ORM integration>>;
+there is <<mapper-pojo-standalone-indexing-listener-triggered,no such feature available for the Standalone POJO Mapper>>.
 +
-See <<indexing-plan>> for more details on the search indexing plan.
+In both cases, the <<indexing-plan,indexing plan>> will deduce from those changes
+whether entities need to be reindexed, be it the changed entity itself
+or <<mapping-indexedembedded,other entities that embed the changed entity in their index>>.
 +
-Listener-triggered indexing is a way of detecting entity changes without a user explicitly telling Hibernate Search about them.
-It is possible to do so with the <<mapper-orm,Hibernate ORM integration>> where change entity events are reported to
-Hibernate Search, which can then construct the search indexing plan on its own.
-This allows to keep indexes in sync with a database when the <<mapper-orm,Hibernate ORM integration>> is used and entity changes
-are made through Hibernate ORM means. See <<listener-triggered-indexing-possible-limitations,possible limitations>> of listener-triggered indexing.
-+
-When an entity changes, the mapper detects the change and stores the information in an indexing plan.
-Upon transaction commit, these changes are processed (either in the same thread or in a background process,
+Upon transaction commit, changes in the indexing plan are processed (either in the same thread or in a background process,
 depending on the <<coordination,coordination strategy>>),
 and documents are generated, then sent to the backend for indexing.
 The backend puts the documents in an internal queue, and will index documents in batches, in background processes,
 notifying the mapper when it's done.
-+
-NOTE: Listener-triggered indexing only makes sense in the context of <<mapper-orm>> and
-there is <<mapper-pojo-standalone-indexing-listener-triggered,no similar option available for the Standalone POJO Mapper>>.
 +
 See <<listener-triggered-indexing>> for details.
 Searching::

--- a/documentation/src/main/asciidoc/public/reference/_backend-elasticsearch.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_backend-elasticsearch.adoc
@@ -474,7 +474,7 @@ The `simple` layout is a bit more complex than it could be, but it follows the b
 
 Using aliases has a significant advantage over directly targeting the index:
 it makes full reindexing on a live application possible without downtime,
-which is useful in particular when <<indexing-automatic,automatic indexing>> is disabled
+which is useful in particular when <<listener-triggered-indexing,listener-triggered indexing>> is disabled
 (<<indexing-automatic-configuration,completely>> or <<mapping-reindexing-reindexonupdate,partially>>)
 and you need to fully reindex periodically (for example on a daily basis).
 

--- a/documentation/src/main/asciidoc/public/reference/_backend-lucene.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_backend-lucene.adoc
@@ -905,16 +905,15 @@ are pushed to the index itself,
 so that a crash or power loss will no longer result in data loss.
 
 Some operations are critical and are always committed before they are considered complete.
-This is the case for changes triggered by <<indexing-automatic,automatic indexing>>
+This is the case for changes triggered by <<listener-triggered-indexing,listener-triggered indexing>>
 (unless <<indexing-plan-synchronization,configured otherwise>>),
 and also for large-scale operations such as a <<indexing-workspace,purge>>.
 When such an operation is encountered, a commit will be performed immediately,
 guaranteeing that the operation is only considered complete after all changes are safely stored on disk.
 
-Other operations, however, are not expected to be committed immediately.
-This is the case for changes contributed by the <<indexing-massindexer,mass indexer>>,
-or by automatic indexing when using the
-<<indexing-plan-synchronization,`async` synchronization strategy>>.
+However, other operations, like changes contributed by the <<indexing-massindexer,mass indexer>>
+or when <<architecture-hsearch-indexing,indexing>> is using the <<indexing-plan-synchronization,`async` synchronization strategy>>,
+are not expected to be committed immediately.
 
 Performance-wise, committing may be an expensive operation,
 which is why Hibernate Search tries not to commit too often.
@@ -942,8 +941,8 @@ The default for this property is `1000`.
 ====
 Setting the commit interval to 0 will force Hibernate Search to commit after every batch of changes,
 which may result in a much lower throughput,
-both for <<indexing-automatic,automatic indexing>>
-and <<indexing-massindexer,mass indexing>>.
+in particular for <<architecture-hsearch-indexing,explicit or listener-triggered indexing>>
+but even more so for <<indexing-massindexer,mass indexing>>.
 ====
 
 [NOTE]
@@ -953,7 +952,7 @@ which may cancel out the potential performance gains from setting a higher commi
 
 By default, the commit interval may only improve throughput
 of the <<indexing-massindexer,mass indexer>>.
-If you want changes triggered by <<indexing-automatic,automatic indexing>>
+If you want changes triggered <<architecture-hsearch-indexing,explicitly or by listeners>>
 to benefit from it too, you will need to select a non-default
 <<indexing-plan-synchronization,synchronization strategy>>,
 so as not to require a commit after each change.
@@ -1100,7 +1099,7 @@ larger values provide better search performance if the index does not change oft
 With smaller values, merging happens more often and thus uses more resources,
 but the total number of segments will be lower on average, increasing read performance.
 Thus, larger values (`> 10`) are best for <<indexing-massindexer,mass indexing>>,
-and smaller values (`< 10`) are best for <<indexing-automatic,automatic indexing>>.
+and smaller values (`< 10`) are best for <<architecture-hsearch-indexing,explicit or listener-triggered indexing>>.
 
 The value must not be lower than `2`.
 

--- a/documentation/src/main/asciidoc/public/reference/_binding-valuebridge.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_binding-valuebridge.adoc
@@ -38,7 +38,7 @@ A single value bridge cannot populate more than one index field.
 A value bridge is expected to be applied to "atomic" data, such as a `LocalDate`;
 if it is applied to an entity, for example, extracting data from its properties,
 Hibernate Search will not be aware of which properties are used
-and will not be able to automatically trigger reindexing when these properties change.
+and will not be able to <<listener-triggered-indexing,detect that reindexing is required>> when these properties change.
 
 Below is an example of a custom value bridge that converts
 a custom `ISBN` type to its string representation to index it:

--- a/documentation/src/main/asciidoc/public/reference/_concepts.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_concepts.adoc
@@ -66,14 +66,14 @@ The goal of _mapping_, in Hibernate search, is to resolve these mismatches
 by defining how to transform one or more entities into a document,
 and how to resolve a search hit back into the original entity.
 This is the main added value of Hibernate Search,
-the basis for everything else from automatic indexing to the various search DSLs.
+the basis for everything else from <<architecture-hsearch-indexing,indexing>> to the various search DSLs.
 
 Mapping is usually configured using annotations in the entity model,
 but this can also be achieved using a programmatic API.
 To learn more about how to configure mapping, see <<mapping>>.
 
 To learn how to index the resulting documents, see <<indexing>>
-(hint: for the <<mapper-orm,Hibernate ORM integration>>, it's automatic).
+(hint: for the <<mapper-orm,Hibernate ORM integration>>, it's <<listener-triggered-indexing,automatic>>).
 
 To learn how to search with an API
 that takes advantage of the mapping to be closer to the entity model,
@@ -201,7 +201,7 @@ but they are a trade-off that improves performance.
 
 Different factors influence when refreshes and commit happen:
 
-* <<indexing-automatic,Automatic indexing>> and <<indexing-plan,indexing plans>> will, by default,
+* <<listener-triggered-indexing,Listener-triggered indexing>> and <<indexing-plan,explicit indexing>> will, by default,
 require that a commit of the index writer is performed after each set of changes,
 meaning the changes are safe after the Hibernate ORM transaction commit returns (for the <<mapper-orm,Hibernate ORM integration>>)
 or the ``SearchSession``'s `close()` method returns (for the <<mapper-pojo-standalone,Standalone POJO Mapper>>).

--- a/documentation/src/main/asciidoc/public/reference/_configuration.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_configuration.adoc
@@ -398,7 +398,7 @@ and <<architecture-hsearch-components-backend,backends>>.
 
 Hibernate Search generally propagates exceptions occurring in background threads to the user thread,
 but in some cases, such as Lucene segment merging failures,
-or <<indexing-plan-synchronization-failures,some failures during automatic indexing>>,
+or <<indexing-plan-synchronization-failures,some indexing plan synchronization failures>>,
 the exception in background threads cannot be propagated.
 By default, when that happens, the failure is logged at the `ERROR` level.
 

--- a/documentation/src/main/asciidoc/public/reference/_coordination.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_coordination.adoc
@@ -44,7 +44,7 @@ See the following subsections for details about available strategies.
 The default strategy is the simplest and does not involve any additional infrastructure
 for communication between application nodes.
 
-All <<indexing-automatic,automatic indexing>> operations
+All <<architecture-hsearch-indexing,explicit or listener-triggered indexing>> operations
 are executed directly in application threads,
 which gives this strategy the unique ability to provide <<indexing-plan-synchronization,synchronous indexing>>,
 at the cost of a few limitations:
@@ -58,7 +58,7 @@ include::../components/_coordination-comparison-note.adoc[]
 === How indexing works without coordination
 
 [[coordination-none-indexing-detected-changes]]
-Changes have to occur in the ORM session in order to be detected for <<indexing-automatic,automatic indexing>>::
+Changes have to occur in the ORM session in order to trigger <<listener-triggered-indexing,indexing listeners>>::
 See <<indexing-automatic-concepts-changes-in-session>> for more details.
 [[coordination-none-indexing-association-consistency]]
 Associations must be updated on both sides::
@@ -154,7 +154,7 @@ include::../components/_incubating-warning.adoc[]
 The `outbox-polling` strategy implements coordination through
 <<coordination-outbox-polling-schema,additional tables>> in the application database.
 
-<<indexing-automatic,Automatic indexing>> is implemented
+<<architecture-hsearch-indexing,Explicit and listener-triggered indexing>> are implemented
 by pushing events to an outbox table within the same transaction as the entity changes,
 and polling this outbox table from background processors which perform indexing.
 
@@ -195,7 +195,7 @@ include::../components/_coordination-comparison-note.adoc[]
 === [[coordination-database-polling-indexing]] How indexing works with `outbox-polling` coordination
 
 [[coordination-outbox-polling-indexing-detected-changes]]
-Changes have to occur in the ORM session in order to be detected for <<indexing-automatic,automatic indexing>>::
+Changes have to occur in the ORM session in order to trigger <<listener-triggered-indexing,indexing listeners>>::
 See <<indexing-automatic-concepts-changes-in-session>> for more details.
 [[coordination-outbox-polling-indexing-association-consistency]]
 Associations must be updated on both sides::

--- a/documentation/src/main/asciidoc/public/reference/_indexing-automatic.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_indexing-automatic.adoc
@@ -62,7 +62,7 @@ or if you update it regularly by reindexing,
 either using the  <<indexing-massindexer,`MassIndexer`>>
 or <<mapper-orm-indexing-manual,manually>>.
 You can disable automatic indexing by setting the configuration property
-`hibernate.search.automatic_indexing.enabled` to `false`.
+`hibernate.search.indexing.listeners.enabled` to `false`.
 
 [[indexing-automatic-concepts-changes-in-session]]
 == [[mapper-orm-indexing-automatic-concepts-changes-in-session]] In-session entity change detection and limitations

--- a/documentation/src/main/asciidoc/public/reference/_indexing-listener-triggered.asciidoc.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_indexing-listener-triggered.asciidoc.adoc
@@ -1,5 +1,5 @@
-[[indexing-automatic]]
-= [[mapper-orm-indexing-automatic]] [[_automatic_indexing]] Automatic indexing within Hibernate ORM
+[[listener-triggered-indexing]]
+= [[indexing-automatic]] [[mapper-orm-indexing-automatic]] [[_automatic_indexing]] Listener-triggered indexing
 
 include::../components/_mapper-orm-only-note.adoc[]
 
@@ -8,18 +8,18 @@ if that entity is <<mapping-entityindexmapping,mapped to an index>>,
 Hibernate Search updates the relevant index.
 
 Exactly how and when the index update happens depends on the <<coordination,coordination strategy>>;
-see <<indexing-automatic-concepts>> for more information.
+see <<listener-triggered-indexing-concepts>> for more information.
 
-[[indexing-automatic-concepts]]
-== [[mapper-orm-indexing-automatic-concepts]] Overview
+[[listener-triggered-indexing-concepts]]
+== [[indexing-automatic-concepts]][[mapper-orm-indexing-automatic-concepts]] Overview
 
-Below is a summary of how automatic indexing works depending
+Below is a summary of how listener-triggered indexing works depending
 on the configured <<coordination,coordination strategy>>.
 
 Follow the links for more details.
 
 [cols="h,2*^",options="header"]
-.Comparison of automatic indexing depending on the coordination strategy
+.Comparison of listener-triggered indexing depending on the coordination strategy
 |===
 |Coordination strategy
 |<<coordination-none,No coordination>> (default)
@@ -57,11 +57,11 @@ Follow the links for more details.
 [[indexing-automatic-configuration]]
 == [[mapper-orm-indexing-automatic-configuration]] Configuration
 
-Automatic indexing may be unnecessary if your index is read-only
+Listener-triggered indexing may be unnecessary if your index is read-only
 or if you update it regularly by reindexing,
 either using the  <<indexing-massindexer,`MassIndexer`>>
 or <<mapper-orm-indexing-manual,manually>>.
-You can disable automatic indexing by setting the configuration property
+You can disable listener-triggered indexing by setting the configuration property
 `hibernate.search.indexing.listeners.enabled` to `false`.
 
 [[indexing-automatic-concepts-changes-in-session]]
@@ -86,7 +86,7 @@ and to skip reindexing when a property is modified, but does not affect the inde
 [[indexing-automatic-synchronization]]
 == Synchronization with the indexes
 
-Automatic indexing is affected by the synchronization strategy in use in the `SearchSession`.
+Listener-triggered indexing is affected by the synchronization strategy in use in the `SearchSession`.
 
 See <<indexing-plan-synchronization,this section>> for more information.
 
@@ -95,7 +95,7 @@ See <<indexing-plan-synchronization,this section>> for more information.
 
 include::../components/_incubating-warning.adoc[]
 
-In some scenarios, it might be helpful to pause the indexing programmatically, for example,
+In some scenarios, it might be helpful to pause the <<architecture-hsearch-indexing,explicit and listener-triggered indexing>> programmatically, for example,
 when importing larger amounts of data. Hibernate Search allows configuring application-wide
 and session-level filters to manage which types are tracked for changes and indexed.
 

--- a/documentation/src/main/asciidoc/public/reference/_indexing-massindexer.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_indexing-massindexer.adoc
@@ -4,13 +4,13 @@
 [[indexing-massindexer-basics]]
 == [[mapper-orm-indexing-massindexer-basics]] Basics
 
-There are cases where automatic indexing is not enough,
+There are cases where <<architecture-hsearch-indexing,listener-triggered or explicit indexing>> is not enough,
 because pre-existing data has to be indexed:
 
 * when restoring a database backup;
 * when indexes had to be wiped,
 for example because the Hibernate Search <<mapping,mapping>> or some core settings changed;
-* when entities cannot be indexed as they change (e.g. with <<indexing-automatic,automatic indexing>>) for performance reasons,
+* when entities cannot be indexed as they change (e.g. with <<listener-triggered-indexing,listener-triggered indexing>>) for performance reasons,
 and periodic reindexing (every night, ...) is preferred.
 
 To address these situations, Hibernate Search provides the `MassIndexer`:
@@ -244,7 +244,7 @@ will attempt to preload everything in memory.
 |[[mapper-orm-indexing-massindexer-parameters-drop-and-create-schema]]Drops the indexes and their schema (if they exist) and re-creates them before indexing.
 
 Indexes will be unavailable for a short time during the dropping and re-creation,
-so this should only be used when failures of concurrent operations on the indexes (automatic indexing, ...)
+so this should only be used when failures of concurrent operations on the indexes (<<listener-triggered-indexing,listener-triggered indexing>>, ...)
 are acceptable.
 
 This should be used when the existing schema is known to be obsolete,

--- a/documentation/src/main/asciidoc/public/reference/_indexing-plan.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_indexing-plan.adoc
@@ -1,8 +1,8 @@
 [[indexing-plan]]
 = [[mapper-orm-indexing-manual-indexingplan-writes]] [[_deleting_instances_from_the_index]] [[_adding_instances_to_the_index]] Explicitly indexing on entity change events
 
-When <<indexing-automatic,automatic indexing>> is <<mapping-annotations,disabled>>
-or simply not supported (e.g. <<mapper-pojo-standalone-indexing-automatic,with the Standalone POJO Mapper>>),
+When <<listener-triggered-indexing,listener-triggered indexing>> is <<mapping-annotations,disabled>>
+or simply not supported (e.g. <<mapper-pojo-standalone-indexing-listener-triggered,with the Standalone POJO Mapper>>),
 the indexes will start empty and stay that way
 until explicit indexing commands are sent to Hibernate Search.
 
@@ -122,7 +122,7 @@ indexing happens in background threads and is always asynchronous.
 When a transaction is committed (<<mapper-orm,Hibernate ORM integration>>)
 or the `SearchSession` is closed (<<mapper-pojo-standalone,Standalone POJO Mapper>>),
 <<coordination-none,with default coordination settings>>,
-the execution of the indexing plan (<<indexing-automatic,automatic>> or otherwise)
+the execution of the indexing plan (<<listener-triggered-indexing,listener-triggered>> or otherwise)
 can block the application thread
 until indexing reaches a certain level of completion.
 
@@ -204,7 +204,7 @@ The built-in strategies can be retrieved by calling:
 * `IndexingPlanSynchronizationStrategy.readSync()`
 * or `IndexingPlanSynchronizationStrategy.sync()`
 
-.Overriding the automatic indexing synchronization strategy
+.Overriding the indexing plan synchronization strategy
 ====
 [source, JAVA, indent=0]
 ----

--- a/documentation/src/main/asciidoc/public/reference/_indexing.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_indexing.adoc
@@ -3,7 +3,7 @@
 
 :leveloffset: +1
 
-include::_indexing-automatic.adoc[]
+include::_indexing-listener-triggered.asciidoc.adoc[]
 
 include::_indexing-plan.adoc[]
 

--- a/documentation/src/main/asciidoc/public/reference/_limitations.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_limitations.adoc
@@ -2,7 +2,8 @@
 = [[elasticsearch-limitations]] Known issues and limitations
 
 [[limitations-parallel-embedded-update]]
-== Without coordination, in rare cases, automatic indexing involving `@IndexedEmbedded` may lead to out-of sync indexes
+== Without coordination, in rare cases, indexing involving `@IndexedEmbedded` may lead to out-of sync indexes
+// TODO: we might what to better explain "indexing" in the title ^ which is talking about architecture-hsearch-indexing
 
 [[limitations-parallel-embedded-update-description]]
 === Description
@@ -58,13 +59,13 @@ so it can only be addressed completely by configuring <<coordination,coordinatio
 There are no other solutions currently on the roadmap.
 
 [[limitations-backend-indexing-error]]
-== Without coordination, backend errors during automatic indexing may lead to out-of sync indexes
+== Without coordination, backend errors during indexing may lead to out-of sync indexes
 
 [[limitations-backend-indexing-error-description]]
 === Description
 
 With the default settings (<<coordination-none,no coordination>>),
-<<indexing-automatic,automatic indexing>>
+<<architecture-hsearch-indexing,indexing>>
 will actually apply index changes in the backend *just after* the transaction commit,
 without any kind of transaction log for the index changes.
 
@@ -101,7 +102,7 @@ but they will never solve the problem completely,
 and they are not currently on the roadmap.
 
 [[limitations-changes-in-session]]
-== Automatic indexing only considers changes applied directly to entity instances in Hibernate ORM sessions
+== Listener-triggered indexing only considers changes applied directly to entity instances in Hibernate ORM sessions
 
 [[limitations-changes-in-session-description]]
 === Description
@@ -131,7 +132,7 @@ This is tracked as https://hibernate.atlassian.net/browse/HSEARCH-3513[HSEARCH-3
 but is long-term goal.
 
 [[limitations-changes-asymmetric-association-updates]]
-== [[mapper-orm-indexing-automatic-concepts-session-consistency]] Automatic indexing ignores asymmetric association updates
+== [[mapper-orm-indexing-automatic-concepts-session-consistency]] Listener-triggered indexing ignores asymmetric association updates
 
 [[limitations-changes-asymmetric-association-updates-description]]
 === Description
@@ -191,12 +192,12 @@ This is tracked as https://hibernate.atlassian.net/browse/HSEARCH-3513[HSEARCH-3
 but is long-term goal.
 
 [[limitations-indexing-plan-serialization]]
-== Automatic indexing is not compatible with `Session` serialization
+== Listener-triggered indexing is not compatible with `Session` serialization
 
 [[limitations-indexing-plan-serialization-description]]
 === Description
 
-When <<indexing-automatic,automatic indexing>> is enabled,
+When <<listener-triggered-indexing,listener-triggered indexing>> is enabled,
 Hibernate Search collects entity change events
 to build an "indexing plan" inside the ORM `EntityManager`/`Session`.
 The indexing plan holds information relative to which entities need to be re-indexed,

--- a/documentation/src/main/asciidoc/public/reference/_mapper-orm-indexing-manual.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_mapper-orm-indexing-manual.adoc
@@ -6,13 +6,13 @@ include::../components/_mapper-orm-only-note.adoc[]
 [[mapper-orm-indexing-manual-basics]]
 == [[search-batchindex]] Basics
 
-While <<indexing-automatic,automatic indexing>> and
+While <<listener-triggered-indexing,listener-triggered indexing>> and
 the <<indexing-massindexer,`MassIndexer`>>
 or <<mapper-orm-indexing-jsr352,the mass indexing job>>
 should take care of most needs,
 it is sometimes necessary to control indexing manually,
 for example to reindex just a few entity instances
-that were affected by changes to the database that automatic indexing cannot detect,
+that were affected by changes to the database that listener-triggered indexing cannot detect,
 such as JPQL/SQL `insert`, `update` or `delete` queries.
 
 To address these use cases, Hibernate Search exposes several APIs
@@ -29,7 +29,7 @@ A fairly common use case when manipulating large datasets with JPA
 is the link:{hibernateDocUrl}#batch-session-batch-insert[periodic "flush-clear" pattern],
 where a loop reads or writes entities for every iteration
 and flushes then clears the session every `n` iterations.
-This patterns allows processing a large number of entities
+This pattern allows processing a large number of entities
 while keeping the memory footprint reasonably low.
 
 Below is an example of this pattern to persist a large number of entities
@@ -89,8 +89,8 @@ include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexing/Hibe
 <2> Begin the transaction at the beginning of each iteration of the outer loop.
 <3> Only handle a limited number of elements per transaction.
 <4> For every iteration of the loop, instantiate a new entity and persist it.
-Note we're relying on automatic indexing to index the entity,
-but this would work just as well if automatic indexing was disabled,
+Note we're relying on listener-triggered indexing to index the entity,
+but this would work just as well if listener-triggered indexing was disabled,
 only requiring an extra call to index the entity.
 See <<indexing-plan>>.
 <5> Commit the transaction at the end of each iteration of the outer loop.
@@ -144,8 +144,8 @@ include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexing/Hibe
 <1> Get the `SearchSession`.
 <2> Get the search session's indexing plan.
 <3> For every iteration of the loop, instantiate a new entity and persist it.
-Note we're relying on automatic indexing to index the entity,
-but this would work just as well if automatic indexing was disabled,
+Note we're relying on listener-triggered indexing to index the entity,
+but this would work just as well if listener-triggered indexing was disabled,
 only requiring an extra call to index the entity.
 See <<indexing-plan>>.
 <4> After a `flush()`/`clear()`, call `indexingPlan.execute()`.

--- a/documentation/src/main/asciidoc/public/reference/_mapper-orm.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_mapper-orm.adoc
@@ -8,7 +8,7 @@ The Hibernate ORM <<architecture-hsearch-components-mapper,"mapper">> is an inte
 
 Its key features include:
 
-* <<indexing-automatic,Automatic indexing>> of Hibernate ORM entities
+* <<listener-triggered-indexing,Listener-triggered indexing>> of Hibernate ORM entities
 as they are modified in the Hibernate ORM `EntityManager`/`Session`.
 * <<search-dsl-query-entity-loading-options,Loading of managed entities>>
 as hits in the result of a <<search-dsl-query,search query>>.

--- a/documentation/src/main/asciidoc/public/reference/_mapper-pojo-standalone.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_mapper-pojo-standalone.adoc
@@ -20,7 +20,7 @@ beyond the fact they are represented as POJOs,
 it can be more complex to use than the <<mapper-orm,Hibernate ORM integration>>.
 In particular:
 
-* This mapper <<mapper-pojo-standalone-indexing-automatic,does not provide automatic indexing>>:
+* This mapper <<mapper-pojo-standalone-indexing-listener-triggered,cannot detect entity changes on its own>>:
 all indexing <<mapper-pojo-standalone-indexing-plan,must be explicit>>.
 * Loading of entities as hits in the result of a <<search-dsl-query,search query>>
 must be <<mapper-pojo-standalone-search-query-loading,implemented on a case-by-case basis>>.
@@ -133,11 +133,11 @@ for its mapping:
 [[mapper-pojo-standalone-indexing]]
 == Indexing
 
-[[mapper-pojo-standalone-indexing-automatic]]
-=== Automatic indexing
+[[mapper-pojo-standalone-indexing-listener-triggered]]
+=== [[mapper-pojo-standalone-indexing-automatic]] Listener-triggered indexing
 
 The Standalone POJO Mapper does not provide "implicit" indexing
-similar to the <<indexing-automatic,automatic indexing>> in the <<mapper-orm,Hibernate ORM integration>>.
+similar to the <<listener-triggered-indexing,listener-triggered indexing>> in the <<mapper-orm,Hibernate ORM integration>>.
 
 Instead, you must index explicitly with an <<mapper-pojo-standalone-indexing-plan,indexing plan>>.
 

--- a/documentation/src/main/asciidoc/public/reference/_mapping-containerextractor.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_mapping-containerextractor.adoc
@@ -51,8 +51,9 @@ However, such complex mappings are unlikely since they are generally not support
 [NOTE]
 ====
 It is possible to implement and use custom container extractors,
-but at the moment these extractors will not be handled correctly for automatic reindexing,
-so the corresponding property must <<mapping-reindexing-reindexonupdate,have automatic reindexing disabled>>.
+but at the moment Hibernate Search will not detect that the changes to the data inside such container
+must trigger the reindexing of a containing element.
+Hence, the corresponding property must <<mapping-reindexing-reindexonupdate,disable reindexing on change>>.
 
 See https://hibernate.atlassian.net/browse/HSEARCH-3688[HSEARCH-3688] for more information.
 ====

--- a/documentation/src/main/asciidoc/public/reference/_mapping-reindexing.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_mapping-reindexing.adoc
@@ -1,5 +1,5 @@
 [[mapping-reindexing]]
-= [[mapper-orm-reindexing]] Tuning automatic reindexing
+= [[mapper-orm-reindexing]] Tuning when to trigger reindexing
 
 [[mapping-reindexing-basics]]
 == [[mapper-orm-reindexing-basics]] Basics
@@ -28,10 +28,9 @@ things get more complicated.
 Let's consider a mapping where a `Book` entity is mapped to a document,
 and that document must include the `name` property of the `Author` entity
 (for example using <<mapping-indexedembedded,`@IndexedEmbedded`>>).
-Hibernate Search will need to track changes to the author's name,
-and whenever that happens,
-it will need to _retrieve all the books of that author_,
-to reindex these books automatically.
+Whenever an author's name changes,
+Hibernate Search will need to _retrieve all the books of that author_,
+to reindex them.
 
 In practice, this means that whenever an entity mapping relies on an association to another entity,
 this association must be bidirectional:
@@ -39,14 +38,14 @@ if `Book.authors` is `@IndexedEmbedded`,
 Hibernate Search must be aware of an inverse association `Author.books`.
 An exception will be thrown on startup if the inverse association cannot be resolved.
 
-Most of the time, Hibernate Search is able to take advantage of Hibernate ORM metadata
+Most of the time, when the <<mapper-orm>> is used, Hibernate Search is able to take advantage of Hibernate ORM metadata
 (the `mappedBy` attribute of `@OneToOne` and `@OneToMany`)
 to resolve the inverse side of an association,
 so this is all handled transparently.
 
 In some rare cases, with the more complex mappings,
 it is possible that even Hibernate ORM is not aware that an association is bidirectional,
-because `mappedBy` cannot be used.
+because `mappedBy` cannot be used, or because the <<mapper-pojo-standalone>> is being used.
 A few solutions exist:
 
 * The association can simply be ignored.
@@ -97,11 +96,11 @@ When a property is not persisted directly,
 but instead is dynamically computed in a getter that uses other properties as input,
 Hibernate Search will be unable to guess which part of the persistent state
 these properties are based on,
-and thus will be unable to trigger automatic reindexing when the relevant persistent state changes.
+and thus will be unable to <<architecture-hsearch-indexing,trigger reindexing>> when the relevant persistent state changes.
 By default, Hibernate Search will detect such cases on bootstrap and throw an exception.
 
 Annotating the property with `@IndexingDependency(derivedFrom = ...)`
-will give Hibernate Search the information it needs and allow automatic reindexing.
+will give Hibernate Search the information it needs and allow <<architecture-hsearch-indexing,triggering reindexing>>.
 
 .Mapping a derived value with `@IndexingDependency.derivedFrom`
 ====
@@ -117,9 +116,9 @@ that whenever the list of authors changes, the result of `getMainAuthor()` may h
 ====
 
 [[mapping-reindexing-reindexonupdate]]
-== [[mapper-orm-reindexing-reindexonupdate]] Limiting automatic reindexing with `@IndexingDependency`
+== [[mapper-orm-reindexing-reindexonupdate]] Limiting reindexing of containing entities with `@IndexingDependency`
 
-In some cases, fully automatic reindexing is not realistically achievable:
+In some cases, <<architecture-hsearch-indexing,triggering reindexing>> of entities every time a given property changes is not realistically achievable:
 
 * When an association is massive,
 for example a single entity instance is <<mapping-indexedembedded,indexed-embedded>>
@@ -135,13 +134,13 @@ Several options are available to control exactly how updates to a given property
 See the sections below for an explanation of each option.
 
 [[mapping-reindexing-reindexonupdate-shallow]]
-=== [[mapper-orm-reindexing-reindexonupdate-shallow]] `ReindexOnUpdate.SHALLOW`: limiting automatic reindexing to same-entity updates only
+=== [[mapper-orm-reindexing-reindexonupdate-shallow]] `ReindexOnUpdate.SHALLOW`: limiting reindexing to same-entity updates only
 
 `ReindexOnUpdate.SHALLOW` is most useful when an association is highly asymmetric and therefore unidirectional.
 Think associations to "reference" data such as categories, types, cities, countries, ...
 
 It essentially tells Hibernate Search that changing an association
--- adding or removing associated elements, i.e. "shallow" updates -- should trigger automatic reindexing,
+-- adding or removing associated elements, i.e. "shallow" updates -- should trigger reindexing of the object on which the change happened,
 but changing properties of associated entities -- "deep" updates -- should not.
 
 For example, let's consider the (incorrect) mapping below:
@@ -181,39 +180,39 @@ That's what `@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)` is 
 it tells Hibernate Search to ignore the impact of updates to an associated entity.
 See the modified mapping below:
 
-.Limiting automatic reindexing to same-entity updates with `ReindexOnUpdate.SHALLOW`
+.Limiting reindexing to same-entity updates with `ReindexOnUpdate.SHALLOW`
 ====
 [source, JAVA, indent=0, subs="+callouts"]
 ----
 include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/reindexing/reindexonupdate/shallow/correct/Book.java[tags=include;!getters-setters]
 ----
 <1> We use `ReindexOnUpdate.SHALLOW` to tell Hibernate Search that `Book`
-should be re-indexed automatically when it's assigned a new category (`book.setCategory( newCategory )`),
+should be re-indexed when it's assigned a new category (`book.setCategory( newCategory )`),
 but not when properties of its category change (`category.setName( newName )`).
 ====
 
 Hibernate Search will accept the mapping above and boot successfully,
 since the inverse side of the association from `Book` to `BookCategory` is no longer deemed necessary.
 
-Only _shallow_ changes to a book's category will trigger automatic reindexing:
+Only _shallow_ changes to a book's category will trigger reindexing of that book:
 
 * When a book is assigned a new category (`book.setCategory( newCategory )`),
 Hibernate Search will consider it a "shallow" change, since it only affects the `Book` entity.
-Thus, Hibernate Search will reindex the book automatically.
+Thus, Hibernate Search will reindex the book.
 * When a category itself changes (`category.setName( newName )`),
 Hibernate Search will consider it a "deep" change, since it occurs beyond the boundaries of the `Book` entity.
-Thus, Hibernate Search will *not* reindex books of that category automatically.
+Thus, Hibernate Search will *not* reindex books of that category by itself.
 The index will become slightly out-of-sync,
 but this can be solved by <<indexing-massindexer,reindexing>> `Book` entities,
 for example every night.
 
 [[mapping-reindexing-reindexonupdate-no]]
-=== [[mapper-orm-reindexing-reindexonupdate-no]] `ReindexOnUpdate.NO`: disabling automatic reindexing for updates of a particular property
+=== [[mapper-orm-reindexing-reindexonupdate-no]] `ReindexOnUpdate.NO`: disabling reindexing caused by updates of a particular property
 
 `ReindexOnUpdate.NO` is most useful for properties that change very frequently
 and don't need to be up-to-date in the index.
 
-It essentially tells Hibernate Search that changes to that property should not trigger automatic reindexing,
+It essentially tells Hibernate Search that changes to that property should not <<architecture-hsearch-indexing,trigger reindexing>>,
 
 For example, let's consider the mapping below:
 
@@ -229,13 +228,13 @@ include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/reindexing/re
 (based on data not shown here).
 ====
 
-Updates to the name and status, which are rarely updated, can perfectly well trigger automatic reindexing.
+Updates to the name and status, which are rarely updated, can perfectly well trigger reindexing.
 But considering there are thousands of sensors,
-updates to the sensor value cannot reasonably trigger automatic reindexing:
+updates to the sensor value cannot reasonably trigger reindexing:
 reindexing thousands of sensors every few milliseconds probably won't perform well.
 
 In this scenario, however, search on sensor value is not considered critical and indexes don't need to be as fresh.
-We can accept indexes to lag behind a few minutes when it comes to sensor value.
+We can accept indexes to lag behind a few minutes when it comes to a sensor value.
 We can consider setting up a batch process that runs every few seconds
 to reindex all sensors, either through a <<indexing-massindexer,mass indexer>>
 or <<mapper-orm-indexing-manual,other means>>.
@@ -245,22 +244,22 @@ That's what `@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.NO)` is for:
 it tells Hibernate Search to ignore the impact of updates to the `rollingAverage` property.
 See the modified mapping below:
 
-.Disabling automatic reindexing for a particular property with `ReindexOnUpdate.NO`
+.Disabling listener-triggered reindexing for a particular property with `ReindexOnUpdate.NO`
 ====
 [source, JAVA, indent=0, subs="+callouts"]
 ----
 include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/reindexing/reindexonupdate/no/correct/Sensor.java[tags=include;!getters-setters]
 ----
 <1> We use `ReindexOnUpdate.NO` to tell Hibernate Search that updates to `rollingAverage`
-should not trigger automatic reindexing.
+should not <<architecture-hsearch-indexing,trigger reindexing>>.
 ====
 
 With this mapping:
 
 * When a sensor is assigned a new name (`sensor.setName( newName )`) or status (`sensor.setStatus( newStatus )`),
-Hibernate Search will reindex the sensor automatically.
+Hibernate Search will <<architecture-hsearch-indexing,trigger reindexing>> of the sensor.
 * When a sensor is assigned a new rolling average (`sensor.setRollingAverage( newName )`),
-Hibernate Search will *not* reindex the sensor automatically.
+Hibernate Search will *not* <<architecture-hsearch-indexing,trigger reindexing>> of the sensor.
 
 [[mapping-reindexing-programmatic]]
 == [[mapper-orm-reindexing-programmatic]] Programmatic mapping
@@ -284,7 +283,7 @@ include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/reindexing/de
 ----
 ====
 
-.Limiting automatic reindexing with `.indexingDependency().reindexOnUpdate(...)`
+.Limiting <<architecture-hsearch-indexing,triggering reindexing>> with `.indexingDependency().reindexOnUpdate(...)`
 ====
 [source, JAVA, indent=0, subs="+callouts"]
 ----

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmBatchJsr352IT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmBatchJsr352IT.java
@@ -44,7 +44,7 @@ public class HibernateOrmBatchJsr352IT {
 	@Before
 	public void setup() {
 		this.entityManagerFactory = setupHelper.start()
-				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED, false )
+				.withProperty( HibernateOrmMapperSettings.INDEXING_LISTENERS_ENABLED, false )
 				.setup( Book.class, Author.class );
 		initData( entityManagerFactory, HibernateOrmBatchJsr352IT::newAuthor );
 	}

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java
@@ -311,7 +311,7 @@ public class HibernateOrmManualIndexingIT {
 
 	private EntityManagerFactory setup(boolean automaticIndexingEnabled) {
 		return setupHelper.start()
-				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED, automaticIndexingEnabled )
+				.withProperty( HibernateOrmMapperSettings.INDEXING_LISTENERS_ENABLED, automaticIndexingEnabled )
 				.setup( Book.class, Author.class );
 	}
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmMassIndexerIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmMassIndexerIT.java
@@ -46,7 +46,7 @@ public class HibernateOrmMassIndexerIT {
 	@Before
 	public void setup() {
 		this.entityManagerFactory = setupHelper.start()
-				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED, false )
+				.withProperty( HibernateOrmMapperSettings.INDEXING_LISTENERS_ENABLED, false )
 				.setup( Book.class, Author.class );
 		initData( entityManagerFactory, HibernateOrmMassIndexerIT::newAuthor );
 		with( entityManagerFactory ).runNoTransaction( entityManager -> {

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmMassIndexerMultiTenancyIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmMassIndexerMultiTenancyIT.java
@@ -43,7 +43,7 @@ public class HibernateOrmMassIndexerMultiTenancyIT {
 	@Before
 	public void setup() {
 		this.sessionFactory = setupHelper.start()
-				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED, false )
+				.withProperty( HibernateOrmMapperSettings.INDEXING_LISTENERS_ENABLED, false )
 				.tenants( TENANT_1_ID, TENANT_2_ID, TENANT_3_ID )
 				.withProperty( HibernateOrmMapperSettings.MULTI_TENANCY_TENANT_IDS,
 						String.join( ",", TENANT_1_ID, TENANT_2_ID, TENANT_3_ID ) )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/schema/management/ElasticsearchHibernateOrmSchemaManagerIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/schema/management/ElasticsearchHibernateOrmSchemaManagerIT.java
@@ -44,7 +44,7 @@ public class ElasticsearchHibernateOrmSchemaManagerIT {
 						HibernateOrmMapperSettings.SCHEMA_MANAGEMENT_STRATEGY,
 						SchemaManagementStrategyName.NONE
 				)
-				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED, false )
+				.withProperty( HibernateOrmMapperSettings.INDEXING_LISTENERS_ENABLED, false )
 				.setup( Book.class, Author.class );
 	}
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/schema/management/HibernateOrmSchemaManagerIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/schema/management/HibernateOrmSchemaManagerIT.java
@@ -52,7 +52,7 @@ public class HibernateOrmSchemaManagerIT {
 		this.entityManagerFactory = setupHelper.start()
 				.withProperty( HibernateOrmMapperSettings.SCHEMA_MANAGEMENT_STRATEGY,
 						SchemaManagementStrategyName.NONE )
-				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED, false )
+				.withProperty( HibernateOrmMapperSettings.INDEXING_LISTENERS_ENABLED, false )
 				.setup( Book.class, Author.class );
 		initData();
 	}

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/DocumentationSetupHelper.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/DocumentationSetupHelper.java
@@ -138,7 +138,7 @@ public final class DocumentationSetupHelper
 			// Real backend => ensure we clean up everything before and after the tests
 			withProperty( HibernateOrmMapperSettings.SCHEMA_MANAGEMENT_STRATEGY,
 					SchemaManagementStrategyName.DROP_AND_CREATE_AND_DROP );
-			// Override the automatic indexing synchronization strategy according to our needs for testing
+			// Override the indexing plan synchronization strategy according to our needs for testing
 			withProperty( HibernateOrmMapperSettings.INDEXING_PLAN_SYNCHRONIZATION_STRATEGY,
 					IndexingPlanSynchronizationStrategyNames.SYNC );
 			// Set up default mapping if necessary

--- a/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/component/EntityReaderComponentIT.java
+++ b/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/component/EntityReaderComponentIT.java
@@ -72,7 +72,7 @@ public class EntityReaderComponentIT {
 	@ReusableOrmSetupHolder.Setup
 	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		setupContext.withAnnotatedTypes( Company.class )
-				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED, false );
+				.withProperty( HibernateOrmMapperSettings.INDEXING_LISTENERS_ENABLED, false );
 	}
 
 	@Before

--- a/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/component/HibernateSearchPartitionMapperComponentIT.java
+++ b/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/component/HibernateSearchPartitionMapperComponentIT.java
@@ -61,7 +61,7 @@ public class HibernateSearchPartitionMapperComponentIT {
 	@ReusableOrmSetupHolder.Setup
 	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		setupContext.withAnnotatedTypes( Company.class, Person.class )
-				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED, false );
+				.withProperty( HibernateOrmMapperSettings.INDEXING_LISTENERS_ENABLED, false );
 	}
 
 	@Before

--- a/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/component/ValidationUtilComponentIT.java
+++ b/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/component/ValidationUtilComponentIT.java
@@ -39,7 +39,7 @@ public class ValidationUtilComponentIT {
 	@ReusableOrmSetupHolder.Setup
 	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		setupContext.withAnnotatedTypes( Company.class, Person.class )
-				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED, false );
+				.withProperty( HibernateOrmMapperSettings.INDEXING_LISTENERS_ENABLED, false );
 	}
 
 	@Test

--- a/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/BatchIndexingJobIT.java
+++ b/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/BatchIndexingJobIT.java
@@ -83,7 +83,7 @@ public class BatchIndexingJobIT {
 	@ReusableOrmSetupHolder.Setup
 	public void setup(OrmSetupHelper.SetupContext setupContext, ReusableOrmSetupHolder.DataClearConfig dataClearConfig) {
 		setupContext.withAnnotatedTypes( Company.class, Person.class, WhoAmI.class, CompanyGroup.class )
-				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED, false );
+				.withProperty( HibernateOrmMapperSettings.INDEXING_LISTENERS_ENABLED, false );
 
 		dataClearConfig.clearOrder( CompanyGroup.class, Company.class );
 	}

--- a/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/MassIndexingJobWithCompositeIdIT.java
+++ b/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/MassIndexingJobWithCompositeIdIT.java
@@ -72,7 +72,7 @@ public class MassIndexingJobWithCompositeIdIT {
 	@ReusableOrmSetupHolder.Setup
 	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		setupContext.withAnnotatedTypes( EntityWithIdClass.class, EntityWithEmbeddedId.class )
-				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED, false );
+				.withProperty( HibernateOrmMapperSettings.INDEXING_LISTENERS_ENABLED, false );
 	}
 
 	@Before

--- a/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/MassIndexingJobWithMultiTenancyIT.java
+++ b/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/MassIndexingJobWithMultiTenancyIT.java
@@ -58,7 +58,7 @@ public class MassIndexingJobWithMultiTenancyIT {
 	@ReusableOrmSetupHolder.Setup
 	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		setupContext.withAnnotatedTypes( Company.class )
-				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED, false )
+				.withProperty( HibernateOrmMapperSettings.INDEXING_LISTENERS_ENABLED, false )
 				.withBackendProperty( "multi_tenancy.strategy", "discriminator" )
 				.tenants( TARGET_TENANT_ID, UNUSED_TENANT_ID );
 	}

--- a/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/RestartChunkIT.java
+++ b/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/RestartChunkIT.java
@@ -61,7 +61,7 @@ public class RestartChunkIT {
 	@ReusableOrmSetupHolder.Setup
 	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		setupContext.withAnnotatedTypes( SimulatedFailureCompany.class )
-				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED, false );
+				.withProperty( HibernateOrmMapperSettings.INDEXING_LISTENERS_ENABLED, false );
 	}
 
 	@Before

--- a/integrationtest/mapper/orm-batch-jsr352/src/test/resources/META-INF/persistence.xml
+++ b/integrationtest/mapper/orm-batch-jsr352/src/test/resources/META-INF/persistence.xml
@@ -14,7 +14,7 @@
             <property name="hibernate.session_factory_name" value="primary_session_factory" />
             <property name="hibernate.session_factory_name_is_jndi" value="false" />
 
-            <property name="hibernate.search.automatic_indexing.enabled" value="false"/>
+            <property name="hibernate.search.indexing.listeners.enabled" value="false"/>
             <property name="hibernate.search.backend.type" value="lucene" />
             <property name="hibernate.search.backend.directory.type" value="local-heap" />
         </properties>
@@ -26,7 +26,7 @@
             <property name="hibernate.session_factory_name" value="primary_session_factory" />
             <property name="hibernate.session_factory_name_is_jndi" value="false" />
 
-            <property name="hibernate.search.automatic_indexing.enabled" value="false"/>
+            <property name="hibernate.search.indexing.listeners.enabled" value="false"/>
             <property name="hibernate.search.schema_management.strategy" value="drop-and-create-and-drop"/>
             <property name="hibernate.search.backend.type" value="elasticsearch" />
 

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/massindexing/MassIndexingManualSchemaManagementIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/massindexing/MassIndexingManualSchemaManagementIT.java
@@ -52,7 +52,7 @@ public class MassIndexingManualSchemaManagementIT {
 	@Before
 	public void before() {
 		entityManagerFactory = setupHelper.start()
-				.withProperty( "hibernate.search.automatic_indexing.enabled", false )
+				.withProperty( "hibernate.search.indexing.listeners.enabled", false )
 				.withProperty( "hibernate.search.schema_management.strategy", "none" )
 				.setup( Book.class );
 

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/massindexing/MassIndexingMonitorIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/massindexing/MassIndexingMonitorIT.java
@@ -57,7 +57,7 @@ public class MassIndexingMonitorIT {
 	@Before
 	public void before() {
 		entityManagerFactory = setupHelper.start()
-				.withProperty( "hibernate.search.automatic_indexing.enabled", false )
+				.withProperty( "hibernate.search.indexing.listeners.enabled", false )
 				.setup( Book.class );
 
 		prepareBooks( entityManagerFactory, NUMBER_OF_BOOKS );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingEnabledIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingEnabledIT.java
@@ -6,15 +6,20 @@
  */
 package org.hibernate.search.integrationtest.mapper.orm.automaticindexing;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
+import java.util.Arrays;
+import java.util.List;
 import javax.persistence.Basic;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
 import org.hibernate.SessionFactory;
+import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
@@ -22,16 +27,35 @@ import org.hibernate.search.util.impl.test.rule.ExpectedLog4jLog;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 /**
  * Test enabling/disabling automatic indexing.
  */
-@TestForIssue(jiraKey = "HSEARCH-4268")
+@TestForIssue(jiraKey = { "HSEARCH-4268", "HSEARCH-4616" })
+@RunWith(Parameterized.class)
 public class AutomaticIndexingEnabledIT {
+
+	@Parameterized.Parameters(name = "Configuration Setting = {0}")
+	@SuppressWarnings("deprecation")
+	public static List<Object[]> data() {
+		return Arrays.asList( new Object[][] {
+				{ HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED },
+				{ HibernateOrmMapperSettings.INDEXING_LISTENERS_ENABLED }
+		} );
+	}
 
 	private static final String DEPRECATED_STRATEGY_PROPERTY_MESSAGE = "Configuration property "
 			+ "'hibernate.search.automatic_indexing.strategy' is deprecated;"
-			+ " use 'hibernate.search.automatic_indexing.enabled' instead";
+			+ " use 'hibernate.search.indexing.listeners.enabled' instead";
+
+	private static final String DEPRECATED_AUTOMATIC_INDEXING_ENABLED_PROPERTY_MESSAGE = "Configuration property "
+			+ "'hibernate.search.automatic_indexing.enabled' is deprecated;"
+			+ " use 'hibernate.search.indexing.listeners.enabled' instead";
+
+	@Parameterized.Parameter
+	public String configurationSetting;
 
 	@Rule
 	public BackendMock backendMock = new BackendMock();
@@ -42,13 +66,18 @@ public class AutomaticIndexingEnabledIT {
 	@Rule
 	public ExpectedLog4jLog logged = ExpectedLog4jLog.create();
 
+	@SuppressWarnings("deprecation") // because of HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED
 	private SessionFactory setup(Boolean enabled, String strategyName) {
+		if ( enabled != null && HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED.equals( configurationSetting ) ) {
+			logged.expectMessage( DEPRECATED_AUTOMATIC_INDEXING_ENABLED_PROPERTY_MESSAGE ).once();
+		}
+
 		backendMock.expectSchema( IndexedEntity.NAME, b -> b
 				.field( "text", String.class )
 		);
 
 		SessionFactory sessionFactory = ormSetupHelper.start()
-				.withProperty( "hibernate.search.automatic_indexing.enabled", enabled )
+				.withProperty( configurationSetting, enabled )
 				.withProperty( "hibernate.search.automatic_indexing.strategy", strategyName )
 				.setup( IndexedEntity.class );
 		backendMock.verifyExpectationsMet();
@@ -142,6 +171,23 @@ public class AutomaticIndexingEnabledIT {
 					);
 		} );
 		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	public void conflictingSettingsUsed() {
+		backendMock.expectSchema( IndexedEntity.NAME, b -> b
+				.field( "text", String.class )
+		);
+
+		assertThatThrownBy( () -> ormSetupHelper.start()
+				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED, true )
+				.withProperty( HibernateOrmMapperSettings.INDEXING_LISTENERS_ENABLED, true )
+				.setup( IndexedEntity.class ) )
+				.isInstanceOf( SearchException.class )
+				.hasMessageContainingAll(
+						"Both 'hibernate.search.automatic_indexing.enabled' and 'hibernate.search.indexing.listeners.enabled' are configured." +
+								" Use only 'hibernate.search.indexing.listeners.enabled' to enable indexing listeners." );
 	}
 
 	@Entity(name = IndexedEntity.NAME)

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/session/AutomaticIndexingSynchronizationStrategyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/session/AutomaticIndexingSynchronizationStrategyIT.java
@@ -274,7 +274,7 @@ public class AutomaticIndexingSynchronizationStrategyIT {
 				Level.ERROR,
 				CoreMatchers.sameInstance( indexingWorkException ),
 				"Failing operation:",
-				"Automatic indexing of entities",
+				"Background indexing of entities",
 				"Entities that could not be indexed correctly:",
 				IndexedEntity.NAME + "#" + ENTITY_1_ID + " " + IndexedEntity.NAME + "#" + ENTITY_2_ID
 		);
@@ -605,7 +605,7 @@ public class AutomaticIndexingSynchronizationStrategyIT {
 				.extracting( Throwable::getCause ).asInstanceOf( InstanceOfAssertFactories.THROWABLE )
 						.isInstanceOf( SearchException.class )
 						.hasMessageContainingAll(
-								"Unable to index documents for automatic indexing after transaction completion: ",
+								"Unable to index documents for indexing after transaction completion: ",
 								"Indexing failure: " + indexingWorkException.getMessage(),
 								"The following entities may not have been updated correctly in the index: [" + entityReferences + "]"
 						)

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/session/IndexingPlanSynchronizationStrategyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/session/IndexingPlanSynchronizationStrategyIT.java
@@ -276,7 +276,7 @@ public class IndexingPlanSynchronizationStrategyIT {
 				Level.ERROR,
 				CoreMatchers.sameInstance( indexingWorkException ),
 				"Failing operation:",
-				"Automatic indexing of entities",
+				"Background indexing of entities",
 				"Entities that could not be indexed correctly:",
 				IndexedEntity.NAME + "#" + ENTITY_1_ID + " " + IndexedEntity.NAME + "#" + ENTITY_2_ID
 		);
@@ -608,7 +608,7 @@ public class IndexingPlanSynchronizationStrategyIT {
 				.extracting( Throwable::getCause ).asInstanceOf( InstanceOfAssertFactories.THROWABLE )
 						.isInstanceOf( SearchException.class )
 						.hasMessageContainingAll(
-								"Unable to index documents for automatic indexing after transaction completion: ",
+								"Unable to index documents for indexing after transaction completion: ",
 								"Indexing failure: " + indexingWorkException.getMessage(),
 								"The following entities may not have been updated correctly in the index: [" + entityReferences + "]"
 						)

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/dynamicmap/DynamicMapBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/dynamicmap/DynamicMapBaseIT.java
@@ -227,7 +227,7 @@ public class DynamicMapBaseIT {
 		);
 		SessionFactory sessionFactory = ormSetupHelper.start()
 				.withConfiguration( builder -> builder.addHbmFromClassPath( hbmPath ) )
-				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED, false )
+				.withProperty( HibernateOrmMapperSettings.INDEXING_LISTENERS_ENABLED, false )
 				.withProperty(
 						HibernateOrmMapperSettings.MAPPING_CONFIGURER,
 						(HibernateOrmSearchMappingConfigurer) context -> {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingErrorIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingErrorIT.java
@@ -487,7 +487,7 @@ public abstract class AbstractMassIndexingErrorIT {
 		backendMock.expectAnySchema( Book.NAME );
 
 		SessionFactory sessionFactory = ormSetupHelper.start()
-				.withPropertyRadical( HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_ENABLED, false )
+				.withPropertyRadical( HibernateOrmMapperSettings.Radicals.INDEXING_LISTENERS_ENABLED, false )
 				.withPropertyRadical( EngineSettings.Radicals.BACKGROUND_FAILURE_HANDLER, getBackgroundFailureHandlerReference() )
 				.withPropertyRadical( EngineSpiSettings.Radicals.THREAD_PROVIDER, threadSpy.getThreadProvider() )
 				.withConfiguration( configuration )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingFailureIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingFailureIT.java
@@ -790,7 +790,7 @@ public abstract class AbstractMassIndexingFailureIT {
 		backendMock.expectAnySchema( Book.NAME );
 
 		SessionFactory sessionFactory = ormSetupHelper.start()
-				.withPropertyRadical( HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_ENABLED, false )
+				.withPropertyRadical( HibernateOrmMapperSettings.Radicals.INDEXING_LISTENERS_ENABLED, false )
 				.withPropertyRadical( EngineSettings.Radicals.BACKGROUND_FAILURE_HANDLER, getBackgroundFailureHandlerReference() )
 				.withPropertyRadical( EngineSpiSettings.Radicals.THREAD_PROVIDER, threadSpy.getThreadProvider() )
 				.withConfiguration( configuration )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingBaseIT.java
@@ -86,7 +86,7 @@ public class MassIndexingBaseIT {
 	public void setup(OrmSetupHelper.SetupContext setupContext, ReusableOrmSetupHolder.DataClearConfig dataClearConfig) {
 		backendMock.expectAnySchema( Book.INDEX );
 
-		setupContext.withPropertyRadical( HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_ENABLED, false )
+		setupContext.withPropertyRadical( HibernateOrmMapperSettings.Radicals.INDEXING_LISTENERS_ENABLED, false )
 				.withAnnotatedTypes( Book.class );
 
 		if ( TenancyMode.MULTI_TENANCY.equals( tenancyMode ) ) {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingCachingIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingCachingIT.java
@@ -56,7 +56,7 @@ public class MassIndexingCachingIT {
 	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		backendMock.expectAnySchema( IndexedEntity.NAME );
 
-		setupContext.withPropertyRadical( HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_ENABLED, "false" )
+		setupContext.withPropertyRadical( HibernateOrmMapperSettings.Radicals.INDEXING_LISTENERS_ENABLED, "false" )
 				.withProperty( AvailableSettings.JPA_SHARED_CACHE_MODE, SharedCacheMode.ALL.name() )
 				.withProperty( AvailableSettings.GENERATE_STATISTICS, "true" )
 				.withProperty( AvailableSettings.USE_SECOND_LEVEL_CACHE, "true" )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingComplexHierarchyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingComplexHierarchyIT.java
@@ -51,7 +51,7 @@ public class MassIndexingComplexHierarchyIT {
 		backendMock.expectAnySchema( H2_A_C_Indexed.NAME );
 		backendMock.expectAnySchema( H2_B_Indexed.NAME );
 
-		setupContext.withPropertyRadical( HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_ENABLED, false )
+		setupContext.withPropertyRadical( HibernateOrmMapperSettings.Radicals.INDEXING_LISTENERS_ENABLED, false )
 				.withAnnotatedTypes(
 						H1_Root_NotIndexed.class, H1_A_NotIndexed.class, H1_B_Indexed.class,
 						H2_Root_Indexed.class,

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingConditionalExpressionsIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingConditionalExpressionsIT.java
@@ -71,7 +71,7 @@ public class MassIndexingConditionalExpressionsIT {
 		backendMock.expectAnySchema( H3_A_Indexed.NAME );
 		backendMock.expectAnySchema( H3_B_Indexed.NAME );
 
-		setupContext.withPropertyRadical( HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_ENABLED, false )
+		setupContext.withPropertyRadical( HibernateOrmMapperSettings.Radicals.INDEXING_LISTENERS_ENABLED, false )
 				.withAnnotatedTypes(
 						H0_Indexed.class,
 						H1_Root_NotIndexed.class, H1_A_NotIndexed.class, H1_B_Indexed.class,

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingEmbeddedIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingEmbeddedIdIT.java
@@ -65,7 +65,7 @@ public class MassIndexingEmbeddedIdIT {
 		backendMock.expectAnySchema( Book.INDEX );
 
 		sessionFactory = ormSetupHelper.start()
-				.withPropertyRadical( HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_ENABLED, false )
+				.withPropertyRadical( HibernateOrmMapperSettings.Radicals.INDEXING_LISTENERS_ENABLED, false )
 				.setup( Book.class );
 
 		backendMock.verifyExpectationsMet();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingIdClassIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingIdClassIT.java
@@ -50,7 +50,7 @@ public class MassIndexingIdClassIT {
 	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		backendMock.expectAnySchema( IdClassEntity.INDEX );
 
-		setupContext.withPropertyRadical( HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_ENABLED, false )
+		setupContext.withPropertyRadical( HibernateOrmMapperSettings.Radicals.INDEXING_LISTENERS_ENABLED, false )
 				.withAnnotatedTypes( IdClassEntity.class );
 	}
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingInterruptionIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingInterruptionIT.java
@@ -62,7 +62,7 @@ public class MassIndexingInterruptionIT {
 		backendMock.expectAnySchema( Book.INDEX );
 
 		sessionFactory = ormSetupHelper.start()
-				.withPropertyRadical( HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_ENABLED, false )
+				.withPropertyRadical( HibernateOrmMapperSettings.Radicals.INDEXING_LISTENERS_ENABLED, false )
 				.withPropertyRadical( EngineSpiSettings.Radicals.THREAD_PROVIDER, threadSpy.getThreadProvider() )
 				.setup( Book.class );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingMonitorIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingMonitorIT.java
@@ -115,7 +115,7 @@ public class MassIndexingMonitorIT {
 		backendMock.expectAnySchema( Book.INDEX );
 
 		SessionFactory sessionFactory = ormSetupHelper.start()
-				.withPropertyRadical( HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_ENABLED, false )
+				.withPropertyRadical( HibernateOrmMapperSettings.Radicals.INDEXING_LISTENERS_ENABLED, false )
 				.withPropertyRadical( EngineSettings.BACKGROUND_FAILURE_HANDLER, failureHandler )
 				.setup( Book.class );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingNonEntityIdDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingNonEntityIdDocumentIdIT.java
@@ -56,7 +56,7 @@ public class MassIndexingNonEntityIdDocumentIdIT {
 		backendMock.expectAnySchema( Book.INDEX );
 
 		sessionFactory = ormSetupHelper.start()
-				.withPropertyRadical( HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_ENABLED, false )
+				.withPropertyRadical( HibernateOrmMapperSettings.Radicals.INDEXING_LISTENERS_ENABLED, false )
 				.setup( Book.class );
 
 		backendMock.verifyExpectationsMet();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingPrimitiveIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingPrimitiveIdIT.java
@@ -45,7 +45,7 @@ public class MassIndexingPrimitiveIdIT {
 		backendMock.expectAnySchema( EntityWithPrimitiveId.INDEX );
 
 		sessionFactory = ormSetupHelper.start()
-				.withPropertyRadical( HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_ENABLED, false )
+				.withPropertyRadical( HibernateOrmMapperSettings.Radicals.INDEXING_LISTENERS_ENABLED, false )
 				.setup( EntityWithPrimitiveId.class );
 
 		backendMock.verifyExpectationsMet();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchIndexingPlanNonEntityIdDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchIndexingPlanNonEntityIdDocumentIdIT.java
@@ -43,7 +43,7 @@ public class SearchIndexingPlanNonEntityIdDocumentIdIT {
 	public void setup(OrmSetupHelper.SetupContext setupContext) {
 		backendMock.expectAnySchema( IndexedEntity.INDEX_NAME );
 
-		setupContext.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED, false )
+		setupContext.withProperty( HibernateOrmMapperSettings.INDEXING_LISTENERS_ENABLED, false )
 				.withAnnotatedTypes( IndexedEntity.class );
 	}
 

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/AbstractPojoIndexingPlanOperationBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/AbstractPojoIndexingPlanOperationBaseIT.java
@@ -385,7 +385,7 @@ public abstract class AbstractPojoIndexingPlanOperationBaseIT extends AbstractPo
 							Level.ERROR,
 							ExceptionMatcherBuilder.isException( exception )
 									.build(),
-							"Automatic indexing of entities",
+							"Background indexing of entities",
 							"Entities that could not be indexed correctly:"
 					)
 					.once();

--- a/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/LibraryShowcaseMassIndexingIT.java
+++ b/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/LibraryShowcaseMassIndexingIT.java
@@ -28,7 +28,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @TestPropertySource(properties = {
-		"spring.jpa.properties.hibernate.search.automatic_indexing.enabled=false"
+		"spring.jpa.properties.hibernate.search.indexing.listeners.enabled=false"
 })
 @ActiveProfiles(resolver = TestActiveProfilesResolver.class)
 public class LibraryShowcaseMassIndexingIT {

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/configuration/indexingStrategy/ManualIndexingStrategyTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/configuration/indexingStrategy/ManualIndexingStrategyTest.java
@@ -31,7 +31,7 @@ public class ManualIndexingStrategyTest extends SearchTestBase {
 	public void testMultipleEntitiesPerIndex() throws Exception {
 		indexTestEntity();
 		assertEquals(
-				"Due to manual indexing being enabled no automatic indexing should have occurred",
+				"Due to manual indexing being enabled no listener-triggered indexing should have occurred",
 				0,
 				getNumberOfDocumentsInIndex( "TestEntity" )
 		);

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/configuration/indexingStrategy/ManualIndexingStrategyTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/configuration/indexingStrategy/ManualIndexingStrategyTest.java
@@ -44,7 +44,7 @@ public class ManualIndexingStrategyTest extends SearchTestBase {
 
 	@Override
 	public void configure(Map<String,Object> cfg) {
-		cfg.put( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_ENABLED, false );
+		cfg.put( HibernateOrmMapperSettings.INDEXING_LISTENERS_ENABLED, false );
 	}
 
 	private void indexTestEntity() {

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxEventUpdater.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxEventUpdater.java
@@ -86,7 +86,7 @@ public class OutboxEventUpdater {
 				Instant processAfter = ( retryAfter > 0 ) ? Instant.now().plusSeconds( retryAfter ) : Instant.now();
 				event.setProcessAfter( processAfter );
 
-				log.automaticIndexingRetry(
+				log.backgroundIndexingRetry(
 						event.getId(), event.getEntityName(), event.getEntityId(), attempts, processAfter
 				);
 			}

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/logging/impl/Log.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/logging/impl/Log.java
@@ -49,9 +49,9 @@ public interface Log extends BasicLogger {
 	SearchException maxRetryExhausted(int retries);
 
 	@LogMessage(level = WARN)
-	@Message(id = ID_OFFSET + 4, value = "Automatic indexing failed for event #%1$s on entity of type '%2$s' with ID '%3$s'."
+	@Message(id = ID_OFFSET + 4, value = "Background indexing failed for event #%1$s on entity of type '%2$s' with ID '%3$s'."
 			+ " Attempts so far: %4$d. The event will be reprocessed after the moment: %5$s.")
-	void automaticIndexingRetry(UUID eventId, String entityName, String entityId, int attempts, Instant processAfter);
+	void backgroundIndexingRetry(UUID eventId, String entityName, String entityId, int attempts, Instant processAfter);
 
 	@LogMessage(level = DEBUG)
 	@Message(id = ID_OFFSET + 5, value = "Starting outbox event processor '%1$s': %2$s")

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/automaticindexing/AutomaticIndexingStrategyName.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/automaticindexing/AutomaticIndexingStrategyName.java
@@ -17,7 +17,7 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 /**
  * Strategy for automatic indexing in Hibernate Search.
  *
- * @deprecated Use {@link org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings#AUTOMATIC_INDEXING_ENABLED} instead.
+ * @deprecated Use {@link org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings#INDEXING_LISTENERS_ENABLED} instead.
  */
 @Deprecated
 public enum AutomaticIndexingStrategyName {
@@ -27,7 +27,7 @@ public enum AutomaticIndexingStrategyName {
 	 * indexing will only happen when explicitly requested through APIs
 	 * such as {@link SearchSession#indexingPlan()}.
 	 *
-	 * @deprecated Use {@link org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings#AUTOMATIC_INDEXING_ENABLED} instead.
+	 * @deprecated Use {@link org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings#INDEXING_LISTENERS_ENABLED} instead.
 	 */
 	@Deprecated
 	NONE("none"),
@@ -36,7 +36,7 @@ public enum AutomaticIndexingStrategyName {
 	 * Indexing is triggered automatically when entities are modified in the Hibernate ORM session:
 	 * entity insertion, update etc.
 	 *
-	 * @deprecated Use {@link org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings#AUTOMATIC_INDEXING_ENABLED} instead.
+	 * @deprecated Use {@link org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings#INDEXING_LISTENERS_ENABLED} instead.
 	 */
 	@Deprecated
 	SESSION("session");

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/automaticindexing/AutomaticIndexingStrategyName.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/automaticindexing/AutomaticIndexingStrategyName.java
@@ -15,7 +15,7 @@ import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 /**
- * Strategy for automatic indexing in Hibernate Search.
+ * Strategy for listener-triggered indexing in Hibernate Search.
  *
  * @deprecated Use {@link org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings#INDEXING_LISTENERS_ENABLED} instead.
  */
@@ -23,7 +23,7 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 public enum AutomaticIndexingStrategyName {
 
 	/**
-	 * No automatic indexing is performed:
+	 * No listener-triggered indexing is performed:
 	 * indexing will only happen when explicitly requested through APIs
 	 * such as {@link SearchSession#indexingPlan()}.
 	 *

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/cfg/HibernateOrmMapperSettings.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/cfg/HibernateOrmMapperSettings.java
@@ -49,7 +49,10 @@ public final class HibernateOrmMapperSettings {
 	 * or a string that can be parsed into a Boolean value.
 	 * <p>
 	 * Defaults to {@link Defaults#AUTOMATIC_INDEXING_ENABLED}.
+	 *
+	 * @deprecated Use {@link #INDEXING_LISTENERS_ENABLED} instead.
 	 */
+	@Deprecated
 	public static final String AUTOMATIC_INDEXING_ENABLED = PREFIX + Radicals.AUTOMATIC_INDEXING_ENABLED;
 
 	/**
@@ -59,7 +62,7 @@ public final class HibernateOrmMapperSettings {
 	 * <p>
 	 * Defaults to {@link Defaults#AUTOMATIC_INDEXING_STRATEGY}.
 	 *
-	 * @deprecated Use {@link #AUTOMATIC_INDEXING_ENABLED} instead (caution: it expects a boolean value).
+	 * @deprecated Use {@link #INDEXING_LISTENERS_ENABLED} instead (caution: it expects a boolean value).
 	 */
 	@Deprecated
 	public static final String AUTOMATIC_INDEXING_STRATEGY = PREFIX + Radicals.AUTOMATIC_INDEXING_STRATEGY;
@@ -214,6 +217,16 @@ public final class HibernateOrmMapperSettings {
 	public static final String INDEXING_PLAN_SYNCHRONIZATION_STRATEGY = PREFIX + Radicals.INDEXING_PLAN_SYNCHRONIZATION_STRATEGY;
 
 	/**
+	 * Whether Hibernate ORM listeners that detect entity changes and automatically trigger indexing operations are enabled.
+	 * <p>
+	 * Expects a Boolean value such as {@code true} or {@code false},
+	 * or a string that can be parsed into a Boolean value.
+	 * <p>
+	 * Defaults to {@link Defaults#INDEXING_LISTENERS_ENABLED}.
+	 */
+	public static final String INDEXING_LISTENERS_ENABLED = PREFIX + Radicals.INDEXING_LISTENERS_ENABLED;
+
+	/**
 	 * Configuration property keys without the {@link #PREFIX prefix}.
 	 */
 	public static final class Radicals {
@@ -222,8 +235,14 @@ public final class HibernateOrmMapperSettings {
 		}
 
 		public static final String ENABLED = "enabled";
+		@Deprecated
 		public static final String AUTOMATIC_INDEXING = "automatic_indexing";
+		@Deprecated
 		public static final String AUTOMATIC_INDEXING_PREFIX = AUTOMATIC_INDEXING + ".";
+		/**
+		 * @deprecated Use {@link #INDEXING_LISTENERS_ENABLED} instead.
+		 */
+		@Deprecated
 		public static final String AUTOMATIC_INDEXING_ENABLED = AUTOMATIC_INDEXING_PREFIX + AutomaticIndexingRadicals.ENABLED;
 		/**
 		 * @deprecated Use {@link #AUTOMATIC_INDEXING_ENABLED} instead (caution: it expects a boolean value).
@@ -253,27 +272,32 @@ public final class HibernateOrmMapperSettings {
 		public static final String MULTI_TENANCY = "multi_tenancy";
 		public static final String MULTI_TENANCY_PREFIX = MULTI_TENANCY + ".";
 		public static final String MULTI_TENANCY_TENANT_IDS = MULTI_TENANCY_PREFIX + MultiTenancyRadicals.TENANT_IDS;
-		public static final String INDEXING_PLAN_PREFIX = "indexing.plan.";
-		public static final String INDEXING_PLAN_SYNCHRONIZATION_STRATEGY = INDEXING_PLAN_PREFIX + IndexingPlanRadicals.SYNCHRONIZATION_STRATEGY;
-
+		public static final String INDEXING_PREFIX = "indexing.";
+		public static final String INDEXING_PLAN_SYNCHRONIZATION_STRATEGY = INDEXING_PREFIX + IndexingRadicals.PLAN_SYNCHRONIZATION_STRATEGY;
+		public static final String INDEXING_LISTENERS_ENABLED = INDEXING_PREFIX + IndexingRadicals.LISTENERS_ENABLED;
 	}
 
 	/**
 	 * Configuration property keys without the {@link #PREFIX prefix} + {@link Radicals#AUTOMATIC_INDEXING_PREFIX}.
 	 */
+	@Deprecated
 	public static final class AutomaticIndexingRadicals {
 
 		private AutomaticIndexingRadicals() {
 		}
 
+		/**
+		 * @deprecated Use {@link IndexingRadicals#LISTENERS_ENABLED} instead.
+		 */
+		@Deprecated
 		public static final String ENABLED = "enabled";
 		/**
-		 * @deprecated Use {@link #ENABLED} instead (caution: it expects a boolean value).
+		 * @deprecated Use {@link IndexingRadicals#LISTENERS_ENABLED} instead (caution: it expects a boolean value).
 		 */
 		@Deprecated
 		public static final String STRATEGY = "strategy";
 		/**
-		 * @deprecated Use {@link IndexingPlanRadicals#SYNCHRONIZATION_STRATEGY} instead.
+		 * @deprecated Use {@link IndexingRadicals#PLAN_SYNCHRONIZATION_STRATEGY} instead.
 		 */
 		@Deprecated
 		public static final String SYNCHRONIZATION_STRATEGY = "synchronization.strategy";
@@ -286,14 +310,17 @@ public final class HibernateOrmMapperSettings {
 	}
 
 	/**
-	 * Configuration property keys without the {@link #PREFIX prefix} + {@link Radicals#INDEXING_PLAN_PREFIX}.
+	 * Configuration property keys without the {@link #PREFIX prefix} + {@link Radicals#INDEXING_PREFIX}.
 	 */
-	public static final class IndexingPlanRadicals {
+	public static final class IndexingRadicals {
 
-		private IndexingPlanRadicals() {
+		private IndexingRadicals() {
 		}
 
-		public static final String SYNCHRONIZATION_STRATEGY = "synchronization.strategy";
+		public static final String PLAN_PREFIX = "plan.";
+		public static final String PLAN_SYNCHRONIZATION_STRATEGY = PLAN_PREFIX + "synchronization.strategy";
+		public static final String LISTENERS_PREFIX = "listeners.";
+		public static final String LISTENERS_ENABLED = LISTENERS_PREFIX + "enabled";
 	}
 
 	/**
@@ -358,6 +385,7 @@ public final class HibernateOrmMapperSettings {
 				BeanReference.of( CoordinationStrategy.class, NoCoordinationStrategy.NAME );
 		public static final BeanReference<IndexingPlanSynchronizationStrategy> INDEXING_PLAN_SYNCHRONIZATION_STRATEGY =
 				BeanReference.of( IndexingPlanSynchronizationStrategy.class, "write-sync" );
+		public static final boolean INDEXING_LISTENERS_ENABLED = true;
 
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/cfg/HibernateOrmMapperSettings.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/cfg/HibernateOrmMapperSettings.java
@@ -42,7 +42,7 @@ public final class HibernateOrmMapperSettings {
 	public static final String ENABLED = PREFIX + Radicals.ENABLED;
 
 	/**
-	 * Whether automatic indexing is enabled, i.e. whether changes to entities in a Hibernate ORM session
+	 * Whether listener-triggered indexing is enabled, i.e. whether changes to entities in a Hibernate ORM session
 	 * are detected automatically and lead to reindexing.
 	 * <p>
 	 * Expects a Boolean value such as {@code true} or {@code false},
@@ -56,7 +56,7 @@ public final class HibernateOrmMapperSettings {
 	public static final String AUTOMATIC_INDEXING_ENABLED = PREFIX + Radicals.AUTOMATIC_INDEXING_ENABLED;
 
 	/**
-	 * How to enable or disable automatic indexing.
+	 * How to enable or disable listener-triggered indexing.
 	 * <p>
 	 * Expects a {@link org.hibernate.search.mapper.orm.automaticindexing.AutomaticIndexingStrategyName} value, or a String representation of such value.
 	 * <p>

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/coordination/common/spi/CoordinationStrategy.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/coordination/common/spi/CoordinationStrategy.java
@@ -43,7 +43,7 @@ public interface CoordinationStrategy {
 
 	/**
 	 * Creates a {@link PojoMassIndexerAgent},
-	 * able to exert control over other agents that could perform indexing concurrently (e.g. automatic indexing).
+	 * able to exert control over other agents that could perform indexing concurrently (e.g. background processing of entity change events with outbox-polling coordination strategy).
 	 *
 	 * @param context A context with information about the mass indexing that is about to start.
 	 * @return An agent.

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/coordination/common/spi/CoordinationStrategyStartContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/coordination/common/spi/CoordinationStrategyStartContext.java
@@ -52,7 +52,7 @@ public interface CoordinationStrategyStartContext {
 
 	/**
 	 * @return The mapping, providing all information and operations necessary
-	 * for background processing of automatic indexing events.
+	 * for background processing of indexing events.
 	 */
 	AutomaticIndexingMappingContext mapping();
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/coordination/impl/NoCoordinationStrategy.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/coordination/impl/NoCoordinationStrategy.java
@@ -32,7 +32,7 @@ public class NoCoordinationStrategy implements CoordinationStrategy {
 
 	@Override
 	public PojoMassIndexerAgent createMassIndexerAgent(PojoMassIndexerAgentCreateContext context) {
-		// No coordination: we don't prevent automatic indexing from continuing while mass indexing.
+		// No coordination: we don't prevent background indexing from continuing while mass indexing.
 		return PojoMassIndexerAgent.noOp();
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
@@ -131,8 +131,8 @@ public interface Log extends BasicLogger {
 	SearchException hibernateSessionIsClosed(@Cause IllegalStateException cause);
 
 	@Message(id = ID_OFFSET + 18,
-			value = "Invalid automatic indexing synchronization strategy name: '%1$s'. Valid names are: %2$s.")
-	SearchException invalidAutomaticIndexingSynchronizationStrategyName(String invalidRepresentation,
+			value = "Invalid entity loading cache lookup strategy name: '%1$s'. Valid names are: %2$s.")
+	SearchException invalidEntityLoadingCacheLookupStrategyName(String invalidRepresentation,
 			List<String> validRepresentations);
 
 	@LogMessage(level = DEBUG)
@@ -156,10 +156,10 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET + 22, value = "Indexing failure: %1$s.\nThe following entities may not have been updated correctly in the index: %2$s.")
 	SearchException indexingFailure(String causeMessage, List<?> failingEntities, @Cause Throwable cause);
 
-	@Message(id = ID_OFFSET + 23, value = "Unable to process entities for automatic indexing before transaction completion: %1$s")
+	@Message(id = ID_OFFSET + 23, value = "Unable to process entities for indexing before transaction completion: %1$s")
 	SearchException synchronizationBeforeTransactionFailure(String causeMessage, @Cause Throwable cause);
 
-	@Message(id = ID_OFFSET + 24, value = "Unable to index documents for automatic indexing after transaction completion: %1$s")
+	@Message(id = ID_OFFSET + 24, value = "Unable to index documents for indexing after transaction completion: %1$s")
 	SearchException synchronizationAfterTransactionFailure(String causeMessage, @Cause Throwable cause);
 
 	@Message(id = ID_OFFSET + 25, value = "Unable to handle transaction: %1$s")
@@ -231,8 +231,8 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET + 41, value = "No such bean in bean container '%1$s'.")
 	BeanNotFoundException beanNotFoundInBeanContainer(BeanContainer beanContainer);
 
-	@Message(id = ID_OFFSET + 42, value = "Cannot customize the synchronization strategy: "
-			+ " the selected automatic indexing strategy always processes events asynchronously, through a queue.")
+	@Message(id = ID_OFFSET + 42, value = "Cannot customize the indexing plan synchronization strategy: "
+			+ " the selected coordination strategy always processes events asynchronously, through a queue.")
 	SearchException cannotConfigureSynchronizationStrategyWithIndexingEventQueue();
 
 	@LogMessage(level = WARN)

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
@@ -237,7 +237,7 @@ public interface Log extends BasicLogger {
 
 	@LogMessage(level = WARN)
 	@Message(id = ID_OFFSET + 53, value = "Configuration property '%1$s' is deprecated; use '%2$s' instead.")
-	void automaticIndexingStrategyIsDeprecated(String resolveOrRaw, String resolveOrRaw1);
+	void deprecatedPropertyUsedInsteadOfNew(String resolveOrRaw, String resolveOrRaw1);
 
 	@Message(id = ID_OFFSET + 54, value = "Cannot determine the set of all possible tenant identifiers."
 			+ " You must provide this information by setting configuration property '%1$s'"
@@ -332,4 +332,8 @@ public interface Log extends BasicLogger {
 			+ "There will be no alternative provided to replace it. "
 			+ "A dirty check will always be performed when considering triggering the reindexing.")
 	void automaticIndexingEnableDirtyCheckIsDeprecated(String deprecatedProperty);
+
+	@Message(id = ID_OFFSET + 126,
+			value = "Both '%1$s' and '%2$s' are configured. Use only '%2$s' to enable indexing listeners. ")
+	SearchException bothNewAndOldConfigurationPropertiesForIndexingListenersAreUsed(String key1, String key2);
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMappingInitiator.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMappingInitiator.java
@@ -137,7 +137,7 @@ public class HibernateOrmMappingInitiator extends AbstractPojoMappingInitiator<H
 		coordinationStrategyHolder = coordinationStrategyConfiguration.strategyHolder();
 		configuredAutomaticIndexingStrategy = coordinationStrategyConfiguration.createAutomaticIndexingStrategy();
 
-		// If the automatic indexing strategy uses an event queue,
+		// If the underlying coordination strategy uses an event queue,
 		// it will need to send events relative to contained entities,
 		// and thus contained entities need to have an identity mapping.
 		containedEntityIdentityMappingRequired( configuredAutomaticIndexingStrategy.usesAsyncProcessing() );

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/MassIndexer.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/MassIndexer.java
@@ -91,7 +91,7 @@ public interface MassIndexer {
 	 * Drops the indexes and their schema (if they exist) and re-creates them before indexing.
 	 * <p>
 	 * Indexes will be unavailable for a short time during the dropping and re-creation,
-	 * so this should only be used when failures of concurrent operations on the indexes (automatic indexing, ...)
+	 * so this should only be used when failures of concurrent operations on the indexes (indexing caused by entity changes, ...)
 	 * are acceptable.
 	 * <p>
 	 * This should be used when the existing schema is known to be obsolete, for example when the Hibernate Search mapping

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/EntityLoadingCacheLookupStrategy.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/EntityLoadingCacheLookupStrategy.java
@@ -52,7 +52,7 @@ public enum EntityLoadingCacheLookupStrategy {
 		return ParseUtils.parseDiscreteValues(
 				EntityLoadingCacheLookupStrategy.values(),
 				EntityLoadingCacheLookupStrategy::externalRepresentation,
-				log::invalidAutomaticIndexingSynchronizationStrategyName,
+				log::invalidEntityLoadingCacheLookupStrategyName,
 				value
 		);
 	}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/SearchIndexingPlan.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/SearchIndexingPlan.java
@@ -27,7 +27,7 @@ import javax.persistence.Entity;
  * Note that {@link #execute()} will implicitly trigger processing of documents that weren't processed yet,
  * if any, so calling {@link #process()} is not necessary if you call {@link #execute()} just next.
  * <p>
- * {@link #process()} and {@link #execute()} are mostly useful when automatic indexing is disabled,
+ * {@link #process()} and {@link #execute()} are mostly useful when listener-triggered indexing is disabled,
  * to control the indexing process explicitly.
  */
 public interface SearchIndexingPlan {

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/SearchIndexingPlan.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/SearchIndexingPlan.java
@@ -14,13 +14,13 @@ import javax.persistence.Entity;
  * This class is stateful: it queues operations internally to apply them at a later time.
  * <p>
  * When {@link #process()} is called,
- * or when {@link org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings#AUTOMATIC_INDEXING_ENABLED automatic indexing is enabled}
+ * or when {@link org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings#INDEXING_LISTENERS_ENABLED indexing listeners are enabled}
  * and a Hibernate ORM Session {@code flush()} happens,
  * the entities will be processed and index documents will be built
  * and stored in an internal buffer.
  * <p>
  * When {@link #execute()} is called,
- * or when {@link org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings#AUTOMATIC_INDEXING_ENABLED automatic indexing is enabled}
+ * or when {@link org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings#INDEXING_LISTENERS_ENABLED indexing listeners are enabled}
  * and a Hibernate ORM transaction is committed or a Hibernate ORM Session {@code flush()} happens outside of any transaction,
  * the operations will be actually sent to the index.
  * <p>
@@ -107,7 +107,7 @@ public interface SearchIndexingPlan {
 	 * or the automatic write on transaction commit will perform the extraction as necessary.
 	 * <p>
 	 * However, calling this method can be useful before a session is cleared
-	 * if {@link org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings#AUTOMATIC_INDEXING_ENABLED automatic indexing is disabled}:
+	 * if {@link org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings#INDEXING_LISTENERS_ENABLED indexing listeners} are disabled:
 	 * it will make sure the data lost when clearing the session will no longer be necessary for indexing.
 	 * <p>
 	 * Caution: calling this method repeatedly without a call to {@link #execute()}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/SearchWorkspace.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/SearchWorkspace.java
@@ -70,9 +70,9 @@ public interface SearchWorkspace {
 	 * Only to be used by experts fully aware of the implications.
 	 * <p>
 	 * Note that some operations may still be waiting in a queue when {@link #flush()} is called,
-	 * in particular operations queued as part of automatic indexing before a transaction
+	 * in particular operations queued as part of processing an indexing plan before a transaction
 	 * is committed.
-	 * These operations will not be applied immediately just because  a call to {@link #flush()} is issued:
+	 * These operations will not be applied immediately just because a call to {@link #flush()} is issued:
 	 * the "flush" here is a very low-level operation handled by the backend.
 	 */
 	void flush();
@@ -95,8 +95,8 @@ public interface SearchWorkspace {
 	 * Only to be used by experts fully aware of the implications.
 	 * <p>
 	 * Note that some operations may still be waiting in a queue when {@link #refresh()} is called,
-	 * in particular operations queued as part of automatic indexing before a transaction is committed.
-	 * These operations will not be applied immediately just because  a call to {@link #refresh()} is issued:
+	 * in particular operations queued as part of processing an indexing plan before a transaction is committed.
+	 * These operations will not be applied immediately just because a call to {@link #refresh()} is issued:
 	 * the "refresh" here is a very low-level operation handled by the backend.
 	 */
 	void refresh();

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/SearchWorkspace.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/SearchWorkspace.java
@@ -15,8 +15,8 @@ import java.util.concurrent.CompletionStage;
  * A {@link SearchWorkspace} targets a pre-defined set of indexed types (and their indexes),
  * filtered to only affect a single tenant, if relevant.
  * <p>
- * While {@link org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings#AUTOMATIC_INDEXING_ENABLED automatic indexing}
- * generally takes care of indexing entities as they are persisted/deleted in the database,
+ * While {@link org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings#INDEXING_LISTENERS_ENABLED indexing listeners}
+ * generally take care of indexing entities as they are persisted/deleted in the database,
  * there are cases where massive operations must be applied to the index,
  * such as completely purging the index.
  * This is where the {@link SearchWorkspace} comes in.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/ReindexOnUpdate.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/ReindexOnUpdate.java
@@ -9,7 +9,7 @@ package org.hibernate.search.mapper.pojo.automaticindexing;
 import org.hibernate.search.mapper.pojo.extractor.ContainerExtractor;
 
 /**
- * Defines the impact that an update to a value in an entity will have on automatic indexing.
+ * Defines the impact that an update to a value in an entity will have on reindexing of this entity and containing entities.
  * <p>
  * A "value" here means either an entity property or something extracted from that property
  * using a {@link ContainerExtractor}.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
@@ -775,8 +775,8 @@ public interface Log extends BasicLogger {
 			@Cause Exception cause,
 			@Param ProjectionConstructorPath path);
 
-	@Message(value = "Automatic indexing of entities")
-	String automaticIndexing();
+	@Message(value = "Background indexing of entities")
+	String backgroundIndexing();
 
 	@Message(id = ID_OFFSET + 124, value = "Indexing failure: %1$s.\nThe following entities may not have been updated correctly in the index: %2$s.")
 	SearchException indexingFailure(String causeMessage, List<?> failingEntities, @Cause Throwable cause);

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/IndexingDependency.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/IndexingDependency.java
@@ -22,7 +22,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing
 
 /**
  * Given a property, defines how a dependency of the indexing process to this property
- * should affect automatic indexing.
+ * should affect its reindexing.
  * <p>
  * This annotation is generally not needed, as the default behavior is to consider all properties
  * that are actually used in the indexing process as dependencies that trigger reindexing when they are updated.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/spi/PojoMassIndexer.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/spi/PojoMassIndexer.java
@@ -66,7 +66,7 @@ public interface PojoMassIndexer {
 	 * Drops the indexes and their schema (if they exist) and re-creates them before indexing.
 	 * <p>
 	 * Indexes will be unavailable for a short time during the dropping and re-creation,
-	 * so this should only be used when failures of concurrent operations on the indexes (automatic indexing, ...)
+	 * so this should only be used when failures of concurrent operations on the indexes (indexing caused by entity changes, ...)
 	 * are acceptable.
 	 * <p>
 	 * This should be used when the existing schema is known to be obsolete, for example when the Hibernate Search mapping

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/spi/PojoMassIndexerAgent.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/spi/PojoMassIndexerAgent.java
@@ -15,7 +15,7 @@ public interface PojoMassIndexerAgent {
 	}
 
 	/**
-	 * Starts requesting from other agents that could possibly perform indexing (e.g. automatic indexing)
+	 * Starts requesting from other agents that could possibly perform indexing (e.g. indexing plans)
 	 * that they suspend themselves.
 	 * <p>
 	 * Other agents can be considered suspended when the returned future completes successfully;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/spi/PojoMassIndexingMappingContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/spi/PojoMassIndexingMappingContext.java
@@ -28,7 +28,7 @@ public interface PojoMassIndexingMappingContext extends BackendMappingContext {
 
 	/**
 	 * Creates a {@link PojoMassIndexerAgent},
-	 * able to exert control over other agents that could perform indexing concurrently (e.g. automatic indexing).
+	 * able to exert control over other agents that could perform indexing concurrently (e.g. indexing plans).
 	 *
 	 * @param context A context with information about the mass indexing that is about to start.
 	 * @return An agent.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AsyncIndexingPlanSynchronizationStrategy.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AsyncIndexingPlanSynchronizationStrategy.java
@@ -44,13 +44,13 @@ public final class AsyncIndexingPlanSynchronizationStrategy implements IndexingP
 							if ( throwable != null ) {
 								EntityIndexingFailureContext.Builder contextBuilder = EntityIndexingFailureContext.builder();
 								contextBuilder.throwable( throwable );
-								contextBuilder.failingOperation( log.automaticIndexing() );
+								contextBuilder.failingOperation( log.backgroundIndexing() );
 								failureHandler.handle( contextBuilder.build() );
 							}
 							else if ( result != null && result.throwable().isPresent() ) {
 								EntityIndexingFailureContext.Builder contextBuilder = EntityIndexingFailureContext.builder();
 								contextBuilder.throwable( result.throwable().get() );
-								contextBuilder.failingOperation( log.automaticIndexing() );
+								contextBuilder.failingOperation( log.backgroundIndexing() );
 								for ( EntityReference entityReference : result.failingEntities() ) {
 									contextBuilder.failingEntityReference( entityReference );
 								}

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoMapping.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoMapping.java
@@ -195,7 +195,7 @@ public class StandalonePojoMapping extends AbstractPojoMappingImplementor<Standa
 
 	@Override
 	public PojoMassIndexerAgent createMassIndexerAgent(PojoMassIndexerAgentCreateContext context) {
-		// No coordination: we don't prevent automatic indexing from continuing while mass indexing.
+		// No coordination: so we don't need to prevent outbox-polling event processing (since it's not supported) when doing mass-indexing.
 		return PojoMassIndexerAgent.noOp();
 	}
 

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/massindexing/MassIndexer.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/massindexing/MassIndexer.java
@@ -76,7 +76,7 @@ public interface MassIndexer {
 	 * Drops the indexes and their schema (if they exist) and re-creates them before indexing.
 	 * <p>
 	 * Indexes will be unavailable for a short time during the dropping and re-creation,
-	 * so this should only be used when failures of concurrent operations on the indexes (automatic indexing, ...)
+	 * so this should only be used when failures of concurrent operations on the indexes (indexing caused by entity changes, ...)
 	 * are acceptable.
 	 * <p>
 	 * This should be used when the existing schema is known to be obsolete, for example when the Hibernate Search mapping

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/work/SearchWorkspace.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/work/SearchWorkspace.java
@@ -70,12 +70,6 @@ public interface SearchWorkspace {
 	 * <p>
 	 * This is generally not useful as Hibernate Search commits changes automatically.
 	 * Only to be used by experts fully aware of the implications.
-	 * <p>
-	 * Note that some operations may still be waiting in a queue when {@link #flush()} is called,
-	 * in particular operations queued as part of automatic indexing before a transaction
-	 * is committed.
-	 * These operations will not be applied immediately just because  a call to {@link #flush()} is issued:
-	 * the "flush" here is a very low-level operation handled by the backend.
 	 */
 	void flush();
 
@@ -95,11 +89,6 @@ public interface SearchWorkspace {
 	 * or periodically (default for the Elasticsearch backend,
 	 * possible for the Lucene backend by setting a refresh interval).
 	 * Only to be used by experts fully aware of the implications.
-	 * <p>
-	 * Note that some operations may still be waiting in a queue when {@link #refresh()} is called,
-	 * in particular operations queued as part of automatic indexing before a transaction is committed.
-	 * These operations will not be applied immediately just because  a call to {@link #refresh()} is issued:
-	 * the "refresh" here is a very low-level operation handled by the backend.
 	 */
 	void refresh();
 

--- a/orm6/integrationtest/mapper/orm/ant-src-changes.patch
+++ b/orm6/integrationtest/mapper/orm/ant-src-changes.patch
@@ -2073,7 +2073,7 @@ index c032664bb9..4d205fdccf 100644
 @@ -57,7 +57,7 @@ public void setup(OrmSetupHelper.SetupContext setupContext) {
  		backendMock.expectAnySchema( IndexedEntity.NAME );
  
- 		setupContext.withPropertyRadical( HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_ENABLED, "false" )
+ 		setupContext.withPropertyRadical( HibernateOrmMapperSettings.Radicals.INDEXING_LISTENERS_ENABLED, "false" )
 -				.withProperty( AvailableSettings.JPA_SHARED_CACHE_MODE, SharedCacheMode.ALL.name() )
 +				.withProperty( AvailableSettings.JAKARTA_SHARED_CACHE_MODE, SharedCacheMode.ALL.name() )
  				.withProperty( AvailableSettings.GENERATE_STATISTICS, "true" )

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmSetupHelper.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmSetupHelper.java
@@ -149,7 +149,7 @@ public final class OrmSetupHelper
 			withProperties( DEFAULT_PROPERTIES );
 			// Override the schema management strategy according to our needs for testing
 			withProperty( HibernateOrmMapperSettings.SCHEMA_MANAGEMENT_STRATEGY, schemaManagementStrategyName );
-			// Set the automatic indexing strategy according to the expectations
+			// Set the coordination strategy according to the expectations
 			withProperty( "hibernate.search.coordination.strategy", coordinationStrategyExpectations.strategyName );
 			// Ensure we don't build Jandex indexes needlessly:
 			// discovery based on Jandex ought to be tested in real projects that don't use this setup helper.


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4616

This is the first pass at this renaming:
- deprecated the `hibernate.search.automatic_indexing.enabled`
- looked where we used automatic indexing and either replaced it or rephrased it to something else. 
- there're a few `TODO: Yoann, .*`  with some questions 😃. I'd say that it probably wouldn't make sense to go through all the changes before I address those todos.  

Hopefully, this wouldn't be too much "fun" rebasing once we merge the getting-started PR 😆 