### PR TITLE
HSEARCH-4861 Add public BOM

### DIFF
--- a/bom/build/pom.xml
+++ b/bom/build/pom.xml
@@ -18,6 +18,11 @@
     </description>
     <packaging>pom</packaging>
 
+    <properties>
+        <!-- Public modules must be signed. -->
+        <release.gpg.signing.skip>false</release.gpg.signing.skip>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/bom/build/pom.xml
+++ b/bom/build/pom.xml
@@ -1,0 +1,535 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-parent</artifactId>
+        <version>7.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>hibernate-search-build-bom</artifactId>
+    <name>Hibernate Search - Build BOM</name>
+    <description>
+        Provides dependency management for all dependencies required during the build time.
+        Imports the ones from the public BOM.
+    </description>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <!-- Remaining Hibernate Search dependencies -->
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-configuration-properties-collector</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-documentation</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-documentation</artifactId>
+                <type>pom</type>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- Import Hibernate ORM BOM -->
+            <dependency>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-platform</artifactId>
+                <version>${version.org.hibernate.orm}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Imported dependencies that we want to override -->
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+                <version>${version.org.jboss.logging.jboss-logging}</version>
+            </dependency>
+
+            <!-- Other public dependencies -->
+            <!-- Elasticsearch backend -->
+            <dependency>
+                <groupId>org.elasticsearch.client</groupId>
+                <artifactId>elasticsearch-rest-client</artifactId>
+                <version>${version.org.elasticsearch.client}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.elasticsearch.client</groupId>
+                <artifactId>elasticsearch-rest-client-sniffer</artifactId>
+                <version>${version.org.elasticsearch.client}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${version.com.google.code.gson}</version>
+            </dependency>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>auth</artifactId>
+                <version>${version.software.amazon.awssdk}</version>
+            </dependency>
+
+            <!-- Lucene backend -->
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-core</artifactId>
+                <version>${version.org.apache.lucene}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-analysis-common</artifactId>
+                <version>${version.org.apache.lucene}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-queryparser</artifactId>
+                <version>${version.org.apache.lucene}</version>
+                <exclusions>
+                    <!-- This artifact contains unstable, experimental code that we cannot reasonably rely on. -->
+                    <exclusion>
+                        <groupId>org.apache.lucene</groupId>
+                        <artifactId>lucene-sandbox</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-join</artifactId>
+                <version>${version.org.apache.lucene}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-facet</artifactId>
+                <version>${version.org.apache.lucene}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-highlighter</artifactId>
+                <version>${version.org.apache.lucene}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.carrotsearch</groupId>
+                <artifactId>hppc</artifactId>
+                <version>${version.com.carrotsearch.hppc}</version>
+            </dependency>
+
+            <!-- Apache Avro used to serialize/deserialize objects in outbox polling coordination -->
+            <dependency>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro</artifactId>
+                <version>${version.org.apache.avro}</version>
+            </dependency>
+
+            <!-- JakartaEE dependencies -->
+            <dependency>
+                <groupId>jakarta.batch</groupId>
+                <artifactId>jakarta.batch-api</artifactId>
+                <version>${version.jakarta.batch}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- JBeret used by batch-jsr352 jberet module -->
+            <dependency>
+                <groupId>org.jberet</groupId>
+                <artifactId>jberet-core</artifactId>
+                <version>${version.org.jberet}</version>
+                <exclusions>
+                    <!-- These dependencies are marked as "provided" but will never be there at runtime.
+                         This confuses maven-enforcer-plugin, so we'll exclude them. -->
+                    <exclusion>
+                        <groupId>org.jboss.logging</groupId>
+                        <artifactId>jboss-logging-processor</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.infinispan</groupId>
+                        <artifactId>infinispan-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.infinispan</groupId>
+                        <artifactId>infinispan-commons</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <!--
+                We don't really use Jackson directly, but elasticsearch-rest-client-sniffer
+                To resolve dependency convergence issue between `avro` and `elasticsearch-rest-client-sniffer`
+                elasticsearch-rest-client-sniffer only has `jackson-core` while avro has all 3.
+                We want the versions of those to be aligned
+            -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${version.com.fasterxml.jackson}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${version.com.fasterxml.jackson}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${version.com.fasterxml.jackson}</version>
+            </dependency>
+
+            <!-- We only need it for build purposes. -->
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging-annotations</artifactId>
+                <version>${version.org.jboss.logging.jboss-logging-tools}</version>
+                <scope>provided</scope>
+                <optional>true</optional>
+            </dependency>
+
+            <!-- Hibernate Search Test utils and Tests -->
+            <!-- Utils -->
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-test-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-test-orm</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-backend-elasticsearch</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-backend-lucene</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-mapper-stub</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-mapper-pojo-standalone</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-mapper-orm</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-v5migrationhelper</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-jbatch-runtime</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-jberet-se</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <!-- Tests -->
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-backend-tck</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-backend-elasticsearch</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-backend-lucene</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-mapper-pojo-base</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-mapper-orm</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-mapper-orm-cdi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-mapper-orm-spring</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-mapper-orm-envers</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-mapper-orm-realbackend</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-mapper-pojo-standalone-realbackend</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-showcase-library</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-v5migrationhelper-engine</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-v5migrationhelper-orm</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-mapper-orm-coordination-outbox-polling</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-mapper-orm-batch-jsr352</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- Test -->
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${version.junit}</version>
+            </dependency>
+            <!--
+                Manage the upgrade from Hamcrest 1.x to 2.x:
+                http://hamcrest.org/JavaHamcrest/distributables#upgrading-from-hamcrest-1x
+             -->
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest</artifactId>
+                <version>${version.org.hamcrest}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>${version.org.hamcrest}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-library</artifactId>
+                <version>${version.org.hamcrest}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.takari.junit</groupId>
+                <artifactId>takari-cpsuite</artifactId>
+                <version>${version.io.takari.junit}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${version.org.mockito}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${version.log4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${version.log4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>${version.log4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.core</artifactId>
+                <version>${version.org.osgi.core}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${version.org.assertj.assertj-core}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>${version.org.awaitily}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.skyscreamer</groupId>
+                <artifactId>jsonassert</artifactId>
+                <version>${version.org.skyscreamer.jsonassert}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.tomakehurst</groupId>
+                <artifactId>wiremock</artifactId>
+                <version>${version.com.github.tomakehurst.wiremock}</version>
+            </dependency>
+            <dependency>
+                <!-- Dependency management is necessary for Wiremock in particular (it has internal dependency divergence) -->
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${version.org.apache.commons.lang3}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.weld.se</groupId>
+                <artifactId>weld-se-shaded</artifactId>
+                <version>${version.org.jboss.weld}</version>
+            </dependency>
+
+            <!-- JDBC Drivers -->
+            <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>${version.com.h2database}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derby</artifactId>
+                <version>${version.org.apache.derby}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${version.org.postgresql}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mariadb.jdbc</groupId>
+                <artifactId>mariadb-java-client</artifactId>
+                <version>${version.org.mariadb.jdbc}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.mysql</groupId>
+                <artifactId>mysql-connector-j</artifactId>
+                <version>${version.mysql.mysql-connector-java}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.ibm.db2</groupId>
+                <artifactId>jcc</artifactId>
+                <version>${version.com.ibm.db2.jcc}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.oracle.database.jdbc</groupId>
+                <artifactId>ojdbc11</artifactId>
+                <version>${version.com.oracle.database.jdbc}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.sqlserver</groupId>
+                <artifactId>mssql-jdbc</artifactId>
+                <version>${version.com.microsoft.sqlserver.mssql-jdbc}</version>
+            </dependency>
+
+            <!-- Performance tests -->
+            <dependency>
+                <groupId>org.openjdk.jmh</groupId>
+                <artifactId>jmh-core</artifactId>
+                <version>${version.org.openjdk.jmh}</version>
+            </dependency>
+
+            <!-- JBatch runtime -->
+            <dependency>
+                <groupId>com.ibm.jbatch</groupId>
+                <artifactId>com.ibm.jbatch.container</artifactId>
+                <version>${version.com.ibm.jbatch}</version>
+            </dependency>
+
+            <!-- JBeret Core and JBeret SE runtime dependencies -->
+            <dependency>
+                <groupId>org.jboss.marshalling</groupId>
+                <artifactId>jboss-marshalling</artifactId>
+                <version>${version.org.jboss.marshalling}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.security</groupId>
+                <artifactId>wildfly-security-manager</artifactId>
+                <version>${version.org.wildfly.security.wildfly-security-manager}</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jberet</groupId>
+                <artifactId>jberet-se</artifactId>
+                <version>${version.org.jberet}</version>
+            </dependency>
+
+            <!-- For javadocs parsing -->
+            <dependency>
+                <groupId>org.jsoup</groupId>
+                <artifactId>jsoup</artifactId>
+                <version>${version.jsoup}</version>
+            </dependency>
+
+            <!-- We only need these two libs here for testing utils -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${version.org.google.guava}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-math3</artifactId>
+                <version>${version.org.apache.commons.math3}</version>
+            </dependency>
+
+            <!-- Solve dependency convergence issues through exclusions for transitive-only dependencies -->
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-core</artifactId>
+                <!-- DO NOT REMOVE and DO NOT MANAGE the version of this dependency. See the version property declaration. -->
+                <exclusions>
+                    <!-- Also imported by jakarta.xml.bind-api -->
+                    <exclusion>
+                        <groupId>jakarta.activation</groupId>
+                        <artifactId>jakarta.activation-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <!-- To resolve dependency convergence issue between `software.amazon.awssdk` and `org.apache.avro` -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${version.org.slf4j}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/bom/public/pom.xml
+++ b/bom/public/pom.xml
@@ -14,6 +14,11 @@
     <name>Hibernate Search - BOM</name>
     <packaging>pom</packaging>
 
+    <properties>
+        <!-- Public modules must be signed. -->
+        <release.gpg.signing.skip>false</release.gpg.signing.skip>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <!-- Hibernate Search artifacts-->

--- a/bom/public/pom.xml
+++ b/bom/public/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-parent</artifactId>
+        <version>7.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>hibernate-search-bom</artifactId>
+    <name>Hibernate Search - BOM</name>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Hibernate Search artifacts-->
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-engine</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-backend-elasticsearch</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-backend-elasticsearch-aws</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-backend-lucene</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-mapper-pojo-base</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-mapper-pojo-standalone</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-mapper-orm</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-v5migrationhelper-engine</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-v5migrationhelper-orm</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-mapper-orm-batch-jsr352-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-mapper-orm-batch-jsr352-jberet</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-mapper-orm-coordination-outbox-polling</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/build/config/pom.xml
+++ b/build/config/pom.xml
@@ -33,6 +33,18 @@
         <tmpdir.dependencies-javadoc-packagelists>${project.build.directory}/dependencies-javadoc-packagelists</tmpdir.dependencies-javadoc-packagelists>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-build-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.puppycrawl.tools</groupId>

--- a/build/parents/integrationtest/pom.xml
+++ b/build/parents/integrationtest/pom.xml
@@ -58,8 +58,10 @@
         <dependencies>
             <dependency>
                 <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-integrationtest-backend-tck</artifactId>
+                <artifactId>hibernate-search-build-bom</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/build/parents/internal/pom.xml
+++ b/build/parents/internal/pom.xml
@@ -54,48 +54,10 @@
         <dependencies>
             <dependency>
                 <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-util-internal-integrationtest-common</artifactId>
+                <artifactId>hibernate-search-build-bom</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-util-internal-integrationtest-backend-elasticsearch</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-util-internal-integrationtest-backend-lucene</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-util-internal-integrationtest-mapper-stub</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-util-internal-integrationtest-mapper-pojo-standalone</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-util-internal-integrationtest-mapper-orm</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-util-internal-integrationtest-v5migrationhelper</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-util-internal-integrationtest-jbatch-runtime</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-util-internal-integrationtest-jberet-se</artifactId>
-                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/build/parents/public/pom.xml
+++ b/build/parents/public/pom.xml
@@ -25,6 +25,18 @@
         <documentation.config.properties.skip>false</documentation.config.properties.skip>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-build-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/build/parents/public/pom.xml
+++ b/build/parents/public/pom.xml
@@ -23,6 +23,8 @@
     <properties>
         <javadoc.packagelists.directory>${project.build.directory}/dependencies-javadoc-packagelists</javadoc.packagelists.directory>
         <documentation.config.properties.skip>false</documentation.config.properties.skip>
+        <!-- Public modules must be signed. -->
+        <release.gpg.signing.skip>false</release.gpg.signing.skip>
     </properties>
 
     <dependencyManagement>
@@ -319,36 +321,6 @@
                     <plugin>
                         <groupId>com.buschmais.jqassistant</groupId>
                         <artifactId>jqassistant-maven-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>release</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                                <configuration>
-                                    <homedir>${env.RELEASE_GPG_HOMEDIR}</homedir>
-                                    <passphrase>${env.RELEASE_GPG_PASSPHRASE}</passphrase>
-                                </configuration>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/build/reports/pom.xml
+++ b/build/reports/pom.xml
@@ -5,7 +5,8 @@
  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.hibernate.search</groupId>
@@ -31,6 +32,18 @@
         -->
         <enforcer.dependencyconvergence.skip>true</enforcer.dependencyconvergence.skip>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-build-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -38,6 +38,13 @@
          -->
         <dependency>
             <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-bom</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-util-common</artifactId>
             <scope>compile</scope>
         </dependency>

--- a/documentation/src/main/asciidoc/public/getting-started/orm/index.adoc
+++ b/documentation/src/main/asciidoc/public/getting-started/orm/index.adoc
@@ -46,6 +46,25 @@ For more advanced setups, you are encouraged to have a look at the xref:{referen
 == [[gettingstarted-dependencies]] Dependencies
 
 The Hibernate Search artifacts can be found in Maven's http://central.sonatype.org/[Central Repository].
+If you get Hibernate Search from Maven, it is recommended to import Hibernate Search BOM
+as part of your dependency management to keep all its artifact versions aligned:
+
+[source, XML, subs="+attributes"]
+----
+<dependencyManagement>
+    <dependencies>
+        <!-- Import Hibernate Search BOM to get all of its artifact versions aligned: -->
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-bom</artifactId>
+            <version>{hibernateSearchVersion}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+        <!-- Any other dependency management entries -->
+    </dependencies>
+</dependencyManagement>
+----
 
 If you do not want to, or cannot, fetch the JARs from a Maven repository,
 you can get them from the
@@ -67,16 +86,21 @@ If you get Hibernate Search from Maven, use these dependencies:
 +
 [source, XML, subs="+attributes"]
 ----
-<dependency>
-   <groupId>org.hibernate.search</groupId>
-   <artifactId>hibernate-search-mapper-orm</artifactId>
-   <version>{hibernateSearchVersion}</version>
-</dependency>
-<dependency>
-   <groupId>org.hibernate.search</groupId>
-   <artifactId>hibernate-search-backend-lucene</artifactId>
-   <version>{hibernateSearchVersion}</version>
-</dependency>
+<dependencies>
+    <!--
+        Add dependencies without specifying versions
+        as that is already taken care by dependency management:
+    -->
+    <dependency>
+       <groupId>org.hibernate.search</groupId>
+       <artifactId>hibernate-search-mapper-orm</artifactId>
+    </dependency>
+    <dependency>
+       <groupId>org.hibernate.search</groupId>
+       <artifactId>hibernate-search-backend-lucene</artifactId>
+    </dependency>
+    <!-- Any other dependency entries -->
+</dependencies>
 ----
 +
 If you get Hibernate Search from the distribution bundle,
@@ -90,16 +114,21 @@ If you get Hibernate Search from Maven, use these dependencies:
 +
 [source, XML, subs="+attributes"]
 ----
-<dependency>
-   <groupId>org.hibernate.search</groupId>
-   <artifactId>hibernate-search-mapper-orm</artifactId>
-   <version>{hibernateSearchVersion}</version>
-</dependency>
-<dependency>
-   <groupId>org.hibernate.search</groupId>
-   <artifactId>hibernate-search-backend-elasticsearch</artifactId>
-   <version>{hibernateSearchVersion}</version>
-</dependency>
+<dependencies>
+    <!--
+        Add dependencies without specifying versions
+        as that is already taken care by dependency management:
+    -->
+    <dependency>
+       <groupId>org.hibernate.search</groupId>
+       <artifactId>hibernate-search-mapper-orm</artifactId>
+    </dependency>
+    <dependency>
+       <groupId>org.hibernate.search</groupId>
+       <artifactId>hibernate-search-backend-elasticsearch</artifactId>
+    </dependency>
+    <!-- Any other dependency entries -->
+</dependencies>
 ----
 +
 If you get Hibernate Search from the distribution bundle,

--- a/documentation/src/main/asciidoc/public/getting-started/standalone/index.adoc
+++ b/documentation/src/main/asciidoc/public/getting-started/standalone/index.adoc
@@ -49,6 +49,25 @@ For more advanced setups, you are encouraged to have a look at the xref:{referen
 == Dependencies
 
 The Hibernate Search artifacts can be found in Maven's http://central.sonatype.org/[Central Repository].
+If you get Hibernate Search from Maven, it is recommended to import Hibernate Search BOM
+as part of your dependency management to keep all its artifact versions aligned:
+
+[source, XML, subs="+attributes"]
+----
+<dependencyManagement>
+    <dependencies>
+        <!-- Import Hibernate Search BOM to get all of its artifact versions aligned: -->
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-bom</artifactId>
+            <version>{hibernateSearchVersion}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+        <!-- Any other dependency management entries -->
+    </dependencies>
+</dependencyManagement>
+----
 
 If you do not want to, or cannot, fetch the JARs from a Maven repository,
 you can get them from the
@@ -71,16 +90,21 @@ If you get Hibernate Search from Maven, use these dependencies:
 +
 [source, XML, subs="+attributes"]
 ----
-<dependency>
-   <groupId>org.hibernate.search</groupId>
-   <artifactId>hibernate-search-mapper-pojo-standalone</artifactId>
-   <version>{hibernateSearchVersion}</version>
-</dependency>
-<dependency>
-   <groupId>org.hibernate.search</groupId>
-   <artifactId>hibernate-search-backend-lucene</artifactId>
-   <version>{hibernateSearchVersion}</version>
-</dependency>
+<dependencies>
+    <!--
+        Add dependencies without specifying versions
+        as that is already taken care by dependency management:
+    -->
+    <dependency>
+       <groupId>org.hibernate.search</groupId>
+       <artifactId>hibernate-search-mapper-pojo-standalone</artifactId>
+    </dependency>
+    <dependency>
+       <groupId>org.hibernate.search</groupId>
+       <artifactId>hibernate-search-backend-lucene</artifactId>
+    </dependency>
+    <!-- Any other dependency entries -->
+</dependencies>
 ----
 +
 If you get Hibernate Search from the distribution bundle,
@@ -95,16 +119,21 @@ If you get Hibernate Search from Maven, use these dependencies:
 +
 [source, XML, subs="+attributes"]
 ----
-<dependency>
-   <groupId>org.hibernate.search</groupId>
-   <artifactId>hibernate-search-mapper-pojo-standalone</artifactId>
-   <version>{hibernateSearchVersion}</version>
-</dependency>
-<dependency>
-   <groupId>org.hibernate.search</groupId>
-   <artifactId>hibernate-search-backend-elasticsearch</artifactId>
-   <version>{hibernateSearchVersion}</version>
-</dependency>
+<dependencies>
+    <!--
+        Add dependencies without specifying versions
+        as that is already taken care by dependency management:
+    -->
+    <dependency>
+       <groupId>org.hibernate.search</groupId>
+       <artifactId>hibernate-search-mapper-pojo-standalone</artifactId>
+    </dependency>
+    <dependency>
+       <groupId>org.hibernate.search</groupId>
+       <artifactId>hibernate-search-backend-elasticsearch</artifactId>
+    </dependency>
+    <!-- Any other dependency entries -->
+</dependencies>
 ----
 +
 If you get Hibernate Search from the distribution bundle,

--- a/documentation/src/main/asciidoc/public/reference/_compatibility.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_compatibility.adoc
@@ -38,6 +38,31 @@ https://hibernate.org/search/releases/#compatibility-matrix[compatibility matrix
 The https://hibernate.org/community/compatibility-policy/[compatibility policy] may also be of interest.
 ====
 
+[TIP]
+====
+If you get Hibernate Search from Maven, it is recommended to import Hibernate Search BOM
+as part of your dependency management to keep all its artifact versions aligned:
+[source, XML, subs="+attributes"]
+----
+<dependencyManagement>
+    <dependencies>
+        <!--
+            Import Hibernate Search BOM
+            to get all of its artifact versions aligned:
+        -->
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-bom</artifactId>
+            <version>{hibernateSearchVersion}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+        <!-- Any other dependency management entries -->
+    </dependencies>
+</dependencyManagement>
+----
+====
+
 [NOTE]
 .Elasticsearch 7.11+ licensing
 ====
@@ -137,7 +162,8 @@ or by explicitly listing a dependency with its version that we want to be used:
     <dependencies>
         <!--
             Overriding Hibernate ORM version by importing the BOM.
-            Alternatively, can be done by adding specific dependencies as shown below for Elasticsearch dependencies.
+            Alternatively, can be done by adding specific dependencies
+            as shown below for Elasticsearch dependencies.
         -->
         <dependency>
             <groupId>org.hibernate.orm</groupId>
@@ -153,7 +179,10 @@ or by explicitly listing a dependency with its version that we want to be used:
             <type>pom</type>
             <scope>import</scope>
         </dependency>
-        <!-- Since there is no BOM for the Elasticsearch REST client, these dependencies have to be listed explicitly: -->
+        <!--
+            Since there is no BOM for the Elasticsearch REST client,
+            these dependencies have to be listed explicitly:
+        -->
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-client</artifactId>

--- a/documentation/src/main/asciidoc/public/reference/_compatibility.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_compatibility.adoc
@@ -106,16 +106,81 @@ Spring Boot automatically sets the version of dependencies without your knowledg
 While this is ordinarily a good thing, from time to time Spring Boot dependencies will be a little out of date.
 Thus, it is recommended to override Spring Boot's defaults at least for some key dependencies.
 
-With Maven, add this to your POM's `<properties>`:
+With Maven, there are a few ways to override these versions depending on how Spring is added to the application.
+If your application's POM file is using `spring-boot-starter-parent` as its parent POM
+then simply adding version properties to your POM's `<properties>` should help:
 
 [source, XML, subs="+attributes"]
 ----
 <properties>
     <hibernate.version>{hibernateVersion}</hibernate.version>
-    <elasticsearch.version>{elasticsearchClientVersions}</elasticsearch.version>
+    <elasticsearch-client.version>{elasticsearchClientVersions}</elasticsearch-client.version>
     <!-- ... plus any other properties of yours ... -->
 </properties>
 ----
+
+[TIP]
+====
+If, after setting the properties above,
+you still are getting the same version of the libraries,
+check if property names in the Spring Boot's BOM have changed, and if so use the new property name.
+====
+
+Alternatively, if either the `spring-boot-dependencies` or the `spring-boot-starter-parent` is imported into the dependency management (`<dependencyManagement>`)
+then overriding the versions can be done either by importing a BOM listing the dependencies we want to override,
+or by explicitly listing a dependency with its version that we want to be used:
+
+.Override dependencies either with another BOM or explicitly
+[source, XML, subs="+attributes"]
+----
+<dependencyManagement>
+    <dependencies>
+        <!--
+            Overriding Hibernate ORM version by importing the BOM.
+            Alternatively, can be done by adding specific dependencies as shown below for Elasticsearch dependencies.
+        -->
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-platform</artifactId>
+            <version>${version.org.hibernate.orm}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-dependencies</artifactId>
+            <version>{testSpringBootVersion}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+        <!-- Since there is no BOM for the Elasticsearch REST client, these dependencies have to be listed explicitly: -->
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-client</artifactId>
+            <version>{elasticsearchClientVersions}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-client-sniffer</artifactId>
+            <version>{elasticsearchClientVersions}</version>
+        </dependency>
+        <!-- Other dependency management entries -->
+    </dependencies>
+</dependencyManagement>
+----
+
+For other build tools refer to their documentation for details.
+
+[TIP]
+====
+Maven's `dependency` plugin (or your build tool corresponding alternative)
+can be used to verify that the version override was correctly applied, e.g.:
+[source, bash, subs="+attributes"]
+----
+# Show the dependency tree filtering for Hibernate and Elasticsearch dependencies to reduce the output:
+mvn dependency:tree "-Dincludes=org.hibernate.*,org.elasticsearch.*"
+----
+====
 
 [TIP]
 ====

--- a/integrationtest/showcase/library/pom.xml
+++ b/integrationtest/showcase/library/pom.xml
@@ -13,9 +13,6 @@
     <description>Hibernate Search showcase based on the ORM and Elasticsearch integrations, using libraries and books as business objects</description>
 
     <properties>
-        <!-- Override the version of Hibernate ORM pulled by Spring Boot -->
-        <hibernate.version>${version.org.hibernate.orm}</hibernate.version>
-
         <test.elasticsearch.run.skip>${test.elasticsearch.connection.uris.defined}</test.elasticsearch.run.skip>
         <test.database.run.skip>false</test.database.run.skip>
 
@@ -30,12 +27,48 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Override the version of Hibernate ORM pulled by Spring Boot -->
+            <!--
+                Since we are importing a pom and not using it as a parent for this module,
+                we cannot use a version property like:
+                    <hibernate.version>${version.org.hibernate.orm}</hibernate.version>
+                or:
+                    <elasticsearch-client.version>${version.org.elasticsearch.client}</elasticsearch-client.version>
+                to override Spring's dependency version with the one we need. Instead, we are going import our bom to
+                override the versions. Placing it after the Spring bom - doesn't work and dependency versions
+                remain unchanged.
+            -->
+            <dependency>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-platform</artifactId>
+                <version>${version.org.hibernate.orm}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <version>${version.org.springframework.boot}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!-- And as there's no Elasticsearch BOM we just list next dependencies explicitly: -->
+            <dependency>
+                <groupId>org.elasticsearch.client</groupId>
+                <artifactId>elasticsearch-rest-client</artifactId>
+                <version>${version.org.elasticsearch.client}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.elasticsearch.client</groupId>
+                <artifactId>elasticsearch-rest-client-sniffer</artifactId>
+                <version>${version.org.elasticsearch.client}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,8 @@
     </mailingLists>
 
     <modules>
+        <module>bom/public</module>
+        <module>bom/build</module>
         <module>build/config</module>
         <module>build/parents/internal</module>
         <module>util/internal/test/common</module>
@@ -209,6 +211,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.5+ -->
+        <!-- NOTE: when updating this version check if the Jackson version is still aligned. -->
         <version.org.elasticsearch.client>8.8.2</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
@@ -240,17 +243,17 @@
 
         <version.com.google.code.gson>2.9.1</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.20.2</version.software.amazon.awssdk>
-        <!-- Jackson: used by the Elasticsearch REST client, the AWS SDK and in tests (wiremock, ...) -->
-        <version.com.fasterxml.jackson>2.13.4</version.com.fasterxml.jackson>
         <!--
-             In the past, there has been jackson-databind bugfix releases without any jackson-core release,
-             so we had to use different versions, e.g. jackson-core 2.13.4 and jackson-databind 2.13.4.2.
-             That's why we have two separate properties for jackson versions,
-             even though they may have the same value from time to time.
-         -->
-        <version.com.fasterxml.jackson.databind>2.13.4.2</version.com.fasterxml.jackson.databind>
-        <!-- Reactive-streams: used by the AWS SDK -->
-        <version.org.reactivestreams.reactive-streams>1.0.4</version.org.reactivestreams.reactive-streams>
+            Jackson is used by
+                * the Elasticsearch REST client sniffer,
+                * avro
+                * and Wiremock
+            We want to align this version on whatever the REST client is using.
+            But because we also want to include it in the public BOM, maven-enforcer-plugin will not catch that the
+            version is different from whatever version is in those mentioned libraries. So need to update it anytime we
+            are updating the Elasticsearch rest client version.
+        -->
+        <version.com.fasterxml.jackson>2.13.4</version.com.fasterxml.jackson>
         <!-- slf4j: used by the AWS SDK -->
         <version.org.slf4j>1.7.36</version.org.slf4j>
 
@@ -374,6 +377,7 @@
         <version.maven-wrapper-plugin>3.2.0</version.maven-wrapper-plugin>
         <version.impsort-maven-plugin>1.9.0</version.impsort-maven-plugin>
         <version.formatter-maven-plugin>2.23.0</version.formatter-maven-plugin>
+        <version.flatten-maven-plugin>1.5.0</version.flatten-maven-plugin>
 
         <!-- Asciidoctor -->
 
@@ -706,517 +710,6 @@
             **/org/hibernate/search/integrationtest/**
         </sonar.cpd.exclusions>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <!-- Import Hibernate ORM BOM -->
-            <dependency>
-                <groupId>org.hibernate.orm</groupId>
-                <artifactId>hibernate-platform</artifactId>
-                <version>${version.org.hibernate.orm}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <!-- Dependencies we want to override -->
-            <dependency>
-                <groupId>org.jboss.logging</groupId>
-                <artifactId>jboss-logging</artifactId>
-                <version>${version.org.jboss.logging.jboss-logging}</version>
-            </dependency>
-            <!--All other dependencies-->
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-util-common</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-util-internal-test-common</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-util-internal-test-orm</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-engine</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-backend-elasticsearch</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-backend-elasticsearch-aws</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-backend-lucene</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-mapper-pojo-base</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-mapper-pojo-standalone</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-mapper-orm</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-v5migrationhelper-engine</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-v5migrationhelper-orm</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-mapper-orm-batch-jsr352-core</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-mapper-orm-batch-jsr352-jberet</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-mapper-orm-coordination-outbox-polling</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-documentation</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-integrationtest-backend-elasticsearch</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-integrationtest-backend-lucene</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-integrationtest-mapper-pojo-base</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-integrationtest-mapper-orm</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-integrationtest-mapper-orm-cdi</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-integrationtest-mapper-orm-spring</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-integrationtest-mapper-orm-envers</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-integrationtest-mapper-orm-realbackend</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-integrationtest-mapper-pojo-standalone-realbackend</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-integrationtest-showcase-library</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-integrationtest-v5migrationhelper-engine</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-integrationtest-v5migrationhelper-orm</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-integrationtest-mapper-orm-coordination-outbox-polling</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-integrationtest-mapper-orm-batch-jsr352</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-documentation</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.search</groupId>
-                <artifactId>hibernate-search-configuration-properties-collector</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.elasticsearch.client</groupId>
-                <artifactId>elasticsearch-rest-client</artifactId>
-                <version>${version.org.elasticsearch.client}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.elasticsearch.client</groupId>
-                <artifactId>elasticsearch-rest-client-sniffer</artifactId>
-                <version>${version.org.elasticsearch.client}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.code.gson</groupId>
-                <artifactId>gson</artifactId>
-                <version>${version.com.google.code.gson}</version>
-            </dependency>
-            <dependency>
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>auth</artifactId>
-                <version>${version.software.amazon.awssdk}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.logging</groupId>
-                <artifactId>jboss-logging-annotations</artifactId>
-                <version>${version.org.jboss.logging.jboss-logging-tools}</version>
-                <scope>provided</scope>
-                <optional>true</optional>
-            </dependency>
-
-            <!-- Lucene backend -->
-            <dependency>
-                <groupId>org.apache.lucene</groupId>
-                <artifactId>lucene-core</artifactId>
-                <version>${version.org.apache.lucene}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.lucene</groupId>
-                <artifactId>lucene-analysis-common</artifactId>
-                <version>${version.org.apache.lucene}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.lucene</groupId>
-                <artifactId>lucene-queryparser</artifactId>
-                <version>${version.org.apache.lucene}</version>
-                <exclusions>
-                    <!-- This artifact contains unstable, experimental code that we cannot reasonably rely on. -->
-                    <exclusion>
-                        <groupId>org.apache.lucene</groupId>
-                        <artifactId>lucene-sandbox</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.lucene</groupId>
-                <artifactId>lucene-join</artifactId>
-                <version>${version.org.apache.lucene}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.lucene</groupId>
-                <artifactId>lucene-facet</artifactId>
-                <version>${version.org.apache.lucene}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.lucene</groupId>
-                <artifactId>lucene-highlighter</artifactId>
-                <version>${version.org.apache.lucene}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.carrotsearch</groupId>
-                <artifactId>hppc</artifactId>
-                <version>${version.com.carrotsearch.hppc}</version>
-            </dependency>
-
-            <!-- JakartaEE dependencies -->
-            <dependency>
-                <groupId>jakarta.batch</groupId>
-                <artifactId>jakarta.batch-api</artifactId>
-                <version>${version.jakarta.batch}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <!-- Jackson: used by the Elasticsearch REST client and in tests (wiremock, ...) -->
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>${version.com.fasterxml.jackson}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${version.com.fasterxml.jackson}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${version.com.fasterxml.jackson.databind}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.reactivestreams</groupId>
-                <artifactId>reactive-streams</artifactId>
-                <version>${version.org.reactivestreams.reactive-streams}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${version.org.slf4j}</version>
-            </dependency>
-
-            <!-- Apache Avro used to serialize/deserialize objects in outbox polling coordination -->
-            <dependency>
-                <groupId>org.apache.avro</groupId>
-                <artifactId>avro</artifactId>
-                <version>${version.org.apache.avro}</version>
-            </dependency>
-
-            <!-- JBeret used by batch-jsr352 jberet module -->
-            <dependency>
-                <groupId>org.jberet</groupId>
-                <artifactId>jberet-core</artifactId>
-                <version>${version.org.jberet}</version>
-                <exclusions>
-                    <!-- These dependencies are marked as "provided" but will never be there at runtime.
-                         This confuses maven-enforcer-plugin, so we'll exclude them. -->
-                    <exclusion>
-                        <groupId>org.jboss.logging</groupId>
-                        <artifactId>jboss-logging-processor</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.infinispan</groupId>
-                        <artifactId>infinispan-core</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.infinispan</groupId>
-                        <artifactId>infinispan-commons</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <!-- Test -->
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${version.junit}</version>
-            </dependency>
-            <!--
-                Manage the upgrade from Hamcrest 1.x to 2.x:
-                http://hamcrest.org/JavaHamcrest/distributables#upgrading-from-hamcrest-1x
-             -->
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest</artifactId>
-                <version>${version.org.hamcrest}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-core</artifactId>
-                <version>${version.org.hamcrest}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-library</artifactId>
-                <version>${version.org.hamcrest}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.takari.junit</groupId>
-                <artifactId>takari-cpsuite</artifactId>
-                <version>${version.io.takari.junit}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>${version.org.mockito}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-core</artifactId>
-                <version>${version.log4j}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-api</artifactId>
-                <version>${version.log4j}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-slf4j-impl</artifactId>
-                <version>${version.log4j}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.osgi</groupId>
-                <artifactId>org.osgi.core</artifactId>
-                <version>${version.org.osgi.core}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.assertj</groupId>
-                <artifactId>assertj-core</artifactId>
-                <version>${version.org.assertj.assertj-core}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.awaitility</groupId>
-                <artifactId>awaitility</artifactId>
-                <version>${version.org.awaitily}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.skyscreamer</groupId>
-                <artifactId>jsonassert</artifactId>
-                <version>${version.org.skyscreamer.jsonassert}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.tomakehurst</groupId>
-                <artifactId>wiremock</artifactId>
-                <version>${version.com.github.tomakehurst.wiremock}</version>
-            </dependency>
-            <dependency>
-                <!-- Dependency management is necessary for Wiremock in particular (it has internal dependency divergence) -->
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>${version.org.apache.commons.lang3}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-math3</artifactId>
-                <version>${version.org.apache.commons.math3}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.weld.se</groupId>
-                <artifactId>weld-se-shaded</artifactId>
-                <version>${version.org.jboss.weld}</version>
-            </dependency>
-
-            <!-- JDBC Drivers -->
-            <dependency>
-                <groupId>com.h2database</groupId>
-                <artifactId>h2</artifactId>
-                <version>${version.com.h2database}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.derby</groupId>
-                <artifactId>derby</artifactId>
-                <version>${version.org.apache.derby}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.postgresql</groupId>
-                <artifactId>postgresql</artifactId>
-                <version>${version.org.postgresql}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mariadb.jdbc</groupId>
-                <artifactId>mariadb-java-client</artifactId>
-                <version>${version.org.mariadb.jdbc}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.mysql</groupId>
-                <artifactId>mysql-connector-j</artifactId>
-                <version>${version.mysql.mysql-connector-java}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.ibm.db2</groupId>
-                <artifactId>jcc</artifactId>
-                <version>${version.com.ibm.db2.jcc}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.oracle.database.jdbc</groupId>
-                <artifactId>ojdbc11</artifactId>
-                <version>${version.com.oracle.database.jdbc}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.microsoft.sqlserver</groupId>
-                <artifactId>mssql-jdbc</artifactId>
-                <version>${version.com.microsoft.sqlserver.mssql-jdbc}</version>
-            </dependency>
-
-            <!-- Performance tests -->
-            <dependency>
-                <groupId>org.openjdk.jmh</groupId>
-                <artifactId>jmh-core</artifactId>
-                <version>${version.org.openjdk.jmh}</version>
-            </dependency>
-
-            <!-- JBatch runtime -->
-            <dependency>
-                <groupId>com.ibm.jbatch</groupId>
-                <artifactId>com.ibm.jbatch.container</artifactId>
-                <version>${version.com.ibm.jbatch}</version>
-            </dependency>
-
-            <!-- JBeret Core and JBeret SE runtime dependencies -->
-            <dependency>
-                <groupId>org.jboss.marshalling</groupId>
-                <artifactId>jboss-marshalling</artifactId>
-                <version>${version.org.jboss.marshalling}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wildfly.security</groupId>
-                <artifactId>wildfly-security-manager</artifactId>
-                <version>${version.org.wildfly.security.wildfly-security-manager}</version>
-                <scope>compile</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${version.org.google.guava}</version>
-                <scope>compile</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jberet</groupId>
-                <artifactId>jberet-se</artifactId>
-                <version>${version.org.jberet}</version>
-            </dependency>
-
-            <!-- For javadocs parsing -->
-            <dependency>
-                <groupId>org.jsoup</groupId>
-                <artifactId>jsoup</artifactId>
-                <version>${version.jsoup}</version>
-            </dependency>
-
-            <!-- Solve dependency convergence issues through exclusions for transitive-only dependencies -->
-            <dependency>
-                <groupId>org.glassfish.jaxb</groupId>
-                <artifactId>jaxb-core</artifactId>
-                <!-- DO NOT REMOVE and DO NOT MANAGE the version of this dependency. See the version property declaration. -->
-                <exclusions>
-                    <!-- Also imported by jakarta.xml.bind-api -->
-                    <exclusion>
-                        <groupId>jakarta.activation</groupId>
-                        <artifactId>jakarta.activation-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <defaultGoal>install</defaultGoal>
@@ -2271,6 +1764,33 @@
                                 <goal>${goal.formatter-maven-plugin}</goal>
                             </goals>
                             <phase>process-sources</phase>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>${version.flatten-maven-plugin}</version>
+                    <configuration>
+                        <outputDirectory>${project.build.directory}</outputDirectory>
+                        <flattenMode>bom</flattenMode>
+                        <pomElements>
+                            <!-- We want property references to be replaced with values -->
+                            <dependencyManagement>resolve</dependencyManagement>
+                            <!--
+                                We don't want to show any properties in this BOM.
+                                The properties we need will be resolved, others have no value for the users of the BOM.
+                             -->
+                            <properties>remove</properties>
+                        </pomElements>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>flatten-pom</id>
+                            <phase>process-resources</phase>
+                            <goals>
+                                <goal>flatten</goal>
+                            </goals>
                         </execution>
                     </executions>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
             version is different from whatever version is in those mentioned libraries. So need to update it anytime we
             are updating the Elasticsearch rest client version.
         -->
-        <version.com.fasterxml.jackson>2.13.4</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.15.0</version.com.fasterxml.jackson>
         <!-- slf4j: used by the AWS SDK -->
         <version.org.slf4j>1.7.36</version.org.slf4j>
 

--- a/pom.xml
+++ b/pom.xml
@@ -511,6 +511,12 @@
         <!-- Output for property collection -->
         <documentation.config.properties.output.directory>${rootProject.directory}/target</documentation.config.properties.output.directory>
 
+        <!--
+            Determines if gpg signing should happen within the module during the release process.
+            Signing is disabled by default and only enabled (by overriding the property) in a modules that require it.
+        -->
+        <release.gpg.signing.skip>true</release.gpg.signing.skip>
+
         <!-- Test settings -->
         <!-- Set empty default values to avoid Maven leaving property references (${...}) when it doesn't find a value -->
 
@@ -1704,6 +1710,20 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
                     <version>${version.gpg.plugin}</version>
+                    <executions>
+                        <execution>
+                            <id>sign-artifacts</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>sign</goal>
+                            </goals>
+                            <configuration>
+                                <skip>${release.gpg.signing.skip}</skip>
+                                <homedir>${env.RELEASE_GPG_HOMEDIR}</homedir>
+                                <passphrase>${env.RELEASE_GPG_PASSPHRASE}</passphrase>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <artifactId>maven-antrun-plugin</artifactId>
@@ -2435,6 +2455,24 @@
                 <goal.impsort-maven-plugin>check</goal.impsort-maven-plugin>
                 <goal.formatter-maven-plugin>validate</goal.formatter-maven-plugin>
             </properties>
+        </profile>
+
+        <profile>
+            <id>release</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
 
         <!--


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4861
https://hibernate.atlassian.net/browse/HSEARCH-4896

Since I didn't want to move the properties from the root pom as those are grouped nicely there, I've ended up creating two BOMs with root as a parent. 
I've used the quarkus plugin to generate the effective public BOM and filtered out a few things from it that got into it only for build or dependency convergence resolution reasons. 
Let's see if this builds on CI 🙈 😄 