### PR TITLE
Configure Groovy upgrade rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,9 @@ updates:
       # JRuby releases way too often (every two weeks?) and is only used during the build; ignore all patch updates
       - dependency-name: "org.jruby:jruby-complete"
         update-types: ["version-update:semver-patch"]
+      # Groovy is only used during the build; ignore all patch updates
+      - dependency-name: "org.apache.groovy:groovy-jsr223"
+        update-types: [ "version-update:semver-patch" ]
       # We don't care that much about being on the very latest version of some integration test dependencies
       - dependency-name: "org.springframework.boot:*"
         update-types: [ "version-update:semver-patch" ]

--- a/pom.xml
+++ b/pom.xml
@@ -403,7 +403,7 @@
         <version.sonar.plugin>3.9.1.2184</version.sonar.plugin>
         <version.scripting.plugin>3.0.0</version.scripting.plugin>
         <version.gpg.plugin>3.1.0</version.gpg.plugin>
-        <version.org.apache.groovy.groovy-jsr223>4.0.12</version.org.apache.groovy.groovy-jsr223>
+        <version.org.apache.groovy.groovy-jsr223>4.0.13</version.org.apache.groovy.groovy-jsr223>
         <version.com.puppycrawl.tools.checkstyle>10.9.3</version.com.puppycrawl.tools.checkstyle>
         <version.versions.plugin>2.12.0</version.versions.plugin>
         <version.maven-wrapper-plugin>3.2.0</version.maven-wrapper-plugin>


### PR DESCRIPTION
- Configure groovy upgrade rule
- and also bump groovy-jsr223 from 4.0.12 to 4.0.13

Bumps [groovy-jsr223](https://github.com/apache/groovy) from 4.0.12 to 4.0.13.
- [Commits](https://github.com/apache/groovy/commits)

---
updated-dependencies:
- dependency-name: org.apache.groovy:groovy-jsr223 dependency-type: direct:production update-type: version-update:semver-patch ...

<!--
Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HSEARCH.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HSEARCH-<digits>`).
-->