### PR TITLE
Followup: HSEARCH-4915 Do not rely on the number of shards in the error message

### DIFF
--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/ElasticsearchShardsFailedExceptionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/ElasticsearchShardsFailedExceptionIT.java
@@ -61,8 +61,7 @@ public class ElasticsearchShardsFailedExceptionIT {
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll(
 						"Elasticsearch request failed",
-						"\"successful\": 1,",
-						"\"failed\": 1,"
+						"\"type\": \"query_shard_exception\","
 				);
 	}
 
@@ -75,8 +74,7 @@ public class ElasticsearchShardsFailedExceptionIT {
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll(
 						"Elasticsearch request failed",
-						"\"successful\": 1,",
-						"\"failed\": 1,"
+						"\"type\": \"query_shard_exception\","
 				);
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4915

Since different ES versions will create a different number of shards by default 1/5/etc.. I thought that we've already removed the older versions of ES that were creating five shards as a default....  but apparently not, and the same goes for the older versions of Open Search ...
6.2 does not need any changes since the test adjustment is already present there.