### PR TITLE
[Backport to 6.2] HSEARCH-4915 Errors returned by OpenSearch/ElasticSearch not forwarded to caller

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchBackendSettings.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchBackendSettings.java
@@ -349,6 +349,6 @@ public final class ElasticsearchBackendSettings {
 		public static final BeanReference<IndexLayoutStrategy> LAYOUT_STRATEGY =
 				BeanReference.of( IndexLayoutStrategy.class, SimpleIndexLayoutStrategy.NAME );
 		public static final int SCROLL_TIMEOUT = 60;
-		public static final boolean QUERY_SHARD_FAILURE_IGNORE = false;
+		public static final boolean QUERY_SHARD_FAILURE_IGNORE = true;
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchBackendSettings.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchBackendSettings.java
@@ -301,6 +301,23 @@ public final class ElasticsearchBackendSettings {
 	public static final String MAX_KEEP_ALIVE = "max_keep_alive";
 
 	/**
+	 * This property defines if partial shard failures are ignored.
+	 * <p>
+	 * In case all shards fail, Elasticsearch cluster will return a 400 status code itself,
+	 * but if only some of the shards fail, then the client will receive a successful partial response from the shards
+	 * that were successful.
+	 * <p>
+	 * To prevent getting any partial results this setting can be set to {@code false}.
+	 * While if the partial failures should be ignored and considered as valid results then the value should be set to {@code true}.
+	 * <p>
+	 * Expects a Boolean value such as {@code true} or {@code false},
+	 * or a string that can be parsed into a Boolean value.
+	 * <p>
+	 * Defaults to {@link Defaults#QUERY_SHARD_FAILURE_IGNORE}.
+	 */
+	public static final String QUERY_SHARD_FAILURE_IGNORE = "query.shard_failure.ignore";
+
+	/**
 	 * Default values for the different settings if no values are given.
 	 */
 	public static final class Defaults {
@@ -332,5 +349,6 @@ public final class ElasticsearchBackendSettings {
 		public static final BeanReference<IndexLayoutStrategy> LAYOUT_STRATEGY =
 				BeanReference.of( IndexLayoutStrategy.class, SimpleIndexLayoutStrategy.NAME );
 		public static final int SCROLL_TIMEOUT = 60;
+		public static final boolean QUERY_SHARD_FAILURE_IGNORE = false;
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/Elasticsearch56ProtocolDialect.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/Elasticsearch56ProtocolDialect.java
@@ -32,8 +32,8 @@ public class Elasticsearch56ProtocolDialect implements ElasticsearchProtocolDial
 	}
 
 	@Override
-	public ElasticsearchWorkFactory createWorkFactory(GsonProvider gsonProvider) {
-		return new Elasticsearch56WorkFactory( gsonProvider );
+	public ElasticsearchWorkFactory createWorkFactory(GsonProvider gsonProvider, Boolean ignoreShardFailures) {
+		return new Elasticsearch56WorkFactory( gsonProvider, ignoreShardFailures );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/Elasticsearch60ProtocolDialect.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/Elasticsearch60ProtocolDialect.java
@@ -32,8 +32,8 @@ public class Elasticsearch60ProtocolDialect implements ElasticsearchProtocolDial
 	}
 
 	@Override
-	public ElasticsearchWorkFactory createWorkFactory(GsonProvider gsonProvider) {
-		return new Elasticsearch56WorkFactory( gsonProvider );
+	public ElasticsearchWorkFactory createWorkFactory(GsonProvider gsonProvider, Boolean ignoreShardFailures) {
+		return new Elasticsearch56WorkFactory( gsonProvider, ignoreShardFailures );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/Elasticsearch63ProtocolDialect.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/Elasticsearch63ProtocolDialect.java
@@ -32,8 +32,8 @@ public class Elasticsearch63ProtocolDialect implements ElasticsearchProtocolDial
 	}
 
 	@Override
-	public ElasticsearchWorkFactory createWorkFactory(GsonProvider gsonProvider) {
-		return new Elasticsearch63WorkFactory( gsonProvider );
+	public ElasticsearchWorkFactory createWorkFactory(GsonProvider gsonProvider, Boolean ignoreShardFailures) {
+		return new Elasticsearch63WorkFactory( gsonProvider, ignoreShardFailures );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/Elasticsearch64ProtocolDialect.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/Elasticsearch64ProtocolDialect.java
@@ -32,8 +32,8 @@ public class Elasticsearch64ProtocolDialect implements ElasticsearchProtocolDial
 	}
 
 	@Override
-	public ElasticsearchWorkFactory createWorkFactory(GsonProvider gsonProvider) {
-		return new Elasticsearch63WorkFactory( gsonProvider );
+	public ElasticsearchWorkFactory createWorkFactory(GsonProvider gsonProvider, Boolean ignoreShardFailures) {
+		return new Elasticsearch63WorkFactory( gsonProvider, ignoreShardFailures );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/Elasticsearch67ProtocolDialect.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/Elasticsearch67ProtocolDialect.java
@@ -32,8 +32,8 @@ public class Elasticsearch67ProtocolDialect implements ElasticsearchProtocolDial
 	}
 
 	@Override
-	public ElasticsearchWorkFactory createWorkFactory(GsonProvider gsonProvider) {
-		return new Elasticsearch67WorkFactory( gsonProvider );
+	public ElasticsearchWorkFactory createWorkFactory(GsonProvider gsonProvider, Boolean ignoreShardFailures) {
+		return new Elasticsearch67WorkFactory( gsonProvider, ignoreShardFailures );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/Elasticsearch70ProtocolDialect.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/Elasticsearch70ProtocolDialect.java
@@ -32,8 +32,8 @@ public class Elasticsearch70ProtocolDialect implements ElasticsearchProtocolDial
 	}
 
 	@Override
-	public ElasticsearchWorkFactory createWorkFactory(GsonProvider gsonProvider) {
-		return new Elasticsearch7WorkFactory( gsonProvider );
+	public ElasticsearchWorkFactory createWorkFactory(GsonProvider gsonProvider, Boolean ignoreShardFailures) {
+		return new Elasticsearch7WorkFactory( gsonProvider, ignoreShardFailures );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/Elasticsearch80ProtocolDialect.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/Elasticsearch80ProtocolDialect.java
@@ -32,8 +32,8 @@ public class Elasticsearch80ProtocolDialect implements ElasticsearchProtocolDial
 	}
 
 	@Override
-	public ElasticsearchWorkFactory createWorkFactory(GsonProvider gsonProvider) {
-		return new Elasticsearch7WorkFactory( gsonProvider );
+	public ElasticsearchWorkFactory createWorkFactory(GsonProvider gsonProvider, Boolean ignoreShardFailures) {
+		return new Elasticsearch7WorkFactory( gsonProvider, ignoreShardFailures );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/Elasticsearch81ProtocolDialect.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/Elasticsearch81ProtocolDialect.java
@@ -32,8 +32,8 @@ public class Elasticsearch81ProtocolDialect implements ElasticsearchProtocolDial
 	}
 
 	@Override
-	public ElasticsearchWorkFactory createWorkFactory(GsonProvider gsonProvider) {
-		return new Elasticsearch7WorkFactory( gsonProvider );
+	public ElasticsearchWorkFactory createWorkFactory(GsonProvider gsonProvider, Boolean ignoreShardFailures) {
+		return new Elasticsearch7WorkFactory( gsonProvider, ignoreShardFailures );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/ElasticsearchProtocolDialect.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/ElasticsearchProtocolDialect.java
@@ -37,7 +37,7 @@ public interface ElasticsearchProtocolDialect {
 
 	ElasticsearchSearchSyntax createSearchSyntax();
 
-	ElasticsearchWorkFactory createWorkFactory(GsonProvider gsonProvider);
+	ElasticsearchWorkFactory createWorkFactory(GsonProvider gsonProvider, Boolean ignoreShardFailures);
 
 	ElasticsearchSearchResultExtractorFactory createSearchResultExtractorFactory();
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchLinkImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchLinkImpl.java
@@ -56,6 +56,12 @@ class ElasticsearchLinkImpl implements ElasticsearchLink {
 					.withDefault( ElasticsearchBackendSettings.Defaults.SCROLL_TIMEOUT )
 					.build();
 
+	private static final ConfigurationProperty<Boolean> QUERY_SHARD_FAILURE_IGNORE =
+			ConfigurationProperty.forKey( ElasticsearchBackendSettings.QUERY_SHARD_FAILURE_IGNORE )
+					.asBoolean()
+					.withDefault( ElasticsearchBackendSettings.Defaults.QUERY_SHARD_FAILURE_IGNORE )
+					.build();
+
 	private final BeanHolder<? extends ElasticsearchClientFactory> clientFactoryHolder;
 	private final BackendThreads threads;
 	private final GsonProvider defaultGsonProvider;
@@ -145,7 +151,7 @@ class ElasticsearchLinkImpl implements ElasticsearchLink {
 			gsonProvider = GsonProvider.create( GsonBuilder::new, logPrettyPrinting );
 			indexMetadataSyntax = protocolDialect.createIndexMetadataSyntax();
 			searchSyntax = protocolDialect.createSearchSyntax();
-			workFactory = protocolDialect.createWorkFactory( gsonProvider );
+			workFactory = protocolDialect.createWorkFactory( gsonProvider, QUERY_SHARD_FAILURE_IGNORE.get( propertySource ) );
 			searchResultExtractorFactory = protocolDialect.createSearchResultExtractorFactory();
 			scrollTimeout = SCROLL_TIMEOUT.get( propertySource );
 		}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/factory/impl/Elasticsearch56WorkFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/factory/impl/Elasticsearch56WorkFactory.java
@@ -22,14 +22,18 @@ import com.google.gson.JsonObject;
  */
 public class Elasticsearch56WorkFactory extends Elasticsearch63WorkFactory {
 
-	public Elasticsearch56WorkFactory(GsonProvider gsonProvider) {
-		super( gsonProvider );
+	public Elasticsearch56WorkFactory(GsonProvider gsonProvider, Boolean ignoreShardFailures) {
+		super( gsonProvider, ignoreShardFailures );
 	}
 
 	@Override
 	public <T> SearchWork.Builder<T> search(JsonObject payload,
 			ElasticsearchSearchResultExtractor<T> searchResultExtractor) {
-		return SearchWork.Builder.forElasticsearch62AndBelow( payload, searchResultExtractor );
+		SearchWork.Builder<T> builder = SearchWork.Builder.forElasticsearch62AndBelow( payload, searchResultExtractor );
+		if ( ignoreShardFailures ) {
+			builder.ignoreShardFailures();
+		}
+		return builder;
 	}
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/factory/impl/Elasticsearch63WorkFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/factory/impl/Elasticsearch63WorkFactory.java
@@ -25,8 +25,8 @@ import org.hibernate.search.backend.elasticsearch.work.impl.PutIndexMappingWork;
 @SuppressWarnings("deprecation") // We use Paths.DOC on purpose
 public class Elasticsearch63WorkFactory extends Elasticsearch67WorkFactory {
 
-	public Elasticsearch63WorkFactory(GsonProvider gsonProvider) {
-		super( gsonProvider );
+	public Elasticsearch63WorkFactory(GsonProvider gsonProvider, Boolean ignoreShardFailures) {
+		super( gsonProvider, ignoreShardFailures );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/factory/impl/Elasticsearch67WorkFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/factory/impl/Elasticsearch67WorkFactory.java
@@ -34,8 +34,8 @@ import com.google.gson.JsonObject;
 @SuppressWarnings("deprecation") // We use Paths.DOC on purpose
 public class Elasticsearch67WorkFactory extends Elasticsearch7WorkFactory {
 
-	public Elasticsearch67WorkFactory(GsonProvider gsonProvider) {
-		super( gsonProvider );
+	public Elasticsearch67WorkFactory(GsonProvider gsonProvider, Boolean ignoreShardFailures) {
+		super( gsonProvider, ignoreShardFailures );
 	}
 
 
@@ -57,7 +57,11 @@ public class Elasticsearch67WorkFactory extends Elasticsearch7WorkFactory {
 	@Override
 	public <T> SearchWork.Builder<T> search(JsonObject payload,
 			ElasticsearchSearchResultExtractor<T> searchResultExtractor) {
-		return SearchWork.Builder.forElasticsearch63to68( payload, searchResultExtractor );
+		SearchWork.Builder<T> builder = SearchWork.Builder.forElasticsearch63to68( payload, searchResultExtractor );
+		if ( ignoreShardFailures ) {
+			builder.ignoreShardFailures();
+		}
+		return builder;
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/factory/impl/Elasticsearch7WorkFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/factory/impl/Elasticsearch7WorkFactory.java
@@ -47,9 +47,11 @@ import com.google.gson.JsonObject;
 public class Elasticsearch7WorkFactory implements ElasticsearchWorkFactory {
 
 	protected final GsonProvider gsonProvider;
+	protected final Boolean ignoreShardFailures;
 
-	public Elasticsearch7WorkFactory(GsonProvider gsonProvider) {
+	public Elasticsearch7WorkFactory(GsonProvider gsonProvider, Boolean ignoreShardFailures) {
 		this.gsonProvider = gsonProvider;
+		this.ignoreShardFailures = ignoreShardFailures;
 	}
 
 	@Override
@@ -94,7 +96,11 @@ public class Elasticsearch7WorkFactory implements ElasticsearchWorkFactory {
 
 	@Override
 	public <T> SearchWork.Builder<T> search(JsonObject payload, ElasticsearchSearchResultExtractor<T> searchResultExtractor) {
-		return SearchWork.Builder.forElasticsearch7AndAbove( payload, searchResultExtractor );
+		SearchWork.Builder<T> builder = SearchWork.Builder.forElasticsearch7AndAbove( payload, searchResultExtractor );
+		if ( ignoreShardFailures ) {
+			builder.ignoreShardFailures();
+		}
+		return builder;
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/SearchWork.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/SearchWork.java
@@ -92,7 +92,7 @@ public class SearchWork<R> extends AbstractNonBulkableWork<R> {
 
 		private Builder(JsonObject payload, ElasticsearchSearchResultExtractor<R> resultExtractor, Boolean trackTotalHits,
 				boolean allowPartialSearchResultsSupported) {
-			super( ElasticsearchRequestSuccessAssessor.DEFAULT_INSTANCE );
+			super( ElasticsearchRequestSuccessAssessor.SHARD_FAILURE_CHECKED_INSTANCE );
 			this.payload = payload;
 			this.resultExtractor = resultExtractor;
 			this.trackTotalHits = trackTotalHits;
@@ -133,6 +133,11 @@ public class SearchWork<R> extends AbstractNonBulkableWork<R> {
 			if ( trackTotalHits != null && trackTotalHits ) {
 				trackTotalHits = false;
 			}
+			return this;
+		}
+
+		public Builder<R> ignoreShardFailures() {
+			resultAssessor = ElasticsearchRequestSuccessAssessor.DEFAULT_INSTANCE;
 			return this;
 		}
 

--- a/documentation/src/main/asciidoc/public/reference/_backend-elasticsearch.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_backend-elasticsearch.adoc
@@ -1346,6 +1346,24 @@ hibernate.search.backend.scroll_timeout = 60
 ----
 The default for this property is `60`.
 
+[[backend-elasticsearch-search-ignore-partial-shard-failure]]
+=== Partial shard failure
+
+With the Elasticsearch backend, <<search-dsl-query-fetching-results,fetching results>> may result in partial shard failures,
+i.e. some of the shards will fail to produce results while the others will succeed.
+In such situations, an Elasticsearch cluster will produce a response with a successful status code, but will contain additional
+information on failed shards, and the reason they have failed.
+
+By default, Hibernate Search will check if any shards have failed while fetching the results and if so -- will throw an exception.
+
+Use the following configuration property at the backend level to change the default behaviour:
+
+[source]
+----
+hibernate.search.backend.query.shard_failure.ignore = true
+----
+The default for this property is `false`.
+
 [[backend-elasticsearch-access-client]]
 == [[elasticsearch-client-access]] Retrieving the REST client
 

--- a/documentation/src/main/asciidoc/public/reference/_backend-elasticsearch.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_backend-elasticsearch.adoc
@@ -1354,15 +1354,16 @@ i.e. some of the shards will fail to produce results while the others will succe
 In such situations, an Elasticsearch cluster will produce a response with a successful status code, but will contain additional
 information on failed shards, and the reason they have failed.
 
-By default, Hibernate Search will check if any shards have failed while fetching the results and if so -- will throw an exception.
+By default, Hibernate Search will **not** check if any shards have failed while fetching the results
+and will silently ignore any such partial shard failures.
 
 Use the following configuration property at the backend level to change the default behaviour:
 
 [source]
 ----
-hibernate.search.backend.query.shard_failure.ignore = true
+hibernate.search.backend.query.shard_failure.ignore = false
 ----
-The default for this property is `false`.
+The default for this property is `true`.
 
 [[backend-elasticsearch-access-client]]
 == [[elasticsearch-client-access]] Retrieving the REST client

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/ElasticsearchShardsFailedExceptionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/ElasticsearchShardsFailedExceptionIT.java
@@ -1,0 +1,111 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.elasticsearch.search;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchHitsAssert.assertThatHits;
+
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
+import org.hibernate.search.engine.backend.common.DocumentReference;
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
+import org.hibernate.search.engine.search.query.SearchQuery;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ElasticsearchShardsFailedExceptionIT {
+
+
+	@Rule
+	public final SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private final SimpleMappedIndex<IndexBinding> index = SimpleMappedIndex.of( IndexBinding::new ).name( "index1" );
+	private final SimpleMappedIndex<IndexBinding> index2 = SimpleMappedIndex.of( IndexBinding::new ).name( "index2" );
+
+	public void setup(boolean ignoreShardFailures) {
+		setupHelper.start().withIndexes( index, index2 )
+				.withBackendProperty( ElasticsearchBackendSettings.QUERY_SHARD_FAILURE_IGNORE, ignoreShardFailures )
+				.withIndexProperty(
+						index.name(),
+						ElasticsearchIndexSettings.SCHEMA_MANAGEMENT_MAPPING_FILE,
+						"hsearch-4915/index1.json"
+				)
+				.withIndexProperty(
+						index2.name(),
+						ElasticsearchIndexSettings.SCHEMA_MANAGEMENT_MAPPING_FILE,
+						"hsearch-4915/index2.json"
+				)
+				.setup();
+
+		initData();
+	}
+
+	@Test
+	public void failureFetch() {
+		setup( false );
+		SearchQuery<DocumentReference> query = createQuery();
+
+		assertThatThrownBy( () -> query.fetchAllHits() )
+				.isInstanceOf( SearchException.class )
+				.hasMessageContainingAll(
+						"Elasticsearch request failed",
+						"\"type\": \"query_shard_exception\","
+				);
+	}
+
+	@Test
+	public void failureScroll() {
+		setup( false );
+		SearchQuery<DocumentReference> query = createQuery();
+
+		assertThatThrownBy( () -> query.scroll( 1 ).next() )
+				.isInstanceOf( SearchException.class )
+				.hasMessageContainingAll(
+						"Elasticsearch request failed",
+						"\"type\": \"query_shard_exception\","
+				);
+	}
+
+	@Test
+	public void success() {
+		setup( true );
+		SearchQuery<DocumentReference> query = createQuery();
+		assertThatHits( query.fetchAllHits() )
+				.hasDocRefHitsExactOrder( index.typeName(), "1" );
+	}
+
+	private SearchQuery<DocumentReference> createQuery() {
+		StubMappingScope scope = index.createScope( index2 );
+
+		SearchPredicateFactory factory = scope.predicate();
+		SearchPredicate predicate = factory.range().field( "field" ).greaterThan( "tex" ).toPredicate();
+
+		return scope.query().where( predicate ).toQuery();
+	}
+
+	private void initData() {
+		index.bulkIndexer()
+				.add( "1", document -> document.addValue( index.binding().normalizedStringField, "text" ) )
+				.join();
+	}
+
+	private static class IndexBinding {
+		final IndexFieldReference<String> normalizedStringField;
+
+		IndexBinding(IndexSchemaElement root) {
+			normalizedStringField = root.field( "field", c -> c.asString() ).toReference();
+		}
+	}
+}

--- a/integrationtest/backend/elasticsearch/src/test/resources/hsearch-4915/index1.json
+++ b/integrationtest/backend/elasticsearch/src/test/resources/hsearch-4915/index1.json
@@ -1,0 +1,14 @@
+{
+  "properties": {
+    "_entity_type": {
+      "type": "keyword",
+      "index": false
+    },
+    "field": {
+      "type": "keyword"
+    }
+  },
+  "_source": {
+    "enabled": false
+  }
+}

--- a/integrationtest/backend/elasticsearch/src/test/resources/hsearch-4915/index2.json
+++ b/integrationtest/backend/elasticsearch/src/test/resources/hsearch-4915/index2.json
@@ -1,0 +1,14 @@
+{
+  "properties": {
+    "_entity_type": {
+      "type": "keyword",
+      "index": false
+    },
+    "field": {
+      "type": "integer"
+    }
+  },
+  "_source": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4915

A backport of https://github.com/hibernate/hibernate-search/pull/3652