### PR TITLE
HSEARCH-4744 Try to read a nested jar on JDK13+

### DIFF
--- a/integrationtest/mapper/orm-spring-uberjar/application/pom.xml
+++ b/integrationtest/mapper/orm-spring-uberjar/application/pom.xml
@@ -1,0 +1,114 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-integrationtest-spring-repackaged</artifactId>
+        <version>7.0.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-integrationtest-spring-repackaged-application</artifactId>
+
+    <name>Hibernate Search ITs - Spring Repackaged JAR Application</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-integrationtest-spring-repackaged-model</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-backend-lucene</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <exclusions>
+                <!-- Using JBoss Logging -->
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <!-- Using JBoss Logging -->
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${version.org.springframework.boot}</version>
+                <executions>
+                    <execution>
+                        <id>repackage</id>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <mainClass>
+                        org.hibernate.search.integrationtest.spring.repackaged.application.RepackagedApplication
+                    </mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skip>${failsafe.spring.skip}</skip>
+                    <environmentVariables>
+                        <!--
+                             The test settings add a different suffix to this value for each test execution.
+                             We can't add this suffix (${random.uuid}) here due to IDEA limitations:
+                             IDEA just ignores this environment variable if it finds a reference to an unknown property
+                             such as "${random.uuid}".
+                         -->
+                        <LUCENE_ROOT_PATH>${project.build.directory}/test-indexes/</LUCENE_ROOT_PATH>
+                    </environmentVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>it</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/integrationtest/mapper/orm-spring-uberjar/application/src/main/java/org/hibernate/search/integrationtest/spring/repackaged/application/Config.java
+++ b/integrationtest/mapper/orm-spring-uberjar/application/src/main/java/org/hibernate/search/integrationtest/spring/repackaged/application/Config.java
@@ -1,0 +1,66 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.spring.repackaged.application;
+
+import java.util.List;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+
+import acme.org.hibernate.search.integrationtest.spring.repackaged.model.MyEntity;
+import acme.org.hibernate.search.integrationtest.spring.repackaged.model.MyProjection;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EntityScan({ "acme.org.hibernate.search.integrationtest.spring.repackaged.model" })
+public class Config {
+
+	@Bean
+	public TestHibernateSearch testHibernateSearch(EntityManagerFactory entityManagerFactory) {
+		return new TestHibernateSearch( entityManagerFactory );
+	}
+
+	public static class TestHibernateSearch {
+		final EntityManagerFactory entityManagerFactory;
+
+		public TestHibernateSearch(EntityManagerFactory entityManagerFactory) {
+			this.entityManagerFactory = entityManagerFactory;
+		}
+
+		@PostConstruct
+		public void check() {
+			try ( EntityManager entityManager = entityManagerFactory.createEntityManager(); ) {
+				EntityTransaction transaction = entityManager.getTransaction();
+				transaction.begin();
+				MyEntity entity = new MyEntity();
+				entity.id = 1L;
+				entity.name = "name";
+				entityManager.persist( entity );
+				transaction.commit();
+
+				transaction.begin();
+				SearchSession session = Search.session( entityManager );
+				List<MyProjection> myProjections = session.search( MyEntity.class )
+						.select( MyProjection.class )
+						.where( f -> f.match().field( "name" ).matching( "name" ) )
+						.fetchAllHits();
+				if ( myProjections.isEmpty() ) {
+					throw new IllegalStateException( "Incorrect count of projections." );
+				}
+				transaction.commit();
+				System.out.println( "Hibernate Search read the nested JAR." );
+			}
+		}
+	}
+}

--- a/integrationtest/mapper/orm-spring-uberjar/application/src/main/java/org/hibernate/search/integrationtest/spring/repackaged/application/RepackagedApplication.java
+++ b/integrationtest/mapper/orm-spring-uberjar/application/src/main/java/org/hibernate/search/integrationtest/spring/repackaged/application/RepackagedApplication.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.spring.repackaged.application;
+
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+
+// CHECKSTYLE:OFF: HideUtilityClassConstructor
+@SpringBootApplication
+public class RepackagedApplication {
+	public static void main(String[] args) {
+		ConfigurableApplicationContext ctx =
+				new SpringApplicationBuilder( RepackagedApplication.class ).web( WebApplicationType.NONE ).run();
+		System.out.println( "Spring Boot application started" );
+		ctx.getBean( Config.TestHibernateSearch.class );
+		ctx.close();
+	}
+}
+// CHECKSTYLE:ON

--- a/integrationtest/mapper/orm-spring-uberjar/application/src/main/resources/application.yaml
+++ b/integrationtest/mapper/orm-spring-uberjar/application/src/main/resources/application.yaml
@@ -1,0 +1,13 @@
+spring.jpa:
+  properties:
+    hibernate:
+      dialect: org.hibernate.dialect.H2Dialect
+    hibernate.search:
+      backend:
+        directory.root: ${LUCENE_ROOT_PATH:target/test-indexes}/${random.uuid}
+
+spring.datasource:
+  driver-class: org.h2.Driver
+  url: jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1
+  username: sa
+  password: sa

--- a/integrationtest/mapper/orm-spring-uberjar/application/src/test/java/org/hibernate/search/integrationtest/spring/repackaged/application/RepackagedApplicationIT.java
+++ b/integrationtest/mapper/orm-spring-uberjar/application/src/test/java/org/hibernate/search/integrationtest/spring/repackaged/application/RepackagedApplicationIT.java
@@ -1,0 +1,21 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.spring.repackaged.application;
+
+import org.junit.Test;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class RepackagedApplicationIT {
+
+	@Test
+	public void contextLoads() {
+		// just make sure that the context is correctly loaded.
+	}
+
+}

--- a/integrationtest/mapper/orm-spring-uberjar/model/pom.xml
+++ b/integrationtest/mapper/orm-spring-uberjar/model/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-integrationtest-spring-repackaged</artifactId>
+        <version>7.0.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-integrationtest-spring-repackaged-model</artifactId>
+
+    <name>Hibernate Search ITs - Spring Repackaged JAR Model</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>
+

--- a/integrationtest/mapper/orm-spring-uberjar/model/src/main/java/acme/org/hibernate/search/integrationtest/spring/repackaged/model/MyEntity.java
+++ b/integrationtest/mapper/orm-spring-uberjar/model/src/main/java/acme/org/hibernate/search/integrationtest/spring/repackaged/model/MyEntity.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package acme.org.hibernate.search.integrationtest.spring.repackaged.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+@Entity
+@Indexed
+public class MyEntity {
+
+	@Id
+	public Long id;
+
+	@FullTextField(projectable = Projectable.YES)
+	public String name;
+}

--- a/integrationtest/mapper/orm-spring-uberjar/model/src/main/java/acme/org/hibernate/search/integrationtest/spring/repackaged/model/MyOtherEntity.java
+++ b/integrationtest/mapper/orm-spring-uberjar/model/src/main/java/acme/org/hibernate/search/integrationtest/spring/repackaged/model/MyOtherEntity.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package acme.org.hibernate.search.integrationtest.spring.repackaged.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+@Entity
+@Indexed
+public class MyOtherEntity {
+
+	@Id
+	Long id;
+
+	@FullTextField(projectable = Projectable.YES)
+	String name;
+}

--- a/integrationtest/mapper/orm-spring-uberjar/model/src/main/java/acme/org/hibernate/search/integrationtest/spring/repackaged/model/MyProjection.java
+++ b/integrationtest/mapper/orm-spring-uberjar/model/src/main/java/acme/org/hibernate/search/integrationtest/spring/repackaged/model/MyProjection.java
@@ -1,0 +1,19 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package acme.org.hibernate.search.integrationtest.spring.repackaged.model;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FieldProjection;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ProjectionConstructor;
+
+public class MyProjection {
+	public String name;
+
+	@ProjectionConstructor
+	public MyProjection(@FieldProjection(path = "name") String name) {
+		this.name = name;
+	}
+}

--- a/integrationtest/mapper/orm-spring-uberjar/pom.xml
+++ b/integrationtest/mapper/orm-spring-uberjar/pom.xml
@@ -1,0 +1,69 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-integrationtest</artifactId>
+        <version>7.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-integrationtest-spring-repackaged</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Hibernate Search ITs - Spring Repackaged JAR</name>
+    <description>Testing if Hibernate Search will start correctly inside a Spring's repackaged jar</description>
+
+    <modules>
+        <module>model</module>
+        <module>application</module>
+        <module>test</module>
+    </modules>
+
+    <properties>
+        <!--
+            Remove Hibernate system properties from parent settings:
+            They are supposed to be handled by the spring.datasource subsystem
+            and not by the Hibernate internal pool!
+            See also the failsafe configuration.
+         -->
+        <failsafe.jvm.args.hibernate-orm></failsafe.jvm.args.hibernate-orm>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Override the version of Hibernate ORM pulled by Spring Boot -->
+            <!--
+                Since we are importing a pom and not using it as a parent for this module,
+                we cannot use a version property like:
+                    <hibernate.version>${version.org.hibernate.orm}</hibernate.version>
+                or:
+                    <elasticsearch-client.version>${version.org.elasticsearch.client}</elasticsearch-client.version>
+                to override Spring's dependency version with the one we need. Instead, we are going import our bom to
+                override the versions. Placing it after the Spring bom - doesn't work and dependency versions
+                remain unchanged.
+            -->
+            <dependency>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-platform</artifactId>
+                <version>${version.org.hibernate.orm}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${version.org.springframework.boot}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>
+

--- a/integrationtest/mapper/orm-spring-uberjar/test/pom.xml
+++ b/integrationtest/mapper/orm-spring-uberjar/test/pom.xml
@@ -1,0 +1,109 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-integrationtest-spring-repackaged</artifactId>
+        <version>7.0.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-integrationtest-spring-repackaged-test</artifactId>
+
+    <name>Hibernate Search ITs - Spring Repackaged JAR Test</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-integrationtest-spring-repackaged-application</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-loader</artifactId>
+            <version>${version.org.springframework.boot}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <artifactItems>
+                        <artifactItem>
+                            <groupId>org.hibernate.search</groupId>
+                            <artifactId>hibernate-search-integrationtest-spring-repackaged-application</artifactId>
+                            <version>${project.version}</version>
+                            <type>jar</type>
+                            <overWrite>false</overWrite>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                            <destFileName>app.jar</destFileName>
+                        </artifactItem>
+                    </artifactItems>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skip>${failsafe.spring.skip}</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>it</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <!--
+                                We don't want to execute the spring jar if we are not running the tests.
+                             -->
+                            <skip>${failsafe.spring.skip}</skip>
+                            <mainClass>org.springframework.boot.loader.JarLauncher</mainClass>
+                            <arguments>
+                                <argument>-jar</argument>
+                                <argument>${project.build.directory}/lib/app.jar</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/integrationtest/mapper/orm-spring-uberjar/test/src/test/java/org/hibernate/search/integrationtest/spring/repackaged/test/RepackagedAppIT.java
+++ b/integrationtest/mapper/orm-spring-uberjar/test/src/test/java/org/hibernate/search/integrationtest/spring/repackaged/test/RepackagedAppIT.java
@@ -1,0 +1,71 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.spring.repackaged.test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.util.jar.JarEntry;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ProjectionConstructor;
+import org.hibernate.search.util.common.jar.impl.JandexUtils;
+
+import org.junit.Test;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.Index;
+
+import acme.org.hibernate.search.integrationtest.spring.repackaged.model.MyEntity;
+import acme.org.hibernate.search.integrationtest.spring.repackaged.model.MyProjection;
+import org.springframework.boot.loader.jar.JarFile;
+
+public class RepackagedAppIT {
+
+	/**
+	 * Test makes sure that our utils can read the classes from the nested jar inside a Spring's repackaged uberjar.
+	 * We try to create index and then see that that index has the info we need e.g. projection/entity classes etc.
+	 */
+	@Test
+	public void canReadJar() throws Exception {
+		Path target = Path.of( this.getClass().getProtectionDomain().getCodeSource().getLocation().toURI() );
+		Path jar = target.resolve( "../lib/app.jar" );
+
+		try ( JarFile outerJar = new JarFile( jar.toFile() ) ) {
+			for ( JarEntry jarEntry : outerJar ) {
+				if ( jarEntry.getName().contains( "hibernate-search-integrationtest-spring-repackaged-model" ) ) {
+					URL innerJarURL = outerJar.getNestedJarFile( jarEntry ).getUrl();
+
+					try ( URLClassLoader isolatedClassLoader = new URLClassLoader( new URL[] { innerJarURL }, null ) ) {
+						Class<?> classInIsolatedClassLoader = isolatedClassLoader.loadClass( MyEntity.class.getName() );
+						URL location = classInIsolatedClassLoader.getProtectionDomain().getCodeSource().getLocation();
+						assertThat( location.getProtocol() ).isEqualTo( "jar" );
+						Index index = JandexUtils.readOrBuildIndex( location );
+
+						ClassInfo classInfo = index.getClassByName( DotName.createSimple( MyEntity.class.getName() ) );
+						assertThat( classInfo ).isNotNull();
+						FieldInfo name = classInfo.field( "name" );
+						assertThat( name ).isNotNull();
+						assertThat( name.type().name().toString() ).isEqualTo( String.class.getName() );
+
+						classInfo = index.getClassByName( DotName.createSimple( MyProjection.class.getName() ) );
+						assertThat( classInfo ).isNotNull();
+						assertThat(
+								classInfo.annotation( DotName.createSimple( ProjectionConstructor.class.getName() ) ) )
+								.isNotNull();
+						name = classInfo.field( "name" );
+						assertThat( name ).isNotNull();
+						assertThat( name.type().name().toString() ).isEqualTo( String.class.getName() );
+					}
+				}
+			}
+		}
+	}
+}

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -42,6 +42,7 @@
             <modules>
                 <!-- Spring Boot 3 requires at minimum JDK 17. Hence, we want to ignore these modules on JDK 11: -->
                 <module>mapper/orm-spring</module>
+                <module>mapper/orm-spring-uberjar</module>
                 <module>showcase/library</module>
             </modules>
         </profile>

--- a/util/common/pom.xml
+++ b/util/common/pom.xml
@@ -76,5 +76,24 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>testWithJdk11</id>
+            <activation>
+                <property>
+                    <name>java-version.test.release</name>
+                    <value>11</value>
+                </property>
+            </activation>
+            <properties>
+                <!--
+                    We want to use a different version of Spring Boot when testing with JDK11
+                    since 3+ requires JDK17+ and our tests won't run on JDK11.
+                -->
+                <version.org.springframework.boot>2.7.14</version.org.springframework.boot>
+            </properties>
+        </profile>
+    </profiles>
 </project>
 

--- a/util/common/src/main/java/org/hibernate/search/util/common/logging/impl/Log.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/logging/impl/Log.java
@@ -135,7 +135,10 @@ public interface Log extends BasicLogger {
 	IOException cannotInterpretCodeSourceUrl(URL url);
 
 	@Message(id = ID_OFFSET + 18,
-			value = "Cannot open a ZIP filesystem for code source at '%1$s', because the URI points to content inside a nested JAR.")
-	IOException cannotOpenNestedJar(URI uri);
+			value = "Cannot open a ZIP filesystem for code source at '%1$s', because the URI points to content inside a nested JAR. "
+					+ "Run your application on JDK13+ to get nested JAR support, "
+					+ "or disable JAR scanning by setting a mapping configurer that calls .discoverAnnotatedTypesFromRootMappingAnnotations(false). "
+					+ "See the reference documentation for information about mapping configurers.")
+	SearchException cannotOpenNestedJar(URI uri, @Cause Throwable e);
 
 }

--- a/util/common/src/test/java/org/hibernate/search/util/common/jar/impl/CodeSourceTest.java
+++ b/util/common/src/test/java/org/hibernate/search/util/common/jar/impl/CodeSourceTest.java
@@ -240,14 +240,34 @@ public class CodeSourceTest {
 					try ( InputStream is = codeSource.readOrNull( NON_EXISTING_FILE_RELATIVE_PATH ) ) {
 						assertThat( is ).isNull();
 					}
-					// TODO HSEARCH-4744 support reading the content of nested JARs
-					assertThatThrownBy( codeSource::classesPathOrFail )
-							.isInstanceOf( IOException.class )
-							.hasMessageContainingAll(
-									"Cannot open filesystem for code source at",
-									location.toString(),
-									"URI points to content inside a nested JAR"
-							);
+					if ( Runtime.version().feature() > 12 ) {
+						// we are on JDK13+ and we should be able to read the nested JAR:
+						Path nestedClassesPath = codeSource.classesPathOrFail();
+						Path nestedJarRoot = nestedClassesPath.getRoot();
+
+						try ( Stream<Path> files = Files.walk( nestedJarRoot ).filter( Files::isRegularFile ) ) {
+							assertThat( files )
+									.containsExactlyInAnyOrder(
+											nestedJarRoot.resolve( META_INF_FILE_RELATIVE_PATH ),
+											nestedClassesPath.resolve( SIMPLE_CLASS_RELATIVE_PATH )
+									);
+						}
+					}
+					else {
+						// we are on JDK11/12 and inner JAR cannot be opened:
+						assertThatThrownBy( codeSource::classesPathOrFail )
+								.isInstanceOf( IOException.class )
+								.hasMessageContainingAll(
+										"Cannot open filesystem for code source at",
+										location.toString(),
+										"Cannot open a ZIP filesystem for code source at",
+										location.toString(),
+										"because the URI points to content inside a nested JAR.",
+										"Run your application on JDK13+ to get nested JAR support",
+										"or disable JAR scanning by setting a mapping configurer that calls .discoverAnnotatedTypesFromRootMappingAnnotations(false)",
+										"See the reference documentation for information about mapping configurers."
+								);
+					}
 				}
 			}
 		}

--- a/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/jar/JarTestUtils.java
+++ b/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/jar/JarTestUtils.java
@@ -53,6 +53,11 @@ public final class JarTestUtils {
 			URI jarUri = new URI( "jar:file", null, jarPath.toUri().getPath(), null );
 			Map<String, String> zipFsEnv = new HashMap<>();
 			zipFsEnv.put( "create", "true" );
+			if ( Runtime.version().feature() < 17 ) {
+				// tests that run on JDK11 and try to use Spring Boot 2.7 cannot work with a compressed jar,
+				// so we try to create it with no compression:
+				zipFsEnv.put( "noCompression", "true" );
+			}
 			if ( additionalZipFsEnv != null ) {
 				zipFsEnv.putAll( additionalZipFsEnv );
 			}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4744

I've changed the exception from IO to Search one so that we wouldn't need a throwing bi function. Since the util tests do not run on JDK11 it seems safe to just update the test to expect that the jar will get processed OK. 
Also, I've tried these changes on a spring project -- worked fine when running as a repackaged jar. 