### PR TITLE
HSEARCH-4602 Upgrade to CDI 4 / HSEARCH-4395 cleanup dependabot rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,10 +37,7 @@ updates:
       # See b8f044eea92d6f2dd3421779f54b8923e00a26b7
       - dependency-name: org.asciidoctor:asciidoctorj-pdf
       # We strictly align these dependencies on the version used in Hibernate ORM.
-      - dependency-name: "org.jboss:jandex"
       - dependency-name: "io.smallrye:jandex"
-      - dependency-name: "javax.persistence:javax.persistence-api"
-      - dependency-name: "javax.enterprise:cdi-api"
       - dependency-name: "jakarta.persistence:jakarta.persistence-api"
       - dependency-name: "jakarta.enterprise:jakarta.enterprise.cdi-api"
       - dependency-name: "jakarta.xml.bind:jakarta.xml.bind-api"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,9 +44,6 @@ updates:
       - dependency-name: "net.bytebuddy:*"
       # Newer majors of the following artifacts comply with the Jakarta specification (jakarta.* packages),
       # but we comply with Java EE (javax.* packages) for now.
-      # TODO HSEARCH-4394 Remove these when switching to Jakarta EE as the default standard
-      - dependency-name: "org.jboss.weld.se:*"
-        update-types: ["version-update:semver-major"]
       - dependency-name: "org.jberet:*"
         update-types: ["version-update:semver-major"]
       # Sticking to Derby 10.15 for now since later versions require JDK 17+, and we need to test with JDK 11.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,10 +42,6 @@ updates:
       - dependency-name: "jakarta.enterprise:jakarta.enterprise.cdi-api"
       - dependency-name: "jakarta.xml.bind:jakarta.xml.bind-api"
       - dependency-name: "net.bytebuddy:*"
-      # Newer majors of the following artifacts comply with the Jakarta specification (jakarta.* packages),
-      # but we comply with Java EE (javax.* packages) for now.
-      - dependency-name: "org.jberet:*"
-        update-types: ["version-update:semver-major"]
       # Sticking to Derby 10.15 for now since later versions require JDK 17+, and we need to test with JDK 11.
       # See https://db.apache.org/derby/derby_downloads.html
       - dependency-name: "org.apache.derby:*"

--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,7 @@
         <version.org.apache.commons.lang3>3.12.0</version.org.apache.commons.lang3>
         <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
         <version.org.apache.avro>1.11.1</version.org.apache.avro>
-        <version.org.jboss.weld>4.0.3.Final</version.org.jboss.weld>
+        <version.org.jboss.weld>5.1.1.Final</version.org.jboss.weld>
 
         <!-- >>> JDBC Drivers -->
         <version.com.h2database>2.1.214</version.com.h2database>

--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
 
         <!-- >>> JSR 352 -->
         <version.jakarta.batch>2.1.1</version.jakarta.batch>
-        <version.org.jberet>2.0.4.Final</version.org.jberet>
+        <version.org.jberet>2.1.1.Final</version.org.jberet>
 
         <!-- >>> Java EE/Jakarta EE dependencies -->
         <!-- Used in the JSR352 integration in particular, but also in the ORM integration (?) and various tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -271,7 +271,7 @@
         <version.jakarta.persistence>3.1.0</version.jakarta.persistence>
         <version.jakarta.transaction-api>2.0.1</version.jakarta.transaction-api>
         <version.jakarta.interceptor-api>2.0.1</version.jakarta.interceptor-api>
-        <version.jakarta.enterprise>3.0.1</version.jakarta.enterprise>
+        <version.jakarta.enterprise>4.0.1</version.jakarta.enterprise>
         <version.jakarta.xml.bind>4.0.0</version.jakarta.xml.bind>
 
         <!-- >>> JSR 352 -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4602
https://hibernate.atlassian.net/browse/HSEARCH-4395
https://hibernate.atlassian.net/browse/HSEARCH-4891

Opening as a draft as this is based on https://github.com/hibernate/hibernate-search/pull/3562 
BTW do Weld and Jberet deserve their own tickets for an upgrade? 😃 