### PR TITLE
HSEARCH-4725 Follow-up: Make tests compatible with JDK 8/11

### DIFF
--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorObjectProjectionCycleIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorObjectProjectionCycleIT.java
@@ -99,7 +99,7 @@ public class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjec
 	public void brokenCycle_includePaths() {
 		class Model {
 			@Indexed(index = INDEX_NAME)
-			static class Level1 {
+			class Level1 {
 				@DocumentId
 				public Integer id;
 				@FullTextField
@@ -169,7 +169,7 @@ public class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjec
 	public void brokenCycle_excludePaths() {
 		class Model {
 			@Indexed(index = INDEX_NAME)
-			static class Level1 {
+			class Level1 {
 				@DocumentId
 				public Integer id;
 				@FullTextField
@@ -239,7 +239,7 @@ public class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjec
 	public void brokenCycle_includeDepth() {
 		class Model {
 			@Indexed(index = INDEX_NAME)
-			static class Level1 {
+			class Level1 {
 				@DocumentId
 				public Integer id;
 				@FullTextField


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4725

I've noticed that jdk 8/11 build didn't like static classes 😞 : 
https://ci.hibernate.org/blue/organizations/jenkins/hibernate-search/detail/main/697/pipeline/106
