### PR TITLE
HSEARCH-4916 Test against latest OpenSearch 1.3.12

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -243,7 +243,7 @@ stage('Configure') {
 					// --------------------------------------------
 					// OpenSearch
 					// Not testing 1.0 - 1.2 to make the build quicker.
-					new OpenSearchLocalBuildEnvironment(version: '1.3.11', condition: TestCondition.AFTER_MERGE),
+					new OpenSearchLocalBuildEnvironment(version: '1.3.12', condition: TestCondition.AFTER_MERGE),
 					// See https://opensearch.org/lines/1x.html for a list of all 1.x versions
 					new OpenSearchLocalBuildEnvironment(version: '2.0.1', condition: TestCondition.ON_DEMAND),
 					new OpenSearchLocalBuildEnvironment(version: '2.1.0', condition: TestCondition.ON_DEMAND),


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4916

TCK tests passed locally; let's see if they will also pass on CI