### PR TITLE
Backport HSEARCH-4892 to branch 6.2 - Bump version.org.apache.avro from 1.11.1 to 1.11.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,7 +333,7 @@
         <version.com.github.tomakehurst.wiremock>2.27.2</version.com.github.tomakehurst.wiremock>
         <version.org.apache.commons.lang3>3.12.0</version.org.apache.commons.lang3>
         <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
-        <version.org.apache.avro>1.11.1</version.org.apache.avro>
+        <version.org.apache.avro>1.11.2</version.org.apache.avro>
         <version.org.jboss.weld>3.1.9.Final</version.org.jboss.weld>
         <version.org.jboss.weld.jakarta>4.0.3.Final</version.org.jboss.weld.jakarta>
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4892

backport of https://github.com/hibernate/hibernate-search/pull/3581