### PR TITLE
HSEARCH-4699 Rely on Hibernate ORM's BOM (hibernate-platform) to align on ORM's version of dependencies

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -105,15 +105,11 @@
         <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
-            <!-- DO NOT REMOVE and DO NOT MANAGE the version of this dependency. See the version property declaration. -->
-            <version>${version.jakarta.persistence}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
-            <!-- DO NOT REMOVE and DO NOT MANAGE the version of this dependency. See the version property declaration. -->
-            <version>${version.jakarta.transaction-api}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/integrationtest/java/modules/orm-coordination-outbox-polling-elasticsearch/pom.xml
+++ b/integrationtest/java/modules/orm-coordination-outbox-polling-elasticsearch/pom.xml
@@ -55,8 +55,6 @@
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <!-- DO NOT REMOVE and DO NOT MANAGE the version of this dependency. See the version property declaration. -->
-            <version>${version.net.bytebuddy}</version>
         </dependency>
 
         <dependency>

--- a/integrationtest/mapper/orm-spring/pom.xml
+++ b/integrationtest/mapper/orm-spring/pom.xml
@@ -32,17 +32,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- The Spring BOM uses a version of bytebuddy that's too old for Mockito to work correctly -->
-            <dependency>
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy</artifactId>
-                <version>${version.net.bytebuddy}</version>
-            </dependency>
-            <dependency>
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy-agent</artifactId>
-                <version>${version.net.bytebuddy}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/integrationtest/showcase/library/pom.xml
+++ b/integrationtest/showcase/library/pom.xml
@@ -37,17 +37,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- The Spring BOM uses a version of bytebuddy that's too old for Mockito to work correctly -->
-            <dependency>
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy</artifactId>
-                <version>${version.net.bytebuddy}</version>
-            </dependency>
-            <dependency>
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy-agent</artifactId>
-                <version>${version.net.bytebuddy}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/mapper/orm-coordination-outbox-polling/pom.xml
+++ b/mapper/orm-coordination-outbox-polling/pom.xml
@@ -57,8 +57,6 @@
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
-            <!-- DO NOT REMOVE and DO NOT MANAGE the version of this dependency. See the version property declaration. -->
-            <version>${version.jakarta.xml.bind}</version>
         </dependency>
 
         <dependency>

--- a/mapper/orm/pom.xml
+++ b/mapper/orm/pom.xml
@@ -38,8 +38,6 @@
         <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
-            <!-- DO NOT REMOVE and DO NOT MANAGE the version of this dependency. See the version property declaration. -->
-            <version>${version.jakarta.persistence}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.enterprise</groupId>
@@ -51,20 +49,14 @@
         <dependency>
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
-            <!-- DO NOT REMOVE and DO NOT MANAGE the version of this dependency. See the version property declaration. -->
-            <version>${version.jakarta.transaction-api}</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate.common</groupId>
             <artifactId>hibernate-commons-annotations</artifactId>
-            <!-- DO NOT REMOVE and DO NOT MANAGE the version of this dependency. See the version property declaration. -->
-            <version>${version.org.hibernate.commons.annotations}</version>
         </dependency>
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
-            <!-- DO NOT REMOVE and DO NOT MANAGE the version of this dependency. See the version property declaration. -->
-            <version>${version.io.smallrye.jandex}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
@@ -83,8 +75,6 @@
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <!-- DO NOT REMOVE and DO NOT MANAGE the version of this dependency. See the version property declaration. -->
-            <version>${version.net.bytebuddy}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/mapper/pojo-base/pom.xml
+++ b/mapper/pojo-base/pom.xml
@@ -31,8 +31,6 @@
         <dependency>
             <groupId>org.hibernate.common</groupId>
             <artifactId>hibernate-commons-annotations</artifactId>
-            <!-- DO NOT REMOVE and DO NOT MANAGE the version of this dependency. See the version property declaration. -->
-            <version>${version.org.hibernate.commons.annotations}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -265,27 +265,15 @@
              when the versions start diverging, thanks to the maven-enforcer-plugin
              and to our own explicit dependencies in the relevant artifacts.
           -->
-        <version.org.hibernate.commons.annotations>6.0.6.Final</version.org.hibernate.commons.annotations>
-        <version.net.bytebuddy>1.12.18</version.net.bytebuddy>
-        <version.io.smallrye.jandex>3.0.5</version.io.smallrye.jandex>
-        <version.jakarta.persistence>3.1.0</version.jakarta.persistence>
-        <version.jakarta.transaction-api>2.0.1</version.jakarta.transaction-api>
-        <version.jakarta.interceptor-api>2.0.1</version.jakarta.interceptor-api>
         <version.jakarta.enterprise>4.0.1</version.jakarta.enterprise>
-        <version.jakarta.xml.bind>4.0.0</version.jakarta.xml.bind>
 
         <!-- >>> JSR 352 -->
         <version.jakarta.batch>2.1.1</version.jakarta.batch>
         <version.org.jberet>2.1.1.Final</version.org.jberet>
 
         <!-- >>> Java EE/Jakarta EE dependencies -->
-        <!-- Used in the JSR352 integration in particular, but also in the ORM integration (?) and various tests -->
-        <version.jakarta.inject-api>2.0.1</version.jakarta.inject-api>
         <!-- This is used to generate a link to the Jakarta EE javadoc -->
         <javadoc.jakarta.batch.url>https://jakarta.ee/specifications/batch/2.0/apidocs/</javadoc.jakarta.batch.url>
-
-        <!-- >>> Tools (Maven plugins, ...) -->
-        <version.javax.enterprise>2.0</version.javax.enterprise>
 
         <!-- Test dependencies -->
 
@@ -715,6 +703,21 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Import Hibernate ORM BOM -->
+            <dependency>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-platform</artifactId>
+                <version>${version.org.hibernate.orm}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Dependencies we want to override -->
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+                <version>${version.org.jboss.logging.jboss-logging}</version>
+            </dependency>
+            <!--All other dependencies-->
             <dependency>
                 <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-util-common</artifactId>
@@ -878,16 +881,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.hibernate.orm</groupId>
-                <artifactId>hibernate-core</artifactId>
-                <version>${version.org.hibernate.orm}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.orm</groupId>
-                <artifactId>hibernate-envers</artifactId>
-                <version>${version.org.hibernate.orm}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.elasticsearch.client</groupId>
                 <artifactId>elasticsearch-rest-client</artifactId>
                 <version>${version.org.elasticsearch.client}</version>
@@ -906,11 +899,6 @@
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>auth</artifactId>
                 <version>${version.software.amazon.awssdk}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.logging</groupId>
-                <artifactId>jboss-logging</artifactId>
-                <version>${version.org.jboss.logging.jboss-logging}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.logging</groupId>
@@ -965,11 +953,6 @@
             </dependency>
 
             <!-- JakartaEE dependencies -->
-            <dependency>
-                <groupId>jakarta.inject</groupId>
-                <artifactId>jakarta.inject-api</artifactId>
-                <version>${version.jakarta.inject-api}</version>
-            </dependency>
             <dependency>
                 <groupId>jakarta.batch</groupId>
                 <artifactId>jakarta.batch-api</artifactId>
@@ -1173,25 +1156,6 @@
                 <groupId>org.openjdk.jmh</groupId>
                 <artifactId>jmh-core</artifactId>
                 <version>${version.org.openjdk.jmh}</version>
-            </dependency>
-
-            <!-- Hibernate ORM testing tools -->
-            <dependency>
-                <groupId>org.hibernate.orm</groupId>
-                <artifactId>hibernate-testing</artifactId>
-                <version>${version.org.hibernate.orm}</version>
-                <exclusions>
-                    <!-- we use Log4J 2 -->
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
-                    <!-- We don't need this stuff, and it causes dependency divergence errors -->
-                    <exclusion>
-                        <groupId>org.wildfly.transaction</groupId>
-                        <artifactId>wildfly-transaction-client-jakarta</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <!-- JBatch runtime -->

--- a/util/common/pom.xml
+++ b/util/common/pom.xml
@@ -28,8 +28,6 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
-            <!-- DO NOT REMOVE and DO NOT MANAGE the version of this dependency. See the version property declaration. -->
-            <version>${version.io.smallrye.jandex}</version>
         </dependency>
 
         <dependency>

--- a/util/internal/integrationtest/jberet-se/pom.xml
+++ b/util/internal/integrationtest/jberet-se/pom.xml
@@ -45,8 +45,6 @@
         <dependency>
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
-            <!-- DO NOT REMOVE and DO NOT MANAGE the version of this dependency. See the version property declaration. -->
-            <version>${version.jakarta.transaction-api}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/util/internal/integrationtest/v5migrationhelper/pom.xml
+++ b/util/internal/integrationtest/v5migrationhelper/pom.xml
@@ -53,8 +53,6 @@
         <dependency>
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
-            <!-- DO NOT REMOVE and DO NOT MANAGE the version of this dependency. See the version property declaration. -->
-            <version>${version.jakarta.transaction-api}</version>
         </dependency>
 
         <dependency>

--- a/util/internal/test/common/pom.xml
+++ b/util/internal/test/common/pom.xml
@@ -78,20 +78,14 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
-            <!-- DO NOT MANAGE this dependency. See the version property declaration. -->
-            <version>${version.io.smallrye.jandex}</version>
         </dependency>
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <!-- DO NOT MANAGE this dependency. See the version property declaration. -->
-            <version>${version.net.bytebuddy}</version>
         </dependency>
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy-agent</artifactId>
-            <!-- DO NOT MANAGE this dependency. See the version property declaration. -->
-            <version>${version.net.bytebuddy}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4699

Should we ask the ORM team to add the following dependency to their bom:
```xml
<dependency>
     <groupId>jakarta.enterprise</groupId>
     <artifactId>jakarta.enterprise.cdi-api</artifactId>
     <!-- DO NOT REMOVE and DO NOT MANAGE the version of this dependency. See the version property declaration. -->
     <version>${version.jakarta.enterprise}</version>
</dependency>
```