### PR TITLE
Various build dependecy updates

### DIFF
--- a/.github/hibernate-github-bot.yml
+++ b/.github/hibernate-github-bot.yml
@@ -4,7 +4,7 @@ jira:
   ignore:
       # Allow build dependency upgrades i.e. maven plugin version upgrades to not follow the PR formatting rules:
     - user: dependabot[bot]
-      titlePattern: ".*\\b(maven|surefire)\\b.*\\bplugin\\b.*"
+      titlePattern: ".*\\b((maven|surefire)\\b.*\\bplugin|owasp)\\b.*"
       # Allow Groovy (that is only used for scripting maven plugin) version upgrades to not follow the PR formatting rules:
     - user: dependabot[bot]
       titlePattern: ".*\\bgroovy-jsr223\\b.*"
@@ -31,3 +31,6 @@ jira:
     # Eclipse compiler:
     - user: dependabot[bot]
       titlePattern: ".*\\borg.codehaus.plexus.plexus-compiler\\b.*"
+    # JBeret integration tests runtime dependencies:
+    - user: dependabot[bot]
+      titlePattern: ".*\\b(jboss-marshalling|wildfly-security-manager)\\b.*"

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -159,7 +159,7 @@
         <version.com.ibm.jbatch>2.1.1</version.com.ibm.jbatch>
 
         <!-- >>> JSR 352: JBeret SE dependencies -->
-        <version.org.jboss.marshalling>2.1.1.Final</version.org.jboss.marshalling>
+        <version.org.jboss.marshalling>2.1.2.Final</version.org.jboss.marshalling>
         <version.org.wildfly.security.wildfly-security-manager>1.1.2.Final</version.org.wildfly.security.wildfly-security-manager>
         <version.org.google.guava>32.1.2-jre</version.org.google.guava>
 

--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@
         <version.surefire.plugin.java-version.asm>9.5</version.surefire.plugin.java-version.asm>
         <version.jacoco.plugin>0.8.10</version.jacoco.plugin>
         <version.com.buschmais.jqassistant.plugin>2.0.6</version.com.buschmais.jqassistant.plugin>
-        <version.docker.maven.plugin>0.43.3</version.docker.maven.plugin>
+        <version.docker.maven.plugin>0.43.4</version.docker.maven.plugin>
         <version.moditect.plugin>1.0.0.Final</version.moditect.plugin>
         <version.sonar.plugin>3.9.1.2184</version.sonar.plugin>
         <version.scripting.plugin>3.0.0</version.scripting.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
         <version.compiler.plugin>3.11.0</version.compiler.plugin>
         <version.dependency.plugin>3.6.0</version.dependency.plugin>
         <!-- Check dependencies for security vulnerabilities -->
-        <version.dependency-check.plugin>8.3.1</version.dependency-check.plugin>
+        <version.dependency-check.plugin>8.4.0</version.dependency-check.plugin>
         <version.exec.plugin>3.1.0</version.exec.plugin>
         <version.forbiddenapis.plugin>3.5.1</version.forbiddenapis.plugin>
         <version.jandex.plugin>3.1.2</version.jandex.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
         <version.surefire.plugin>3.1.2</version.surefire.plugin>
         <version.surefire.plugin.java-version.asm>9.5</version.surefire.plugin.java-version.asm>
         <version.jacoco.plugin>0.8.10</version.jacoco.plugin>
-        <version.com.buschmais.jqassistant.plugin>2.0.5</version.com.buschmais.jqassistant.plugin>
+        <version.com.buschmais.jqassistant.plugin>2.0.6</version.com.buschmais.jqassistant.plugin>
         <version.docker.maven.plugin>0.43.3</version.docker.maven.plugin>
         <version.moditect.plugin>1.0.0.Final</version.moditect.plugin>
         <version.sonar.plugin>3.9.1.2184</version.sonar.plugin>


### PR DESCRIPTION
Since the marshalling dependency is used for ITs, let's run a build with it upgraded.