### PR TITLE
[6.2] HSEARCH-4907 Fix links and formatting in the migration guide

### DIFF
--- a/documentation/src/main/asciidoc/migration/index.adoc
+++ b/documentation/src/main/asciidoc/migration/index.adoc
@@ -20,7 +20,7 @@ NOTE: If you think something is missing or something does not work, please link:
 
 If you're looking to migrate from an earlier version,
 you should migrate step-by-step, from one minor version to the next,
-following the migration guide of link:https://hibernate.org/search/documentation/[each version].
+following the migration guide of link:https://hibernate.org/search/documentation/migrate/[each version].
 
 [WARNING]
 ====
@@ -42,6 +42,9 @@ Hibernate Search's requirements did not change in version {hibernateSearchVersio
 
 [[data-format]]
 == Data format and schema changes
+
+[[indexes]]
+=== Indexes
 
 Indexes created with Hibernate Search {hibernateSearchPreviousStableVersionShort}
 can be read from and written to with Hibernate Search {hibernateSearchVersion}.
@@ -309,6 +312,7 @@ If your bean reference contains a comma, it may no longer be interpreted correct
 The suggested workaround is to avoid using commas in bean names.
 +
 This affects the following configuration properties:
++
 ** `hibernate.search.backend.analysis.configurer`
 ** `hibernate.search.backend.query.caching.configurer`
 ** `hibernate.search.mapping.configurer`


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4907

See also #3615 (similar, but not identical)