### PR TITLE
HSEARCH-4892 Bump version.org.apache.avro from 1.11.1 to 1.11.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
         <version.com.github.tomakehurst.wiremock>3.0.0-beta-10</version.com.github.tomakehurst.wiremock>
         <version.org.apache.commons.lang3>3.12.0</version.org.apache.commons.lang3>
         <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
-        <version.org.apache.avro>1.11.1</version.org.apache.avro>
+        <version.org.apache.avro>1.11.2</version.org.apache.avro>
         <version.org.jboss.weld>5.1.1.Final</version.org.jboss.weld>
 
         <!-- >>> JDBC Drivers -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4892