### PR TITLE
HSEARCH-4907 Follow-up: Clarify that hibernate.search.automatic_indexing.enable_dirty_check still works for now

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingDirtyCheckIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingDirtyCheckIT.java
@@ -31,7 +31,8 @@ public class AutomaticIndexingDirtyCheckIT {
 			+ "'hibernate.search.automatic_indexing.enable_dirty_check' is deprecated. "
 			+ "This setting will be removed in a future version. "
 			+ "There will be no alternative provided to replace it. "
-			+ "A dirty check will always be performed when considering triggering the reindexing.";
+			+ "After the removal of this property in a future version, "
+			+ "a dirty check will always be performed when considering whether to trigger reindexing.";
 
 	@Rule
 	public BackendMock backendMock = new BackendMock();

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/cfg/HibernateOrmMapperSettings.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/cfg/HibernateOrmMapperSettings.java
@@ -98,7 +98,8 @@ public final class HibernateOrmMapperSettings {
 	 * Defaults to {@link Defaults#AUTOMATIC_INDEXING_ENABLE_DIRTY_CHECK}.
 	 *
 	 * @deprecated This setting will be removed in a future version. There will be no alternative provided to replace it.
-	 * A dirty check will always be performed when considering triggering the reindexing.
+	 * After the removal of this property in a future version,
+	 * a dirty check will always be performed when considering whether to trigger reindexing.
 	 */
 	@Deprecated
 	public static final String AUTOMATIC_INDEXING_ENABLE_DIRTY_CHECK = PREFIX + Radicals.AUTOMATIC_INDEXING_ENABLE_DIRTY_CHECK;
@@ -260,7 +261,8 @@ public final class HibernateOrmMapperSettings {
 				AUTOMATIC_INDEXING_PREFIX + AutomaticIndexingRadicals.SYNCHRONIZATION_STRATEGY;
 		/**
 		 * @deprecated This setting will be removed in a future version. There will be no alternative provided to replace it.
-		 * A dirty check will always be performed when considering triggering the reindexing.
+		 * After the removal of this property in a future version,
+		 * a dirty check will always be performed when considering whether to trigger reindexing.
 		 */
 		@Deprecated
 		public static final String AUTOMATIC_INDEXING_ENABLE_DIRTY_CHECK =
@@ -310,7 +312,8 @@ public final class HibernateOrmMapperSettings {
 		public static final String SYNCHRONIZATION_STRATEGY = "synchronization.strategy";
 		/**
 		 * @deprecated This setting will be removed in a future version. There will be no alternative provided to replace it.
-		 * A dirty check will always be performed when considering triggering the reindexing.
+		 * After the removal of this property in a future version,
+		 * a dirty check will always be performed when considering whether to trigger reindexing.
 		 */
 		@Deprecated
 		public static final String ENABLE_DIRTY_CHECK = "enable_dirty_check";
@@ -381,7 +384,8 @@ public final class HibernateOrmMapperSettings {
 								"write-sync" );
 		/**
 		 * @deprecated This setting will be removed in a future version. There will be no alternative provided to replace it.
-		 * A dirty check will always be performed when considering triggering the reindexing.
+		 * After the removal of this property in a future version,
+		 * a dirty check will always be performed when considering whether to trigger reindexing.
 		 */
 		@Deprecated
 		public static final boolean AUTOMATIC_INDEXING_ENABLE_DIRTY_CHECK = true;

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
@@ -331,7 +331,8 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET + 125, value = "Configuration property '%1$s' is deprecated. "
 			+ "This setting will be removed in a future version. "
 			+ "There will be no alternative provided to replace it. "
-			+ "A dirty check will always be performed when considering triggering the reindexing.")
+			+ "After the removal of this property in a future version, "
+			+ "a dirty check will always be performed when considering whether to trigger reindexing.")
 	void automaticIndexingEnableDirtyCheckIsDeprecated(String deprecatedProperty);
 
 	@Message(id = ID_OFFSET + 126,


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4907

Same as #3620 but on the main branch, since it appears javadoc and runtime warnings were using a similar warning to the migration guide.