### PR TITLE
HSEARCH-4875 Upgrade -orm6 artifacts to Hibernate ORM 6.2.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,7 @@
         <version.jakarta.xml.bind.orm5>3.0.1</version.jakarta.xml.bind.orm5>
 
         <!-- >>> ORM 6 with Jakarta Persistence -->
-        <version.org.hibernate.orm>6.2.4.Final</version.org.hibernate.orm>
+        <version.org.hibernate.orm>6.2.5.Final</version.org.hibernate.orm>
         <javadoc.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/javadocs/</javadoc.org.hibernate.orm.url>
         <documentation.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/userguide/html_single/Hibernate_User_Guide.html</documentation.org.hibernate.orm.url>
         <!-- These version must be kept in sync with the version of the dependency in Hibernate ORM 6.


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4875

Also added a commit to `orm6-in-main-code` - https://github.com/hibernate/hibernate-search/commit/66d230fd2328a43b66c9aa9e14a6fbf14ae2978c and rebased that branch since there were some merge conflicts.