### PR TITLE
HSEARCH-4901 Use `element-list` along side `package-list` for javadoc links

### DIFF
--- a/build/config/pom.xml
+++ b/build/config/pom.xml
@@ -105,19 +105,11 @@
                                     <artifactId>jakarta.batch-api</artifactId>
                                     <classifier>javadoc</classifier>
                                     <type>jar</type>
-                                    <version>${version.javax.batch}</version>
-                                    <outputDirectory>${tmpdir.dependencies-javadoc-packagelists}/batch-api</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>jakarta.batch</groupId>
-                                    <artifactId>jakarta.batch-api</artifactId>
-                                    <classifier>javadoc</classifier>
-                                    <type>jar</type>
-                                    <version>${version.javax.batch}</version>
+                                    <version>${version.jakarta.batch}</version>
                                     <outputDirectory>${tmpdir.dependencies-javadoc-packagelists}/batch-api</outputDirectory>
                                 </artifactItem>
                             </artifactItems>
-                            <includes>package-list</includes>
+                            <includes>package-list,element-list</includes>
                             <overWriteSnapshots>true</overWriteSnapshots>
                         </configuration>
                     </execution>

--- a/build/parents/public/pom.xml
+++ b/build/parents/public/pom.xml
@@ -52,7 +52,7 @@
                         <!-- Fail on error alternative -->
                         <quiet>true</quiet>
                         <verbose>false</verbose>
-                        <failOnWarnings>true</failOnWarnings>
+                        <failOnWarnings>${failOnJavadocWarning}</failOnWarnings>
                         <failOnError>true</failOnError>
                         <release>${maven.compiler.release}</release>
                         <!-- Exclude implementation classes from the javadoc -->
@@ -86,11 +86,6 @@
                             <offlineLink>
                                 <url>${javadoc.org.apache.lucene.queryparser.url}</url>
                                 <location>${javadoc.packagelists.directory}/lucene-queryparser</location>
-                            </offlineLink>
-                            <!-- For javax.batch in the JSR 352 modules -->
-                            <offlineLink>
-                                <url>${javadoc.javaee.url}</url>
-                                <location>${javadoc.packagelists.directory}/batch-api</location>
                             </offlineLink>
                             <!-- For jakarta.batch in the JSR 352 modules -->
                             <offlineLink>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -24,6 +24,11 @@
     <properties>
         <!-- Skip artifact deployment: we publish through other means. -->
         <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+        <!--
+            Any javadoc warnings should've been caught already while the previous modules were built.
+            Also see additional explanations on this property in the `hibernate-search-mapper-orm-batch-jsr352-core` module.
+        -->
+        <failOnJavadocWarning>false</failOnJavadocWarning>
     </properties>
 
     <dependencies>

--- a/mapper/orm-batch-jsr352/core/pom.xml
+++ b/mapper/orm-batch-jsr352/core/pom.xml
@@ -21,6 +21,16 @@
 
     <properties>
         <java.module.name>org.hibernate.search.batch.jsr352.core</java.module.name>
+        <!--
+            We want to skip the javadoc warnings for this module, since Jakarta Batch API is using proper modules,
+            resulting in a warning like:
+                [WARNING] Javadoc Warnings
+                [WARNING] warning: The code being documented uses packages in the unnamed module, but the packages defined in https://jakarta.ee/specifications/batch/2.1/apidocs/ are in named modules.
+                [WARNING] 1 warning
+            when trying to build this module. Since it cannot be suppressed, but the generated docs are actually OK
+            and links point to correct addresses, we just ignore all warnings for this module.
+        -->
+        <failOnJavadocWarning>false</failOnJavadocWarning>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,7 @@
 
         <!-- >>> Java EE/Jakarta EE dependencies -->
         <!-- This is used to generate a link to the Jakarta EE javadoc -->
-        <javadoc.jakarta.batch.url>https://jakarta.ee/specifications/batch/2.0/apidocs/</javadoc.jakarta.batch.url>
+        <javadoc.jakarta.batch.url>https://jakarta.ee/specifications/batch/2.1/apidocs/</javadoc.jakarta.batch.url>
 
         <!-- Test dependencies -->
 
@@ -480,8 +480,8 @@
          -->
         <maven.min.version>3.8.1</maven.min.version>
 
-        <!-- Whether javadoc problems (errors, warnings) should fail the build) -->
-        <failOnJavadocError>true</failOnJavadocError>
+        <!-- Whether javadoc warnings should fail the build -->
+        <failOnJavadocWarning>true</failOnJavadocWarning>
 
         <!-- Can be overridden by subprojects if dependency convergence cannot be achieved -->
         <enforcer.dependencyconvergence.skip>false</enforcer.dependencyconvergence.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,7 @@
         <version.org.slf4j>1.7.36</version.org.slf4j>
 
         <!-- >>> ORM 6 with Jakarta Persistence -->
+        <!-- IMPORTANT: Make sure that version.jakarta.persistence aligns with the imported version! -->
         <version.org.hibernate.orm>6.2.6.Final</version.org.hibernate.orm>
 
         <javadoc.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/javadocs/</javadoc.org.hibernate.orm.url>
@@ -266,6 +267,12 @@
              and to our own explicit dependencies in the relevant artifacts.
           -->
         <version.jakarta.enterprise>4.0.1</version.jakarta.enterprise>
+        <!--
+            IMPORTANT:
+            Even though we are importing the Hibernate ORM BOM where Jakarta Persistence is managed, we don't have easy access
+            to its version. We need a version to be able to display it in the docs. This property is exactly to address that need.
+        -->
+        <version.jakarta.persistence>3.1.0</version.jakarta.persistence>
 
         <!-- >>> JSR 352 -->
         <version.jakarta.batch>2.1.1</version.jakarta.batch>
@@ -273,7 +280,7 @@
 
         <!-- >>> Java EE/Jakarta EE dependencies -->
         <!-- This is used to generate a link to the Jakarta EE javadoc -->
-        <javadoc.jakarta.batch.url>https://jakarta.ee/specifications/batch/2.1/apidocs/</javadoc.jakarta.batch.url>
+        <javadoc.jakarta.batch.url>https://jakarta.ee/specifications/batch/${parsed-version.jakarta.batch.majorVersion}.${parsed-version.jakarta.batch.minorVersion}/apidocs/</javadoc.jakarta.batch.url>
 
         <!-- Test dependencies -->
 
@@ -1428,6 +1435,16 @@
                         <configuration>
                             <propertyPrefix>parsed-version.jakarta.persistence</propertyPrefix>
                             <versionString>${version.jakarta.persistence}</versionString>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>parse-jakarta-batch-version</id>
+                        <goals>
+                            <goal>parse-version</goal>
+                        </goals>
+                        <configuration>
+                            <propertyPrefix>parsed-version.jakarta.batch</propertyPrefix>
+                            <versionString>${version.jakarta.batch}</versionString>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4901

- jakarta batch api is causing a warning when generating the javadocs (see more details in the POM comments)
- also noticed that `version.jakarta.persistence` wasn't parsed anymore, since that property wasn't present. I've added it back to the pom with some comments. I have looked for some plugins or how we could get the version coming from the ORM BOM. There is `dependencyversion-maven-plugin` but it doesn't seem to work. I've also tried to see if we could add these as properties to the hibernate-platform, but didn't find anything useful to do it in Gradle. 