### PR TITLE
HSEARCH-4909 Add more info on indexing plan synchronization and coordination

### DIFF
--- a/documentation/src/main/asciidoc/public/reference/_indexing-plan.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_indexing-plan.adoc
@@ -113,10 +113,12 @@ include::../components/_writing-reading-intro-note.adoc[]
 
 [WARNING]
 ====
-Indexing synchronization is only relevant when <<coordination-none,coordination is disabled>>.
-
-With coordination strategies such as <<coordination-outbox-polling,`outbox-polling`>>,
-indexing happens in background threads and is always asynchronous.
+When using the <<coordination-outbox-polling,`outbox-polling` coordination strategy>>,
+the actual indexing plan performing the index changes
+is created asynchronously in a background thread.
+Because of that, with that coordination strategy it does not make sense
+to set a non-default indexing plan synchronization strategy,
+and doing so will lead to an exception on startup.
 ====
 
 When a transaction is committed (<<mapper-orm,Hibernate ORM integration>>)

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
@@ -623,12 +623,6 @@ public interface Log extends BasicLogger {
 					+ " Valid names for mapped entity types are: %2$s")
 	SearchException unknownEntityNameForMappedEntityType(String invalidName, Collection<String> validNames);
 
-	@Message(id = ID_OFFSET + 90, value = "The required identifier type '%1$s'"
-			+ " does not match the actual identifier type '%2$s':"
-			+ " the required identifier must be a superclass of the actual identifier.")
-	SearchException wrongRequiredIdentifierType(@FormatWith(ClassFormatter.class) Class<?> requiredIdentifierType,
-			@FormatWith(ClassFormatter.class) Class<?> actualIdentifierType);
-
 	/*
 	 * This is not an exception factory nor a logging statement.
 	 * The returned string is passed to the FailureHandler,


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4909

I've scrolled through other log messages looking for conflicting configs and it seems mostly old/new property set at the same time, which I think we shouldn't document additionally 😃; indexing plan filter limitation is already mentioned in the reference; nothing else caught my eye 😃 