### PR TITLE
HSEARCH-4900 Add custom enforcer rules

### DIFF
--- a/bom/public/pom.xml
+++ b/bom/public/pom.xml
@@ -96,6 +96,30 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-custom-bom-rules</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <dependencyManagementIncludesAllPublicArtifactsRule/>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.hibernate.search</groupId>
+                        <artifactId>hibernate-search-build-enforcer</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/build/config/pom.xml
+++ b/build/config/pom.xml
@@ -68,6 +68,48 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <!--
+                        We cannot include this execution in the root pom because it depends on a project artifact
+                        that we need to build first.
+                        It should be enough to only run this rule on this build module, since the check it performs is always
+                        the same - get the property value, and compare it to the dependency version from dependency management.
+                    -->
+                    <execution>
+                        <id>enforce-custom-rules</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <versionAlignRule>
+                                    <propertiesToCheck>
+                                        <!--
+                                            We want to make sure that the value we store in the property matches
+                                            the version that is imported from the Hibernate ORM BOM
+                                         -->
+                                        <item>
+                                            <property>${version.jakarta.persistence}</property>
+                                            <artifact>jakarta.persistence:jakarta.persistence-api</artifact>
+                                            <failOnNotFound>true</failOnNotFound>
+                                        </item>
+                                    </propertiesToCheck>
+                                </versionAlignRule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.hibernate.search</groupId>
+                        <artifactId>hibernate-search-build-enforcer</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <!-- See https://maven.apache.org/plugins/maven-dependency-plugin/examples/unpacking-artifacts.html -->

--- a/build/enforcer/pom.xml
+++ b/build/enforcer/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-parent</artifactId>
+        <version>7.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-build-enforcer</artifactId>
+
+    <name>Hibernate Search Build - Enforcer Rules</name>
+    <description>Hibernate Search custom enforcer rules</description>
+
+    <properties>
+
+        <!--
+            We want to skip these checks since this module is built before the build-config,
+            as a result the required files to run the checks will be missing.
+         -->
+        <checkstyle.skip>true</checkstyle.skip>
+        <forbiddenapis.skip>true</forbiddenapis.skip>
+        <format.skip>true</format.skip>
+
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+        <jqassistant.skip>true</jqassistant.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven.enforcer</groupId>
+            <artifactId>enforcer-api</artifactId>
+            <version>${version.enforcer.plugin}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven.min.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <!--
+                        We don't want to enforce the rules on this module since it is only to create a custom enforcer rule,
+                        and additionally, it is using javax-inject so this would not match our main enforcer rules.
+                    -->
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <!-- generate index of project components -->
+                <groupId>org.eclipse.sisu</groupId>
+                <artifactId>sisu-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>main-index</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/build/enforcer/src/main/java/org/hibernate/search/build/enforcer/DependencyManagementIncludesAllPublicArtifactsRule.java
+++ b/build/enforcer/src/main/java/org/hibernate/search/build/enforcer/DependencyManagementIncludesAllPublicArtifactsRule.java
@@ -1,0 +1,64 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.build.enforcer;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.project.MavenProject;
+
+@Named("dependencyManagementIncludesAllPublicArtifactsRule") // rule name - must start with lowercase character
+public class DependencyManagementIncludesAllPublicArtifactsRule extends AbstractEnforcerRule {
+
+	private static final String HIBERNATE_SEARCH_PARENT_PUBLIC = "hibernate-search-parent-public";
+	// Inject needed Maven components
+	@Inject
+	private MavenSession session;
+
+	public void execute() throws EnforcerRuleException {
+
+		Map<String, Dependency> dependencies = session.getCurrentProject()
+				.getDependencyManagement()
+				.getDependencies()
+				.stream()
+				.collect( Collectors.toMap( Dependency::getArtifactId, Function.identity() ) );
+
+		for ( MavenProject project : session.getAllProjects() ) {
+			if ( isAnyParentPublicParent( project )
+					&& !isProjectNotDeployed( project )
+					&& ( dependencies.remove( project.getArtifactId() ) == null ) ) {
+				throw new EnforcerRuleException(
+						"`" + project.getGroupId() + ":" + project.getArtifactId()
+								+ "` is missing in the dependency management." );
+			}
+		}
+
+		if ( !dependencies.isEmpty() ) {
+			throw new EnforcerRuleException( "Unexpected dependencies listed in the dependency management section: "
+					+ dependencies.values() );
+		}
+	}
+
+	private boolean isAnyParentPublicParent(MavenProject project) {
+		return project.hasParent()
+				&& ( HIBERNATE_SEARCH_PARENT_PUBLIC.equals( project.getParent().getArtifactId() )
+						|| isAnyParentPublicParent( project.getParent() ) );
+	}
+
+	private boolean isProjectNotDeployed(MavenProject project) {
+		return Boolean.TRUE.toString()
+				.equals( project.getProperties().getOrDefault( "skipNexusStagingDeployMojo", Boolean.FALSE ).toString() );
+	}
+}

--- a/build/enforcer/src/main/java/org/hibernate/search/build/enforcer/VersionAlignData.java
+++ b/build/enforcer/src/main/java/org/hibernate/search/build/enforcer/VersionAlignData.java
@@ -1,0 +1,48 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.build.enforcer;
+
+public class VersionAlignData {
+
+	private String property;
+	private String artifact;
+	private boolean failOnNotFound = false;
+
+	public String getProperty() {
+		return property;
+	}
+
+	public void setProperty(String property) {
+		this.property = property;
+	}
+
+	public String getArtifact() {
+		return artifact;
+	}
+
+	public void setArtifact(String artifact) {
+		this.artifact = artifact;
+	}
+
+	public boolean isFailOnNotFound() {
+		return failOnNotFound;
+	}
+
+	public void setFailOnNotFound(boolean failOnNotFound) {
+		this.failOnNotFound = failOnNotFound;
+	}
+
+	@Override
+	public String toString() {
+		return "{" +
+				"property='" + property + '\'' +
+				", artifact='" + artifact + '\'' +
+				", failOnNotFound=" + failOnNotFound +
+				'}';
+	}
+
+}

--- a/build/enforcer/src/main/java/org/hibernate/search/build/enforcer/VersionAlignRule.java
+++ b/build/enforcer/src/main/java/org/hibernate/search/build/enforcer/VersionAlignRule.java
@@ -1,0 +1,58 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.build.enforcer;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+
+@Named("versionAlignRule") // rule name - must start with lowercase character
+public class VersionAlignRule extends AbstractEnforcerRule {
+
+	/**
+	 * Rule parameter as list of items.
+	 */
+	private List<VersionAlignData> propertiesToCheck;
+
+	// Inject needed Maven components
+	@Inject
+	private MavenSession session;
+
+	public void execute() throws EnforcerRuleException {
+		for ( VersionAlignData data : propertiesToCheck ) {
+			boolean found = false;
+			for ( Dependency dependency : session.getCurrentProject().getDependencyManagement().getDependencies() ) {
+				if ( data.getArtifact().equals( dependency.getGroupId() + ":" + dependency.getArtifactId() ) ) {
+					if ( !dependency.getVersion().equals( data.getProperty() ) ) {
+						throw new EnforcerRuleException( "Property for version of " + dependency
+								+ " is incorrect. Version property is set to " + data.getProperty() );
+					}
+					else {
+						found = true;
+					}
+				}
+			}
+			if ( !found && data.isFailOnNotFound() ) {
+				throw new EnforcerRuleException(
+						"Wasn't able to find the `" + data.getArtifact() + "` among managed dependencies." );
+			}
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "VersionAlignRule{" +
+				"propertiesToCheck=" + propertiesToCheck +
+				'}';
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,7 @@
     </mailingLists>
 
     <modules>
+        <module>build/enforcer</module>
         <module>bom/public</module>
         <module>bom/build</module>
         <module>build/config</module>
@@ -378,6 +379,7 @@
         <version.impsort-maven-plugin>1.9.0</version.impsort-maven-plugin>
         <version.formatter-maven-plugin>2.23.0</version.formatter-maven-plugin>
         <version.flatten-maven-plugin>1.5.0</version.flatten-maven-plugin>
+        <version.sisu-maven-plugin>0.9.0.M1</version.sisu-maven-plugin>
 
         <!-- Asciidoctor -->
 
@@ -1813,6 +1815,11 @@
                             </goals>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.eclipse.sisu</groupId>
+                    <artifactId>sisu-maven-plugin</artifactId>
+                    <version>${version.sisu-maven-plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4900

since we've changed what we include in the BOM, the original idea wasn't making sense anymore, so instead, I have added a couple of simple rules that would:
- check we've included all public artifacts in the BOM
- check the jakarta-persistence version property matches whatever the Hibernate ORM BOM tells us it should be.

Overall, it looks like these custom rules can be pretty flexible since they have access to the entire project structure and to Maven itself (to resolve dependencies from a repository, for example) 