### PR TITLE
HSEARCH-4882 Avoid compilation failures when calling AnnotationMappingConfigurationContext#add without Jandex in the classpath

### DIFF
--- a/documentation/src/main/asciidoc/public/reference/_mapping-configuration.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_mapping-configuration.adoc
@@ -62,7 +62,7 @@ From that context, either:
 * call `annotationMappingContext.add( MyType.class )` to explicitly tell Hibernate Search
 to process annotation on `MyType`, and to discover other types annotated with
 <<mapping-classpath-scanning-basics,root mapping annotations>> in the JAR containing `MyType`.
-* OR (advanced usage) call `annotationMappingContext.add( <an IndexView instance> )` to explicitly tell Hibernate Search
+* OR (advanced usage, incubating) call `annotationMappingContext.addJandexIndex( <an IndexView instance> )` to explicitly tell Hibernate Search
 to look for types annotated with
 <<mapping-classpath-scanning-basics,root mapping annotations>> in the given Jandex index.
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMappingInitiator.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMappingInitiator.java
@@ -94,7 +94,7 @@ public class HibernateOrmMappingInitiator extends AbstractPojoMappingInitiator<H
 
 		this.basicTypeMetadataProvider = basicTypeMetadataProvider;
 		if ( jandexIndex != null ) {
-			annotationMapping().add( jandexIndex );
+			annotationMapping().addJandexIndex( jandexIndex );
 		}
 		this.introspector = introspector;
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/AnnotationMappingConfigurationContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/AnnotationMappingConfigurationContext.java
@@ -9,6 +9,7 @@ package org.hibernate.search.mapper.pojo.mapping.definition.annotation;
 import java.util.Set;
 
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.RootMapping;
+import org.hibernate.search.util.common.annotation.Incubating;
 
 import org.jboss.jandex.IndexView;
 
@@ -30,7 +31,7 @@ public interface AnnotationMappingConfigurationContext {
 	 * @return {@code this}, for method chaining.
 	 * @see RootMapping
 	 * @see ProjectionConstructor
-	 * @see #add(IndexView)
+	 * @see #addJandexIndex(IndexView)
 	 * @see #discoverJandexIndexesFromAddedTypes(boolean)
 	 */
 	AnnotationMappingConfigurationContext discoverAnnotatedTypesFromRootMappingAnnotations(boolean enabled);
@@ -40,7 +41,7 @@ public interface AnnotationMappingConfigurationContext {
 	 * from types added through {@link #add(Class)} or {@link #add(Set)}.
 	 * {@code false} if that discovery should be disabled.
 	 * @return {@code this}, for method chaining.
-	 * @see #add(IndexView)
+	 * @see #addJandexIndex(IndexView)
 	 * @see #buildMissingDiscoveredJandexIndexes(boolean)
 	 */
 	AnnotationMappingConfigurationContext discoverJandexIndexesFromAddedTypes(boolean enabled);
@@ -51,7 +52,7 @@ public interface AnnotationMappingConfigurationContext {
 	 * {@code false} if Hibernate Search should ignore JARs without a Jandex index.
 	 * @return {@code this}, for method chaining.
 	 * @see #discoverJandexIndexesFromAddedTypes(boolean)
-	 * @see #add(IndexView)
+	 * @see #addJandexIndex(IndexView)
 	 */
 	AnnotationMappingConfigurationContext buildMissingDiscoveredJandexIndexes(boolean enabled);
 
@@ -82,6 +83,7 @@ public interface AnnotationMappingConfigurationContext {
 	 * @see #discoverAnnotatedTypesFromRootMappingAnnotations(boolean)
 	 * @see #discoverJandexIndexesFromAddedTypes(boolean)
 	 */
-	AnnotationMappingConfigurationContext add(IndexView jandexIndex);
+	@Incubating
+	AnnotationMappingConfigurationContext addJandexIndex(IndexView jandexIndex);
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationMappingConfigurationContextImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationMappingConfigurationContextImpl.java
@@ -99,7 +99,7 @@ public class AnnotationMappingConfigurationContextImpl implements AnnotationMapp
 	}
 
 	@Override
-	public AnnotationMappingConfigurationContext add(IndexView jandexIndex) {
+	public AnnotationMappingConfigurationContext addJandexIndex(IndexView jandexIndex) {
 		explicitJandexIndexes.add( jandexIndex );
 		return this;
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4882

If we overload the existing 'add' methods, then the compiler will fail when we call any 'add' method without Jandex in the classpath, even if it's not the one that uses Jandex.