### PR TITLE
HSEARCH-4877 [Infinispan] Provided identifier bridge not applied in Search DSL and `id` projection

### DIFF
--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/providedid/ProvidedIdIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/providedid/ProvidedIdIT.java
@@ -10,25 +10,32 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.hibernate.search.engine.backend.types.converter.runtime.FromDocumentValueConvertContext;
+import org.hibernate.search.engine.backend.types.converter.runtime.ToDocumentValueConvertContext;
+import org.hibernate.search.engine.backend.types.converter.runtime.spi.FromDocumentValueConvertContextImpl;
+import org.hibernate.search.engine.backend.types.converter.runtime.spi.ToDocumentValueConvertContextImpl;
+import org.hibernate.search.engine.backend.types.converter.spi.DslConverter;
+import org.hibernate.search.engine.backend.types.converter.spi.ProjectionConverter;
 import org.hibernate.search.engine.environment.bean.BeanReference;
-import org.hibernate.search.mapper.pojo.common.spi.PojoEntityReference;
-import org.hibernate.search.util.impl.integrationtest.mapper.pojo.standalone.StandalonePojoMappingSetupHelper;
-import org.hibernate.search.mapper.pojo.standalone.mapping.SearchMapping;
-import org.hibernate.search.engine.search.query.SearchQuery;
-import org.hibernate.search.mapper.pojo.standalone.session.SearchSession;
+import org.hibernate.search.integrationtest.mapper.pojo.mapping.definition.BridgeTestUtils;
 import org.hibernate.search.mapper.pojo.bridge.IdentifierBridge;
 import org.hibernate.search.mapper.pojo.bridge.runtime.IdentifierBridgeFromDocumentIdentifierContext;
 import org.hibernate.search.mapper.pojo.bridge.runtime.IdentifierBridgeToDocumentIdentifierContext;
+import org.hibernate.search.mapper.pojo.common.spi.PojoEntityReference;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
-import org.hibernate.search.engine.common.EntityReference;
+import org.hibernate.search.mapper.pojo.standalone.mapping.SearchMapping;
+import org.hibernate.search.mapper.pojo.standalone.session.SearchSession;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.common.rule.StubSearchWorkBehavior;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.StubBackendUtils;
+import org.hibernate.search.util.impl.integrationtest.common.stub.backend.document.model.impl.StubIndexModel;
+import org.hibernate.search.util.impl.integrationtest.mapper.pojo.standalone.StandalonePojoMappingSetupHelper;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,6 +47,46 @@ public class ProvidedIdIT {
 
 	@Rule
 	public StandalonePojoMappingSetupHelper setupHelper = StandalonePojoMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );
+
+	private StubIndexModel indexModel;
+
+	@Test
+	public void converters() {
+		final String entityAndIndexName = "indexed";
+		@Indexed
+		class IndexedEntity {
+		}
+
+		// Schema
+		backendMock.expectSchema( entityAndIndexName, b -> { },
+				indexModel -> this.indexModel = indexModel );
+		SearchMapping mapping = withBaseConfiguration()
+				.withAnnotatedEntityType( IndexedEntity.class, entityAndIndexName )
+				.setup();
+		backendMock.verifyExpectationsMet();
+
+		// DslConverter
+		@SuppressWarnings("unchecked")
+		DslConverter<Object, String> dslConverter =
+				(DslConverter<Object, String>) indexModel.identifier().dslConverter();
+		ToDocumentValueConvertContext toDocumentConvertContext =
+				new ToDocumentValueConvertContextImpl( BridgeTestUtils.toBackendMappingContext( mapping ) );
+		assertThat( dslConverter.toDocumentValue( 120, toDocumentConvertContext ) )
+				.isEqualTo( "120" );
+		assertThat( dslConverter.unknownTypeToDocumentValue( 120, toDocumentConvertContext ) )
+				.isEqualTo( "120" );
+
+		// ProjectionConverter
+		@SuppressWarnings("unchecked")
+		ProjectionConverter<String, Object> projectionConverter =
+				(ProjectionConverter<String, Object>) indexModel.identifier().projectionConverter();
+		try ( SearchSession searchSession = mapping.createSession() ) {
+			FromDocumentValueConvertContext fromDocumentConvertContext =
+					new FromDocumentValueConvertContextImpl( BridgeTestUtils.toBackendSessionContext( searchSession ) );
+			assertThat( projectionConverter.fromDocumentValue( "120", fromDocumentConvertContext ) )
+					.isEqualTo( 120 );
+		}
+	}
 
 	@Test
 	public void indexAndSearch() {
@@ -59,7 +106,7 @@ public class ProvidedIdIT {
 		try ( SearchSession session = mapping.createSession() ) {
 			IndexedEntity entity1 = new IndexedEntity();
 
-			session.indexingPlan().add( "42", null, entity1 );
+			session.indexingPlan().add( 42, null, entity1 );
 
 			backendMock.expectWorks( entityAndIndexName )
 					.add( "42", b -> { } );
@@ -68,6 +115,7 @@ public class ProvidedIdIT {
 
 		// Searching
 		try ( SearchSession session = mapping.createSession() ) {
+			// Check provided ID bridge is applied when fetching entity references
 			backendMock.expectSearchReferences(
 					Collections.singletonList( entityAndIndexName ),
 					StubSearchWorkBehavior.of(
@@ -75,14 +123,24 @@ public class ProvidedIdIT {
 							StubBackendUtils.reference( entityAndIndexName, "42" )
 					)
 			);
-
-			SearchQuery<EntityReference> query = session.search( IndexedEntity.class )
+			assertThat( session.search( IndexedEntity.class )
 					.selectEntityReference()
-					.where( f -> f.matchAll() )
-					.toQuery();
+					.where( f -> f.matchAll() ).fetchAllHits() )
+					.containsExactly( PojoEntityReference.withName( IndexedEntity.class, entityAndIndexName, 42 ) );
 
-			assertThat( query.fetchAll().hits() )
-					.containsExactly( PojoEntityReference.withName( IndexedEntity.class, entityAndIndexName, "42" ) );
+			// Check provided ID bridge is applied when fetching IDs
+			backendMock.expectSearchIds(
+					Collections.singletonList( entityAndIndexName ),
+					b -> { },
+					StubSearchWorkBehavior.of(
+							1L,
+							Arrays.asList( "42" )
+					)
+			);
+			assertThat( session.search( IndexedEntity.class )
+					.select( f -> f.id() )
+					.where( f -> f.matchAll() ).fetchAllHits() )
+					.containsExactly( 42 );
 		}
 		backendMock.verifyExpectationsMet();
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoIndexModelBinder.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoIndexModelBinder.java
@@ -107,7 +107,13 @@ public final class PojoIndexModelBinder {
 			BoundPojoModelPathPropertyNode<?, I> modelPath,
 			IdentifierBinder binder, Map<String, Object> params) {
 		PojoTypeModel<I> identifierTypeModel = modelPath.valueWithoutExtractors().getTypeModel();
+		return bindIdentifier( indexedEntityBindingContext, identifierTypeModel, binder, params );
+	}
 
+	public <I> BoundIdentifierBridge<I> bindIdentifier(
+			Optional<IndexedEntityBindingContext> indexedEntityBindingContext,
+			PojoTypeModel<I> identifierTypeModel,
+			IdentifierBinder binder, Map<String, Object> params) {
 		IdentifierBinder defaultedBinder = binder;
 		if ( binder == null ) {
 			defaultedBinder = bridgeResolver.resolveIdentifierBinderForType( identifierTypeModel );

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoIndexedTypeManagerBuilder.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoIndexedTypeManagerBuilder.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 
 import org.hibernate.search.engine.environment.bean.BeanHolder;
 import org.hibernate.search.engine.environment.bean.BeanReference;
-import org.hibernate.search.engine.environment.bean.BeanResolver;
 import org.hibernate.search.engine.mapper.mapping.building.spi.MappedIndexManagerBuilder;
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexManager;
 import org.hibernate.search.mapper.pojo.automaticindexing.building.impl.PojoImplicitReindexingResolverBuildingHelper;
@@ -61,8 +60,7 @@ class PojoIndexedTypeManagerBuilder<E> {
 			MappedIndexManagerBuilder indexManagerBuilder,
 			PojoIndexedTypeExtendedMappingCollector extendedMappingCollector,
 			BeanReference<? extends IdentifierBridge<Object>> providedIdentifierBridge,
-			BoundRoutingBridge<E> routingBridge,
-			BeanResolver beanResolver) {
+			BoundRoutingBridge<E> routingBridge) {
 		this.entityName = entityName;
 		this.typeModel = typeModel;
 		this.indexManagerBuilder = indexManagerBuilder;
@@ -71,8 +69,7 @@ class PojoIndexedTypeManagerBuilder<E> {
 				typeModel,
 				mappingHelper,
 				Optional.of( indexManagerBuilder.rootBindingContext() ),
-				providedIdentifierBridge,
-				beanResolver
+				providedIdentifierBridge
 		);
 		this.routingBridge = routingBridge;
 		this.processorBuilder = new PojoIndexingProcessorOriginalTypeNodeBuilder<>(

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoMapper.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoMapper.java
@@ -253,7 +253,7 @@ public class PojoMapper<MPBS extends MappingPartialBuildState> implements Mapper
 		PojoIndexedTypeManagerBuilder<E> builder = new PojoIndexedTypeManagerBuilder<>( entityName, indexedEntityType,
 				mappingHelper, indexManagerBuilder,
 				delegate.createIndexedTypeExtendedMappingCollector( indexedEntityType, entityName ),
-				providedIdentifierBridge, routingBridge, mappingHelper.beanResolver() );
+				providedIdentifierBridge, routingBridge );
 
 		// Put the builder in the map before anything else, so it will be closed on error
 		indexedTypeManagerBuilders.put( indexedEntityType, builder );
@@ -416,8 +416,7 @@ public class PojoMapper<MPBS extends MappingPartialBuildState> implements Mapper
 					reindexingResolver.associationInverseSideResolver().dirtyContainingAssociationFilter() );
 
 			PojoRootIdentityMappingCollector<T> identityMappingCollector = new PojoRootIdentityMappingCollector<>(
-					entityType, mappingHelper, Optional.empty(), providedIdentifierBridge,
-					mappingHelper.beanResolver()
+					entityType, mappingHelper, Optional.empty(), providedIdentifierBridge
 			);
 			collectIndexMapping( entityType, identityMappingCollector.toMappingCollectorRootNode() );
 			IdentifierMappingImplementor<?, T> identifierMapping = identityMappingCollector


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4877
