### PR TITLE
HSEARCH-4917 Group build dependency updates in the Dependabot's config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,17 +53,12 @@ updates:
       # AWS SDK releases way too often (every week?); ignore all patch updates
       - dependency-name: "software.amazon.awssdk:*"
         update-types: ["version-update:semver-patch"]
-      # JRuby releases way too often (every two weeks?) and is only used during the build; ignore all patch updates
-      - dependency-name: "org.jruby:jruby-complete"
-        update-types: ["version-update:semver-patch"]
       # Groovy is only used during the build; ignore all patch updates
       - dependency-name: "org.apache.groovy:groovy-jsr223"
         update-types: [ "version-update:semver-patch" ]
       # We don't care that much about being on the very latest version of some integration test dependencies
       - dependency-name: "org.springframework.boot:*"
         update-types: [ "version-update:semver-patch" ]
-        # ignore spring boot 3+ for now as some required dependencies are not compatible with this version yet:
-        versions: ["[3.0.0,)"]
       # We strictly align these dependencies on the version used in Hibernate ORM.
       - dependency-name: "io.smallrye:jandex"
       - dependency-name: "jakarta.persistence:jakarta.persistence-api"
@@ -86,3 +81,7 @@ updates:
         update-types: ["version-update:semver-major"]
       # We only define a maven's minimum version, so we don't need it to be updated to the latest:
       - dependency-name: "org.apache.maven:maven-core"
+      # This dependency uses classifiers (-jdk8, ...) in its version, and dependabot can't decide which versions are relevant.
+      # See https://github.com/dependabot/dependabot-core/issues/4028
+      # And, additionally, it is only for performance testing.
+      - dependency-name: "org.bsc.maven:maven-processor-plugin"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,39 @@ updates:
     # We don't trigger Jenkins or GitHub Actions builds on pull requests from dependabot,
     # so we can safely use a high limit here.
     open-pull-requests-limit: 20
+    groups:
+      # This group combines all build-only dependencies. Published artifacts do not depend on them.
+      # Grouping such dependencies will make Dependabot create PRs with a branch name
+      # following the pattern (`dependabot/maven/build-dependencies-.*`)
+      # and with a title like `Bump the build-dependencies group with 8 updates` that we can easily
+      # use for Hibernate Bot rules.
+      build-dependencies:
+        patterns:
+          # Maven plugin patterns:
+          - "*maven*plugin*"
+          - "*surefire*"
+          - "*forbiddenapis*"
+          - "*owasp*"
+          # DB drivers:
+          - "com.h2database:h2"
+          - "org.apache.derby:derby"
+          - "org.postgresql:postgresql"
+          - "org.mariadb.jdbc:mariadb-java-client"
+          - "com.mysql:mysql-connector-j"
+          - "com.ibm.db2:jcc"
+          - "com.oracle.database.jdbc:ojdbc*"
+          - "com.microsoft.sqlserver:mssql-jdbc"
+          # Other test dependencies
+          - "org.apache.groovy:groovy-jsr223" # used for scripting maven plugin
+          - "org.apache.commons:commons-lang3" # used in hibernate-search-util-common tests
+          - "org.apache.commons:commons-math3" # used to solve dependency convergence for Wiremock
+          - "org.openjdk.jmh:*" # performance testing dependency
+          - "com.google.guava:guava" # Guava is used in our test utils
+          - "org.asciidoctor:*" # Asciidoctor is used for rendering the documentation
+          - "org.codehaus.plexus:*" # Eclipse compiler
+          - "org.jboss.marshalling:jboss-marshalling" # JBeret IT dependency
+          - "org.wildfly.security:wildfly-security-manager" # JBeret IT dependency
+          - "org.springframework.boot:*" # Spring is only for ITs
     ignore:
       # These dependencies are updated manually
       - dependency-name: "org.hibernate:*"

--- a/.github/hibernate-github-bot.yml
+++ b/.github/hibernate-github-bot.yml
@@ -2,35 +2,6 @@
 jira:
   projectKey: "HSEARCH"
   ignore:
-      # Allow build dependency upgrades i.e. maven plugin version upgrades to not follow the PR formatting rules:
+      # See the `build-dependencies` group in the Dependabot's configuration file
     - user: dependabot[bot]
-      titlePattern: ".*\\b((maven|surefire)\\b.*\\bplugin|owasp)\\b.*"
-      # Allow Groovy (that is only used for scripting maven plugin) version upgrades to not follow the PR formatting rules:
-    - user: dependabot[bot]
-      titlePattern: ".*\\bgroovy-jsr223\\b.*"
-      # Allow database drivers upgrades (since we only use them for tests)
-    - user: dependabot[bot]
-      titlePattern: ".*\\b(h2|derby|postgresql|mariadb-java-client|mysql-connector-j|jcc|ojdbc8|mssql-jdbc)\\b.*"
-      # Allow common utils upgrades, since we only use them for tests:
-      #   * commons-lang3 (to solve dependency convergence for Wiremock)
-      #   * commons-math3 (used in hibernate-search-util-common tests)
-    - user: dependabot[bot]
-      titlePattern: ".*\\borg.apache.commons:(commons-lang3|commons-math3)\\b.*"
-      # Allow JMH upgrades, since it is a performance testing dependency
-    - user: dependabot[bot]
-      titlePattern: ".*\\borg.openjdk.jmh\\b.*"
-    # Guava is used in our test utils:
-    - user: dependabot[bot]
-      titlePattern: ".*\\bcom.google.guava\\b.*"
-    # Asciidoctor is used for rendering the documentation:
-    - user: dependabot[bot]
-      titlePattern: ".*\\b(org.asciidoctor|org.jruby)\\b.*"
-    # Forbidden APIs:
-    - user: dependabot[bot]
-      titlePattern: ".*\\bforbiddenapis\\b.*"
-    # Eclipse compiler:
-    - user: dependabot[bot]
-      titlePattern: ".*\\borg.codehaus.plexus.plexus-compiler\\b.*"
-    # JBeret integration tests runtime dependencies:
-    - user: dependabot[bot]
-      titlePattern: ".*\\b(jboss-marshalling|wildfly-security-manager)\\b.*"
+      titlePattern: "Bump the build-dependencies group with \\d+ updates?"

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -147,7 +147,7 @@
         <version.org.apache.derby>10.15.2.0</version.org.apache.derby>
         <version.org.postgresql>42.6.0</version.org.postgresql>
         <version.org.mariadb.jdbc>3.1.4</version.org.mariadb.jdbc>
-        <version.mysql.mysql-connector-java>8.1.0</version.mysql.mysql-connector-java>
+        <version.mysql.mysql-connector-j>8.1.0</version.mysql.mysql-connector-j>
         <version.com.ibm.db2.jcc>11.5.8.0</version.com.ibm.db2.jcc>
         <version.com.oracle.database.jdbc>23.2.0.0</version.com.oracle.database.jdbc>
         <version.com.microsoft.sqlserver.mssql-jdbc>12.2.0.jre11</version.com.microsoft.sqlserver.mssql-jdbc>
@@ -678,7 +678,7 @@
             <dependency>
                 <groupId>com.mysql</groupId>
                 <artifactId>mysql-connector-j</artifactId>
-                <version>${version.mysql.mysql-connector-java}</version>
+                <version>${version.mysql.mysql-connector-j}</version>
             </dependency>
             <dependency>
                 <groupId>com.ibm.db2</groupId>

--- a/util/common/pom.xml
+++ b/util/common/pom.xml
@@ -78,24 +78,5 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>testWithJdk11</id>
-            <activation>
-                <property>
-                    <name>java-version.test.release</name>
-                    <value>11</value>
-                </property>
-            </activation>
-            <properties>
-                <!--
-                    We want to use a different version of Spring Boot when testing with JDK11
-                    since 3+ requires JDK17+ and our tests won't run on JDK11.
-                -->
-                <version.org.springframework.boot>2.7.14</version.org.springframework.boot>
-            </properties>
-        </profile>
-    </profiles>
 </project>
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4917

I've tried to use `|` in the patterns, thinking it would allow me to combine some, but as you can see ... it didn't work, so patterns are listed in a more dependency-explicit way 😃 
I've also removed the jruby rule as now we have a config that does not need jruby dependency. And as we've upgraded our spring tests we can now do some upgrades of it from time to time, hence that version limit for it is gone. While testing it on my repo `org.bsc.maven:maven-processor-plugin` kept coming up with a jre8 version... so there's an ignore rule for it now too 😈😃 