### PR TITLE
HSEARCH-4555 Bump jboss-logging from 3.5.1.Final to 3.5.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <!-- Main dependencies -->
 
         <!-- >>> Common -->
-        <version.org.jboss.logging.jboss-logging>3.5.1.Final</version.org.jboss.logging.jboss-logging>
+        <version.org.jboss.logging.jboss-logging>3.5.2.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.2.1.Final</version.org.jboss.logging.jboss-logging-tools>
         <javadoc.org.hibernate.search.url>https://docs.jboss.org/hibernate/search/${parsed-version.org.hibernate.search.majorVersion}.${parsed-version.org.hibernate.search.minorVersion}/api/</javadoc.org.hibernate.search.url>
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4555

I think we can reuse the 4555 since it wasn't released yet.


Bumps [jboss-logging](https://github.com/jboss-logging/jboss-logging) from 3.5.1.Final to 3.5.2.Final.
- [Release notes](https://github.com/jboss-logging/jboss-logging/releases)
- [Commits](https://github.com/jboss-logging/jboss-logging/compare/3.5.1.Final...3.5.2.Final)

---
updated-dependencies:
- dependency-name: org.jboss.logging:jboss-logging dependency-type: direct:production update-type: version-update:semver-patch ...

<!--
Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HSEARCH.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HSEARCH-<digits>`).
-->