### PR TITLE
HSEARCH-4395 Remove duplicated property for H2 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,6 @@
         <version.org.awaitily>4.2.0</version.org.awaitily>
         <version.org.skyscreamer.jsonassert>1.5.1</version.org.skyscreamer.jsonassert>
         <version.io.takari.junit>1.2.7</version.io.takari.junit>
-        <version.com.h2database>2.2.220</version.com.h2database>
         <version.com.github.tomakehurst.wiremock>3.0.0-beta-10</version.com.github.tomakehurst.wiremock>
         <version.org.apache.commons.lang3>3.12.0</version.org.apache.commons.lang3>
         <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
@@ -296,7 +295,7 @@
         <version.org.jboss.weld>5.1.1.Final</version.org.jboss.weld>
 
         <!-- >>> JDBC Drivers -->
-        <version.com.h2database>2.1.214</version.com.h2database>
+        <version.com.h2database>2.2.220</version.com.h2database>
         <!-- Sticking to Derby 10.15 for now since later versions require JDK 17+, and we need to test with JDK 11.
              See https://db.apache.org/derby/derby_downloads.html -->
         <version.org.apache.derby>10.15.2.0</version.org.apache.derby>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4395

I've noticed that Depedabot was complaining that the version needs to be upgraded ... 
Using the switch-to-orm6 ticket since we've done "a few changes" to poms within that task 😄 
This property is also duplicated in the 6.2 branch, but since the version match for both properties there, it gives predictable results. 

