### PR TITLE
HSEARCH-4884   Configuration property to have a dedicated docvalue field for the root document id in the Lucene backend's document

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/cfg/LuceneBackendSettings.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/cfg/LuceneBackendSettings.java
@@ -9,6 +9,7 @@ package org.hibernate.search.backend.lucene.cfg;
 import org.hibernate.search.backend.lucene.analysis.LuceneAnalysisConfigurer;
 import org.hibernate.search.backend.lucene.cache.QueryCachingConfigurer;
 import org.hibernate.search.backend.lucene.multitenancy.MultiTenancyStrategyName;
+import org.hibernate.search.backend.lucene.schema.SchemaIdStrategy;
 
 import org.apache.lucene.util.Version;
 
@@ -94,6 +95,15 @@ public final class LuceneBackendSettings {
 	public static final String THREAD_POOL_SIZE = "thread_pool.size";
 
 	/**
+	 * Strategy that defines how to read/write IDs to/from a document.
+	 * <p>
+	 * Expects a {@link SchemaIdStrategy} value, or a String representation of such value.
+	 * <p>
+	 * Defaults to {@link Defaults#SCHEMA_ID_STRATEGY}.
+	 */
+	public static final String SCHEMA_ID_STRATEGY = "schema.id.strategy";
+
+	/**
 	 * Default values for the different settings if no values are given.
 	 */
 	public static final class Defaults {
@@ -110,5 +120,8 @@ public final class LuceneBackendSettings {
 		 */
 		@Deprecated
 		public static final MultiTenancyStrategyName MULTI_TENANCY_STRATEGY = MultiTenancyStrategyName.NONE;
+
+		@SuppressWarnings("deprecation")
+		public static final SchemaIdStrategy SCHEMA_ID_STRATEGY = SchemaIdStrategy.LUCENE_8;
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneIdReader.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneIdReader.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.document.impl;
+
+import java.io.IOException;
+
+import org.hibernate.search.backend.lucene.cfg.LuceneBackendSettings;
+
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.LeafReader;
+
+public interface LuceneIdReader {
+
+	/**
+	 * Creates a {@link BinaryDocValues} backed up by a specific field depending on a configured ID read/write strategy.
+	 *
+	 * @param reader The reader to retrieve IDs from.
+	 * @return Returns {@link BinaryDocValues} for the ID field.
+	 * @throws IOException On I/O error occurred while creating doc values.
+	 * @see LuceneBackendSettings#SCHEMA_ID_STRATEGY
+	 */
+	BinaryDocValues idDocValues(LeafReader reader) throws IOException;
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneIdReaderWriter.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneIdReaderWriter.java
@@ -1,0 +1,14 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.document.impl;
+
+/**
+ * Implementations decide to which fields to write IDs to and how, later, to read them back from the index.
+ */
+public interface LuceneIdReaderWriter extends LuceneIdWriter, LuceneIdReader {
+
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneIdWriter.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneIdWriter.java
@@ -1,0 +1,22 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.document.impl;
+
+import org.hibernate.search.backend.lucene.cfg.LuceneBackendSettings;
+
+import org.apache.lucene.document.Document;
+
+public interface LuceneIdWriter {
+	/**
+	 * Writes an ID to the document. Implementations chose which filed name to use
+	 * and how many fields are used to represent the ID.
+	 * @param id The id to add to the document.
+	 * @param document The document to write to.
+	 * @see LuceneBackendSettings#SCHEMA_ID_STRATEGY
+	 */
+	void write(String id, Document document);
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneIndexEntryFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneIndexEntryFactory.java
@@ -14,16 +14,19 @@ public class LuceneIndexEntryFactory {
 
 	private final LuceneIndexModel model;
 	private final MultiTenancyStrategy multiTenancyStrategy;
+	private final LuceneIdWriter idWriter;
 
-	public LuceneIndexEntryFactory(LuceneIndexModel model, MultiTenancyStrategy multiTenancyStrategy) {
+	public LuceneIndexEntryFactory(LuceneIndexModel model, MultiTenancyStrategy multiTenancyStrategy,
+			LuceneIdWriter idWriter) {
 		this.model = model;
 		this.multiTenancyStrategy = multiTenancyStrategy;
+		this.idWriter = idWriter;
 	}
 
 	public LuceneIndexEntry create(String tenantId, String id, String routingKey,
 			DocumentContributor documentContributor) {
 		LuceneRootDocumentBuilder builder = new LuceneRootDocumentBuilder(
-				model, multiTenancyStrategy
+				model, multiTenancyStrategy, idWriter
 		);
 		documentContributor.contribute( builder );
 		return builder.build( tenantId, id, routingKey );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneLegacyIdReaderWriter.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneLegacyIdReaderWriter.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.document.impl;
+
+import java.io.IOException;
+
+import org.hibernate.search.backend.lucene.lowlevel.common.impl.MetadataFields;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReader;
+
+public final class LuceneLegacyIdReaderWriter implements LuceneIdReaderWriter {
+
+	public static final LuceneIdReaderWriter INSTANCE = new LuceneLegacyIdReaderWriter();
+
+	private LuceneLegacyIdReaderWriter() {
+	}
+
+	@Override
+	public BinaryDocValues idDocValues(LeafReader reader) throws IOException {
+		return DocValues.getBinary( reader, MetadataFields.idFieldName() );
+	}
+
+	@Override
+	public void write(String id, Document document) {
+		document.add( MetadataFields.searchableRetrievableMetadataField( MetadataFields.idFieldName(), id ) );
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneModernIdReaderWriter.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneModernIdReaderWriter.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.document.impl;
+
+import java.io.IOException;
+
+import org.hibernate.search.backend.lucene.lowlevel.common.impl.MetadataFields;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReader;
+
+public final class LuceneModernIdReaderWriter implements LuceneIdReaderWriter {
+
+	public static final LuceneIdReaderWriter INSTANCE = new LuceneModernIdReaderWriter();
+
+	private LuceneModernIdReaderWriter() {
+	}
+
+	@Override
+	public BinaryDocValues idDocValues(LeafReader reader) throws IOException {
+		return DocValues.getBinary( reader, MetadataFields.idDocValueFieldName() );
+	}
+
+	@Override
+	public void write(String id, Document document) {
+		document.add( MetadataFields.searchableMetadataField( MetadataFields.idFieldName(), id ) );
+		document.add( MetadataFields.retrievableMetadataField( MetadataFields.idDocValueFieldName(), id ) );
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneRootDocumentBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneRootDocumentBuilder.java
@@ -18,10 +18,13 @@ import org.apache.lucene.document.Document;
 public class LuceneRootDocumentBuilder extends AbstractLuceneDocumentElementBuilder {
 
 	private final MultiTenancyStrategy multiTenancyStrategy;
+	private final LuceneIdWriter idWriter;
 
-	LuceneRootDocumentBuilder(LuceneIndexModel model, MultiTenancyStrategy multiTenancyStrategy) {
+	LuceneRootDocumentBuilder(LuceneIndexModel model, MultiTenancyStrategy multiTenancyStrategy,
+			LuceneIdWriter idWriter) {
 		super( model, model.root(), new LuceneDocumentContentImpl() );
 		this.multiTenancyStrategy = multiTenancyStrategy;
+		this.idWriter = idWriter;
 	}
 
 	public LuceneIndexEntry build(String tenantId, String id, String routingKey) {
@@ -42,7 +45,7 @@ public class LuceneRootDocumentBuilder extends AbstractLuceneDocumentElementBuil
 		Document document = documentContent.finalizeDocument( multiTenancyStrategy, tenantId, routingKey );
 		document.add(
 				MetadataFields.searchableMetadataField( MetadataFields.typeFieldName(), MetadataFields.TYPE_MAIN_DOCUMENT ) );
-		document.add( MetadataFields.searchableRetrievableMetadataField( MetadataFields.idFieldName(), id ) );
+		idWriter.write( id, document );
 
 		// In the list of documents, a child must appear before its parent,
 		// so we let children contribute their document first.

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/impl/LuceneBackendImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/impl/LuceneBackendImpl.java
@@ -13,6 +13,7 @@ import java.util.concurrent.CompletableFuture;
 import org.hibernate.search.backend.lucene.LuceneBackend;
 import org.hibernate.search.backend.lucene.analysis.model.impl.LuceneAnalysisDefinitionRegistry;
 import org.hibernate.search.backend.lucene.cache.impl.LuceneQueryCachingContext;
+import org.hibernate.search.backend.lucene.document.impl.LuceneIdReaderWriter;
 import org.hibernate.search.backend.lucene.document.model.dsl.impl.LuceneIndexRootBuilder;
 import org.hibernate.search.backend.lucene.index.impl.IndexManagerBackendContext;
 import org.hibernate.search.backend.lucene.index.impl.LuceneIndexManagerBuilder;
@@ -61,6 +62,7 @@ public class LuceneBackendImpl implements BackendImplementor, LuceneBackend {
 			LuceneAnalysisDefinitionRegistry analysisDefinitionRegistry,
 			LuceneQueryCachingContext cachingContext,
 			MultiTenancyStrategy multiTenancyStrategy,
+			LuceneIdReaderWriter idReaderWriter,
 			TimingSource timingSource,
 			FailureHandler failureHandler) {
 		this.backendName = backendName;
@@ -77,7 +79,7 @@ public class LuceneBackendImpl implements BackendImplementor, LuceneBackend {
 		this.indexManagerBackendContext = new IndexManagerBackendContext(
 				this, eventContext, threads, similarity,
 				workFactory, multiTenancyStrategy,
-				timingSource, analysisDefinitionRegistry,
+				idReaderWriter, timingSource, analysisDefinitionRegistry,
 				failureHandler,
 				readOrchestrator
 		);

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/IndexManagerBackendContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/IndexManagerBackendContext.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import org.hibernate.search.backend.lucene.LuceneBackend;
 import org.hibernate.search.backend.lucene.analysis.model.impl.LuceneAnalysisDefinitionRegistry;
 import org.hibernate.search.backend.lucene.cfg.LuceneIndexSettings;
+import org.hibernate.search.backend.lucene.document.impl.LuceneIdReaderWriter;
 import org.hibernate.search.backend.lucene.document.impl.LuceneIndexEntryFactory;
 import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexModel;
 import org.hibernate.search.backend.lucene.lowlevel.directory.spi.DirectoryHolder;
@@ -71,6 +72,7 @@ public class IndexManagerBackendContext implements WorkExecutionBackendContext, 
 	private final Similarity similarity;
 	private final LuceneWorkFactory workFactory;
 	private final MultiTenancyStrategy multiTenancyStrategy;
+	private final LuceneIdReaderWriter idReaderWriter;
 	private final TimingSource timingSource;
 	private final LuceneAnalysisDefinitionRegistry analysisDefinitionRegistry;
 	private final FailureHandler failureHandler;
@@ -82,7 +84,7 @@ public class IndexManagerBackendContext implements WorkExecutionBackendContext, 
 			Similarity similarity,
 			LuceneWorkFactory workFactory,
 			MultiTenancyStrategy multiTenancyStrategy,
-			TimingSource timingSource,
+			LuceneIdReaderWriter idReaderWriter, TimingSource timingSource,
 			LuceneAnalysisDefinitionRegistry analysisDefinitionRegistry,
 			FailureHandler failureHandler,
 			LuceneSyncWorkOrchestrator readOrchestrator) {
@@ -91,6 +93,7 @@ public class IndexManagerBackendContext implements WorkExecutionBackendContext, 
 		this.threads = threads;
 		this.similarity = similarity;
 		this.multiTenancyStrategy = multiTenancyStrategy;
+		this.idReaderWriter = idReaderWriter;
 		this.timingSource = timingSource;
 		this.analysisDefinitionRegistry = analysisDefinitionRegistry;
 		this.workFactory = workFactory;
@@ -164,7 +167,8 @@ public class IndexManagerBackendContext implements WorkExecutionBackendContext, 
 				scope,
 				sessionContext,
 				loadingContextBuilder,
-				rootProjection
+				rootProjection,
+				idReaderWriter
 		);
 	}
 
@@ -177,7 +181,7 @@ public class IndexManagerBackendContext implements WorkExecutionBackendContext, 
 	}
 
 	LuceneIndexEntryFactory createLuceneIndexEntryFactory(LuceneIndexModel model) {
-		return new LuceneIndexEntryFactory( model, multiTenancyStrategy );
+		return new LuceneIndexEntryFactory( model, multiTenancyStrategy, idReaderWriter );
 	}
 
 	IOStrategy createIOStrategy(ConfigurationPropertySource propertySource) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
@@ -712,4 +712,9 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET + 173, value = "'%1$s' cannot be nested in an object projection. "
 			+ "%2$s")
 	SearchException cannotUseProjectionInNestedContext(String projection, String hint, @Param EventContext eventContext);
+
+	@Message(id = ID_OFFSET + 174, value = "Invalid Lucene schema ID strategy name: '%1$s'."
+			+ " Valid names are: %2$s.")
+	SearchException invalidLuceneIdStrategy(String invalidRepresentation, List<String> validRepresentations);
+
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/collector/impl/IdentifierValues.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/collector/impl/IdentifierValues.java
@@ -8,19 +8,23 @@ package org.hibernate.search.backend.lucene.lowlevel.collector.impl;
 
 import java.io.IOException;
 
-import org.hibernate.search.backend.lucene.lowlevel.common.impl.MetadataFields;
+import org.hibernate.search.backend.lucene.document.impl.LuceneIdReader;
 
 import org.apache.lucene.index.BinaryDocValues;
-import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
 
 public final class IdentifierValues implements Values<String> {
 
+	private final LuceneIdReader idReader;
 	private BinaryDocValues currentLeafIdDocValues;
+
+	public IdentifierValues(LuceneIdReader idReader) {
+		this.idReader = idReader;
+	}
 
 	@Override
 	public void context(LeafReaderContext context) throws IOException {
-		this.currentLeafIdDocValues = DocValues.getBinary( context.reader(), MetadataFields.idFieldName() );
+		this.currentLeafIdDocValues = idReader.idDocValues( context.reader() );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/common/impl/MetadataFields.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/common/impl/MetadataFields.java
@@ -16,13 +16,22 @@ import org.apache.lucene.util.BytesRef;
 public class MetadataFields {
 
 	private static final FieldType METADATA_FIELD_TYPE_WITH_INDEX;
+	private static final FieldType METADATA_FIELD_TYPE_WITH_DOCVALUES;
 	private static final FieldType METADATA_FIELD_TYPE_WITH_INDEX_WITH_DOCVALUES;
+
 	static {
 		METADATA_FIELD_TYPE_WITH_INDEX = new FieldType();
 		METADATA_FIELD_TYPE_WITH_INDEX.setTokenized( false );
 		METADATA_FIELD_TYPE_WITH_INDEX.setOmitNorms( true );
 		METADATA_FIELD_TYPE_WITH_INDEX.setIndexOptions( IndexOptions.DOCS );
 		METADATA_FIELD_TYPE_WITH_INDEX.freeze();
+
+		METADATA_FIELD_TYPE_WITH_DOCVALUES = new FieldType();
+		METADATA_FIELD_TYPE_WITH_DOCVALUES.setTokenized( false );
+		METADATA_FIELD_TYPE_WITH_DOCVALUES.setOmitNorms( true );
+		METADATA_FIELD_TYPE_WITH_DOCVALUES.setIndexOptions( IndexOptions.NONE );
+		METADATA_FIELD_TYPE_WITH_DOCVALUES.setDocValuesType( DocValuesType.BINARY );
+		METADATA_FIELD_TYPE_WITH_DOCVALUES.freeze();
 
 		METADATA_FIELD_TYPE_WITH_INDEX_WITH_DOCVALUES = new FieldType();
 		METADATA_FIELD_TYPE_WITH_INDEX_WITH_DOCVALUES.setTokenized( false );
@@ -35,6 +44,8 @@ public class MetadataFields {
 	private static final String INTERNAL_FIELD_PREFIX = "__HSEARCH_";
 
 	private static final String ID_FIELD_NAME = internalFieldName( "id" );
+
+	private static final String ID_DOCVALUE_FIELD_NAME = internalFieldName( "id_docvalue" );
 
 	private static final String ROUTING_KEY_FIELD_NAME = internalFieldName( "routing_key" );
 
@@ -64,12 +75,20 @@ public class MetadataFields {
 		return new Field( name, value, METADATA_FIELD_TYPE_WITH_INDEX );
 	}
 
+	public static IndexableField retrievableMetadataField(String name, String value) {
+		return new Field( name, new BytesRef( value ), METADATA_FIELD_TYPE_WITH_DOCVALUES );
+	}
+
 	public static IndexableField searchableRetrievableMetadataField(String name, String value) {
 		return new Field( name, new BytesRef( value ), METADATA_FIELD_TYPE_WITH_INDEX_WITH_DOCVALUES );
 	}
 
 	public static String idFieldName() {
 		return ID_FIELD_NAME;
+	}
+
+	public static String idDocValueFieldName() {
+		return ID_DOCVALUE_FIELD_NAME;
 	}
 
 	public static String routingKeyFieldName() {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/schema/SchemaIdStrategy.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/schema/SchemaIdStrategy.java
@@ -1,0 +1,57 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.schema;
+
+import java.lang.invoke.MethodHandles;
+
+import org.hibernate.search.backend.lucene.logging.impl.Log;
+import org.hibernate.search.engine.cfg.spi.ParseUtils;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
+
+/**
+ * Strategy that defines how to read/write IDs to/from a document.
+ */
+public enum SchemaIdStrategy {
+	/**
+	 * Currently used strategy that is compatible with the current and indexes from previous Hibernate Search versions.
+	 * @deprecated It will be removed in a future version of Hibernate Search that will support Lucene 9.
+	 * Use {@link #LUCENE_9} instead. Note that switching to {@link #LUCENE_9 a new strategy} will
+	 * require indexes to be recreated and repopulated.
+	 */
+	@Deprecated
+	LUCENE_8( "lucene8" ),
+	/**
+	 * This strategy will create documents compatible with future versions of Hibernate Search.
+	 * Switching to this strategy for existing applications will require indexes to be recreated and repopulated.
+	 */
+	LUCENE_9( "lucene9" );
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
+	private final String externalRepresentation;
+
+	SchemaIdStrategy(String externalRepresentation) {
+		this.externalRepresentation = externalRepresentation;
+	}
+
+	/**
+	 * @return The expected string representation in configuration properties.
+	 */
+	public String externalRepresentation() {
+		return externalRepresentation;
+	}
+
+	// This method conforms to the MicroProfile Config specification. Do not change its signature.
+	public static SchemaIdStrategy of(String value) {
+		return ParseUtils.parseDiscreteValues(
+				SchemaIdStrategy.values(),
+				SchemaIdStrategy::externalRepresentation,
+				log::invalidLuceneIdStrategy,
+				value
+		);
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneDocumentReferenceProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneDocumentReferenceProjection.java
@@ -37,7 +37,7 @@ class LuceneDocumentReferenceProjection extends AbstractLuceneProjection<Documen
 
 	@Override
 	public Values<DocumentReference> values(ProjectionExtractContext context) {
-		return DocumentReferenceValues.simple( context.collectorExecutionContext() );
+		return DocumentReferenceValues.simple( context );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneEntityLoadingProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneEntityLoadingProjection.java
@@ -39,7 +39,7 @@ public class LuceneEntityLoadingProjection<E> extends AbstractLuceneProjection<E
 	@Override
 	public Values<Object> values(ProjectionExtractContext context) {
 		ProjectionHitMapper<?> mapper = context.projectionHitMapper();
-		return new DocumentReferenceValues<Object>( context.collectorExecutionContext() ) {
+		return new DocumentReferenceValues<Object>( context.idReader(), context.collectorExecutionContext() ) {
 			@Override
 			protected Object toReference(String typeName, String identifier) {
 				return mapper.planLoading( new LuceneDocumentReference( typeName, identifier ) );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneEntityReferenceProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneEntityReferenceProjection.java
@@ -37,7 +37,7 @@ public class LuceneEntityReferenceProjection<R> extends AbstractLuceneProjection
 
 	@Override
 	public Values<DocumentReference> values(ProjectionExtractContext context) {
-		return DocumentReferenceValues.simple( context.collectorExecutionContext() );
+		return DocumentReferenceValues.simple( context );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneIdProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneIdProjection.java
@@ -40,7 +40,7 @@ public class LuceneIdProjection<I> extends AbstractLuceneProjection<I>
 
 	@Override
 	public Values<String> values(ProjectionExtractContext context) {
-		return new IdentifierValues();
+		return new IdentifierValues( context.idReader() );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/ProjectionExtractContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/ProjectionExtractContext.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.backend.lucene.search.projection.impl;
 
+import org.hibernate.search.backend.lucene.document.impl.LuceneIdReader;
 import org.hibernate.search.backend.lucene.lowlevel.collector.impl.TopDocsDataCollectorExecutionContext;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
@@ -13,11 +14,13 @@ public class ProjectionExtractContext {
 
 	private final TopDocsDataCollectorExecutionContext collectorExecutionContext;
 	private final ProjectionHitMapper<?> projectionHitMapper;
+	private final LuceneIdReader idReader;
 
 	public ProjectionExtractContext(TopDocsDataCollectorExecutionContext collectorExecutionContext,
-			ProjectionHitMapper<?> projectionHitMapper) {
+			ProjectionHitMapper<?> projectionHitMapper, LuceneIdReader idReader) {
 		this.collectorExecutionContext = collectorExecutionContext;
 		this.projectionHitMapper = projectionHitMapper;
+		this.idReader = idReader;
 	}
 
 	public TopDocsDataCollectorExecutionContext collectorExecutionContext() {
@@ -26,5 +29,9 @@ public class ProjectionExtractContext {
 
 	public ProjectionHitMapper<?> projectionHitMapper() {
 		return projectionHitMapper;
+	}
+
+	public LuceneIdReader idReader() {
+		return idReader;
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilder.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import org.hibernate.search.backend.lucene.document.impl.LuceneIdReader;
 import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.lowlevel.common.impl.MetadataFields;
 import org.hibernate.search.backend.lucene.lowlevel.query.impl.Queries;
@@ -66,6 +67,7 @@ public class LuceneSearchQueryBuilder<H> implements SearchQueryBuilder<H>, Lucen
 
 	private final SearchLoadingContextBuilder<?, ?> loadingContextBuilder;
 	private final LuceneSearchProjection<H> rootProjection;
+	private final LuceneIdReader idReader;
 
 	private Query luceneQuery;
 	private List<SortField> sortFields;
@@ -83,12 +85,13 @@ public class LuceneSearchQueryBuilder<H> implements SearchQueryBuilder<H>, Lucen
 			LuceneSearchQueryIndexScope<?> scope,
 			BackendSessionContext sessionContext,
 			SearchLoadingContextBuilder<?, ?> loadingContextBuilder,
-			LuceneSearchProjection<H> rootProjection) {
+			LuceneSearchProjection<H> rootProjection, LuceneIdReader idReader) {
 		this.workFactory = workFactory;
 		this.queryOrchestrator = queryOrchestrator;
 
 		this.scope = scope;
 		this.sessionContext = sessionContext;
+		this.idReader = idReader;
 		this.routingKeys = new HashSet<>();
 
 		this.loadingContextBuilder = loadingContextBuilder;
@@ -275,7 +278,8 @@ public class LuceneSearchQueryBuilder<H> implements SearchQueryBuilder<H>, Lucen
 				rootExtractor,
 				aggregations == null ? Collections.emptyMap() : aggregations,
 				extractionRequirements,
-				timeoutManager
+				timeoutManager,
+				idReader
 		);
 
 		return new LuceneSearchQueryImpl<>(

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearcherImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearcherImpl.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.Map;
 
+import org.hibernate.search.backend.lucene.document.impl.LuceneIdReader;
 import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.lowlevel.collector.impl.TimeoutCountCollectorManager;
 import org.hibernate.search.backend.lucene.lowlevel.reader.impl.IndexReaderMetadataResolver;
@@ -44,17 +45,19 @@ class LuceneSearcherImpl<H> implements LuceneSearcher<LuceneLoadableSearchResult
 	private final ExtractionRequirements extractionRequirements;
 
 	private TimeoutManager timeoutManager;
+	private final LuceneIdReader idReader;
 
 	LuceneSearcherImpl(LuceneSearchQueryRequestContext requestContext,
 			LuceneSearchProjection.Extractor<?, H> rootExtractor,
 			Map<AggregationKey<?>, LuceneSearchAggregation<?>> aggregations,
 			ExtractionRequirements extractionRequirements,
-			TimeoutManager timeoutManager) {
+			TimeoutManager timeoutManager, LuceneIdReader idReader) {
 		this.requestContext = requestContext;
 		this.rootExtractor = rootExtractor;
 		this.aggregations = aggregations;
 		this.extractionRequirements = extractionRequirements;
 		this.timeoutManager = timeoutManager;
+		this.idReader = idReader;
 	}
 
 	@Override
@@ -100,7 +103,8 @@ class LuceneSearcherImpl<H> implements LuceneSearcher<LuceneLoadableSearchResult
 						totalHitCountThreshold );
 
 		return new LuceneExtractableSearchResult<>( requestContext, indexSearcher, luceneCollectors,
-				rootExtractor, aggregations, timeoutManager );
+				rootExtractor, aggregations, timeoutManager, idReader
+		);
 	}
 
 	@Override

--- a/documentation/src/main/asciidoc/public/reference/_backend-lucene.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_backend-lucene.adoc
@@ -559,6 +559,40 @@ When indexing, a discriminator field holding the tenant ID is populated transpar
 When searching, a filter targeting the tenant ID field is added transparently to the search query
 to only return search hits for the current tenant.
 
+[[backend-lucene-schema-id-strategy]]
+=== ID strategy
+
+With the upcoming Lucene 9 upgrade, Hibernate Search will require backward incompatible schema changes.
+In particular, the way it works with IDs will change.
+This means that once the change happens, all Lucene indexes must be recreated, and data needs to be repopulated.
+
+To give users more flexibility in deciding when to prepare for these upcoming changes,
+Hibernate Search offers a backend-level configuration property
+that switches the schema id strategy to be compatible with future versions:
+
+[source]
+----
+hibernate.search.backend.schema.id.strategy = lucene9
+----
+
+See the following subsections for details about available strategies.
+
+[[backend-lucene-schema-id-strategy-lucene8]]
+==== `lucene8`
+
+Currently used strategy that is compatible with the current indexes.
+It is deprecated and will be removed in a future version of Hibernate Search that will support Lucene 9.
+
+[[backend-lucene-schema-id-strategy-lucene9]]
+==== `lucene9`
+
+This strategy will create documents compatible with future versions of Hibernate Search.
+Switching to this strategy for existing applications will require indexes to be recreated and repopulated.
+The easiest way to do so is to use <<indexing-massindexer,the `MassIndexer`>> with <<indexing-massindexer-parameters-drop-and-create-schema,`dropAndCreateSchemaOnStart(true)`>>.
+
+NOTE: Switching to this strategy as soon as an opportunity arises is recommended.
+Doing so should allow for a smoother future upgrade of Hibernate Search.
+
 [[backend-lucene-analysis]]
 == Analysis
 

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/mapping/LuceneSchemaIdStrategyIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/mapping/LuceneSchemaIdStrategyIT.java
@@ -1,0 +1,77 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.lucene.mapping;
+
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
+
+import org.hibernate.search.backend.lucene.cfg.LuceneBackendSettings;
+import org.hibernate.search.backend.lucene.schema.SchemaIdStrategy;
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+public class LuceneSchemaIdStrategyIT {
+
+	@Rule
+	public final SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private final SimpleMappedIndex<IndexBinding> index = SimpleMappedIndex.of( IndexBinding::new );
+
+	public void setup(SchemaIdStrategy strategy) {
+		setupHelper.start()
+				.withBackendProperty( LuceneBackendSettings.SCHEMA_ID_STRATEGY, strategy )
+				.withIndex( index )
+				.setup();
+
+		initData();
+	}
+
+	private void test() {
+		assertThatQuery( index.createScope().query()
+				.select( f -> f.id() )
+				.where( f -> f.matchAll() )
+				.toQuery() )
+				.hasHitsAnyOrder(
+						"ID:1"
+				);
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	public void lucene8() {
+		setup( SchemaIdStrategy.LUCENE_8 );
+		test();
+	}
+
+	@Test
+	public void lucene9() {
+		setup( SchemaIdStrategy.LUCENE_9 );
+
+		test();
+	}
+
+	private void initData() {
+		index.bulkIndexer()
+				.add( "ID:1", document -> {
+					document.addValue( index.binding().string, "keyword" );
+				} )
+				.join();
+	}
+
+	private static class IndexBinding {
+		final IndexFieldReference<String> string;
+
+		IndexBinding(IndexSchemaElement root) {
+			string = root.field( "keyword", f -> f.asString().projectable( Projectable.YES ) ).toReference();
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4884

That seems doable 😃, I've cherrypicked a first commit that originally introduced the change. And in the second commit, I've added a way we could pick which way to go. Do you have any suggestions for the property name? and how does this look overall? 