### PR TITLE
HSEARCH-4910 Update Elasticsearch image config for tests

### DIFF
--- a/build/container/elasticsearch/env-7.0.properties
+++ b/build/container/elasticsearch/env-7.0.properties
@@ -1,0 +1,3 @@
+# Disable some features that are not needed in our tests and just slow down startup
+xpack.ml.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-7.1.properties
+++ b/build/container/elasticsearch/env-7.1.properties
@@ -1,0 +1,3 @@
+# Disable some features that are not needed in our tests and just slow down startup
+xpack.ml.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-7.10.properties
+++ b/build/container/elasticsearch/env-7.10.properties
@@ -1,0 +1,5 @@
+# Disable some features that are not needed in our tests and just slow down startup
+indices.lifecycle.history_index_enabled=false
+stack.templates.enabled=false
+xpack.ml.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-7.11.properties
+++ b/build/container/elasticsearch/env-7.11.properties
@@ -1,0 +1,5 @@
+# Disable some features that are not needed in our tests and just slow down startup
+indices.lifecycle.history_index_enabled=false
+stack.templates.enabled=false
+xpack.ml.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-7.12.properties
+++ b/build/container/elasticsearch/env-7.12.properties
@@ -1,0 +1,5 @@
+# Disable some features that are not needed in our tests and just slow down startup
+indices.lifecycle.history_index_enabled=false
+stack.templates.enabled=false
+xpack.ml.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-7.13.properties
+++ b/build/container/elasticsearch/env-7.13.properties
@@ -1,0 +1,5 @@
+# Disable some features that are not needed in our tests and just slow down startup
+indices.lifecycle.history_index_enabled=false
+stack.templates.enabled=false
+xpack.ml.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-7.14.properties
+++ b/build/container/elasticsearch/env-7.14.properties
@@ -1,0 +1,5 @@
+# Disable some features that are not needed in our tests and just slow down startup
+indices.lifecycle.history_index_enabled=false
+stack.templates.enabled=false
+xpack.ml.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-7.15.properties
+++ b/build/container/elasticsearch/env-7.15.properties
@@ -1,0 +1,5 @@
+# Disable some features that are not needed in our tests and just slow down startup
+indices.lifecycle.history_index_enabled=false
+stack.templates.enabled=false
+xpack.ml.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-7.16.properties
+++ b/build/container/elasticsearch/env-7.16.properties
@@ -1,0 +1,7 @@
+# Disable some features that are not needed in our tests and just slow down startup
+cluster.deprecation_indexing.enabled=false
+indices.lifecycle.history_index_enabled=false
+slm.history_index_enabled=false
+stack.templates.enabled=false
+xpack.ml.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-7.17.properties
+++ b/build/container/elasticsearch/env-7.17.properties
@@ -1,0 +1,7 @@
+# Disable some features that are not needed in our tests and just slow down startup
+cluster.deprecation_indexing.enabled=false
+indices.lifecycle.history_index_enabled=false
+slm.history_index_enabled=false
+stack.templates.enabled=false
+xpack.ml.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-7.2.properties
+++ b/build/container/elasticsearch/env-7.2.properties
@@ -1,0 +1,3 @@
+# Disable some features that are not needed in our tests and just slow down startup
+xpack.ml.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-7.3.properties
+++ b/build/container/elasticsearch/env-7.3.properties
@@ -1,0 +1,3 @@
+# Disable some features that are not needed in our tests and just slow down startup
+xpack.ml.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-7.4.properties
+++ b/build/container/elasticsearch/env-7.4.properties
@@ -1,0 +1,3 @@
+# Disable some features that are not needed in our tests and just slow down startup
+xpack.ml.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-7.5.properties
+++ b/build/container/elasticsearch/env-7.5.properties
@@ -1,0 +1,3 @@
+# Disable some features that are not needed in our tests and just slow down startup
+xpack.ml.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-7.6.properties
+++ b/build/container/elasticsearch/env-7.6.properties
@@ -1,0 +1,4 @@
+# Disable some features that are not needed in our tests and just slow down startup
+indices.lifecycle.history_index_enabled=false
+xpack.ml.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-7.7.properties
+++ b/build/container/elasticsearch/env-7.7.properties
@@ -1,0 +1,4 @@
+# Disable some features that are not needed in our tests and just slow down startup
+indices.lifecycle.history_index_enabled=false
+xpack.ml.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-7.8.properties
+++ b/build/container/elasticsearch/env-7.8.properties
@@ -1,0 +1,4 @@
+# Disable some features that are not needed in our tests and just slow down startup
+indices.lifecycle.history_index_enabled=false
+xpack.ml.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-7.9.properties
+++ b/build/container/elasticsearch/env-7.9.properties
@@ -1,0 +1,5 @@
+# Disable some features that are not needed in our tests and just slow down startup
+indices.lifecycle.history_index_enabled=false
+stack.templates.enabled=false
+xpack.ml.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-8.0.properties
+++ b/build/container/elasticsearch/env-8.0.properties
@@ -1,0 +1,8 @@
+# Disable some features that are not needed in our tests and just slow down startup
+cluster.deprecation_indexing.enabled=false
+indices.lifecycle.history_index_enabled=false
+slm.history_index_enabled=false
+stack.templates.enabled=false
+xpack.ml.enabled=false
+xpack.monitoring.templates.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-8.1.properties
+++ b/build/container/elasticsearch/env-8.1.properties
@@ -1,0 +1,8 @@
+# Disable some features that are not needed in our tests and just slow down startup
+cluster.deprecation_indexing.enabled=false
+indices.lifecycle.history_index_enabled=false
+slm.history_index_enabled=false
+stack.templates.enabled=false
+xpack.ml.enabled=false
+xpack.monitoring.templates.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-8.2.properties
+++ b/build/container/elasticsearch/env-8.2.properties
@@ -1,0 +1,8 @@
+# Disable some features that are not needed in our tests and just slow down startup
+cluster.deprecation_indexing.enabled=false
+indices.lifecycle.history_index_enabled=false
+slm.history_index_enabled=false
+stack.templates.enabled=false
+xpack.ml.enabled=false
+xpack.monitoring.templates.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-8.3.properties
+++ b/build/container/elasticsearch/env-8.3.properties
@@ -1,0 +1,8 @@
+# Disable some features that are not needed in our tests and just slow down startup
+cluster.deprecation_indexing.enabled=false
+indices.lifecycle.history_index_enabled=false
+slm.history_index_enabled=false
+stack.templates.enabled=false
+xpack.ml.enabled=false
+xpack.monitoring.templates.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-8.4.properties
+++ b/build/container/elasticsearch/env-8.4.properties
@@ -1,0 +1,8 @@
+# Disable some features that are not needed in our tests and just slow down startup
+cluster.deprecation_indexing.enabled=false
+indices.lifecycle.history_index_enabled=false
+slm.history_index_enabled=false
+stack.templates.enabled=false
+xpack.ml.enabled=false
+xpack.monitoring.templates.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-8.5.properties
+++ b/build/container/elasticsearch/env-8.5.properties
@@ -1,0 +1,8 @@
+# Disable some features that are not needed in our tests and just slow down startup
+cluster.deprecation_indexing.enabled=false
+indices.lifecycle.history_index_enabled=false
+slm.history_index_enabled=false
+stack.templates.enabled=false
+xpack.ml.enabled=false
+xpack.monitoring.templates.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-8.6.properties
+++ b/build/container/elasticsearch/env-8.6.properties
@@ -1,0 +1,8 @@
+# Disable some features that are not needed in our tests and just slow down startup
+cluster.deprecation_indexing.enabled=false
+indices.lifecycle.history_index_enabled=false
+slm.history_index_enabled=false
+stack.templates.enabled=false
+xpack.ml.enabled=false
+xpack.monitoring.templates.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-8.7.properties
+++ b/build/container/elasticsearch/env-8.7.properties
@@ -1,0 +1,8 @@
+# Disable some features that are not needed in our tests and just slow down startup
+cluster.deprecation_indexing.enabled=false
+indices.lifecycle.history_index_enabled=false
+slm.history_index_enabled=false
+stack.templates.enabled=false
+xpack.ml.enabled=false
+xpack.monitoring.templates.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-8.8.properties
+++ b/build/container/elasticsearch/env-8.8.properties
@@ -1,0 +1,10 @@
+# Disable some features that are not needed in our tests and just slow down startup
+cluster.deprecation_indexing.enabled=false
+indices.lifecycle.history_index_enabled=false
+slm.history_index_enabled=false
+stack.templates.enabled=false
+xpack.ent_search.enabled=false
+xpack.ml.enabled=false
+xpack.monitoring.templates.enabled=false
+xpack.profiling.enabled=false
+xpack.watcher.enabled=false

--- a/build/container/elasticsearch/env-8.9.properties
+++ b/build/container/elasticsearch/env-8.9.properties
@@ -1,0 +1,10 @@
+# Disable some features that are not needed in our tests and just slow down startup
+cluster.deprecation_indexing.enabled=false
+indices.lifecycle.history_index_enabled=false
+slm.history_index_enabled=false
+stack.templates.enabled=false
+xpack.ent_search.enabled=false
+xpack.ml.enabled=false
+xpack.monitoring.templates.enabled=false
+xpack.profiling.enabled=false
+xpack.watcher.enabled=false

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -1121,6 +1121,16 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>parse-elasticsearch-test-version</id>
+                        <goals>
+                            <goal>parse-version</goal>
+                        </goals>
+                        <configuration>
+                            <propertyPrefix>parsed-version.test.elasticsearch.version</propertyPrefix>
+                            <versionString>${test.elasticsearch.version}</versionString>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>parse-gson-version</id>
                         <goals>
                             <goal>parse-version</goal>

--- a/build/parents/integrationtest/pom.xml
+++ b/build/parents/integrationtest/pom.xml
@@ -93,16 +93,6 @@
                                              it's not practical for testing, so we disable that.
                                          -->
                                         <xpack.security.enabled>false</xpack.security.enabled>
-                                        <!-- Disable some features that are not needed in our tests and just slow down startup -->
-                                        <xpack.profiling.enabled>false</xpack.profiling.enabled>
-                                        <xpack.monitoring.templates.enabled>false</xpack.monitoring.templates.enabled>
-                                        <xpack.ml.enabled>false</xpack.ml.enabled>
-                                        <xpack.watcher.enabled>false</xpack.watcher.enabled>
-                                        <xpack.ent_search.enabled>false</xpack.ent_search.enabled>
-                                        <stack.templates.enabled>false</stack.templates.enabled>
-                                        <cluster.deprecation_indexing.enabled>false</cluster.deprecation_indexing.enabled>
-                                        <indices.lifecycle.history_index_enabled>false</indices.lifecycle.history_index_enabled>
-                                        <slm.history_index_enabled>false</slm.history_index_enabled>
                                         <!-- Limit the RAM usage.
                                              Recent versions of ES limit themselves to 50% of the total available RAM,
                                              but on CI this is sometimes too much, as we also have the Maven JVM
@@ -117,6 +107,7 @@
                                          -->
                                         <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                     </env>
+                                    <envPropertyFile>${rootProject.directory}/build/container/elasticsearch/env-${parsed-version.test.elasticsearch.version.majorVersion}.${parsed-version.test.elasticsearch.version.minorVersion}.properties</envPropertyFile>
                                     <tmpfs>/var/lib/elasticsearch</tmpfs>
                                     <ports>
                                         <port>9200:9200</port>

--- a/build/parents/integrationtest/pom.xml
+++ b/build/parents/integrationtest/pom.xml
@@ -98,7 +98,11 @@
                                         <xpack.monitoring.templates.enabled>false</xpack.monitoring.templates.enabled>
                                         <xpack.ml.enabled>false</xpack.ml.enabled>
                                         <xpack.watcher.enabled>false</xpack.watcher.enabled>
+                                        <xpack.ent_search.enabled>false</xpack.ent_search.enabled>
                                         <stack.templates.enabled>false</stack.templates.enabled>
+                                        <cluster.deprecation_indexing.enabled>false</cluster.deprecation_indexing.enabled>
+                                        <indices.lifecycle.history_index_enabled>false</indices.lifecycle.history_index_enabled>
+                                        <slm.history_index_enabled>false</slm.history_index_enabled>
                                         <!-- Limit the RAM usage.
                                              Recent versions of ES limit themselves to 50% of the total available RAM,
                                              but on CI this is sometimes too much, as we also have the Maven JVM

--- a/build/parents/integrationtest/pom.xml
+++ b/build/parents/integrationtest/pom.xml
@@ -93,6 +93,12 @@
                                              it's not practical for testing, so we disable that.
                                          -->
                                         <xpack.security.enabled>false</xpack.security.enabled>
+                                        <!-- Disable some features that are not needed in our tests and just slow down startup -->
+                                        <xpack.profiling.enabled>false</xpack.profiling.enabled>
+                                        <xpack.monitoring.templates.enabled>false</xpack.monitoring.templates.enabled>
+                                        <xpack.ml.enabled>false</xpack.ml.enabled>
+                                        <xpack.watcher.enabled>false</xpack.watcher.enabled>
+                                        <stack.templates.enabled>false</stack.templates.enabled>
                                         <!-- Limit the RAM usage.
                                              Recent versions of ES limit themselves to 50% of the total available RAM,
                                              but on CI this is sometimes too much, as we also have the Maven JVM
@@ -107,6 +113,7 @@
                                          -->
                                         <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
                                     </env>
+                                    <tmpfs>/var/lib/elasticsearch</tmpfs>
                                     <ports>
                                         <port>9200:9200</port>
                                     </ports>

--- a/build/parents/integrationtest/pom.xml
+++ b/build/parents/integrationtest/pom.xml
@@ -128,7 +128,7 @@
                                             <method>GET</method>
                                             <status>200</status>
                                         </http>
-                                        <time>20000</time>
+                                        <time>30000</time>
                                     </wait>
                                 </run>
                             </image>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4910

Looking more at those templates being loaded, there's also `stack.templates.enabled` (https://www.elastic.co/guide/en/elasticsearch/reference/current/index-management-settings.html), but it seems to have no effect if passed as env variable (I guess it should be a part of elasticsearch.yml config? or maybe it just not related to the templates being loaded 😃)... 
for my local start with the changes:
```
[INFO] DOCKER> [elastic/elasticsearch:8.9.0] "elasticsearch": Waited on url http://localhost:9200 5609 ms
```
without the changes:
```
[INFO] DOCKER> [elastic/elasticsearch:8.9.0] "elasticsearch": Waited on url http://localhost:9200 6147 ms
```
soooo hopefully will be a tod better for CI builds too...