### PR TITLE
HSEARCH-4925 Follow-up: Improve documentation (and tests) of Elasticsearch/OpenSearch compatibility

### DIFF
--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateAnalyzerIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateAnalyzerIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.elasticsearch.schema.management;
 
 import static org.hibernate.search.util.impl.test.JsonHelper.assertJsonEquals;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
@@ -39,7 +39,7 @@ public class ElasticsearchIndexSchemaManagerUpdateAnalyzerIT {
 
 	@Before
 	public void checkAssumption() {
-		assumeFalse(
+		assumeTrue(
 				"This test only is only relevant if we are allowed to open/close Elasticsearch indexes.",
 				ElasticsearchTckBackendFeatures.supportsIndexClosingAndOpening()
 		);

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateCustomMappingIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateCustomMappingIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.integrationtest.backend.elasticsearch.schema.manage
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hibernate.search.util.impl.test.JsonHelper.assertJsonEquals;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
@@ -41,7 +41,7 @@ public class ElasticsearchIndexSchemaManagerUpdateCustomMappingIT {
 
 	@Before
 	public void checkAssumption() {
-		assumeFalse(
+		assumeTrue(
 				"This test only is only relevant if we are allowed to open/close Elasticsearch indexes.",
 				ElasticsearchTckBackendFeatures.supportsIndexClosingAndOpening()
 		);

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateCustomSettingsIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateCustomSettingsIT.java
@@ -9,7 +9,7 @@ package org.hibernate.search.integrationtest.backend.elasticsearch.schema.manage
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hibernate.search.util.impl.test.JsonHelper.assertJsonEquals;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
@@ -44,7 +44,7 @@ public class ElasticsearchIndexSchemaManagerUpdateCustomSettingsIT {
 
 	@Before
 	public void checkAssumption() {
-		assumeFalse(
+		assumeTrue(
 				"This test only is only relevant if we are allowed to open/close Elasticsearch indexes.",
 				ElasticsearchTckBackendFeatures.supportsIndexClosingAndOpening()
 		);

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateNormalizerIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateNormalizerIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.elasticsearch.schema.management;
 
 import static org.hibernate.search.util.impl.test.JsonHelper.assertJsonEquals;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
@@ -39,7 +39,7 @@ public class ElasticsearchIndexSchemaManagerUpdateNormalizerIT {
 
 	@Before
 	public void checkAssumption() {
-		assumeFalse(
+		assumeTrue(
 				"This test only is only relevant if we are allowed to open/close Elasticsearch indexes.",
 				ElasticsearchTckBackendFeatures.supportsIndexClosingAndOpening()
 		);


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4925

Follows up on #3671.

Looks like I made a very dumb mistake resulting in relevant tests never being executed.

I suppose we don't currently test on any platform where `supportsIndexClosingAndOpening()` would return `false`, and that's why the inverted assumption didn't cause any failure...

But let's leave the assumption anyway, because we'll need it to test Amazon OpenSearch Serverless.