### PR TITLE
HSEARCH-4532 Change agent/event payload mapping

### DIFF
--- a/documentation/src/main/asciidoc/migration/index.adoc
+++ b/documentation/src/main/asciidoc/migration/index.adoc
@@ -62,6 +62,52 @@ Reading and writing to Lucene indexes created with Hibernate Search {hibernateSe
 using Hibernate Search {hibernateSearchVersion} may lead to exceptions, since there were incompatible changes applied to internal fields.
 You must recreate your Lucene indexes and reindex your database. The easiest way to do so is to use link:{hibernateSearchDocUrl}#indexing-massindexer[the `MassIndexer`] with link:{hibernateSearchDocUrl}#indexing-massindexer-parameters-drop-and-create-schema[`dropAndCreateSchemaOnStart(true)`].
 
+[[outboxpolling]]
+=== Outbox polling system tables
+
+If you use the incubating link:{hibernateSearchDocUrl}#coordination-outbox-polling[`outbox-polling` coordination strategy],
+with the PostgreSQL database you will be impacted by the changes to entities that represents the outbox event and agent,
+requiring database schema changes.
+The `payload` column changes its type from `oid` to `bytea` for both outbox event and agent tables.
+You can find suggested migration scripts below:
+
+.Postgresql:
+[,sql]
+----
+-- Change outbox event `payload` column type to bytea:
+-- Note the way existing LOBs are retrieved using lo_get function.
+alter table hsearch_outbox_event
+    alter column payload type bytea using lo_get(payload);
+
+-- Change agent `payload` column type to bytea:
+-- Note: even though agent table should've not used payload column so far, we still need to have a type cast.
+-- It can be done either with the same `lo_get()` function call, or with a pair of casts like `cast( cast( payload as text ) as bytea )`:
+alter table hsearch_agent
+    alter column payload type bytea using lo_get(payload);
+----
+Other databases:
+
+* CockroachDB: no migration required. Type of the `payload` is `bytes` in both cases.
+* MySQL: no migration required. Type of the `payload` is `longblob` in both cases.
+* MariaDB: no migration required. Type of the `payload` is `longblob` in both cases.
+* DB2: no migration required. Type of the `payload` is `blob` in both cases.
+* Oracle: no migration required. Type of the `payload` is `blob` in both cases.
+* MSSQL: no migration required. Type of the `payload` is `varbinary(max)` in both cases.
+* H2: no migration required. Type of the `payload` is `blob` in both cases.
+
+[NOTE]
+====
+In case database migration cannot be performed immediately when upgrading to a new version of Hibernate Search,
+a pair of configuration properties is available:
+[source]
+----
+hibernate.search.coordination.entity.mapping.agent.payload_type=materialized_blob
+hibernate.search.coordination.entity.mapping.outboxevent.payload_type=materialized_blob
+----
+Keep in mind that these properties are temporary, to help with the migration,
+and will be removed in the future versions of Hibernate Search.
+====
+
 [[configuration]]
 == Configuration changes
 

--- a/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/schema/OutboxPollingCustomEntityMappingIT.java
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/schema/OutboxPollingCustomEntityMappingIT.java
@@ -32,7 +32,9 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
 import org.hibernate.search.integrationtest.mapper.orm.coordination.outboxpolling.testsupport.util.OutboxEventFilter;
 import org.hibernate.search.integrationtest.mapper.orm.coordination.outboxpolling.testsupport.util.TestingOutboxPollingInternalConfigurer;
+import org.hibernate.search.mapper.orm.coordination.outboxpolling.avro.impl.EventPayloadSerializationUtils;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.HibernateOrmMapperOutboxPollingSettings;
+import org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.PayloadType;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.impl.HibernateOrmMapperOutboxPollingImplSettings;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.Agent;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.OutboxPollingAgentAdditionalJaxbMappingProducer;
@@ -40,13 +42,17 @@ import org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl.Out
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.event.impl.OutboxPollingOutboxEventAdditionalJaxbMappingProducer;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingQueueEventPayload;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.CoordinationStrategyExpectations;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.test.rule.ExpectedLog4jLog;
 
 import org.junit.Rule;
 import org.junit.Test;
+
+import org.apache.logging.log4j.Level;
 
 public class OutboxPollingCustomEntityMappingIT {
 
@@ -78,6 +84,9 @@ public class OutboxPollingCustomEntityMappingIT {
 				CUSTOM_SCHEMA,
 		};
 	}
+
+	@Rule
+	public ExpectedLog4jLog logged = ExpectedLog4jLog.create();
 
 	@Rule
 	public BackendMock backendMock = new BackendMock();
@@ -384,6 +393,91 @@ public class OutboxPollingCustomEntityMappingIT {
 				);
 	}
 
+	@Test
+	public void validMappingWithDefaultPayloadType() {
+		testPayloadType( null );
+	}
+
+	@Test
+	public void validMappingWithExplicitDefaultPayloadType() {
+		testPayloadType( PayloadType.LONG32VARBINARY );
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	public void validMappingWithNonDefaultPayloadType() {
+		testPayloadType( PayloadType.MATERIALIZED_BLOB );
+	}
+
+	@SuppressWarnings("deprecation")
+	private void testPayloadType(PayloadType payloadType) {
+		KeysStatementInspector statementInspector = new KeysStatementInspector();
+
+		backendMock.expectAnySchema( IndexedEntity.INDEX );
+		OrmSetupHelper.SetupContext setupContext = ormSetupHelper.start()
+				.withProperty(
+						HibernateOrmMapperOutboxPollingImplSettings.COORDINATION_INTERNAL_CONFIGURER,
+						new TestingOutboxPollingInternalConfigurer().outboxEventFilter( eventFilter )
+				)
+				// Allow ORM to create schema as we want to use non-default for this testcase:
+				.withProperty( "jakarta.persistence.create-database-schemas", true )
+				.withProperty( "hibernate.show_sql", true )
+				.withProperty( "hibernate.format_sql", true )
+				.withProperty( "hibernate.session_factory.statement_inspector", statementInspector );
+
+		if ( payloadType != null ) {
+			setupContext
+					.withProperty(
+							HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_AGENT_PAYLOAD_TYPE,
+							payloadType
+					)
+					.withProperty(
+							HibernateOrmMapperOutboxPollingSettings.COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_PAYLOAD_TYPE,
+							payloadType
+					);
+			logged.expectEvent(
+					Level.WARN,
+					"Configuration property `hibernate.search.coordination.entity.mapping.outboxevent.payload_type` is deprecated and will be removed in the future versions of Hibernate Search",
+					"This property is only to help with the schema migration and should not be used as a long term solution"
+			);
+			logged.expectEvent(
+					Level.WARN,
+					"Configuration property `hibernate.search.coordination.entity.mapping.agent.payload_type` is deprecated and will be removed in the future versions of Hibernate Search",
+					"This property is only to help with the schema migration and should not be used as a long term solution"
+			);
+		}
+		sessionFactory = setupContext.setup( IndexedEntity.class );
+
+		backendMock.verifyExpectationsMet();
+
+		int id = 1;
+		with( sessionFactory ).runInTransaction( session -> {
+			IndexedEntity entity = new IndexedEntity();
+			entity.setId( id );
+			entity.setIndexedField( "value for the field" );
+			session.persist( entity );
+
+			backendMock.expectWorks( IndexedEntity.INDEX )
+					.add( "1", f -> f.field( "indexedField", "value for the field" ) );
+		} );
+
+		await().untilAsserted( () -> {
+			with( sessionFactory ).runInTransaction( session -> {
+				assertEventPayload( session );
+				assertAgentPayload( session );
+			} );
+		} );
+		// The events were hidden until now, to ensure they were not processed in separate batches.
+		// Make them visible to Hibernate Search now.
+		eventFilter.showAllEventsUpToNow( sessionFactory );
+		eventFilter.awaitUntilNoMoreVisibleEvents( sessionFactory );
+
+		backendMock.verifyExpectationsMet();
+
+		assertThat( statementInspector.countByKey( ORIGINAL_OUTBOX_EVENT_TABLE_NAME ) ).isPositive();
+		assertThat( statementInspector.countByKey( ORIGINAL_AGENT_TABLE_NAME ) ).isPositive();
+	}
+
 	private void assertEventUUIDVersion(Session session, int expectedVersion) {
 		List<OutboxEvent> events = eventFilter.findOutboxEventsNoFilter( session );
 		assertThat( events )
@@ -404,6 +498,27 @@ public class OutboxPollingCustomEntityMappingIT {
 				.extracting( Agent::getId )
 				.extracting( UUID::version )
 				.containsOnly( expectedVersion );
+	}
+
+	private void assertEventPayload(Session session) {
+		List<OutboxEvent> events = eventFilter.findOutboxEventsNoFilter( session );
+		assertThat( events ).hasSize( 1 );
+		byte[] payload = events.get( 0 ).getPayload();
+		assertThat( payload ).isNotEmpty();
+		// check that we can deserialize whatever was saved:
+		PojoIndexingQueueEventPayload deserialized = EventPayloadSerializationUtils.deserialize( payload );
+		assertThat( deserialized.routes.currentRoute().routingKey() ).isNull();
+	}
+
+	private void assertAgentPayload(Session session) {
+		List<Agent> agents = session.createQuery(
+				"select a from " + OutboxPollingAgentAdditionalJaxbMappingProducer.ENTITY_NAME + " a ",
+				Agent.class
+		)
+				.getResultList();
+		assertThat( agents ).hasSize( 1 );
+		// agent payload is currently null
+		assertThat( agents.get( 0 ).getPayload() ).isNull();
 	}
 
 	private Dialect getDialect() {

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/HibernateOrmMapperOutboxPollingSettings.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/HibernateOrmMapperOutboxPollingSettings.java
@@ -428,6 +428,25 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 			PREFIX + Radicals.COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_UUID_TYPE;
 
 	/**
+	 * The name of the {@link org.hibernate.type.SqlTypes SQL type} used for representing the payload in the outbox event table.
+	 * <p>
+	 * Supported values are:
+	 * <ul>
+	 *     <li>{@link PayloadType#MATERIALIZED_BLOB}, used in previous versions of Hibernate Search.</li>
+	 *     <li>{@link PayloadType#LONG32VARBINARY}, the new default and the value that will be used moving forward.</li>
+	 * </ul>
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * {@value HibernateOrmMapperOutboxPollingSettings#COORDINATION_STRATEGY_NAME}.
+	 * <p>
+	 * The default value is {@link  Defaults#COORDINATION_ENTITY_MAPPING_AGENT_PAYLOAD_TYPE}.
+	 * @deprecated The setting is only available to help migrate existing applications to the current version of Hibernate Search.
+	 * This setting will be removed in the future releases.
+	 */
+	@Deprecated
+	public static final String COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_PAYLOAD_TYPE =
+			PREFIX + Radicals.COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_PAYLOAD_TYPE;
+
+	/**
 	 * The database catalog to use for the agent table.
 	 * <p>
 	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
@@ -487,6 +506,26 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 			PREFIX + Radicals.COORDINATION_ENTITY_MAPPING_AGENT_UUID_TYPE;
 
 	/**
+	 * The name of the {@link org.hibernate.type.SqlTypes SQL type} used for representing the payload in the agent table.
+	 * <p>
+	 * Supported values are:
+	 * <ul>
+	 *     <li>{@link PayloadType#MATERIALIZED_BLOB}, used in previous versions of Hibernate Search.</li>
+	 *     <li>{@link PayloadType#LONG32VARBINARY}, the new default and the value that will be used moving forward.</li>
+	 * </ul>
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * {@value HibernateOrmMapperOutboxPollingSettings#COORDINATION_STRATEGY_NAME}.
+	 * <p>
+	 * The default value is {@link  Defaults#COORDINATION_ENTITY_MAPPING_AGENT_PAYLOAD_TYPE}.
+	 * @deprecated The setting is only available to help migrate existing applications to the current version of Hibernate Search.
+	 * This setting will be removed in the future releases.
+	 */
+	@Deprecated
+	public static final String COORDINATION_ENTITY_MAPPING_AGENT_PAYLOAD_TYPE =
+			PREFIX + Radicals.COORDINATION_ENTITY_MAPPING_AGENT_PAYLOAD_TYPE;
+
+
+	/**
 	 * Configuration property keys without the {@link #PREFIX prefix}.
 	 */
 	public static final class Radicals {
@@ -532,6 +571,9 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 				COORDINATION_PREFIX + CoordinationRadicals.ENTITY_MAPPING_OUTBOXEVENT_UUID_GEN_STRATEGY;
 		public static final String COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_UUID_TYPE =
 				COORDINATION_PREFIX + CoordinationRadicals.ENTITY_MAPPING_OUTBOXEVENT_UUID_TYPE;
+		@Deprecated
+		public static final String COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_PAYLOAD_TYPE =
+				COORDINATION_PREFIX + CoordinationRadicals.ENTITY_MAPPING_OUTBOXEVENT_PAYLOAD_TYPE;
 		public static final String COORDINATION_ENTITY_MAPPING_AGENT_CATALOG =
 				COORDINATION_PREFIX + CoordinationRadicals.ENTITY_MAPPING_AGENT_CATALOG;
 		public static final String COORDINATION_ENTITY_MAPPING_AGENT_SCHEMA =
@@ -542,6 +584,9 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 				COORDINATION_PREFIX + CoordinationRadicals.ENTITY_MAPPING_AGENT_UUID_GEN_STRATEGY;
 		public static final String COORDINATION_ENTITY_MAPPING_AGENT_UUID_TYPE =
 				COORDINATION_PREFIX + CoordinationRadicals.ENTITY_MAPPING_AGENT_UUID_TYPE;
+		@Deprecated
+		public static final String COORDINATION_ENTITY_MAPPING_AGENT_PAYLOAD_TYPE =
+				COORDINATION_PREFIX + CoordinationRadicals.ENTITY_MAPPING_AGENT_PAYLOAD_TYPE;
 	}
 
 	/**
@@ -576,6 +621,8 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 		public static final String ENTITY_MAPPING_AGENT_CATALOG = ENTITY_MAPPING_AGENT_PREFIX + "catalog";
 		public static final String ENTITY_MAPPING_AGENT_UUID_GEN_STRATEGY = ENTITY_MAPPING_AGENT_PREFIX + "uuid_gen_strategy";
 		public static final String ENTITY_MAPPING_AGENT_UUID_TYPE = ENTITY_MAPPING_AGENT_PREFIX + "uuid_type";
+		@Deprecated
+		public static final String ENTITY_MAPPING_AGENT_PAYLOAD_TYPE = ENTITY_MAPPING_AGENT_PREFIX + "payload_type";
 		public static final String ENTITY_MAPPING_OUTBOXEVENT_PREFIX = ENTITY_MAPPING_PREFIX + "outboxevent.";
 		public static final String ENTITY_MAPPING_OUTBOXEVENT_TABLE = ENTITY_MAPPING_OUTBOXEVENT_PREFIX + "table";
 		public static final String ENTITY_MAPPING_OUTBOXEVENT_SCHEMA = ENTITY_MAPPING_OUTBOXEVENT_PREFIX + "schema";
@@ -583,6 +630,8 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 		public static final String ENTITY_MAPPING_OUTBOXEVENT_UUID_GEN_STRATEGY =
 				ENTITY_MAPPING_OUTBOXEVENT_PREFIX + "uuid_gen_strategy";
 		public static final String ENTITY_MAPPING_OUTBOXEVENT_UUID_TYPE = ENTITY_MAPPING_OUTBOXEVENT_PREFIX + "uuid_type";
+		@Deprecated
+		public static final String ENTITY_MAPPING_OUTBOXEVENT_PAYLOAD_TYPE = ENTITY_MAPPING_OUTBOXEVENT_PREFIX + "payload_type";
 	}
 
 	/**
@@ -613,12 +662,16 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 		public static final UuidGenerationStrategy COORDINATION_ENTITY_MAPPING_AGENT_UUID_GEN_STRATEGY =
 				UuidGenerationStrategy.AUTO;
 		public static final String COORDINATION_ENTITY_MAPPING_AGENT_UUID_TYPE = "default";
+		@Deprecated
+		public static final PayloadType COORDINATION_ENTITY_MAPPING_AGENT_PAYLOAD_TYPE = PayloadType.LONG32VARBINARY;
 
 		// Must not be longer than 20 characters, so that the generator does not exceed the 30 characters for Oracle11g
 		public static final String COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_TABLE = HSEARCH_PREFIX + "OUTBOX_EVENT";
 		public static final UuidGenerationStrategy COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_UUID_GEN_STRATEGY =
 				UuidGenerationStrategy.AUTO;
 		public static final String COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_UUID_TYPE = "default";
+		@Deprecated
+		public static final PayloadType COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_PAYLOAD_TYPE = PayloadType.LONG32VARBINARY;
 	}
 
 	/**

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/PayloadType.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/PayloadType.java
@@ -1,0 +1,50 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg;
+
+import java.lang.invoke.MethodHandles;
+
+import org.hibernate.search.engine.cfg.spi.ParseUtils;
+import org.hibernate.search.mapper.orm.coordination.outboxpolling.logging.impl.Log;
+import org.hibernate.search.util.common.annotation.Incubating;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
+
+@Incubating
+public enum PayloadType {
+	/**
+	 * Using {@link org.hibernate.type.SqlTypes#MATERIALIZED_BLOB} to store the payload.
+	 */
+	@Deprecated
+	MATERIALIZED_BLOB( "materialized_blob" ),
+
+	/**
+	 * Using {@link org.hibernate.type.SqlTypes#LONG32VARBINARY} to store the payload.
+	 */
+	LONG32VARBINARY( "long32varbinary" );
+
+	private final String externalRepresentation;
+
+	PayloadType(String externalRepresentation) {
+		this.externalRepresentation = externalRepresentation;
+	}
+
+	public String externalRepresentation() {
+		return externalRepresentation;
+	}
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
+	// This method conforms to the MicroProfile Config specification. Do not change its signature.
+	public static PayloadType of(String value) {
+		return ParseUtils.parseDiscreteValues(
+				PayloadType.values(),
+				PayloadType::externalRepresentation,
+				log::invalidPayloadTypeName,
+				value
+		);
+	}
+}

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/impl/PayloadMappingUtils.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/impl/PayloadMappingUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.impl;
+
+import java.util.Locale;
+
+import org.hibernate.Length;
+import org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.PayloadType;
+import org.hibernate.search.util.common.AssertionFailure;
+
+public final class PayloadMappingUtils {
+	private PayloadMappingUtils() {
+	}
+
+	private static final String MATERIALIZED_BLOB_TEMPLATE =
+			"<property name=\"payload\" nullable=\"%s\" type=\"materialized_blob\"></property>";
+
+	// We are using the `Length.LONG32` constant to make sure that ORM will try to use the `LONG32VARBINARY` if possible
+	// and in particular with PostgreSQL it will result in bytea instead of lob types (oid)
+	private static final String LONG32VARBINARY_TEMPLATE =
+			"<property name=\"payload\" nullable=\"%s\" length=\"" + Length.LONG32 + "\"></property>";
+
+	@SuppressWarnings("deprecation")
+	public static String payload(PayloadType type, boolean nullable) {
+		String template;
+		switch ( type ) {
+			case MATERIALIZED_BLOB:
+				template = MATERIALIZED_BLOB_TEMPLATE;
+				break;
+			case LONG32VARBINARY:
+				template = LONG32VARBINARY_TEMPLATE;
+				break;
+			default:
+				throw new AssertionFailure( "Unsupported PayloadType: " + type );
+		}
+		return String.format( Locale.ROOT, template, nullable );
+	}
+}

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/spi/HibernateOrmMapperOutboxPollingSpiSettings.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/cfg/spi/HibernateOrmMapperOutboxPollingSpiSettings.java
@@ -44,6 +44,7 @@ public final class HibernateOrmMapperOutboxPollingSpiSettings {
 	 * {@link HibernateOrmMapperOutboxPollingSettings#COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_TABLE},
 	 * {@link HibernateOrmMapperOutboxPollingSettings#COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_UUID_GEN_STRATEGY},
 	 * {@link HibernateOrmMapperOutboxPollingSettings#COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_UUID_TYPE},
+	 * {@link HibernateOrmMapperOutboxPollingSettings#COORDINATION_ENTITY_MAPPING_OUTBOXEVENT_PAYLOAD_TYPE}.
 	 * An exception ({@link org.hibernate.search.util.common.SearchException} will be thrown in case of such misconfiguration.
 	 */
 	public static final String OUTBOXEVENT_ENTITY_MAPPING = PREFIX + Radicals.OUTBOXEVENT_ENTITY_MAPPING;
@@ -65,6 +66,7 @@ public final class HibernateOrmMapperOutboxPollingSpiSettings {
 	 * {@link HibernateOrmMapperOutboxPollingSettings#COORDINATION_ENTITY_MAPPING_AGENT_TABLE},
 	 * {@link HibernateOrmMapperOutboxPollingSettings#COORDINATION_ENTITY_MAPPING_AGENT_UUID_GEN_STRATEGY},
 	 * {@link HibernateOrmMapperOutboxPollingSettings#COORDINATION_ENTITY_MAPPING_AGENT_UUID_TYPE},
+	 * {@link HibernateOrmMapperOutboxPollingSettings#COORDINATION_ENTITY_MAPPING_AGENT_PAYLOAD_TYPE}.
 	 * An exception ({@link org.hibernate.search.util.common.SearchException} will be thrown in case of such misconfiguration.
 	 */
 	public static final String AGENT_ENTITY_MAPPING = PREFIX + Radicals.AGENT_ENTITY_MAPPING;

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingOutboxEventAdditionalJaxbMappingProducer.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingOutboxEventAdditionalJaxbMappingProducer.java
@@ -27,7 +27,9 @@ import org.hibernate.search.engine.cfg.spi.ConfigurationProperty;
 import org.hibernate.search.engine.cfg.spi.OptionalConfigurationProperty;
 import org.hibernate.search.mapper.orm.bootstrap.spi.HibernateSearchOrmMappingProducer;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.HibernateOrmMapperOutboxPollingSettings;
+import org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.PayloadType;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.UuidGenerationStrategy;
+import org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.impl.PayloadMappingUtils;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.impl.UuidDataTypeUtils;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cfg.spi.HibernateOrmMapperOutboxPollingSpiSettings;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.OutboxPollingAgentAdditionalJaxbMappingProducer;
@@ -62,14 +64,8 @@ public final class OutboxPollingOutboxEventAdditionalJaxbMappingProducer
 			"        <property name=\"entityName\" type=\"string\" length=\"256\" nullable=\"false\" />\n" +
 			"        <property name=\"entityId\" type=\"string\" length=\"256\" nullable=\"false\" />\n" +
 			"        <property name=\"entityIdHash\" type=\"integer\" index=\"entityIdHash\" nullable=\"false\" />\n" +
-			"        <property name=\"payload\" type=\"materialized_blob\" nullable=\"false\">\n" +
-			// HSEARCH-4727: this column length will be ignored in most dialects, since the blob type is normally unbounded,
-			// but it will force Hibernate ORM to simulate an unbounded BLOB type with DB2.
-			// Using 2147483647 as it's the documented maximum length of BLOBs in DB2:
-			// https://www.ibm.com/docs/en/db2-for-zos/11?topic=types-large-objects-lobs
-			// TODO HSEARCH-4395/HSEARCH-4532 drop this length definition with ORM 6, because ORM 6 will ignore it.
-			"                <column length=\"2147483647\" />\n" +
-			"        </property>\n" +
+			// Payload column:
+			"        %6$s\n" +
 			"        <property name=\"retries\" type=\"integer\" nullable=\"false\" />\n" +
 			"        <property name=\"processAfter\" type=\"instant\" index=\"processAfter\" nullable=\"false\" />\n" +
 			"        <property name=\"status\" index=\"status\" nullable=\"false\">\n" +
@@ -80,11 +76,15 @@ public final class OutboxPollingOutboxEventAdditionalJaxbMappingProducer
 			"    </class>\n" +
 			"</hibernate-mapping>\n";
 
+	@SuppressWarnings("deprecation")
 	public static final String ENTITY_DEFINITION = String.format(
 			Locale.ROOT, ENTITY_DEFINITION_TEMPLATE, "", "",
 			HibernateOrmMapperOutboxPollingSettings.Defaults.COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_TABLE,
 			HibernateOrmMapperOutboxPollingSettings.Defaults.COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_UUID_GEN_STRATEGY,
-			UuidDataTypeUtils.UUID_CHAR
+			UuidDataTypeUtils.UUID_CHAR,
+			PayloadMappingUtils.payload(
+					HibernateOrmMapperOutboxPollingSettings.Defaults.COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_PAYLOAD_TYPE,
+					false )
 	);
 
 	private static final OptionalConfigurationProperty<String> OUTBOXEVENT_ENTITY_MAPPING =
@@ -123,6 +123,13 @@ public final class OutboxPollingOutboxEventAdditionalJaxbMappingProducer
 					.asString()
 					.build();
 
+	@SuppressWarnings("deprecation")
+	private static final OptionalConfigurationProperty<PayloadType> ENTITY_MAPPING_OUTBOXEVENT_PAYLOAD_TYPE =
+			ConfigurationProperty.forKey(
+					HibernateOrmMapperOutboxPollingSettings.CoordinationRadicals.ENTITY_MAPPING_OUTBOXEVENT_PAYLOAD_TYPE )
+					.as( PayloadType.class, PayloadType::of )
+					.build();
+
 	@Override
 	@SuppressForbiddenApis(reason = "Strangely, this SPI involves the internal MappingBinder class,"
 			+ " and there's nothing we can do about it")
@@ -135,11 +142,14 @@ public final class OutboxPollingOutboxEventAdditionalJaxbMappingProducer
 		Optional<String> table = ENTITY_MAPPING_OUTBOXEVENT_TABLE.get( propertySource );
 		Optional<UuidGenerationStrategy> uuidStrategy = ENTITY_MAPPING_OUTBOXEVENT_UUID_GEN_STRATEGY.get( propertySource );
 		Optional<String> uuidType = ENTITY_MAPPING_OUTBOXEVENT_UUID_TYPE.get( propertySource );
+		Optional<PayloadType> payloadType = ENTITY_MAPPING_OUTBOXEVENT_PAYLOAD_TYPE.get( propertySource );
 
 		// only allow configuring the entire mapping or table/catalog/schema/generator/datatype names
 		if ( mapping.isPresent()
 				&& ( schema.isPresent()
-						|| catalog.isPresent() || table.isPresent() || uuidStrategy.isPresent() || uuidType.isPresent() ) ) {
+						|| catalog.isPresent() || table.isPresent() || uuidStrategy.isPresent() || uuidType.isPresent()
+						|| payloadType.isPresent() ) ) {
+
 			throw log.outboxEventConfigurationPropertyConflict(
 					OUTBOXEVENT_ENTITY_MAPPING.resolveOrRaw( propertySource ),
 					new String[] {
@@ -147,9 +157,14 @@ public final class OutboxPollingOutboxEventAdditionalJaxbMappingProducer
 							ENTITY_MAPPING_OUTBOXEVENT_CATALOG.resolveOrRaw( propertySource ),
 							ENTITY_MAPPING_OUTBOXEVENT_TABLE.resolveOrRaw( propertySource ),
 							ENTITY_MAPPING_OUTBOXEVENT_UUID_GEN_STRATEGY.resolveOrRaw( propertySource ),
-							ENTITY_MAPPING_OUTBOXEVENT_UUID_TYPE.resolveOrRaw( propertySource )
+							ENTITY_MAPPING_OUTBOXEVENT_UUID_TYPE.resolveOrRaw( propertySource ),
+							ENTITY_MAPPING_OUTBOXEVENT_PAYLOAD_TYPE.resolveOrRaw( propertySource )
 					}
 			);
+		}
+		if ( payloadType.isPresent() ) {
+			log.usingDeprecatedPayloadTypeConfigurationProperty(
+					ENTITY_MAPPING_OUTBOXEVENT_PAYLOAD_TYPE.resolveOrRaw( propertySource ) );
 		}
 
 		String resolvedUuidType = UuidDataTypeUtils.uuidType(
@@ -157,18 +172,24 @@ public final class OutboxPollingOutboxEventAdditionalJaxbMappingProducer
 						HibernateOrmMapperOutboxPollingSettings.Defaults.COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_UUID_TYPE ),
 				dialect );
 
+		@SuppressWarnings("deprecation")
 		String entityDefinition = mapping.orElseGet( () -> String.format(
 				Locale.ROOT,
 				ENTITY_DEFINITION_TEMPLATE,
 				schema.orElse( "" ),
 				catalog.orElse( "" ),
-				table.orElse( HibernateOrmMapperOutboxPollingSettings.Defaults.COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_TABLE ),
+				table.orElse(
+						HibernateOrmMapperOutboxPollingSettings.Defaults.COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_TABLE ),
 				uuidStrategy.orElse(
 						HibernateOrmMapperOutboxPollingSettings.Defaults.COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_UUID_GEN_STRATEGY )
 						.strategy(),
-				resolvedUuidType
-		)
-		);
+				resolvedUuidType,
+				PayloadMappingUtils.payload(
+						payloadType.orElse(
+								HibernateOrmMapperOutboxPollingSettings.Defaults.COORDINATION_ENTITY_MAPPING_OUTBOX_EVENT_PAYLOAD_TYPE ),
+						false
+				)
+		) );
 
 		log.outboxEventGeneratedEntityMapping( entityDefinition );
 		Origin origin = new Origin( SourceType.OTHER, HIBERNATE_SEARCH );

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/logging/impl/Log.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/logging/impl/Log.java
@@ -194,4 +194,14 @@ public interface Log extends BasicLogger {
 			+ " Valid names are: %2$s.")
 	SearchException invalidOutboxEventProcessingOrderName(String name, List<String> values);
 
+	@Message(id = ID_OFFSET + 32, value = "Invalid name for the payload type: '%1$s'."
+			+ " Valid names are: %2$s.")
+	SearchException invalidPayloadTypeName(String name, List<String> values);
+
+	@LogMessage(level = WARN)
+	@Message(id = ID_OFFSET + 33,
+			value = "Configuration property `%1$s` is deprecated and will be removed in the future versions of Hibernate Search."
+					+ " This property is only to help with the schema migration and should not be used as a long term solution.")
+	void usingDeprecatedPayloadTypeConfigurationProperty(String configurationProperty);
+
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4532

From what it looks, only Postgresql is affected by the changes. I've tried running the tests on other DBs we are testing against, and those didn't change their "create table scripts" keeping the same column type.

I was thinking if we should go with 1 or 2 config properties and went with 2 so that users could use a setting for one entity and replace the entire mapping for the other (hopefully nobody is going to do so 😆 but if they really wanted to -- they could)