### PR TITLE
[6.2] HSEARCH-4907 Follow-up: Clarify that hibernate.search.automatic_indexing.enable_dirty_check still works for now

### DIFF
--- a/documentation/src/main/asciidoc/migration/index.adoc
+++ b/documentation/src/main/asciidoc/migration/index.adoc
@@ -322,7 +322,7 @@ Additionally, some configuration properties have been deprecated:
 * `hibernate.search.automatic_indexing.synchronization.strategy` is now deprecated in favor of `hibernate.search.indexing.plan.synchronization.strategy`.
 * `hibernate.search.automatic_indexing.enabled` is now deprecated in favor of `hibernate.search.indexing.listeners.enabled`.
 * `hibernate.search.automatic_indexing.enable_dirty_check` is now deprecated with no alternative to replace it.
-A dirty check will always be performed when considering triggering the reindexing.
+After its removal in a future version, a dirty check will always be performed when considering whether to trigger reindexing.
 
 [[api]]
 == API changes

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingDirtyCheckIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingDirtyCheckIT.java
@@ -31,7 +31,8 @@ public class AutomaticIndexingDirtyCheckIT {
 			+ "'hibernate.search.automatic_indexing.enable_dirty_check' is deprecated. "
 			+ "This setting will be removed in a future version. "
 			+ "There will be no alternative provided to replace it. "
-			+ "A dirty check will always be performed when considering triggering the reindexing.";
+			+ "After the removal of this property in a future version, "
+			+ "a dirty check will always be performed when considering whether to trigger reindexing.";
 
 	@Rule
 	public BackendMock backendMock = new BackendMock();

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/cfg/HibernateOrmMapperSettings.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/cfg/HibernateOrmMapperSettings.java
@@ -98,7 +98,8 @@ public final class HibernateOrmMapperSettings {
 	 * Defaults to {@link Defaults#AUTOMATIC_INDEXING_ENABLE_DIRTY_CHECK}.
 	 *
 	 * @deprecated This setting will be removed in a future version. There will be no alternative provided to replace it.
-	 * A dirty check will always be performed when considering triggering the reindexing.
+	 * After the removal of this property in a future version,
+	 * a dirty check will always be performed when considering whether to trigger reindexing.
 	 */
 	@Deprecated
 	public static final String AUTOMATIC_INDEXING_ENABLE_DIRTY_CHECK = PREFIX + Radicals.AUTOMATIC_INDEXING_ENABLE_DIRTY_CHECK;
@@ -260,7 +261,8 @@ public final class HibernateOrmMapperSettings {
 				AUTOMATIC_INDEXING_PREFIX + AutomaticIndexingRadicals.SYNCHRONIZATION_STRATEGY;
 		/**
 		 * @deprecated This setting will be removed in a future version. There will be no alternative provided to replace it.
-		 * A dirty check will always be performed when considering triggering the reindexing.
+		 * After the removal of this property in a future version,
+		 * a dirty check will always be performed when considering whether to trigger reindexing.
 		 */
 		@Deprecated
 		public static final String AUTOMATIC_INDEXING_ENABLE_DIRTY_CHECK =
@@ -310,7 +312,8 @@ public final class HibernateOrmMapperSettings {
 		public static final String SYNCHRONIZATION_STRATEGY = "synchronization.strategy";
 		/**
 		 * @deprecated This setting will be removed in a future version. There will be no alternative provided to replace it.
-		 * A dirty check will always be performed when considering triggering the reindexing.
+		 * After the removal of this property in a future version,
+		 * a dirty check will always be performed when considering whether to trigger reindexing.
 		 */
 		@Deprecated
 		public static final String ENABLE_DIRTY_CHECK = "enable_dirty_check";
@@ -381,7 +384,8 @@ public final class HibernateOrmMapperSettings {
 								"write-sync" );
 		/**
 		 * @deprecated This setting will be removed in a future version. There will be no alternative provided to replace it.
-		 * A dirty check will always be performed when considering triggering the reindexing.
+		 * After the removal of this property in a future version,
+		 * a dirty check will always be performed when considering whether to trigger reindexing.
 		 */
 		@Deprecated
 		public static final boolean AUTOMATIC_INDEXING_ENABLE_DIRTY_CHECK = true;

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
@@ -335,7 +335,8 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET + 125, value = "Configuration property '%1$s' is deprecated. "
 			+ "This setting will be removed in a future version. "
 			+ "There will be no alternative provided to replace it. "
-			+ "A dirty check will always be performed when considering triggering the reindexing.")
+			+ "After the removal of this property in a future version, "
+			+ "a dirty check will always be performed when considering whether to trigger reindexing.")
 	void automaticIndexingEnableDirtyCheckIsDeprecated(String deprecatedProperty);
 
 	@Message(id = ID_OFFSET + 126,


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4907

The previous wording was apparently confusing and made it seem like the property is already ignored; see https://github.com/quarkusio/quarkus-updates/pull/47#discussion_r1280427545