### PR TITLE
Backport HSEARCH-4899 to branch 6.2 - Use the links to Appendix instead of Javadocs where possible in reference documentation

### DIFF
--- a/build/configuration-properties-collector/src/main/java/org/hibernate/search/configuration/properties/collector/impl/AsciiDocWriter.java
+++ b/build/configuration-properties-collector/src/main/java/org/hibernate/search/configuration/properties/collector/impl/AsciiDocWriter.java
@@ -21,9 +21,15 @@ import java.util.stream.Collectors;
 public class AsciiDocWriter implements BiConsumer<Map<String, ConfigurationProperty>, Writer> {
 
 	private final Predicate<Map.Entry<String, ConfigurationProperty>> filter;
+	private final String additionalPrefix;
 
 	public AsciiDocWriter(Predicate<Map.Entry<String, ConfigurationProperty>> filter) {
+		this( filter, "" );
+	}
+
+	public AsciiDocWriter(Predicate<Map.Entry<String, ConfigurationProperty>> filter, String additionalPrefix) {
 		this.filter = filter;
+		this.additionalPrefix = additionalPrefix;
 	}
 
 	@Override
@@ -47,7 +53,7 @@ public class AsciiDocWriter implements BiConsumer<Map<String, ConfigurationPrope
 		try {
 			for ( Map.Entry<String, Collection<ConfigurationProperty>> entry : groups.entrySet() ) {
 				tryToWriteLine( writer, "[[configuration-properties-aggregated-",
-						entry.getValue().iterator().next().anchorPrefix(), "]]" );
+						entry.getValue().iterator().next().anchorPrefix(), additionalPrefix, "]]" );
 				tryToWriteLine( writer, "== ", entry.getKey() );
 				writer.write( '\n' );
 				for ( ConfigurationProperty el : entry.getValue() ) {

--- a/build/configuration-properties-collector/src/main/java/org/hibernate/search/configuration/properties/collector/impl/ConfigurationPropertyProcessor.java
+++ b/build/configuration-properties-collector/src/main/java/org/hibernate/search/configuration/properties/collector/impl/ConfigurationPropertyProcessor.java
@@ -91,7 +91,8 @@ public class ConfigurationPropertyProcessor implements AutoCloseable {
 				writeProperties(
 						fileName + "-spi.adoc",
 						new AsciiDocWriter(
-								SPI_FILTER
+								SPI_FILTER,
+								"-spi"
 						)
 				);
 			}

--- a/documentation/src/main/asciidoc/public/reference/_backend-elasticsearch.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_backend-elasticsearch.adoc
@@ -56,10 +56,8 @@ In particular your production Elasticsearch cluster is probably not reachable at
 so you will need to set the address of your cluster by <<backend-elasticsearch-configuration-client,configuring the client>>.
 
 Configuration properties are mentioned in the relevant parts of this documentation.
-You can find a full reference of available properties in the Hibernate Search javadoc:
-
-* link:{hibernateSearchJavadocUrl}/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchBackendSettings.html[org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings].
-* link:{hibernateSearchJavadocUrl}/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchIndexSettings.html[org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings].
+You can find a full reference of available properties in
+<<configuration-properties-aggregated-hibernate-search-backend-elasticsearch, the Elasticsearch backend configuration properties appendix>>.
 
 [[backend-elasticsearch-configuration-elasticsearch-cluster]]
 == [[elasticsearch-integration-server-configuration]] Configuration of the Elasticsearch cluster

--- a/documentation/src/main/asciidoc/public/reference/_backend-lucene.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_backend-lucene.adoc
@@ -10,10 +10,8 @@ In particular, you might want to
 <<backend-lucene-configuration-directory-local-filesystem-location,set the location of your indexes in the filesystem>>.
 
 Other configuration properties are mentioned in the relevant parts of this documentation.
-You can find a full reference of available properties in the Hibernate Search javadoc:
-
-* link:{hibernateSearchJavadocUrl}/org/hibernate/search/backend/lucene/cfg/LuceneBackendSettings.html[org.hibernate.search.backend.lucene.cfg.LuceneBackendSettings].
-* link:{hibernateSearchJavadocUrl}/org/hibernate/search/backend/lucene/cfg/LuceneIndexSettings.html[org.hibernate.search.backend.lucene.cfg.LuceneIndexSettings].
+You can find a full reference of available properties in
+<<configuration-properties-aggregated-hibernate-search-backend-lucene, the Lucene backend configuration properties appendix>>.
 
 [[backend-lucene-configuration-directory]]
 == [[search-configuration-directory]] Index storage (`Directory`)

--- a/documentation/src/main/asciidoc/public/reference/_configuration.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_configuration.adoc
@@ -125,8 +125,8 @@ is equivalent to `hibernate.search.backend.hosts`.
 is equivalent to `hibernate.search.backends.myBackend.hosts`.
 +
 For a list of available property keys,
-see link:{hibernateSearchJavadocUrl}/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchBackendSettings.html[ElasticsearchBackendSettings]
-or link:{hibernateSearchJavadocUrl}/org/hibernate/search/backend/lucene/cfg/LuceneBackendSettings.html[LuceneBackendSettings]
+see <<configuration-properties-aggregated-hibernate-search-backend-elasticsearch, the Elasticsearch backend configuration properties appendix>>
+or <<configuration-properties-aggregated-hibernate-search-backend-lucene, the Lucene backend configuration properties appendix>>.
 
 IndexSettings::
 +
@@ -137,8 +137,9 @@ is equivalent to `hibernate.search.backend.indexes.myIndex.indexing.queue_size`.
 is equivalent to `hibernate.search.backends.myBackend.indexes.myIndex.indexing.queue_size`.
 +
 For a list of available property keys,
-see link:{hibernateSearchJavadocUrl}/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchIndexSettings.html[ElasticsearchIndexSettings]
-or link:{hibernateSearchJavadocUrl}/org/hibernate/search/backend/lucene/cfg/LuceneIndexSettings.html[LuceneIndexSettings]
+see <<configuration-properties-aggregated-hibernate-search-backend-elasticsearch, the Elasticsearch backend configuration properties appendix>>
+or <<configuration-properties-aggregated-hibernate-search-backend-lucene, the Lucene backend configuration properties appendix>>.
+Look for properties having a variant starting with a `hibernate.search.backend.indexes`.
 
 .Using the helper to build hibernate configuration
 ====

--- a/documentation/src/main/asciidoc/public/reference/_mapper-orm.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_mapper-orm.adoc
@@ -51,5 +51,5 @@ For example `MyEntity.myEmbedded` or `MyEntity.myEmbedded.myNestedEmbedded`.
 == [[mapper-orm-mapping-configuration-other]] Other configuration
 
 Other configuration properties are mentioned in the relevant parts of this documentation.
-You can find a full reference of available properties in the Hibernate Search javadoc:
-link:{hibernateSearchJavadocUrl}/org/hibernate/search/mapper/orm/cfg/HibernateOrmMapperSettings.html[org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings].
+You can find a full reference of available properties in
+<<configuration-properties-aggregated-hibernate-search-mapper-orm, the ORM integration configuration properties appendix>>.

--- a/documentation/src/main/asciidoc/public/reference/_mapper-pojo-standalone.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_mapper-pojo-standalone.adoc
@@ -345,5 +345,5 @@ and indexing happens immediately after that instead of happening on transaction 
 == Other configuration
 
 Other configuration properties are mentioned in the relevant parts of this documentation.
-You can find a full reference of available properties in the Hibernate Search javadoc:
-link:{hibernateSearchJavadocUrl}/org/hibernate/search/mapper/pojo/standalone/cfg/StandalonePojoMapperSettings.html[org.hibernate.search.mapper.pojo.standalone.cfg.StandalonePojoMapperSettings].
+You can find a full reference of available properties in
+<<configuration-properties-aggregated-hibernate-search-mapper-pojo-standalone, the Standalone POJO Mapper configuration properties appendix>>.


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4899

backport of https://github.com/hibernate/hibernate-search/pull/3594