### PR TITLE
HSEARCH-4889 Forbid usage of internal/incubating Hibernate ORM code (API/SPI/...)

### DIFF
--- a/build/config/pom.xml
+++ b/build/config/pom.xml
@@ -162,18 +162,25 @@
                             <goal>java</goal>
                         </goals>
                         <configuration>
-                            <mainClass>org.hibernate.checkstyle.report.ReportGenerator</mainClass>
+                            <mainClass>org.hibernate.checkstyle.report.AnnotationReportGenerator</mainClass>
                             <arguments>
                                 <!-- The location of classes to process: -->
                                 <argument>${tmpdir.dependencies-to-parse}/hibernate-core</argument>
                                 <!--
-                                    The report output file path.
+                                    The report output directory path.
                                     We write to the build output directory so that the report is included in the jar:
                                 -->
-                                <argument>${project.build.outputDirectory}/hibernate-core-incubating.txt</argument>
+                                <argument>${project.build.outputDirectory}</argument>
+                                <!-- The report file name main part. Generator will add any suffixes and extensions it needs to it. -->
+                                <argument>hibernate-core-incubating</argument>
                                 <!-- The annotation to look for: -->
                                 <argument>org.hibernate.Incubating</argument>
                                 <!-- Ignore rules: -->
+                                <!--
+                                    Rules can start with a `-Rinternal ` or a `-Rpublic ` prefixes.
+                                    This would mean that a corresponding pattern will only be applied to filtering of internal/public rules.
+                                    If no prefix is specified then rule is considered to be both public and internal at the same time.
+                                -->
                                 <argument>^org\.hibernate\.query\.Query$</argument>
                                 <argument>^org\.hibernate\.query\.SelectionQuery$</argument>
                                 <argument>^org\.hibernate\.query\.MutationQuery$</argument>
@@ -190,17 +197,37 @@
                                 <argument>^org\.hibernate\.type\.spi\.TypeConfiguration$</argument>
                                 <argument>^org\.hibernate\.query\.spi\.ScrollableResultsImplementor$</argument>
                                 <argument>^org\.hibernate\.query\.sqm\.spi\.SqmCreationContext$</argument>
-
-                                <!-- Rules for things used in tests: -->
-                                <argument>^org\.hibernate\.SessionEventListener$</argument>
-                                <argument>^org\.hibernate\.tool\.schema\.spi\.SchemaCreator$</argument>
-                                <argument>^org\.hibernate\.tool\.schema\.spi\.SchemaValidator$</argument>
-                                <argument>^org\.hibernate\.tool\.schema\.spi\.SchemaMigrator$</argument>
-                                <argument>^org\.hibernate\.tool\.schema\.spi\.SchemaDropper$</argument>
-                                <argument>^org\.hibernate\.tool\.schema\.spi\.SchemaManagementTool$</argument>
-                                <argument>^org\.hibernate\.tool\.schema\.spi\.ExtractionTool$</argument>
-                                <argument>^org\.hibernate\.tool\.schema\.spi\.ExecutionOptions$</argument>
-                                <argument>^org\.hibernate\.collection\.spi\.LazyInitializable$</argument>
+                            </arguments>
+                            <!--
+                                While this will include more than we really need, it is easier to do so.
+                                Alternatively, if we would use plugin dependencies and add Jandex there,
+                                we would need to explicitly specify the version of Jandex, since dependency management
+                                doesn't seem to work on dependencies added to a plugin configuration >_<
+                            -->
+                            <includeProjectDependencies>true</includeProjectDependencies>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-hibernate-core-internal-report</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>org.hibernate.checkstyle.report.InternalReportGenerator</mainClass>
+                            <arguments>
+                                <!-- The location of classes to process: -->
+                                <argument>${tmpdir.dependencies-to-parse}/hibernate-core</argument>
+                                <!--
+                                    The report output directory path.
+                                    We write to the build output directory so that the report is included in the jar:
+                                -->
+                                <argument>${project.build.outputDirectory}</argument>
+                                <!-- The report file name main part. Generator will add any suffixes and extensions it needs to it. -->
+                                <argument>hibernate-core-internal-packages</argument>
+                                <!-- The base package to start from: -->
+                                <argument>org.hibernate</argument>
+                                <!-- Ignore rules: -->
                             </arguments>
                             <!--
                                 While this will include more than we really need, it is easier to do so.

--- a/build/config/pom.xml
+++ b/build/config/pom.xml
@@ -31,6 +31,7 @@
         <format.skip>true</format.skip>
 
         <tmpdir.dependencies-javadoc-packagelists>${project.build.directory}/dependencies-javadoc-packagelists</tmpdir.dependencies-javadoc-packagelists>
+        <tmpdir.dependencies-to-parse>${project.build.directory}/dependencies-to-parse</tmpdir.dependencies-to-parse>
     </properties>
 
     <dependencyManagement>
@@ -46,6 +47,10 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>jandex</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
@@ -123,6 +128,87 @@
                             </artifactItems>
                             <includes>package-list,element-list</includes>
                             <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-dependencies-incubating-report</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.hibernate.orm</groupId>
+                                    <artifactId>hibernate-core</artifactId>
+                                    <type>jar</type>
+                                    <version>${version.org.hibernate.orm}</version>
+                                    <outputDirectory>${tmpdir.dependencies-to-parse}/hibernate-core</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-hibernate-core-incubating-report</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>org.hibernate.checkstyle.report.ReportGenerator</mainClass>
+                            <arguments>
+                                <!-- The location of classes to process: -->
+                                <argument>${tmpdir.dependencies-to-parse}/hibernate-core</argument>
+                                <!--
+                                    The report output file path.
+                                    We write to the build output directory so that the report is included in the jar:
+                                -->
+                                <argument>${project.build.outputDirectory}/hibernate-core-incubating.txt</argument>
+                                <!-- The annotation to look for: -->
+                                <argument>org.hibernate.Incubating</argument>
+                                <!-- Ignore rules: -->
+                                <argument>^org\.hibernate\.query\.Query$</argument>
+                                <argument>^org\.hibernate\.query\.SelectionQuery$</argument>
+                                <argument>^org\.hibernate\.query\.MutationQuery$</argument>
+                                <argument>^org\.hibernate\.query\.BindableType$</argument>
+
+                                <argument>^org\.hibernate\.metamodel\.MappingMetamodel$</argument>
+                                <argument>^org\.hibernate\.metamodel\.mapping\.Bindable$</argument>
+                                <argument>^org\.hibernate\.metamodel\.mapping\.SelectableMapping$</argument>
+                                <argument>^org\.hibernate\.metamodel\.mapping\.SelectablePath$</argument>
+                                <argument>^org\.hibernate\.metamodel\.model\.domain\.JpaMetamodel$</argument>
+
+                                <argument>^org\.hibernate\.boot\.spi\.BootstrapContext$</argument>
+                                <argument>^org\.hibernate\.collection\.spi\.PersistentCollection$</argument>
+                                <argument>^org\.hibernate\.type\.spi\.TypeConfiguration$</argument>
+                                <argument>^org\.hibernate\.query\.spi\.ScrollableResultsImplementor$</argument>
+                                <argument>^org\.hibernate\.query\.sqm\.spi\.SqmCreationContext$</argument>
+
+                                <!-- Rules for things used in tests: -->
+                                <argument>^org\.hibernate\.SessionEventListener$</argument>
+                                <argument>^org\.hibernate\.tool\.schema\.spi\.SchemaCreator$</argument>
+                                <argument>^org\.hibernate\.tool\.schema\.spi\.SchemaValidator$</argument>
+                                <argument>^org\.hibernate\.tool\.schema\.spi\.SchemaMigrator$</argument>
+                                <argument>^org\.hibernate\.tool\.schema\.spi\.SchemaDropper$</argument>
+                                <argument>^org\.hibernate\.tool\.schema\.spi\.SchemaManagementTool$</argument>
+                                <argument>^org\.hibernate\.tool\.schema\.spi\.ExtractionTool$</argument>
+                                <argument>^org\.hibernate\.tool\.schema\.spi\.ExecutionOptions$</argument>
+                                <argument>^org\.hibernate\.collection\.spi\.LazyInitializable$</argument>
+                            </arguments>
+                            <!--
+                                While this will include more than we really need, it is easier to do so.
+                                Alternatively, if we would use plugin dependencies and add Jandex there,
+                                we would need to explicitly specify the version of Jandex, since dependency management
+                                doesn't seem to work on dependencies added to a plugin configuration >_<
+                            -->
+                            <includeProjectDependencies>true</includeProjectDependencies>
                         </configuration>
                     </execution>
                 </executions>

--- a/build/config/src/main/java/org/hibernate/checkstyle/report/AnnotationReportGenerator.java
+++ b/build/config/src/main/java/org/hibernate/checkstyle/report/AnnotationReportGenerator.java
@@ -1,0 +1,64 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.checkstyle.report;
+
+import static org.hibernate.checkstyle.report.ReportGeneratorHelper.createIndex;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+
+public class AnnotationReportGenerator {
+
+	public static void main(String[] args) throws IOException {
+		generateReport(
+				args[1],
+				args[2],
+				args[3],
+				createIndex( args[0] ),
+				new ReportGeneratorRules( 4, args )
+		);
+	}
+
+	private static void generateReport(
+			String outputPath,
+			String reportName,
+			String annotationName,
+			Index index,
+			ReportGeneratorRules ignoreRules)
+			throws IOException {
+		List<AnnotationInstance> incubating = index.getAnnotations( DotName.createSimple( annotationName ) );
+
+		try ( Writer writer = new OutputStreamWriter(
+				new FileOutputStream( Path.of( outputPath ).resolve( reportName + ".txt" ).toFile() ),
+				StandardCharsets.UTF_8 );
+				Writer writerInternal = new OutputStreamWriter(
+						new FileOutputStream( Path.of( outputPath ).resolve( reportName + "-internal.txt" ).toFile() ),
+						StandardCharsets.UTF_8
+				) ) {
+			writer.write( "@defaultMessage Do not use code marked with " + annotationName + " annotation\n" );
+
+			for ( AnnotationInstance annotationInstance : incubating ) {
+				AnnotationTarget target = annotationInstance.target();
+				String path = ReportGeneratorHelper.determinePath( target );
+				if ( path != null ) {
+					ReportGeneratorHelper.writeReportLines( writer, path, ignoreRules.matchAnyPublicRule( path ) );
+					ReportGeneratorHelper.writeReportLines( writerInternal, path, ignoreRules.matchAnyInternalRule( path ) );
+				}
+			}
+		}
+	}
+}

--- a/build/config/src/main/java/org/hibernate/checkstyle/report/InternalReportGenerator.java
+++ b/build/config/src/main/java/org/hibernate/checkstyle/report/InternalReportGenerator.java
@@ -1,0 +1,80 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.checkstyle.report;
+
+import static org.hibernate.checkstyle.report.ReportGeneratorHelper.createIndex;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+
+public class InternalReportGenerator {
+
+	public static void main(String[] args) throws IOException {
+		generateReport(
+				args[1],
+				args[2],
+				args[3],
+				createIndex( args[0] ),
+				new ReportGeneratorRules( 4, args )
+		);
+	}
+
+	private static void generateReport(
+			String outputPath,
+			String reportName,
+			String basePackageToScan,
+			Index index,
+			ReportGeneratorRules ignoreRules)
+			throws IOException {
+
+		Collection<DotName> packages = allPackages( index, basePackageToScan );
+		try ( Writer writer = new OutputStreamWriter(
+				new FileOutputStream( Path.of( outputPath ).resolve( reportName + ".txt" ).toFile() ),
+				StandardCharsets.UTF_8 );
+				Writer writerInternal = new OutputStreamWriter(
+						new FileOutputStream( Path.of( outputPath ).resolve( reportName + "-internal.txt" ).toFile() ),
+						StandardCharsets.UTF_8
+				) ) {
+			writer.write( "@defaultMessage Do not use code from internal packages\n" );
+
+			for ( DotName pakcage : packages ) {
+				String path = pakcage.toString();
+				ReportGeneratorHelper.writeReportLines( writer, path, ignoreRules.matchAnyPublicRule( path ) );
+				ReportGeneratorHelper.writeReportLines( writerInternal, path, ignoreRules.matchAnyInternalRule( path ) );
+			}
+		}
+	}
+
+	private static Collection<DotName> allPackages(Index index, String base) {
+		Set<DotName> result = new TreeSet<>();
+
+		doAllPackages( index, DotName.createSimple( base ), result );
+
+		return result;
+	}
+
+	private static final Pattern INTERNAL_PACKAGE = Pattern.compile( "^.+\\.internal\\b.*$" );
+
+	private static void doAllPackages(Index index, DotName current, Set<DotName> result) {
+		if ( INTERNAL_PACKAGE.matcher( current.toString() ).matches() ) {
+			result.add( current );
+		}
+		index.getSubpackages( current ).forEach( p -> doAllPackages( index, p, result ) );
+	}
+
+}

--- a/build/config/src/main/java/org/hibernate/checkstyle/report/ReportGenerator.java
+++ b/build/config/src/main/java/org/hibernate/checkstyle/report/ReportGenerator.java
@@ -1,0 +1,164 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.checkstyle.report;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodParameterInfo;
+
+public class ReportGenerator {
+
+	public static void main(String[] args) throws IOException {
+		generateReport(
+				args[1],
+				args[2],
+				createIndex( args[0] ),
+				createIgnoreRules( args )
+		);
+	}
+
+	private static void generateReport(String outputPath, String annotationName, Index index, Set<Pattern> ignoreRules)
+			throws IOException {
+		List<AnnotationInstance> incubating = index.getAnnotations( DotName.createSimple( annotationName ) );
+
+		try ( Writer writer = new OutputStreamWriter( new FileOutputStream( outputPath ), StandardCharsets.UTF_8 ) ) {
+			writer.write( "@defaultMessage Do not use code marked with " + annotationName + " annotation" );
+			writer.write( '\n' );
+			for ( AnnotationInstance annotationInstance : incubating ) {
+				AnnotationTarget target = annotationInstance.target();
+				String path = determinePath( target );
+				if ( path != null ) {
+					matchAnyIgnoreRule( path, ignoreRules ).ifPresent( rule -> {
+						try {
+							writer.write( "# Ignoring the following line because of the `" + rule.pattern() + "` rule:\n# " );
+						}
+						catch (IOException e) {
+							// just rethrow the exception as a runtime one:
+							throw new RuntimeException( e );
+						}
+					} );
+
+					writer.write( path );
+					writer.write( '\n' );
+				}
+			}
+		}
+	}
+
+	private static Optional<Pattern> matchAnyIgnoreRule(String path, Set<Pattern> rules) {
+		for ( Pattern rule : rules ) {
+			if ( rule.matcher( path ).matches() ) {
+				return Optional.of( rule );
+			}
+		}
+		return Optional.empty();
+	}
+
+	private static Set<Pattern> createIgnoreRules(String[] args) {
+		if ( args.length > 3 ) {
+			HashSet<Pattern> result = new HashSet<>();
+			for ( int index = 3; index < args.length; index++ ) {
+				result.add( Pattern.compile( args[index] ) );
+			}
+			return result;
+		}
+		else {
+			return Collections.emptySet();
+		}
+	}
+
+	private static Index createIndex(String sourcesPath) throws IOException {
+		List<File> classFiles = new ArrayList<>();
+		Files.walkFileTree( Path.of( sourcesPath ), new SimpleFileVisitor<>() {
+			@Override
+			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+				if ( file.getFileName().toString().endsWith( "class" ) ) {
+					classFiles.add( file.toFile() );
+				}
+				return FileVisitResult.CONTINUE;
+			}
+		} );
+
+		return Index.of( classFiles.toArray( File[]::new ) );
+	}
+
+	private static String determinePath(AnnotationTarget usageLocation) {
+		switch ( usageLocation.kind() ) {
+			case CLASS: {
+				final DotName name = usageLocation.asClass().name();
+				if ( name.local().equals( "package-info" ) ) {
+					return name.packagePrefix();
+				}
+				return name.toString();
+			}
+			case FIELD: {
+				final FieldInfo fieldInfo = usageLocation.asField();
+				return fieldInfo.declaringClass().name().toString()
+						+ "#"
+						+ fieldInfo.name();
+			}
+			case METHOD: {
+				final MethodInfo methodInfo = usageLocation.asMethod();
+				return methodInfo.declaringClass().name().toString()
+						+ "#"
+						+ methodInfo.name()
+						+ parameters( methodInfo );
+			}
+			default: {
+				return null;
+			}
+		}
+	}
+
+	private static String parameters(MethodInfo methodInfo) {
+		return methodInfo.parameters().stream()
+				.map( ReportGenerator::parameterTypeToString )
+				.collect( Collectors.joining( ",", "(", ")" ) );
+	}
+
+	private static String parameterTypeToString(MethodParameterInfo parameter) {
+		switch ( parameter.type().kind() ) {
+			case CLASS:
+			case PRIMITIVE:
+			case VOID:
+			case TYPE_VARIABLE:
+			case UNRESOLVED_TYPE_VARIABLE:
+			case WILDCARD_TYPE:
+			case TYPE_VARIABLE_REFERENCE:
+			case PARAMETERIZED_TYPE:
+				return parameter.type().name().toString();
+			case ARRAY:
+				return parameter.type().asArrayType().component().name().toString() + "[]";
+			default:
+				throw new AssertionError( "Unknown parameter type: " + parameter.type().kind() );
+		}
+	}
+}

--- a/build/config/src/main/java/org/hibernate/checkstyle/report/ReportGeneratorRules.java
+++ b/build/config/src/main/java/org/hibernate/checkstyle/report/ReportGeneratorRules.java
@@ -1,0 +1,58 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.checkstyle.report;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+final class ReportGeneratorRules {
+	private static final String INTERNAL_PREFIX = "-Rinternal ";
+	private static final String PUBLIC_PREFIX = "-Rpublic ";
+	private final Set<Pattern> publicRules;
+	private final Set<Pattern> internalRules;
+
+	ReportGeneratorRules(int start, String[] args) {
+		Set<Pattern> internal = new HashSet<>();
+		Set<Pattern> pub = new HashSet<>();
+		for ( int index = start; index < args.length; index++ ) {
+			String regex = args[index];
+			if ( regex.startsWith( INTERNAL_PREFIX ) ) {
+				internal.add( Pattern.compile( regex.substring( INTERNAL_PREFIX.length() ) ) );
+			}
+			else if ( regex.startsWith( PUBLIC_PREFIX ) ) {
+				pub.add( Pattern.compile( regex.substring( PUBLIC_PREFIX.length() ) ) );
+			}
+			else {
+				Pattern pattern = Pattern.compile( regex );
+				internal.add( pattern );
+				pub.add( pattern );
+			}
+		}
+		publicRules = Collections.unmodifiableSet( pub );
+		internalRules = Collections.unmodifiableSet( internal );
+	}
+
+	Optional<Pattern> matchAnyPublicRule(String path) {
+		return matchAnyIgnoreRule( path, publicRules );
+	}
+
+	Optional<Pattern> matchAnyInternalRule(String path) {
+		return matchAnyIgnoreRule( path, internalRules );
+	}
+
+	private Optional<Pattern> matchAnyIgnoreRule(String path, Set<Pattern> rules) {
+		for ( Pattern rule : rules ) {
+			if ( rule.matcher( path ).matches() ) {
+				return Optional.of( rule );
+			}
+		}
+		return Optional.empty();
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1327,6 +1327,13 @@
                                         <type>jar</type>
                                         <path>hibernate-core-incubating.txt</path>
                                     </signaturesArtifact>
+                                    <signaturesArtifact>
+                                        <groupId>org.hibernate.search</groupId>
+                                        <artifactId>hibernate-search-build-config</artifactId>
+                                        <version>${project.version}</version>
+                                        <type>jar</type>
+                                        <path>hibernate-core-internal-packages.txt</path>
+                                    </signaturesArtifact>
                                 </signaturesArtifacts>
                             </configuration>
                             <phase>compile</phase>
@@ -1351,13 +1358,6 @@
                                         <version>${project.version}</version>
                                         <type>jar</type>
                                         <path>forbidden-internal.txt</path>
-                                    </signaturesArtifact>
-                                    <signaturesArtifact>
-                                        <groupId>org.hibernate.search</groupId>
-                                        <artifactId>hibernate-search-build-config</artifactId>
-                                        <version>${project.version}</version>
-                                        <type>jar</type>
-                                        <path>hibernate-core-incubating.txt</path>
                                     </signaturesArtifact>
                                 </signaturesArtifacts>
                             </configuration>
@@ -1384,13 +1384,6 @@
                                         <version>${project.version}</version>
                                         <type>jar</type>
                                         <path>forbidden-internal.txt</path>
-                                    </signaturesArtifact>
-                                    <signaturesArtifact>
-                                        <groupId>org.hibernate.search</groupId>
-                                        <artifactId>hibernate-search-build-config</artifactId>
-                                        <version>${project.version}</version>
-                                        <type>jar</type>
-                                        <path>hibernate-core-incubating.txt</path>
                                     </signaturesArtifact>
                                 </signaturesArtifacts>
                             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1320,6 +1320,13 @@
                                         <type>jar</type>
                                         <path>forbidden-public.txt</path>
                                     </signaturesArtifact>
+                                    <signaturesArtifact>
+                                        <groupId>org.hibernate.search</groupId>
+                                        <artifactId>hibernate-search-build-config</artifactId>
+                                        <version>${project.version}</version>
+                                        <type>jar</type>
+                                        <path>hibernate-core-incubating.txt</path>
+                                    </signaturesArtifact>
                                 </signaturesArtifacts>
                             </configuration>
                             <phase>compile</phase>
@@ -1344,6 +1351,13 @@
                                         <version>${project.version}</version>
                                         <type>jar</type>
                                         <path>forbidden-internal.txt</path>
+                                    </signaturesArtifact>
+                                    <signaturesArtifact>
+                                        <groupId>org.hibernate.search</groupId>
+                                        <artifactId>hibernate-search-build-config</artifactId>
+                                        <version>${project.version}</version>
+                                        <type>jar</type>
+                                        <path>hibernate-core-incubating.txt</path>
                                     </signaturesArtifact>
                                 </signaturesArtifacts>
                             </configuration>
@@ -1370,6 +1384,13 @@
                                         <version>${project.version}</version>
                                         <type>jar</type>
                                         <path>forbidden-internal.txt</path>
+                                    </signaturesArtifact>
+                                    <signaturesArtifact>
+                                        <groupId>org.hibernate.search</groupId>
+                                        <artifactId>hibernate-search-build-config</artifactId>
+                                        <version>${project.version}</version>
+                                        <type>jar</type>
+                                        <path>hibernate-core-incubating.txt</path>
                                     </signaturesArtifact>
                                 </signaturesArtifacts>
                             </configuration>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4889

This is using Jandex to generate text files compatible with forbiddenapis. There are two report generators - one for incubating stuff and another for internal packages. 
I think this would be more flexible for us if for example, we'd need only to include some classes from an entire package marked as incubating in ORM, then we could ignore the package itself and look for all the classes in it to print in the file.
I have added regex rules per each thing currently "violating" the usage (and I was surprised to see some of them 😃). 