### PR TITLE
Followup HSEARCH-4861 Make tests work on nondefault JDKs

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -173,21 +173,6 @@
 
         <version.jsoup>1.15.3</version.jsoup>
 
-        <!-- Properties overridden in profiles to disable certain tests that only work with specific Java versions -->
-        <!-- These are only used in integration tests, hence the default to "none", which is overridden in integration tests -->
-        <java-version.test.java17.add-main-source-phase.default>none</java-version.test.java17.add-main-source-phase.default>
-        <java-version.test.java17.add-main-source-phase>${java-version.test.java17.add-main-source-phase.default}</java-version.test.java17.add-main-source-phase>
-        <!-- These are used in all modules -->
-        <java-version.test.java11.add-test-source-phase>generate-test-sources</java-version.test.java11.add-test-source-phase>
-        <java-version.test.java17.add-test-source-phase>generate-test-sources</java-version.test.java17.add-test-source-phase>
-
-        <!--
-            This is an explicit setting to control compiler plugin execution for the no `-parameters` flag case.
-            Needed as when `testIncludes` doesn't match any test classes, it brings all test sources and re-compiles them.
-         -->
-        <maven.compiler.testSources.noParameterCompilation.skip>true</maven.compiler.testSources.noParameterCompilation.skip>
-        <java-version.test.java17.noParameters.skip>${maven.compiler.testSources.noParameterCompilation.skip}</java-version.test.java17.noParameters.skip>
-
         <!-- Whether javadoc warnings should fail the build -->
         <failOnJavadocWarning>true</failOnJavadocWarning>
 
@@ -1088,42 +1073,6 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
-                    <execution>
-                        <id>add-main-source-java17</id>
-                        <phase>${java-version.test.java17.add-main-source-phase}</phase>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>src/main/java17</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>add-test-source-java17</id>
-                        <phase>${java-version.test.java17.add-test-source-phase}</phase>
-                        <goals>
-                            <goal>add-test-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>src/test/java17</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>add-test-source-java17-noparameters</id>
-                        <phase>${java-version.test.java17.add-test-source-phase}</phase>
-                        <goals>
-                            <goal>add-test-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>src/test/java17-noparameters</source>
-                            </sources>
-                        </configuration>
-                    </execution>
                     <execution>
                         <id>parse-hibernate-version</id>
                         <goals>

--- a/integrationtest/mapper/orm-spring-uberjar/test/pom.xml
+++ b/integrationtest/mapper/orm-spring-uberjar/test/pom.xml
@@ -87,14 +87,14 @@
                     <execution>
                         <phase>verify</phase>
                         <goals>
-                            <goal>java</goal>
+                            <goal>exec</goal>
                         </goals>
                         <configuration>
                             <!--
                                 We don't want to execute the spring jar if we are not running the tests.
                              -->
                             <skip>${failsafe.spring.skip}</skip>
-                            <mainClass>org.springframework.boot.loader.JarLauncher</mainClass>
+                            <executable>${java-version.test.launcher}</executable>
                             <arguments>
                                 <argument>-jar</argument>
                                 <argument>${project.build.directory}/lib/app.jar</argument>

--- a/pom.xml
+++ b/pom.xml
@@ -338,6 +338,20 @@
 
         <!-- Test settings -->
 
+        <!-- Properties overridden in profiles to disable certain tests that only work with specific Java versions -->
+        <!-- These are only used in integration tests, hence the default to "none", which is overridden in integration tests -->
+        <java-version.test.java17.add-main-source-phase.default>none</java-version.test.java17.add-main-source-phase.default>
+        <java-version.test.java17.add-main-source-phase>${java-version.test.java17.add-main-source-phase.default}</java-version.test.java17.add-main-source-phase>
+        <!-- These are used in all modules -->
+        <java-version.test.java17.add-test-source-phase>generate-test-sources</java-version.test.java17.add-test-source-phase>
+
+        <!--
+            This is an explicit setting to control compiler plugin execution for the no `-parameters` flag case.
+            Needed as when `testIncludes` doesn't match any test classes, it brings all test sources and re-compiles them.
+         -->
+        <maven.compiler.testSources.noParameterCompilation.skip>true</maven.compiler.testSources.noParameterCompilation.skip>
+        <java-version.test.java17.noParameters.skip>${maven.compiler.testSources.noParameterCompilation.skip}</java-version.test.java17.noParameters.skip>
+
         <!-- Container images for various integration tests -->
         <!-- The latest version of Elasticsearch tested against by default -->
         <version.org.elasticsearch.latest>8.9.0</version.org.elasticsearch.latest>
@@ -1205,6 +1219,42 @@
                         <configuration>
                             <propertyPrefix>parsed-version.org.hibernate.search.previous-stable</propertyPrefix>
                             <versionString>${version.org.hibernate.search.previous-stable}</versionString>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-main-source-java17</id>
+                        <phase>${java-version.test.java17.add-main-source-phase}</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/main/java17</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-test-source-java17</id>
+                        <phase>${java-version.test.java17.add-test-source-phase}</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/test/java17</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-test-source-java17-noparameters</id>
+                        <phase>${java-version.test.java17.add-test-source-phase}</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/test/java17-noparameters</source>
+                            </sources>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4861

follows up on https://github.com/hibernate/hibernate-search/pull/3618