### PR TITLE
HSEARCH-4861 Use expected hibernate version in spring mapper tests

### DIFF
--- a/integrationtest/mapper/orm-spring/pom.xml
+++ b/integrationtest/mapper/orm-spring/pom.xml
@@ -25,6 +25,22 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Override the version of Hibernate ORM pulled by Spring Boot -->
+            <!--
+                Since we are importing a pom and not using it as a parent for this module,
+                we cannot use a version property like:
+                    <hibernate.version>${version.org.hibernate.orm}</hibernate.version>
+                to override Spring's dependency version with the one we need. Instead, we are going import our bom to
+                override the versions. Placing it after the Spring bom - doesn't work and dependency versions
+                remain unchanged.
+            -->
+            <dependency>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-platform</artifactId>
+                <version>${version.org.hibernate.orm}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4861

followup on https://github.com/hibernate/hibernate-search/pull/3588 / https://github.com/hibernate/hibernate-search/pull/3602