### PR TITLE
HSEARCH-4912 Use Maven 3.9.4 in CI builds and as a required minimum version for the build

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.4/apache-maven-3.9.4-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,7 +134,7 @@ import org.hibernate.jenkins.pipeline.helpers.alternative.AlternativeMultiMap
  */
 
 @Field final String DEFAULT_JDK_TOOL = 'OpenJDK 17 Latest'
-@Field final String MAVEN_TOOL = 'Apache Maven 3.8'
+@Field final String MAVEN_TOOL = 'Apache Maven 3.9'
 
 // Default node pattern, to be used for resource-intensive stages.
 // Should not include the controller node.

--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -44,7 +44,7 @@ def pullContainerImages() {
 }
 
 def withMavenWorkspace(Closure body) {
-	withMaven(jdk: 'OpenJDK 17 Latest', maven: 'Apache Maven 3.8',
+	withMaven(jdk: 'OpenJDK 17 Latest', maven: 'Apache Maven 3.9',
 			mavenLocalRepo: env.WORKSPACE_TMP + '/.m2repository',
 			options: [artifactsPublisher(disabled: true)]) {
 		body()

--- a/ci/performance/elasticsearch/Jenkinsfile
+++ b/ci/performance/elasticsearch/Jenkinsfile
@@ -13,7 +13,7 @@ import groovy.transform.Field
 @Library('hibernate-jenkins-pipeline-helpers@1.2')
 import org.hibernate.jenkins.pipeline.helpers.job.JobHelper
 
-@Field final String MAVEN_TOOL = 'Apache Maven 3.8'
+@Field final String MAVEN_TOOL = 'Apache Maven 3.9'
 @Field final String JDK_TOOL = 'OpenJDK 11 Latest'
 
 // Performance node pattern, to be used for stages involving performance tests.

--- a/ci/performance/lucene/Jenkinsfile
+++ b/ci/performance/lucene/Jenkinsfile
@@ -13,7 +13,7 @@ import groovy.transform.Field
 @Library('hibernate-jenkins-pipeline-helpers@1.2')
 import org.hibernate.jenkins.pipeline.helpers.job.JobHelper
 
-@Field final String MAVEN_TOOL = 'Apache Maven 3.8'
+@Field final String MAVEN_TOOL = 'Apache Maven 3.9'
 @Field final String JDK_TOOL = 'OpenJDK 11 Latest'
 
 // Performance node pattern, to be used for stages involving performance tests.

--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
 		label 'Worker&&Containers'
 	}
 	tools {
-		maven 'Apache Maven 3.8'
+		maven 'Apache Maven 3.9'
 		jdk 'OpenJDK 17 Latest'
 	}
 	options {

--- a/pom.xml
+++ b/pom.xml
@@ -227,12 +227,10 @@
 
         <!-- Maven version required for the build -->
         <!--
-             We need at least 3.6.2, which includes Maven-resolver 1.4.0+,
-             which fixes https://issues.apache.org/jira/browse/MRESOLVER-33
-             WARNING: Do not forget to call 'mvn -N io.takari:maven:wrapper'
+             WARNING: Do not forget to call 'mvn wrapper:wrapper'
              when you update this property!
          -->
-        <maven.min.version>3.8.1</maven.min.version>
+        <maven.min.version>3.9.4</maven.min.version>
 
         <!-- Set this through a property so that it can be overridden from the commandline -->
         <maven.compiler.failOnWarning>true</maven.compiler.failOnWarning>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4912
