### PR TITLE
HSEARCH-4861 Follow-up: Move Avro Maven plugin management to build/parents/build/pom.xml

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -1102,9 +1102,19 @@
                         </execution>
                     </executions>
                 </plugin>
-                <!--
-                    Test configuration
-                 -->
+                <plugin>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro-maven-plugin</artifactId>
+                    <!-- Managing the version here and not in the root POM,
+                         contrary to other Maven plugins,
+                         because we want to align on the runtime dependency to Avro,
+                         and that one is managed in this POM
+                         so the corresponding version is not available in the root POM. -->
+                    <version>${version.org.apache.avro}</version>
+            </plugin>
+            <!--
+                Test configuration
+             -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -889,11 +889,6 @@
                     <version>${version.docker.maven.plugin}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.avro</groupId>
-                    <artifactId>avro-maven-plugin</artifactId>
-                    <version>${version.org.apache.avro}</version>
-                </plugin>
-                <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>${version.jacoco.plugin}</version>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4861

Follows up on #3588 , #3602 , #3606 , #3618 , #3627 

Without this patch, we get this in build logs:

```
[WARNING] Failed to retrieve plugin descriptor for org.apache.avro:avro-maven-plugin:${version.org.apache.avro}: Plugin org.apache.avro:avro-maven-plugin:${version.org.apache.avro} or one of its dependencies could not be resolved: Failed to read artifact descriptor for org.apache.avro:avro-maven-plugin:jar:${version.org.apache.avro}
```