### PR TITLE
Bump version.org.google.guava from 31.1-jre to 32.1.2-jre

### DIFF
--- a/.github/hibernate-github-bot.yml
+++ b/.github/hibernate-github-bot.yml
@@ -19,3 +19,6 @@ jira:
       # Allow JMH upgrades, since it is a performance testing dependency
     - user: dependabot[bot]
       titlePattern: ".*\\borg.openjdk.jmh\\b.*"
+    # Guava is used in our test utils:
+    - user: dependabot[bot]
+      titlePattern: ".*\\bcom.google.guava\\b.*"

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -161,7 +161,7 @@
         <!-- >>> JSR 352: JBeret SE dependencies -->
         <version.org.jboss.marshalling>2.1.1.Final</version.org.jboss.marshalling>
         <version.org.wildfly.security.wildfly-security-manager>1.1.2.Final</version.org.wildfly.security.wildfly-security-manager>
-        <version.org.google.guava>31.1-jre</version.org.google.guava>
+        <version.org.google.guava>32.1.2-jre</version.org.google.guava>
 
         <!-- >>> Spring integration tests -->
         <version.org.springframework.boot>3.1.1</version.org.springframework.boot>


### PR DESCRIPTION
Seem like dependabot couldn't find a newer version 🤷🏻‍♂️😃 