### PR TITLE
HSEARCH-4784 Add a script to produce a list of IT modules based on changes

### DIFF
--- a/ci/list-integration-tests-for-modified-modules.sh
+++ b/ci/list-integration-tests-for-modified-modules.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+# Lists test modules based on git diff check.
+
+if (( $# < 2 ))
+then
+	echo 1>&2 "Usage: $0 <main branch, which we'll compare to to identify changes> <branch with changes we want to identify>"
+	echo 1>&2 "Aborting."
+	exit 1
+fi
+
+# `exec` will echo a based dir and the artifact id.
+#   Basedir is going to be used to figure out to which module folder the modified files belong to
+#   Artifact ID is going to be used to match the basedir to an id that can be later passed as a mvn build parameter
+#
+# The output format is `artifact-id-and-basedir-output :artifactId=basedir`.
+# The prefix (`artifact-id-and-basedir-output`) is used for easier identification of the lines we are interested in from maven's output
+readarray -t lines < <(./mvnw exec:exec@print-artifact-id-and-basedir | grep artifact-id-and-basedir-output | awk '{print $2}')
+
+declare -a artifacts
+declare -a paths
+
+# We split the `:artifactId=basedir` and put them in their own arrays.
+# Basedir will be used as patterns to determine which module the change belongs to.
+for index in "${!lines[@]}"
+do
+	artifacts[index]=${lines[$index]%=*}
+	paths[index]=${lines[$index]#*=}
+	paths[index]="${paths[index]//${paths[0]}"/"/""}"
+done
+
+# get the diffs, which will produce relative paths of modified files:
+readarray -t lines < <(git --no-pager diff --name-only $1..$2)
+
+declare -A modifiedArtifactIds
+
+# using an associated array as a set to have a unique collection of modified artifact IDs
+for modifiedFile in "${lines[@]}"
+do
+  for index in "${!paths[@]}"
+    do
+      if [[ $modifiedFile =~ ${paths[$index]} ]]; then
+          modifiedArtifactIds[${artifacts[$index]}]="modified"
+      fi
+    done
+done
+
+if [ "${#modifiedArtifactIds[@]}" -ne 0 ]; then
+   $(dirname "$(realpath "$0")")/list-dependent-integration-tests.sh "${!modifiedArtifactIds[@]}"
+fi
+

--- a/pom.xml
+++ b/pom.xml
@@ -1173,6 +1173,23 @@
                             <inheritIo>true</inheritIo>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>print-artifact-id-and-basedir</id>
+                        <!--
+                            We don't want this to be executed on a regular basis.
+                            This output is used in the implementation of `list-integration-tests-for-modified-modules.sh`.
+                            See the script itself for any details.
+                         -->
+                        <phase>none</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>echo</executable>
+                            <commandlineArgs>artifact-id-and-basedir-output ${project.artifactId}=${project.basedir}</commandlineArgs>
+                            <inheritIo>true</inheritIo>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4784

Hey Yoann 😃 I've started looking at this CI-related task yesterday. I thought that before I try modifying the job I'll look into  this bit first:

> Ideally we would add some code to detect when changes in a given PR have no impact on a given environment and thus skip some environments. E.g. if there are no changes in hibernate-search-backend-elasticsearch or any of its dependencies (engine, …),  then there’s no need to run tests against all flavors of OpenSearch. That would allow us to expand a bit the subset of environments we test against PRs. But maybe that should be a separate Jira issue?

I've added a script that would generate a list of modules to be tested based on the git diff. With this list, we could check if `hibernate-search-integrationtest-backend-elasticsearch` is present, and if so run those ES/OS-specific jobs... 

Opening this as a draft as it's a script only ...