### PR TITLE
HSEARCH-4894 Use in-memory storage for CockroachDB

### DIFF
--- a/build/parents/integrationtest/pom.xml
+++ b/build/parents/integrationtest/pom.xml
@@ -361,6 +361,15 @@
                                         <exec>
                                             <arg>start-single-node</arg>
                                             <arg>--insecure</arg>
+                                            <!-- Using in-memory storage to make things a bit faster -->
+                                            <arg>--store=type=mem,size=.5</arg>
+                                            <!--
+                                                See https://www.cockroachlabs.com/docs/v23.1/transaction-retry-error-reference.html#readwithinuncertaintyintervalerror.
+                                                Increasing this value will increase the time to recovery of failures as well as the frequency of uncertainty-based read restarts.
+                                                Default value is 500ms.
+                                            -->
+                                            <arg>--max-offset=100ms</arg>
+                                            <arg>--log=sinks: {stderr: {channels: [OPS]}}</arg>
                                         </exec>
                                     </cmd>
                                     <ulimits>

--- a/pom.xml
+++ b/pom.xml
@@ -648,7 +648,7 @@
         <!-- See https://hub.docker.com/r/cockroachdb/cockroach/tags -->
         <test.database.run.cockroachdb.skip>true</test.database.run.cockroachdb.skip>
         <test.database.run.cockroachdb.image.name>cockroachdb/cockroach</test.database.run.cockroachdb.image.name>
-        <test.database.run.cockroachdb.image.tag>v22.1.12</test.database.run.cockroachdb.image.tag>
+        <test.database.run.cockroachdb.image.tag>v23.1.4</test.database.run.cockroachdb.image.tag>
 
         <!-- Property whose sole purpose is to be referenced in the definition of surefire.jvm.args.module
              when Weld is used. -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4894

So using in-memory storage seems to help a bit with the schema operations (while before the change (for a specific test file), it was taking ~10 sec to create and drop the schema, now it is ~3sec)  See https://www.cockroachlabs.com/docs/stable/local-testing.html . Applying other options suggested under that link didn't do much so I haven't added those in this PR. 
Also, while at it, I've upgraded the DB version. It might be just me 😄 but it seemed that tests run a tod faster on this version 😆 