### PR TITLE
HSEARCH-4867 Experimental compatibility with Amazon OpenSearch Serverless

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -312,13 +312,16 @@ You may redefine the distribution/version to use by specifying the properties
 ./mvnw clean install -Dtest.elasticsearch.distribution=elastic -Dtest.elasticsearch.version=6.0.0 
 ```
 The following distribution options are supported:
-* `elastic` - for Elasticsearch distribution
-* `opensearch` - for Opensearch distribution
+* `elastic` for Elasticsearch distribution
+* `opensearch` for OpenSearch (local or Amazon OpenSearch Service)
+* `amazon-opensearch-serverless` for Amazon OpenSearch Serverless
 
 For available versions of Elasticsearch distribution from Elastic see [DockerHub](https://hub.docker.com/r/elastic/elasticsearch/tags).
 Please note that Elasticsearch [distributions starting with version 7.11 are not open-source](https://opensource.org/node/1099).
 
 For available versions of [OpenSearch](https://www.opensearch.org/) distribution see [DockerHub](https://hub.docker.com/r/opensearchproject/opensearch/tags).
+
+For Amazon OpenSearch Serverless, the version must be unset (set to an empty string).
 
 Alternatively, you can prevent the build from launching an Elasticsearch server automatically
 and run Elasticsearch-related tests against your own server using the

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -255,16 +255,22 @@ stage('Configure') {
 					new LocalOpenSearchBuildEnvironment(version: '2.6.0', condition: TestCondition.ON_DEMAND),
 					new LocalOpenSearchBuildEnvironment(version: '2.7.0', condition: TestCondition.ON_DEMAND),
 					new LocalOpenSearchBuildEnvironment(version: '2.8.0', condition: TestCondition.ON_DEMAND),
-					new LocalOpenSearchBuildEnvironment(version: '2.9.0', condition: TestCondition.BEFORE_MERGE)
+					new LocalOpenSearchBuildEnvironment(version: '2.9.0', condition: TestCondition.BEFORE_MERGE),
 					// See https://opensearch.org/lines/2x.html for a list of all 2.x versions
+
+					// --------------------------------------------
+					// Amazon OpenSearch Serverless dialect running against a local OpenSearch instance
+					// WARNING: this does NOT actually run against Amazon OpenSearch Serverless (yet)
+					// See https://hibernate.atlassian.net/browse/HSEARCH-4919
+					new AmazonOpenSearchServerlessLocalBuildEnvironment(condition: TestCondition.AFTER_MERGE)
 			],
 			amazonElasticsearch: [
 					// --------------------------------------------
-					// AWS Elasticsearch service (OpenDistro)
+					// Amazon Elasticsearch Service (OpenDistro)
 					new AmazonElasticsearchServiceBuildEnvironment(version: '7.10', condition: TestCondition.AFTER_MERGE),
 
 					// --------------------------------------------
-					// AWS OpenSearch service
+					// Amazon OpenSearch Service
 					new AmazonOpenSearchServiceBuildEnvironment(version: '1.3', condition: TestCondition.AFTER_MERGE),
 					new AmazonOpenSearchServiceBuildEnvironment(version: '2.5', condition: TestCondition.AFTER_MERGE),
 					// Also test static credentials, but only for the latest version
@@ -748,7 +754,7 @@ class LocalElasticsearchBuildEnvironment extends BuildEnvironment {
 	String version
 	String getTagPrefix() { 'elasticsearch-local' }
 	@Override
-	String getTag() { "$tagPrefix-$version" }
+	String getTag() { tagPrefix + (version ? '-' + version : '') }
 	String getDistribution() { 'elastic' }
 }
 
@@ -757,7 +763,18 @@ class LocalOpenSearchBuildEnvironment extends LocalElasticsearchBuildEnvironment
 	@Override
 	String getTagPrefix() { 'opensearch-local' }
 	@Override
-	String getDistribution() { "opensearch" }
+	String getDistribution() { 'opensearch' }
+}
+
+class AmazonOpenSearchServerlessLocalBuildEnvironment
+		extends LocalOpenSearchBuildEnvironment {
+	{
+		setVersion('')
+	}
+	@Override
+	String getTagPrefix() { 'amazon-opensearch-serverless' }
+	@Override
+	String getDistribution() { 'amazon-opensearch-serverless' }
 }
 
 class AmazonElasticsearchServiceBuildEnvironment extends LocalElasticsearchBuildEnvironment {
@@ -766,7 +783,7 @@ class AmazonElasticsearchServiceBuildEnvironment extends LocalElasticsearchBuild
 	String getTagPrefix() { 'amazon-elasticsearch-service' }
 	@Override
 	String getTag() {
-		"$tagPrefix-$version" + (staticCredentials ? '-credentials-static' : '')
+		tagPrefix + (version ? '-' + version : '') + (staticCredentials ? '-credentials-static' : '')
 	}
 	String getLockedResourcesPrefix() { 'es' }
 	String getLockedResourcesLabel() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -203,72 +203,72 @@ stage('Configure') {
                             slow: true,
                             condition: TestCondition.AFTER_MERGE),
 			],
-			esLocal: [
+			localElasticsearch: [
 					// --------------------------------------------
 					// Elasticsearch distribution from Elastic
 					// Not testing 7.0/7.1/7.2 to make the build quicker.
 					// The only difference with 7.3+ is they have a bug in their BigInteger support.
-					new EsLocalBuildEnvironment(version: '7.2.1', condition: TestCondition.ON_DEMAND),
-					new EsLocalBuildEnvironment(version: '7.6.2', condition: TestCondition.AFTER_MERGE),
+					new LocalElasticsearchBuildEnvironment(version: '7.2.1', condition: TestCondition.ON_DEMAND),
+					new LocalElasticsearchBuildEnvironment(version: '7.6.2', condition: TestCondition.AFTER_MERGE),
 					// Not testing 7.7 to make the build quicker.
 					// The only difference with 7.7+ is how we create templates for tests.
-					new EsLocalBuildEnvironment(version: '7.7.1', condition: TestCondition.ON_DEMAND),
+					new LocalElasticsearchBuildEnvironment(version: '7.7.1', condition: TestCondition.ON_DEMAND),
 					// Not testing 7.9 to make the build quicker.
 					// The only difference with 7.10+ is an additional test for exists on null values,
 					// which is disabled on 7.10 but enabled on all older versions (not just 7.9).
-					new EsLocalBuildEnvironment(version: '7.9.3', condition: TestCondition.AFTER_MERGE),
-					new EsLocalBuildEnvironment(version: '7.10.1', condition: TestCondition.AFTER_MERGE),
+					new LocalElasticsearchBuildEnvironment(version: '7.9.3', condition: TestCondition.AFTER_MERGE),
+					new LocalElasticsearchBuildEnvironment(version: '7.10.1', condition: TestCondition.AFTER_MERGE),
 					// Not testing 7.11 to make the build quicker.
 					// The only difference with 7.12+ is that wildcard predicates on analyzed fields get their pattern normalized,
 					// and that was deemed a bug: https://github.com/elastic/elasticsearch/pull/53127
-					new EsLocalBuildEnvironment(version: '7.11.2', condition: TestCondition.ON_DEMAND),
-					new EsLocalBuildEnvironment(version: '7.12.1', condition: TestCondition.ON_DEMAND),
-					new EsLocalBuildEnvironment(version: '7.13.2', condition: TestCondition.ON_DEMAND),
+					new LocalElasticsearchBuildEnvironment(version: '7.11.2', condition: TestCondition.ON_DEMAND),
+					new LocalElasticsearchBuildEnvironment(version: '7.12.1', condition: TestCondition.ON_DEMAND),
+					new LocalElasticsearchBuildEnvironment(version: '7.13.2', condition: TestCondition.ON_DEMAND),
 					// 7.14 and 7.15 have annoying bugs that make almost all of our test suite fail,
 					// so we don't test them
 					// See https://hibernate.atlassian.net/browse/HSEARCH-4340
-					new EsLocalBuildEnvironment(version: '7.16.3', condition: TestCondition.ON_DEMAND),
-					new EsLocalBuildEnvironment(version: '7.17.12', condition: TestCondition.AFTER_MERGE),
+					new LocalElasticsearchBuildEnvironment(version: '7.16.3', condition: TestCondition.ON_DEMAND),
+					new LocalElasticsearchBuildEnvironment(version: '7.17.12', condition: TestCondition.AFTER_MERGE),
 					// Not testing 8.0 because we know there are problems in 8.0.1 (see https://hibernate.atlassian.net/browse/HSEARCH-4497)
 					// Not testing 8.1-8.6 to make the build quicker.
-					new EsLocalBuildEnvironment(version: '8.1.3', condition: TestCondition.ON_DEMAND),
-					new EsLocalBuildEnvironment(version: '8.2.3', condition: TestCondition.ON_DEMAND),
-					new EsLocalBuildEnvironment(version: '8.3.3', condition: TestCondition.ON_DEMAND),
-					new EsLocalBuildEnvironment(version: '8.4.3', condition: TestCondition.ON_DEMAND),
-					new EsLocalBuildEnvironment(version: '8.5.3', condition: TestCondition.ON_DEMAND),
-					new EsLocalBuildEnvironment(version: '8.6.2', condition: TestCondition.ON_DEMAND),
-					new EsLocalBuildEnvironment(version: '8.7.1', condition: TestCondition.ON_DEMAND),
-					new EsLocalBuildEnvironment(version: '8.8.2', condition: TestCondition.ON_DEMAND),
-					new EsLocalBuildEnvironment(version: '8.9.1', condition: TestCondition.BEFORE_MERGE, isDefault: true),
+					new LocalElasticsearchBuildEnvironment(version: '8.1.3', condition: TestCondition.ON_DEMAND),
+					new LocalElasticsearchBuildEnvironment(version: '8.2.3', condition: TestCondition.ON_DEMAND),
+					new LocalElasticsearchBuildEnvironment(version: '8.3.3', condition: TestCondition.ON_DEMAND),
+					new LocalElasticsearchBuildEnvironment(version: '8.4.3', condition: TestCondition.ON_DEMAND),
+					new LocalElasticsearchBuildEnvironment(version: '8.5.3', condition: TestCondition.ON_DEMAND),
+					new LocalElasticsearchBuildEnvironment(version: '8.6.2', condition: TestCondition.ON_DEMAND),
+					new LocalElasticsearchBuildEnvironment(version: '8.7.1', condition: TestCondition.ON_DEMAND),
+					new LocalElasticsearchBuildEnvironment(version: '8.8.2', condition: TestCondition.ON_DEMAND),
+					new LocalElasticsearchBuildEnvironment(version: '8.9.1', condition: TestCondition.BEFORE_MERGE, isDefault: true),
 
 					// --------------------------------------------
 					// OpenSearch
 					// Not testing 1.0 - 1.2 to make the build quicker.
-					new OpenSearchLocalBuildEnvironment(version: '1.3.12', condition: TestCondition.AFTER_MERGE),
+					new LocalOpenSearchBuildEnvironment(version: '1.3.12', condition: TestCondition.AFTER_MERGE),
 					// See https://opensearch.org/lines/1x.html for a list of all 1.x versions
-					new OpenSearchLocalBuildEnvironment(version: '2.0.1', condition: TestCondition.ON_DEMAND),
-					new OpenSearchLocalBuildEnvironment(version: '2.1.0', condition: TestCondition.ON_DEMAND),
-					new OpenSearchLocalBuildEnvironment(version: '2.2.1', condition: TestCondition.ON_DEMAND),
-					new OpenSearchLocalBuildEnvironment(version: '2.3.0', condition: TestCondition.ON_DEMAND),
-					new OpenSearchLocalBuildEnvironment(version: '2.4.1', condition: TestCondition.ON_DEMAND),
-					new OpenSearchLocalBuildEnvironment(version: '2.5.0', condition: TestCondition.ON_DEMAND),
-					new OpenSearchLocalBuildEnvironment(version: '2.6.0', condition: TestCondition.ON_DEMAND),
-					new OpenSearchLocalBuildEnvironment(version: '2.7.0', condition: TestCondition.ON_DEMAND),
-					new OpenSearchLocalBuildEnvironment(version: '2.8.0', condition: TestCondition.ON_DEMAND),
-					new OpenSearchLocalBuildEnvironment(version: '2.9.0', condition: TestCondition.BEFORE_MERGE)
+					new LocalOpenSearchBuildEnvironment(version: '2.0.1', condition: TestCondition.ON_DEMAND),
+					new LocalOpenSearchBuildEnvironment(version: '2.1.0', condition: TestCondition.ON_DEMAND),
+					new LocalOpenSearchBuildEnvironment(version: '2.2.1', condition: TestCondition.ON_DEMAND),
+					new LocalOpenSearchBuildEnvironment(version: '2.3.0', condition: TestCondition.ON_DEMAND),
+					new LocalOpenSearchBuildEnvironment(version: '2.4.1', condition: TestCondition.ON_DEMAND),
+					new LocalOpenSearchBuildEnvironment(version: '2.5.0', condition: TestCondition.ON_DEMAND),
+					new LocalOpenSearchBuildEnvironment(version: '2.6.0', condition: TestCondition.ON_DEMAND),
+					new LocalOpenSearchBuildEnvironment(version: '2.7.0', condition: TestCondition.ON_DEMAND),
+					new LocalOpenSearchBuildEnvironment(version: '2.8.0', condition: TestCondition.ON_DEMAND),
+					new LocalOpenSearchBuildEnvironment(version: '2.9.0', condition: TestCondition.BEFORE_MERGE)
 					// See https://opensearch.org/lines/2x.html for a list of all 2.x versions
 			],
-			esAws: [
+			amazonElasticsearch: [
 					// --------------------------------------------
 					// AWS Elasticsearch service (OpenDistro)
-					new EsAwsBuildEnvironment(version: '7.10', condition: TestCondition.AFTER_MERGE),
+					new AmazonElasticsearchServiceBuildEnvironment(version: '7.10', condition: TestCondition.AFTER_MERGE),
 
 					// --------------------------------------------
 					// AWS OpenSearch service
-					new OpenSearchAwsBuildEnvironment(version: '1.3', condition: TestCondition.AFTER_MERGE),
-					new OpenSearchAwsBuildEnvironment(version: '2.5', condition: TestCondition.AFTER_MERGE),
+					new AmazonOpenSearchServiceBuildEnvironment(version: '1.3', condition: TestCondition.AFTER_MERGE),
+					new AmazonOpenSearchServiceBuildEnvironment(version: '2.5', condition: TestCondition.AFTER_MERGE),
 					// Also test static credentials, but only for the latest version
-					new OpenSearchAwsBuildEnvironment(version: '2.5', condition: TestCondition.AFTER_MERGE, staticCredentials: true)
+					new AmazonOpenSearchServiceBuildEnvironment(version: '2.5', condition: TestCondition.AFTER_MERGE, staticCredentials: true)
 			]
 	])
 
@@ -568,7 +568,7 @@ stage('Non-default environments') {
 	}
 
 	// Test Elasticsearch integration with multiple versions in a local instance
-	environments.content.esLocal.enabled.each { EsLocalBuildEnvironment buildEnv ->
+	environments.content.localElasticsearch.enabled.each { LocalElasticsearchBuildEnvironment buildEnv ->
 		executions.put(buildEnv.tag, {
 			runBuildOnNode {
 				withMavenWorkspace {
@@ -584,7 +584,7 @@ stage('Non-default environments') {
 	}
 
 	// Test Elasticsearch integration with multiple versions in an AWS instance
-	environments.content.esAws.enabled.each { EsAwsBuildEnvironment buildEnv ->
+	environments.content.amazonElasticsearch.enabled.each { AmazonElasticsearchServiceBuildEnvironment buildEnv ->
 		if (!env.ES_AWS_REGION) {
 			throw new IllegalStateException("Environment variable ES_AWS_REGION is not set")
 		}
@@ -744,42 +744,43 @@ class DatabaseBuildEnvironment extends BuildEnvironment {
 	String getTag() { "database-$dbName" }
 }
 
-class EsLocalBuildEnvironment extends BuildEnvironment {
+class LocalElasticsearchBuildEnvironment extends BuildEnvironment {
 	String version
+	String getTagPrefix() { 'elasticsearch-local' }
 	@Override
-    String getTag() { "elasticsearch-local-$version" }
-    String getDistribution() { "elastic" }
+	String getTag() { "$tagPrefix-$version" }
+	String getDistribution() { 'elastic' }
 }
 
-class OpenSearchLocalBuildEnvironment extends EsLocalBuildEnvironment {
+class LocalOpenSearchBuildEnvironment extends LocalElasticsearchBuildEnvironment {
 	String version
 	@Override
-	String getTag() { "opensearch-local-$version" }
+	String getTagPrefix() { 'opensearch-local' }
 	@Override
 	String getDistribution() { "opensearch" }
 }
 
-class EsAwsBuildEnvironment extends EsLocalBuildEnvironment {
+class AmazonElasticsearchServiceBuildEnvironment extends LocalElasticsearchBuildEnvironment {
 	boolean staticCredentials = false
 	@Override
-	String getTag() { "elasticsearch-aws-$version" + (staticCredentials ? "-credentials-static" : "") }
-	String getNameEmbeddableVersion() {
-		version.replaceAll('\\.', '-')
+	String getTagPrefix() { 'amazon-elasticsearch-service' }
+	@Override
+	String getTag() {
+		"$tagPrefix-$version" + (staticCredentials ? '-credentials-static' : '')
 	}
+	String getLockedResourcesPrefix() { 'es' }
 	String getLockedResourcesLabel() {
-		"es-aws-${nameEmbeddableVersion}"
+		"$lockedResourcesPrefix-aws-${version.replaceAll('\\.', '-')}"
 	}
 }
 
-class OpenSearchAwsBuildEnvironment extends EsAwsBuildEnvironment {
+class AmazonOpenSearchServiceBuildEnvironment extends AmazonElasticsearchServiceBuildEnvironment {
 	@Override
-	String getTag() { "opensearch-aws-$version" + (staticCredentials ? "-credentials-static" : "") }
+	String getTagPrefix() { 'amazon-opensearch-service' }
 	@Override
-	String getDistribution() { "opensearch" }
+	String getDistribution() { 'opensearch' }
 	@Override
-	String getLockedResourcesLabel() {
-		"opensearch-aws-${nameEmbeddableVersion}"
-	}
+	String getLockedResourcesPrefix() { 'opensearch' }
 }
 
 void keepOnlyEnvironmentsMatchingFilter(String regex) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/ElasticsearchDistributionName.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/ElasticsearchDistributionName.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 
 import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.engine.cfg.spi.ParseUtils;
+import org.hibernate.search.util.common.annotation.Incubating;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 public enum ElasticsearchDistributionName {
@@ -22,13 +23,26 @@ public enum ElasticsearchDistributionName {
 	 * <p>
 	 * See: <a href="https://www.elastic.co/elasticsearch/">https://www.elastic.co/elasticsearch/</a>.
 	 */
-	ELASTIC( "elastic" ),
+	ELASTIC( "elastic", "elastic" ),
 	/**
 	 * The OpenSearch distribution from the OpenSearch organization.
 	 * <p>
+	 * When used through Amazon OpenSearch Service, requires extra dependencies for authentication;
+	 * refer to the reference documentation.
+	 * <p>
 	 * See: <a href="https://www.opensearch.org/">https://www.opensearch.org/</a>.
 	 */
-	OPENSEARCH( "opensearch" );
+	OPENSEARCH( "opensearch", "opensearch" ),
+	/**
+	 * Amazon OpenSearch Serverless.
+	 * <p>
+	 * Requires extra dependencies for authentication;
+	 * refer to the reference documentation.
+	 * <p>
+	 * See: <a href="https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-overview.html">https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-overview.html</a>.
+	 */
+	@Incubating
+	AMAZON_OPENSEARCH_SERVERLESS( "amazon-opensearch-serverless", null );
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
@@ -48,14 +62,25 @@ public enum ElasticsearchDistributionName {
 				.collect( Collectors.toList() );
 	}
 
+	public static ElasticsearchDistributionName fromServerResponseRepresentation(String value) {
+		return ParseUtils.parseDiscreteValues(
+				ElasticsearchDistributionName.values(),
+				ElasticsearchDistributionName::serverResponseRepresentation,
+				log::invalidElasticsearchDistributionName,
+				value
+		);
+	}
+
 	static ElasticsearchDistributionName defaultValue() {
 		return ElasticsearchDistributionName.ELASTIC;
 	}
 
 	private final String externalRepresentation;
+	private final String serverResponseRepresentation;
 
-	ElasticsearchDistributionName(String externalRepresentation) {
+	ElasticsearchDistributionName(String externalRepresentation, String serverResponseRepresentation) {
 		this.externalRepresentation = externalRepresentation;
+		this.serverResponseRepresentation = serverResponseRepresentation;
 	}
 
 	@Override
@@ -68,6 +93,10 @@ public enum ElasticsearchDistributionName {
 	 */
 	public String externalRepresentation() {
 		return externalRepresentation;
+	}
+
+	String serverResponseRepresentation() {
+		return serverResponseRepresentation;
 	}
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/ElasticsearchVersion.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/ElasticsearchVersion.java
@@ -8,6 +8,7 @@ package org.hibernate.search.backend.elasticsearch;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.regex.Matcher;
@@ -21,8 +22,10 @@ public class ElasticsearchVersion {
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private static final Pattern VERSION_PATTERN = Pattern.compile( "(\\d+)(?:\\.(\\d+)(?:\\.(\\d+)(?:-(\\w+))?)?)?" );
+	// This matches either no separator with an empty string before or after, or a separator with something left and right.
+	private static final String SEPARATOR_PATTERN_STRING = "(?<=^)|(?=$)|(?<=.):(?=.)";
 	private static final Pattern DISTRIBUTION_AND_VERSION_PATTERN =
-			Pattern.compile( "(?:([^\\d]+):)?(" + VERSION_PATTERN.pattern() + ")" );
+			Pattern.compile( "([^\\d]+)?(?:" + SEPARATOR_PATTERN_STRING + ")(" + VERSION_PATTERN.pattern() + ")?" );
 
 	/**
 	 * @param distributionAndVersionString A version string following the format {@code x.y.z-qualifier} or {@code <distribution>:x.y.z-qualifier},
@@ -35,18 +38,19 @@ public class ElasticsearchVersion {
 	// This method conforms to the MicroProfile Config specification. Do not change its signature.
 	public static ElasticsearchVersion of(String distributionAndVersionString) {
 		final String normalizedDistributionAndVersionString = distributionAndVersionString.trim().toLowerCase( Locale.ROOT );
-		Matcher matcher = DISTRIBUTION_AND_VERSION_PATTERN.matcher( normalizedDistributionAndVersionString );
-		if ( !matcher.matches() ) {
+		Matcher distributionAndVersionMatcher =
+				DISTRIBUTION_AND_VERSION_PATTERN.matcher( normalizedDistributionAndVersionString );
+		if ( !distributionAndVersionMatcher.matches() ) {
 			throw log.invalidElasticsearchVersionWithOptionalDistribution(
 					normalizedDistributionAndVersionString, ElasticsearchDistributionName.allowedExternalRepresentations(),
 					ElasticsearchDistributionName.defaultValue().externalRepresentation(), null );
 		}
 		try {
-			String distributionString = matcher.group( 1 );
+			String distributionString = distributionAndVersionMatcher.group( 1 );
 			return of( distributionString == null
 					? ElasticsearchDistributionName.defaultValue()
 					: ElasticsearchDistributionName.of( distributionString ),
-					matcher.group( 2 ) );
+					distributionAndVersionMatcher.group( 2 ) );
 		}
 		catch (RuntimeException e) {
 			throw log.invalidElasticsearchVersionWithOptionalDistribution(
@@ -60,10 +64,14 @@ public class ElasticsearchVersion {
 	 * @param versionString A version string following the format {@code x.y.z-qualifier},
 	 * where {@code x}, {@code y} and {@code z} are integers and {@code qualifier} is a string of word characters (alphanumeric or '_').
 	 * Incomplete versions are allowed, for example {@code 7.0} or just {@code 7}.
+	 * Null is allowed.
 	 * @return An {@link ElasticsearchVersion} object representing the given version.
 	 * @throws org.hibernate.search.util.common.SearchException If the input string doesn't follow the required format.
 	 */
 	public static ElasticsearchVersion of(ElasticsearchDistributionName distribution, String versionString) {
+		if ( versionString == null ) {
+			return new ElasticsearchVersion( distribution, null, null, null, null );
+		}
 		final String normalizedVersion = versionString.trim().toLowerCase( Locale.ROOT );
 		Matcher matcher = VERSION_PATTERN.matcher( normalizedVersion );
 		if ( !matcher.matches() ) {
@@ -86,12 +94,12 @@ public class ElasticsearchVersion {
 	}
 
 	private final ElasticsearchDistributionName distribution;
-	private final int major;
+	private final Integer major;
 	private final Integer minor;
 	private final Integer micro;
 	private final String qualifier;
 
-	private ElasticsearchVersion(ElasticsearchDistributionName distribution, int major, Integer minor, Integer micro,
+	private ElasticsearchVersion(ElasticsearchDistributionName distribution, Integer major, Integer minor, Integer micro,
 			String qualifier) {
 		this.distribution = distribution;
 		this.major = major;
@@ -101,18 +109,42 @@ public class ElasticsearchVersion {
 	}
 
 	@Override
+	public boolean equals(Object o) {
+		if ( this == o ) {
+			return true;
+		}
+		if ( o == null || getClass() != o.getClass() ) {
+			return false;
+		}
+		ElasticsearchVersion that = (ElasticsearchVersion) o;
+		return distribution == that.distribution
+				&& Objects.equals( major, that.major )
+				&& Objects.equals( minor, that.minor )
+				&& Objects.equals( micro, that.micro )
+				&& Objects.equals( qualifier, that.qualifier );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( distribution, major, minor, micro, qualifier );
+	}
+
+	@Override
 	public String toString() {
 		StringBuilder builder = new StringBuilder();
-		builder.append( distribution ).append( ':' );
-		builder.append( major );
+		builder.append( distribution );
+		if ( major == null ) {
+			return builder.toString();
+		}
+		builder.append( ':' ).append( major );
 		if ( minor != null ) {
-			builder.append( "." ).append( minor );
+			builder.append( '.' ).append( minor );
 		}
 		if ( micro != null ) {
-			builder.append( "." ).append( micro );
+			builder.append( '.' ).append( micro );
 		}
 		if ( qualifier != null ) {
-			builder.append( "-" ).append( qualifier );
+			builder.append( '-' ).append( qualifier );
 		}
 		return builder.toString();
 	}
@@ -121,16 +153,19 @@ public class ElasticsearchVersion {
 	 * @return The version string, i.e. the version without the distribution prefix.
 	 */
 	public String versionString() {
+		if ( major == null ) {
+			return null;
+		}
 		StringBuilder builder = new StringBuilder();
 		builder.append( major );
 		if ( minor != null ) {
-			builder.append( "." ).append( minor );
+			builder.append( '.' ).append( minor );
 		}
 		if ( micro != null ) {
-			builder.append( "." ).append( micro );
+			builder.append( '.' ).append( micro );
 		}
 		if ( qualifier != null ) {
-			builder.append( "-" ).append( qualifier );
+			builder.append( '-' ).append( qualifier );
 		}
 		return builder.toString();
 	}
@@ -145,9 +180,21 @@ public class ElasticsearchVersion {
 
 	/**
 	 * @return The "major" number of this version, i.e. the {@code x} in {@code x.y.z-qualifier}.
+	 * @deprecated Use {@link #majorOptional()} instead.
 	 */
+	@Deprecated
 	public int major() {
+		if ( major == null ) {
+			return 0;
+		}
 		return major;
+	}
+
+	/**
+	 * @return The "major" number of this version, i.e. the {@code x} in {@code x.y.z-qualifier}. May be empty.
+	 */
+	public OptionalInt majorOptional() {
+		return major == null ? OptionalInt.empty() : OptionalInt.of( major );
 	}
 
 	/**
@@ -180,7 +227,7 @@ public class ElasticsearchVersion {
 	 */
 	public boolean matches(ElasticsearchVersion other) {
 		return distribution.equals( other.distribution )
-				&& major == other.major
+				&& ( major == null || major.equals( other.major ) )
 				&& ( minor == null || minor.equals( other.minor ) )
 				&& ( micro == null || micro.equals( other.micro ) )
 				&& ( qualifier == null || qualifier.equals( other.qualifier ) );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchBackendSettings.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchBackendSettings.java
@@ -107,7 +107,10 @@ public final class ElasticsearchBackendSettings {
 	 * Expects a Boolean value such as {@code true} or {@code false},
 	 * or a string that can be parsed into a Boolean value.
 	 * <p>
-	 * Defaults to {@link Defaults#VERSION_CHECK_ENABLED}.
+	 * Defaults to {@code true} when the {@link #VERSION} is unconfigured
+	 * or set to a distribution that supports version checking,
+	 * and to {@code false} when the {@link #VERSION} is set
+	 * to a distribution that does not support version checking (like Amazon OpenSearch Serverless).
 	 */
 	public static final String VERSION_CHECK_ENABLED = "version_check.enabled";
 
@@ -335,6 +338,12 @@ public final class ElasticsearchBackendSettings {
 		public static final boolean DISCOVERY_ENABLED = false;
 		public static final int DISCOVERY_REFRESH_INTERVAL = 10;
 		public static final boolean LOG_JSON_PRETTY_PRINTING = false;
+		/**
+		 * @deprecated The default for the {@link ElasticsearchBackendSettings#VERSION_CHECK_ENABLED} property
+		 * is now dynamic and depends on the value of the {@link ElasticsearchBackendSettings#VERSION} property.
+		 * @see ElasticsearchBackendSettings#VERSION_CHECK_ENABLED
+		 */
+		@Deprecated
 		public static final boolean VERSION_CHECK_ENABLED = true;
 
 		/**

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchIndexSettings.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchIndexSettings.java
@@ -38,7 +38,9 @@ public final class ElasticsearchIndexSettings {
 	 * <p>
 	 * Expects an {@link IndexStatus} value, or a String representation of such value.
 	 * <p>
-	 * Defaults to {@link Defaults#SCHEMA_MANAGEMENT_MINIMAL_REQUIRED_STATUS}.
+	 * Defaults to {@code yellow} when targeting an Elasticsearch distribution that supports index status checking,
+	 * and to no value (no requirement) when targeting an Elasticsearch distribution
+	 * that does not support index status checking (like Amazon OpenSearch Serverless).
 	 */
 	public static final String SCHEMA_MANAGEMENT_MINIMAL_REQUIRED_STATUS = "schema_management.minimal_required_status";
 
@@ -176,6 +178,12 @@ public final class ElasticsearchIndexSettings {
 		private Defaults() {
 		}
 
+		/**
+		 * @deprecated The default for the {@link ElasticsearchIndexSettings#SCHEMA_MANAGEMENT_MINIMAL_REQUIRED_STATUS} property
+		 * is now dynamic and depends on the targeted Elasticsearch distribution.
+		 * @see ElasticsearchIndexSettings#SCHEMA_MANAGEMENT_MINIMAL_REQUIRED_STATUS
+		 */
+		@Deprecated
 		public static final IndexStatus SCHEMA_MANAGEMENT_MINIMAL_REQUIRED_STATUS = IndexStatus.YELLOW;
 		public static final int SCHEMA_MANAGEMENT_MINIMAL_REQUIRED_STATUS_WAIT_TIMEOUT = 10_000;
 		public static final int INDEXING_QUEUE_COUNT = 10;

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/ElasticsearchHttpClientConfigurationContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/ElasticsearchHttpClientConfigurationContext.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.search.backend.elasticsearch.client;
 
+import java.util.Optional;
+
+import org.hibernate.search.backend.elasticsearch.ElasticsearchVersion;
 import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
 import org.hibernate.search.engine.environment.bean.BeanResolver;
 
@@ -34,5 +37,11 @@ public interface ElasticsearchHttpClientConfigurationContext {
 	 * @see <a href="http://hc.apache.org/httpcomponents-client-ga/">the Apache HTTP Client documentation</a>
 	 */
 	HttpAsyncClientBuilder clientBuilder();
+
+	/**
+	 * @return The version of Elasticsearch/OpenSearch configured on the backend.
+	 * May be empty if not configured explicitly (in which case it will only be known after the client is built).
+	 */
+	Optional<ElasticsearchVersion> configuredVersion();
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/ElasticsearchClientFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/ElasticsearchClientFactoryImpl.java
@@ -10,6 +10,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.Optional;
 
+import org.hibernate.search.backend.elasticsearch.ElasticsearchVersion;
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
 import org.hibernate.search.backend.elasticsearch.cfg.spi.ElasticsearchBackendSpiSettings;
 import org.hibernate.search.backend.elasticsearch.client.ElasticsearchHttpClientConfigurer;
@@ -140,7 +141,8 @@ public class ElasticsearchClientFactoryImpl implements ElasticsearchClientFactor
 	public ElasticsearchClientImplementor create(BeanResolver beanResolver, ConfigurationPropertySource propertySource,
 			ThreadProvider threadProvider, String threadNamePrefix,
 			SimpleScheduledExecutor timeoutExecutorService,
-			GsonProvider gsonProvider) {
+			GsonProvider gsonProvider,
+			Optional<ElasticsearchVersion> configuredVersion) {
 		Optional<Integer> requestTimeoutMs = REQUEST_TIMEOUT.get( propertySource );
 		int connectionTimeoutMs = CONNECTION_TIMEOUT.get( propertySource );
 
@@ -156,8 +158,8 @@ public class ElasticsearchClientFactoryImpl implements ElasticsearchClientFactor
 		else {
 			ServerUris hosts = ServerUris.fromOptionalStrings( PROTOCOL.get( propertySource ),
 					HOSTS.get( propertySource ), URIS.get( propertySource ) );
-			restClientHolder = createClient( beanResolver, propertySource, threadProvider, threadNamePrefix, hosts,
-					PATH_PREFIX.get( propertySource ) );
+			restClientHolder = createClient( beanResolver, propertySource, threadProvider, threadNamePrefix,
+					configuredVersion, hosts, PATH_PREFIX.get( propertySource ) );
 			sniffer = createSniffer( propertySource, restClientHolder.get(), hosts );
 		}
 
@@ -170,6 +172,7 @@ public class ElasticsearchClientFactoryImpl implements ElasticsearchClientFactor
 
 	private BeanHolder<? extends RestClient> createClient(BeanResolver beanResolver, ConfigurationPropertySource propertySource,
 			ThreadProvider threadProvider, String threadNamePrefix,
+			Optional<ElasticsearchVersion> configuredVersion,
 			ServerUris hosts, String pathPrefix) {
 		RestClientBuilder builder = RestClient.builder( hosts.asHostsArray() );
 		if ( !pathPrefix.isEmpty() ) {
@@ -191,7 +194,7 @@ public class ElasticsearchClientFactoryImpl implements ElasticsearchClientFactor
 									b,
 									beanResolver, propertySource,
 									threadProvider, threadNamePrefix,
-									hosts,
+									configuredVersion, hosts,
 									httpClientConfigurersHolder.get(), customConfig
 							)
 					)
@@ -239,6 +242,7 @@ public class ElasticsearchClientFactoryImpl implements ElasticsearchClientFactor
 	private HttpAsyncClientBuilder customizeHttpClientConfig(HttpAsyncClientBuilder builder,
 			BeanResolver beanResolver, ConfigurationPropertySource propertySource,
 			ThreadProvider threadProvider, String threadNamePrefix,
+			Optional<ElasticsearchVersion> configuredVersion,
 			ServerUris hosts, Iterable<ElasticsearchHttpClientConfigurer> configurers,
 			Optional<? extends BeanHolder<? extends ElasticsearchHttpClientConfigurer>> customConfig) {
 		builder.setMaxConnTotal( MAX_TOTAL_CONNECTION.get( propertySource ) )
@@ -272,7 +276,7 @@ public class ElasticsearchClientFactoryImpl implements ElasticsearchClientFactor
 		}
 
 		ElasticsearchHttpClientConfigurationContextImpl clientConfigurationContext =
-				new ElasticsearchHttpClientConfigurationContextImpl( beanResolver, propertySource, builder );
+				new ElasticsearchHttpClientConfigurationContextImpl( beanResolver, propertySource, builder, configuredVersion );
 
 		for ( ElasticsearchHttpClientConfigurer configurer : configurers ) {
 			configurer.configure( clientConfigurationContext );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/ElasticsearchHttpClientConfigurationContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/ElasticsearchHttpClientConfigurationContextImpl.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.search.backend.elasticsearch.client.impl;
 
+import java.util.Optional;
+
+import org.hibernate.search.backend.elasticsearch.ElasticsearchVersion;
 import org.hibernate.search.backend.elasticsearch.client.ElasticsearchHttpClientConfigurationContext;
 import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
 import org.hibernate.search.engine.environment.bean.BeanResolver;
@@ -17,14 +20,17 @@ final class ElasticsearchHttpClientConfigurationContextImpl
 	private final BeanResolver beanResolver;
 	private final ConfigurationPropertySource configurationPropertySource;
 	private final HttpAsyncClientBuilder clientBuilder;
+	private final Optional<ElasticsearchVersion> configuredVersion;
 
 	ElasticsearchHttpClientConfigurationContextImpl(
 			BeanResolver beanResolver,
 			ConfigurationPropertySource configurationPropertySource,
-			HttpAsyncClientBuilder clientBuilder) {
+			HttpAsyncClientBuilder clientBuilder,
+			Optional<ElasticsearchVersion> configuredVersion) {
 		this.beanResolver = beanResolver;
 		this.configurationPropertySource = configurationPropertySource;
 		this.clientBuilder = clientBuilder;
+		this.configuredVersion = configuredVersion;
 	}
 
 	@Override
@@ -40,6 +46,11 @@ final class ElasticsearchHttpClientConfigurationContextImpl
 	@Override
 	public HttpAsyncClientBuilder clientBuilder() {
 		return clientBuilder;
+	}
+
+	@Override
+	public Optional<ElasticsearchVersion> configuredVersion() {
+		return configuredVersion;
 	}
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/spi/ElasticsearchClientFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/spi/ElasticsearchClientFactory.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.search.backend.elasticsearch.client.spi;
 
+import java.util.Optional;
+
+import org.hibernate.search.backend.elasticsearch.ElasticsearchVersion;
 import org.hibernate.search.backend.elasticsearch.gson.spi.GsonProvider;
 import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
 import org.hibernate.search.engine.common.execution.spi.SimpleScheduledExecutor;
@@ -21,6 +24,7 @@ public interface ElasticsearchClientFactory {
 	ElasticsearchClientImplementor create(BeanResolver beanResolver, ConfigurationPropertySource propertySource,
 			ThreadProvider threadProvider, String threadNamePrefix,
 			SimpleScheduledExecutor timeoutExecutorService,
-			GsonProvider gsonProvider);
+			GsonProvider gsonProvider,
+			Optional<ElasticsearchVersion> configuredVersion);
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/AmazonOpenSearchServerlessProtocolDialect.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/protocol/impl/AmazonOpenSearchServerlessProtocolDialect.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.dialect.protocol.impl;
+
+import org.hibernate.search.backend.elasticsearch.gson.spi.GsonProvider;
+import org.hibernate.search.backend.elasticsearch.work.factory.impl.AmazonOpenSearchServerlessWorkFactory;
+import org.hibernate.search.backend.elasticsearch.work.factory.impl.ElasticsearchWorkFactory;
+import org.hibernate.search.util.common.annotation.Incubating;
+
+/**
+ * The model dialect for Amazon OpenSearch Serverless.
+ *
+ * @see org.hibernate.search.backend.elasticsearch.ElasticsearchDistributionName#AMAZON_OPENSEARCH_SERVERLESS
+ */
+@Incubating
+public class AmazonOpenSearchServerlessProtocolDialect extends Elasticsearch70ProtocolDialect {
+
+	@Override
+	public ElasticsearchWorkFactory createWorkFactory(GsonProvider gsonProvider, Boolean ignoreShardFailures) {
+		return new AmazonOpenSearchServerlessWorkFactory( gsonProvider, ignoreShardFailures );
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/spi/ElasticsearchDialects.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/spi/ElasticsearchDialects.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.dialect.spi;
+
+import org.hibernate.search.backend.elasticsearch.ElasticsearchVersion;
+import org.hibernate.search.backend.elasticsearch.dialect.impl.ElasticsearchDialectFactory;
+
+/**
+ * Utils for integrations that require advanced checks on Elasticsearch versions,
+ * i.e. for two-phase bootstrap like in Quarkus.
+ */
+public final class ElasticsearchDialects {
+
+	private ElasticsearchDialects() {
+	}
+
+	public static boolean isPreciseEnoughForBootstrap(ElasticsearchVersion version) {
+		return ElasticsearchDialectFactory.isPreciseEnoughForModelDialect( version );
+	}
+
+	public static boolean isPreciseEnoughForStart(ElasticsearchVersion version) {
+		return ElasticsearchDialectFactory.isPreciseEnoughForProtocolDialect( version );
+	}
+
+	public static boolean isVersionCheckImpossible(ElasticsearchVersion version) {
+		return ElasticsearchDialectFactory.isVersionCheckImpossible( version );
+	}
+
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendFactory.java
@@ -121,7 +121,8 @@ public class ElasticsearchBackendFactory implements BackendFactory {
 
 			ElasticsearchModelDialect dialect;
 			ElasticsearchVersion version;
-			if ( configuredVersion.isPresent() ) {
+			if ( configuredVersion.isPresent()
+					&& ElasticsearchDialectFactory.isPreciseEnoughForModelDialect( configuredVersion.get() ) ) {
 				version = configuredVersion.get();
 			}
 			else {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchLinkImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchLinkImpl.java
@@ -44,10 +44,9 @@ class ElasticsearchLinkImpl implements ElasticsearchLink {
 					.as( ElasticsearchVersion.class, ElasticsearchVersion::of )
 					.build();
 
-	private static final ConfigurationProperty<Boolean> VERSION_CHECK_ENABLED =
+	private static final OptionalConfigurationProperty<Boolean> VERSION_CHECK_ENABLED =
 			ConfigurationProperty.forKey( ElasticsearchBackendSettings.VERSION_CHECK_ENABLED )
 					.asBoolean()
-					.withDefault( ElasticsearchBackendSettings.Defaults.VERSION_CHECK_ENABLED )
 					.build();
 
 	private static final ConfigurationProperty<Integer> SCROLL_TIMEOUT =
@@ -141,7 +140,8 @@ class ElasticsearchLinkImpl implements ElasticsearchLink {
 		if ( clientImplementor == null ) {
 			clientImplementor = clientFactoryHolder.get().create(
 					beanResolver, propertySource, threads.getThreadProvider(), threads.getPrefix(),
-					threads.getWorkExecutor(), defaultGsonProvider
+					threads.getWorkExecutor(), defaultGsonProvider,
+					configuredVersionOnBackendCreationOptional
 			);
 			clientFactoryHolder.close(); // We won't need it anymore
 
@@ -173,7 +173,7 @@ class ElasticsearchLinkImpl implements ElasticsearchLink {
 	}
 
 	private ElasticsearchVersion initVersion(ConfigurationPropertySource propertySource) {
-		boolean versionCheckEnabled = VERSION_CHECK_ENABLED.get( propertySource );
+		Optional<Boolean> versionCheckEnabled = VERSION_CHECK_ENABLED.get( propertySource );
 		Optional<ElasticsearchVersion> configuredVersionOptional = VERSION.getAndTransform( propertySource,
 				configuredVersionOnStartOptional -> {
 					Optional<ElasticsearchVersion> resultOptional;
@@ -193,17 +193,39 @@ class ElasticsearchLinkImpl implements ElasticsearchLink {
 						// Default to the version configured when the backend was created
 						resultOptional = configuredVersionOnBackendCreationOptional;
 					}
-					if ( !versionCheckEnabled
-							&& ( !resultOptional.isPresent() || !resultOptional.get().minor().isPresent() ) ) {
-						throw log.impreciseElasticsearchVersionWhenNoVersionCheck(
+
+					// If the version is unset or imprecise,
+					// we will need to retrieve it from the cluster through a version check.
+					// So in that situation, if version checks are disabled explicitly (they're enabled by default),
+					// we'll raise an exception now, in the context of the "version" configuration property.
+					if ( ( resultOptional.isEmpty()
+							|| !ElasticsearchDialectFactory.isPreciseEnoughForProtocolDialect( resultOptional.get() ) )
+							&& versionCheckEnabled.isPresent() && !versionCheckEnabled.get() ) {
+						throw log.impreciseElasticsearchVersionWhenVersionCheckDisabled(
 								VERSION_CHECK_ENABLED.resolveOrRaw( propertySource ) );
 					}
+
 					return resultOptional;
 				} );
 
-		if ( versionCheckEnabled ) {
-			ElasticsearchVersion versionFromCluster =
-					ElasticsearchClientUtils.getElasticsearchVersion( clientImplementor );
+		// If someone tries to force the version check on a distribution that doesn't support them
+		// (Amazon OpenSearch Serverless), we'll raise an exception.
+		boolean versionCheckImpossible = configuredVersionOptional.isPresent()
+				&& ElasticsearchDialectFactory.isVersionCheckImpossible( configuredVersionOptional.get() );
+		if ( versionCheckImpossible && versionCheckEnabled.isPresent() && versionCheckEnabled.get() ) {
+			// Get the configuration property again in order to produce
+			// an error message in the context of the problematic configuration property.
+			VERSION_CHECK_ENABLED.getAndMap( propertySource, enabled -> {
+				if ( enabled ) {
+					throw log.cannotCheckElasticsearchVersion( configuredVersionOptional.get().distribution() );
+				}
+				return enabled;
+			} );
+		}
+
+		// Version checks are disabled by default if we know they're impossible.
+		if ( versionCheckEnabled.orElse( !versionCheckImpossible ) ) {
+			ElasticsearchVersion versionFromCluster = fetchElasticsearchVersion( propertySource );
 			if ( configuredVersionOptional.isPresent() ) {
 				ElasticsearchVersion configuredVersion = configuredVersionOptional.get();
 				if ( !configuredVersion.matches( versionFromCluster ) ) {
@@ -213,8 +235,27 @@ class ElasticsearchLinkImpl implements ElasticsearchLink {
 			return versionFromCluster;
 		}
 		else {
-			// In this case we know the optional is non-empty, see above.
+			// In this case we know the optional is non-empty:
+			// see the checks when retrieving the configured version.
 			return configuredVersionOptional.get();
+		}
+	}
+
+	private ElasticsearchVersion fetchElasticsearchVersion(ConfigurationPropertySource propertySource) {
+		try {
+			ElasticsearchVersion version = ElasticsearchClientUtils.tryGetElasticsearchVersion( clientImplementor );
+			if ( version == null ) {
+				// This can happen when targeting Amazon OpenSearch Service
+				// and we didn't notice the problem early
+				// because the version was unset
+				// or the distribution was incorrectly set to elasticsearch/opensearch.
+				throw log.unableToFetchElasticsearchVersion( VERSION.resolveOrRaw( propertySource ),
+						ElasticsearchDialectFactory.AMAZON_OPENSEARCH_SERVERLESS );
+			}
+			return version;
+		}
+		catch (RuntimeException e) {
+			throw log.failedToDetectElasticsearchVersion( e.getMessage(), e );
 		}
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/schema/management/impl/ElasticsearchSchemaAccessor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/schema/management/impl/ElasticsearchSchemaAccessor.java
@@ -152,12 +152,15 @@ final class ElasticsearchSchemaAccessor {
 			ElasticsearchIndexLifecycleExecutionOptions executionOptions,
 			OperationSubmitter operationSubmitter) {
 		IndexStatus requiredIndexStatus = executionOptions.getRequiredStatus();
+		if ( requiredIndexStatus == null ) {
+			return CompletableFuture.completedFuture( null );
+		}
 		int requiredStatusTimeoutInMs = executionOptions.getRequiredStatusTimeoutInMs();
 
 		URLEncodedString name = indexNames.write();
 
 		NonBulkableWork<?> work =
-				getWorkFactory().waitForIndexStatusWork( name, requiredIndexStatus, requiredStatusTimeoutInMs )
+				getWorkFactory().waitForIndexStatus( name, requiredIndexStatus, requiredStatusTimeoutInMs )
 						.build();
 		return execute( work, operationSubmitter )
 				.exceptionally( Futures.handler( e -> {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/ElasticsearchIndexWorkspace.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/ElasticsearchIndexWorkspace.java
@@ -16,6 +16,7 @@ import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 import org.hibernate.search.backend.elasticsearch.work.factory.impl.ElasticsearchWorkFactory;
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -40,12 +41,23 @@ public class ElasticsearchIndexWorkspace implements IndexWorkspace {
 	}
 
 	@Override
-	public CompletableFuture<?> mergeSegments(OperationSubmitter operationSubmitter) {
+	public CompletableFuture<?> mergeSegments(OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior) {
+		if ( !workFactory.isMergeSegmentsSupported()
+				&& UnsupportedOperationBehavior.IGNORE.equals( unsupportedOperationBehavior ) ) {
+			return CompletableFuture.completedFuture( null );
+		}
 		return orchestrator.submit( workFactory.mergeSegments().index( indexName ).build(), operationSubmitter );
 	}
 
 	@Override
-	public CompletableFuture<?> purge(Set<String> routingKeys, OperationSubmitter operationSubmitter) {
+	public CompletableFuture<?> purge(Set<String> routingKeys, OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior) {
+		if ( !workFactory.isDeleteByQuerySupported()
+				&& UnsupportedOperationBehavior.IGNORE.equals( unsupportedOperationBehavior ) ) {
+			return CompletableFuture.completedFuture( null );
+		}
+
 		JsonArray filters = new JsonArray();
 		JsonObject filter = multiTenancyStrategy.filterOrNull( tenantIds );
 		if ( filter != null ) {
@@ -70,12 +82,22 @@ public class ElasticsearchIndexWorkspace implements IndexWorkspace {
 	}
 
 	@Override
-	public CompletableFuture<?> flush(OperationSubmitter operationSubmitter) {
+	public CompletableFuture<?> flush(OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior) {
+		if ( !workFactory.isFlushSupported()
+				&& UnsupportedOperationBehavior.IGNORE.equals( unsupportedOperationBehavior ) ) {
+			return CompletableFuture.completedFuture( null );
+		}
 		return orchestrator.submit( workFactory.flush().index( indexName ).build(), operationSubmitter );
 	}
 
 	@Override
-	public CompletableFuture<?> refresh(OperationSubmitter operationSubmitter) {
+	public CompletableFuture<?> refresh(OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior) {
+		if ( !workFactory.isRefreshSupported()
+				&& UnsupportedOperationBehavior.IGNORE.equals( unsupportedOperationBehavior ) ) {
+			return CompletableFuture.completedFuture( null );
+		}
 		return orchestrator.submit( workFactory.refresh().index( indexName ).build(), operationSubmitter );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/factory/impl/AmazonOpenSearchServerlessWorkFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/factory/impl/AmazonOpenSearchServerlessWorkFactory.java
@@ -1,0 +1,101 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.work.factory.impl;
+
+import java.lang.invoke.MethodHandles;
+
+import org.hibernate.search.backend.elasticsearch.gson.spi.GsonProvider;
+import org.hibernate.search.backend.elasticsearch.index.IndexStatus;
+import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
+import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
+import org.hibernate.search.backend.elasticsearch.work.impl.CloseIndexWork;
+import org.hibernate.search.backend.elasticsearch.work.impl.DeleteByQueryWork;
+import org.hibernate.search.backend.elasticsearch.work.impl.FlushWork;
+import org.hibernate.search.backend.elasticsearch.work.impl.ForceMergeWork;
+import org.hibernate.search.backend.elasticsearch.work.impl.OpenIndexWork;
+import org.hibernate.search.backend.elasticsearch.work.impl.RefreshWork;
+import org.hibernate.search.backend.elasticsearch.work.impl.WaitForIndexStatusWork;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
+
+import com.google.gson.JsonObject;
+
+/**
+ * A work builder factory for Amazon OpenSearch Serverless.
+ * <p>
+ * Not all operations are supported,
+ * see <a href="https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-genref.html#serverless-operations">the documentation</a>.
+ *
+ * @see org.hibernate.search.backend.elasticsearch.ElasticsearchDistributionName#AMAZON_OPENSEARCH_SERVERLESS
+ */
+public class AmazonOpenSearchServerlessWorkFactory extends Elasticsearch7WorkFactory {
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
+	public AmazonOpenSearchServerlessWorkFactory(GsonProvider gsonProvider, Boolean ignoreShardFailures) {
+		super( gsonProvider, ignoreShardFailures );
+	}
+
+	@Override
+	public boolean isDeleteByQuerySupported() {
+		return false;
+	}
+
+	@Override
+	public DeleteByQueryWork.Builder deleteByQuery(URLEncodedString indexName, JsonObject payload) {
+		throw log.cannotExecuteOperationOnAmazonOpenSearchServerless( "deleteByQuery" );
+	}
+
+	@Override
+	public boolean isFlushSupported() {
+		return false;
+	}
+
+	@Override
+	public FlushWork.Builder flush() {
+		throw log.cannotExecuteOperationOnAmazonOpenSearchServerless( "flush" );
+	}
+
+	@Override
+	public boolean isRefreshSupported() {
+		return false;
+	}
+
+	@Override
+	public RefreshWork.Builder refresh() {
+		throw log.cannotExecuteOperationOnAmazonOpenSearchServerless( "refresh" );
+	}
+
+	@Override
+	public boolean isMergeSegmentsSupported() {
+		return false;
+	}
+
+	@Override
+	public ForceMergeWork.Builder mergeSegments() {
+		throw log.cannotExecuteOperationOnAmazonOpenSearchServerless( "mergeSegments" );
+	}
+
+	@Override
+	public OpenIndexWork.Builder openIndex(URLEncodedString indexName) {
+		throw log.cannotExecuteOperationOnAmazonOpenSearchServerless( "openIndex" );
+	}
+
+	@Override
+	public CloseIndexWork.Builder closeIndex(URLEncodedString indexName) {
+		throw log.cannotExecuteOperationOnAmazonOpenSearchServerless( "closeIndex" );
+	}
+
+	@Override
+	public WaitForIndexStatusWork.Builder waitForIndexStatus(URLEncodedString indexName, IndexStatus requiredStatus,
+			int requiredStatusTimeoutInMs) {
+		throw log.cannotExecuteOperationOnAmazonOpenSearchServerless( "waitForIndexStatus" );
+	}
+
+	@Override
+	public boolean isWaitForIndexStatusSupported() {
+		return false;
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/factory/impl/Elasticsearch7WorkFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/factory/impl/Elasticsearch7WorkFactory.java
@@ -70,8 +70,18 @@ public class Elasticsearch7WorkFactory implements ElasticsearchWorkFactory {
 	}
 
 	@Override
+	public boolean isDeleteByQuerySupported() {
+		return true;
+	}
+
+	@Override
 	public DeleteByQueryWork.Builder deleteByQuery(URLEncodedString indexName, JsonObject payload) {
 		return new DeleteByQueryWork.Builder( indexName, payload, this );
+	}
+
+	@Override
+	public boolean isFlushSupported() {
+		return true;
 	}
 
 	@Override
@@ -80,8 +90,18 @@ public class Elasticsearch7WorkFactory implements ElasticsearchWorkFactory {
 	}
 
 	@Override
+	public boolean isRefreshSupported() {
+		return true;
+	}
+
+	@Override
 	public RefreshWork.Builder refresh() {
 		return new RefreshWork.Builder();
+	}
+
+	@Override
+	public boolean isMergeSegmentsSupported() {
+		return true;
 	}
 
 	@Override
@@ -160,7 +180,12 @@ public class Elasticsearch7WorkFactory implements ElasticsearchWorkFactory {
 	}
 
 	@Override
-	public WaitForIndexStatusWork.Builder waitForIndexStatusWork(URLEncodedString indexName, IndexStatus requiredStatus,
+	public boolean isWaitForIndexStatusSupported() {
+		return true;
+	}
+
+	@Override
+	public WaitForIndexStatusWork.Builder waitForIndexStatus(URLEncodedString indexName, IndexStatus requiredStatus,
 			int requiredStatusTimeoutInMs) {
 		return new WaitForIndexStatusWork.Builder( indexName, requiredStatus, requiredStatusTimeoutInMs );
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/factory/impl/ElasticsearchWorkFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/factory/impl/ElasticsearchWorkFactory.java
@@ -50,11 +50,19 @@ public interface ElasticsearchWorkFactory {
 			URLEncodedString elasticsearchIndexName,
 			String documentIdentifier, String routingKey);
 
+	boolean isDeleteByQuerySupported();
+
 	DeleteByQueryWork.Builder deleteByQuery(URLEncodedString indexName, JsonObject payload);
+
+	boolean isFlushSupported();
 
 	FlushWork.Builder flush();
 
+	boolean isRefreshSupported();
+
 	RefreshWork.Builder refresh();
+
+	boolean isMergeSegmentsSupported();
 
 	ForceMergeWork.Builder mergeSegments();
 
@@ -85,7 +93,9 @@ public interface ElasticsearchWorkFactory {
 
 	PutIndexMappingWork.Builder putIndexTypeMapping(URLEncodedString indexName, RootTypeMapping mapping);
 
-	WaitForIndexStatusWork.Builder waitForIndexStatusWork(URLEncodedString indexName, IndexStatus requiredStatus,
+	boolean isWaitForIndexStatusSupported();
+
+	WaitForIndexStatusWork.Builder waitForIndexStatus(URLEncodedString indexName, IndexStatus requiredStatus,
 			int requiredStatusTimeoutInMs);
 
 	PutIndexAliasesWork.Builder putIndexAliases(URLEncodedString indexName, Map<String, IndexAliasDefinition> aliases);

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchVersionTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchVersionTest.java
@@ -60,6 +60,9 @@ public class ElasticsearchVersionTest {
 				.containsExactly( ElasticsearchDistributionName.OPENSEARCH, 1, 1, 4, null );
 		assertComponents( ElasticsearchVersion.of( "opensearch:1.0.0-rc1" ) )
 				.containsExactly( ElasticsearchDistributionName.OPENSEARCH, 1, 0, 0, "rc1" );
+
+		assertComponents( ElasticsearchVersion.of( "amazon-opensearch-serverless" ) )
+				.containsExactly( ElasticsearchDistributionName.AMAZON_OPENSEARCH_SERVERLESS, null, null, null, null );
 	}
 
 	@Test
@@ -70,6 +73,8 @@ public class ElasticsearchVersionTest {
 				.containsExactly( ElasticsearchDistributionName.ELASTIC, 7, 0, 0, "beta1" );
 		assertComponents( ElasticsearchVersion.of( "OpenSearch:1.0.0-RC1" ) )
 				.containsExactly( ElasticsearchDistributionName.OPENSEARCH, 1, 0, 0, "rc1" );
+		assertComponents( ElasticsearchVersion.of( "Amazon-OpenSearch-Serverless" ) )
+				.containsExactly( ElasticsearchDistributionName.AMAZON_OPENSEARCH_SERVERLESS, null, null, null, null );
 	}
 
 	@Test
@@ -83,18 +88,33 @@ public class ElasticsearchVersionTest {
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll( "Invalid Elasticsearch version",
 						"'elastic7'",
-						"Expected format is 'x.y.z-qualifier' or '<distribution>:x.y.z-qualifier'" );
+						"Expected format is 'x.y.z-qualifier' or '<distribution>:x.y.z-qualifier' or just '<distribution>'" );
 		assertThatThrownBy( () -> ElasticsearchVersion.of( "opensearch;7.0" ) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll( "Invalid Elasticsearch version",
 						"'opensearch;7.0'",
-						"Expected format is 'x.y.z-qualifier' or '<distribution>:x.y.z-qualifier'" );
+						"Expected format is 'x.y.z-qualifier' or '<distribution>:x.y.z-qualifier' or just '<distribution>'" );
 		assertThatThrownBy( () -> ElasticsearchVersion.of( "elasticsearch:7.0" ) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll( "Invalid Elasticsearch version",
 						"'elasticsearch:7.0'",
-						"Expected format is 'x.y.z-qualifier' or '<distribution>:x.y.z-qualifier'",
-						"where '<distribution>' is one of [elastic, opensearch] (defaults to 'elastic')" );
+						"Expected format is 'x.y.z-qualifier' or '<distribution>:x.y.z-qualifier' or just '<distribution>'",
+						"where '<distribution>' is one of [elastic, opensearch, amazon-opensearch-serverless] (defaults to 'elastic')" );
+		assertThatThrownBy( () -> ElasticsearchVersion.of( "elastic:" ) )
+				.isInstanceOf( SearchException.class )
+				.hasMessageContainingAll( "Invalid Elasticsearch version",
+						"'elastic:'",
+						"Expected format is 'x.y.z-qualifier' or '<distribution>:x.y.z-qualifier' or just '<distribution>'" );
+		assertThatThrownBy( () -> ElasticsearchVersion.of( "opensearch:" ) )
+				.isInstanceOf( SearchException.class )
+				.hasMessageContainingAll( "Invalid Elasticsearch version",
+						"'opensearch:'",
+						"Expected format is 'x.y.z-qualifier' or '<distribution>:x.y.z-qualifier' or just '<distribution>'" );
+		assertThatThrownBy( () -> ElasticsearchVersion.of( "amazon-opensearch-service:" ) )
+				.isInstanceOf( SearchException.class )
+				.hasMessageContainingAll( "Invalid Elasticsearch version",
+						"'amazon-opensearch-service:'",
+						"Expected format is 'x.y.z-qualifier' or '<distribution>:x.y.z-qualifier'" );
 	}
 
 	@Test
@@ -132,6 +152,9 @@ public class ElasticsearchVersionTest {
 				.containsExactly( ElasticsearchDistributionName.OPENSEARCH, 1, 1, 4, null );
 		assertComponents( ElasticsearchVersion.of( ElasticsearchDistributionName.OPENSEARCH, "1.0.0-rc1" ) )
 				.containsExactly( ElasticsearchDistributionName.OPENSEARCH, 1, 0, 0, "rc1" );
+
+		assertComponents( ElasticsearchVersion.of( ElasticsearchDistributionName.AMAZON_OPENSEARCH_SERVERLESS, null ) )
+				.containsExactly( ElasticsearchDistributionName.AMAZON_OPENSEARCH_SERVERLESS, null, null, null, null );
 	}
 
 	@Test
@@ -181,6 +204,11 @@ public class ElasticsearchVersionTest {
 		assertMatch( "opensearch:2.0.1", ElasticsearchDistributionName.OPENSEARCH, "2.0.1" ).isTrue();
 		assertMatch( "opensearch:2.1.0", ElasticsearchDistributionName.OPENSEARCH, "2.1.0" ).isTrue();
 		assertMatch( "opensearch:2.1.1", ElasticsearchDistributionName.OPENSEARCH, "2.1.1" ).isTrue();
+	}
+
+	@Test
+	public void exactMatch_amazonOpensearchServerless() {
+		assertMatch( "amazon-opensearch-serverless", ElasticsearchDistributionName.AMAZON_OPENSEARCH_SERVERLESS, null ).isTrue();
 	}
 
 	@Test
@@ -317,7 +345,7 @@ public class ElasticsearchVersionTest {
 	private ObjectArrayAssert<Object> assertComponents(ElasticsearchVersion version) {
 		return assertThat( new Object[] {
 				version.distribution(),
-				version.major(),
+				toNullable( version.majorOptional() ),
 				toNullable( version.minor() ),
 				toNullable( version.micro() ),
 				version.qualifier().orElse( null ) } );

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/client/impl/ElasticsearchClientUtilsTryGetElasticsearchVersionTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/client/impl/ElasticsearchClientUtilsTryGetElasticsearchVersionTest.java
@@ -34,7 +34,7 @@ import org.mockito.junit.MockitoRule;
 import org.mockito.quality.Strictness;
 
 @RunWith(Parameterized.class)
-public class ElasticsearchClientUtilsGetElasticsearchVersionTest {
+public class ElasticsearchClientUtilsTryGetElasticsearchVersionTest {
 
 	@Parameterized.Parameters(name = "{0} - {1}")
 	public static Object[][] data() {
@@ -69,7 +69,7 @@ public class ElasticsearchClientUtilsGetElasticsearchVersionTest {
 	@Mock
 	private ElasticsearchClient clientMock;
 
-	public ElasticsearchClientUtilsGetElasticsearchVersionTest(String distributionString, String versionString,
+	public ElasticsearchClientUtilsTryGetElasticsearchVersionTest(String distributionString, String versionString,
 			ElasticsearchDistributionName expectedDistribution,
 			int expectedMajor, int expectedMinor, int expectedMicro, String expectedQualifier) {
 		this.distributionString = distributionString;
@@ -84,10 +84,10 @@ public class ElasticsearchClientUtilsGetElasticsearchVersionTest {
 	@Test
 	public void testValid() {
 		doMock( distributionString, versionString );
-		ElasticsearchVersion version = ElasticsearchClientUtils.getElasticsearchVersion( clientMock );
+		ElasticsearchVersion version = ElasticsearchClientUtils.tryGetElasticsearchVersion( clientMock );
 		assertThat( version ).isNotNull();
 		assertThat( version.distribution() ).isEqualTo( expectedDistribution );
-		assertThat( version.major() ).isEqualTo( expectedMajor );
+		assertThat( version.majorOptional() ).hasValue( expectedMajor );
 		assertThat( version.minor() ).hasValue( expectedMinor );
 		assertThat( version.micro() ).hasValue( expectedMicro );
 		if ( expectedQualifier != null ) {
@@ -102,10 +102,9 @@ public class ElasticsearchClientUtilsGetElasticsearchVersionTest {
 	public void testInvalid_distribution() {
 		String invalidDistributionName = "QWDWQD" + distributionString;
 		doMock( invalidDistributionName, versionString );
-		assertThatThrownBy( () -> ElasticsearchClientUtils.getElasticsearchVersion( clientMock ) )
+		assertThatThrownBy( () -> ElasticsearchClientUtils.tryGetElasticsearchVersion( clientMock ) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll(
-						"Unable to detect the Elasticsearch version running on the cluster",
 						"Invalid Elasticsearch distribution name",
 						"'" + invalidDistributionName.toLowerCase( Locale.ROOT ) + "'",
 						"Valid names are: [elastic, opensearch]" );
@@ -115,13 +114,23 @@ public class ElasticsearchClientUtilsGetElasticsearchVersionTest {
 	public void testInvalid_version() {
 		String invalidVersionString = versionString.substring( 0, versionString.length() - 1 ) + "-A-B";
 		doMock( distributionString, invalidVersionString );
-		assertThatThrownBy( () -> ElasticsearchClientUtils.getElasticsearchVersion( clientMock ) )
+		assertThatThrownBy( () -> ElasticsearchClientUtils.tryGetElasticsearchVersion( clientMock ) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll(
-						"Unable to detect the Elasticsearch version running on the cluster",
 						"Invalid Elasticsearch version",
 						"'" + invalidVersionString.toLowerCase( Locale.ROOT ) + "'",
 						"Expected format is 'x.y.z-qualifier'" );
+	}
+
+	@Test
+	public void testHttpStatus404() {
+		// This should only happen on Amazon OpenSearch Service,
+		// which doesn't allow retrieving the version.
+		when( clientMock.submit( any() ) )
+				.thenReturn( CompletableFuture.completedFuture( new ElasticsearchResponse(
+						new HttpHost( "mockHost:9200" ), 404, "", null ) ) );
+		ElasticsearchVersion version = ElasticsearchClientUtils.tryGetElasticsearchVersion( clientMock );
+		assertThat( version ).isNull();
 	}
 
 	private void doMock(String theDistributionString, String theVersionString) {

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/spi/ElasticsearchDialectsTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/spi/ElasticsearchDialectsTest.java
@@ -1,0 +1,86 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.dialect.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.hibernate.search.backend.elasticsearch.ElasticsearchVersion;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class ElasticsearchDialectsTest {
+
+	@Parameterized.Parameters(name = "{0}")
+	public static List<Object[]> params() {
+		return Arrays.asList(
+				// Unsupported versions may still be precise enough
+				params( "0.90.12", true, true, false ),
+				params( "5", true, false, false ),
+				params( "5.6", true, true, false ),
+				params( "5.6.1", true, true, false ),
+				// Elasticsearch
+				params( "elastic", false, false, false ),
+				params( "8", true, false, false ),
+				params( "8.9", true, true, false ),
+				params( "8.9.1", true, true, false ),
+				// OpenSearch
+				params( "opensearch", false, false, false ),
+				params( "opensearch:2", true, false, false ),
+				params( "opensearch:2.9", true, true, false ),
+				params( "opensearch:2.9.0", true, true, false ),
+				// Amazon OpenSearch Serverless
+				params( "amazon-opensearch-serverless", true, true, true ),
+				// Technically invalid at the moment, but still precise enough
+				params( "amazon-opensearch-serverless:1", true, true, true ),
+				params( "amazon-opensearch-serverless:1.0", true, true, true ),
+				params( "amazon-opensearch-serverless:1.0.0", true, true, true )
+		);
+	}
+
+	private static Object[] params(String versionString,
+			boolean isPreciseEnoughForBootstrap, boolean isPreciseEnoughForStart, boolean isVersionCheckImpossible) {
+		return new Object[] {
+				ElasticsearchVersion.of( versionString ),
+				isPreciseEnoughForBootstrap,
+				isPreciseEnoughForStart,
+				isVersionCheckImpossible
+		};
+	}
+
+	@Parameterized.Parameter
+	public ElasticsearchVersion version;
+	@Parameterized.Parameter(1)
+	public boolean isPreciseEnoughForBootstrap;
+	@Parameterized.Parameter(2)
+	public boolean isPreciseEnoughForStart;
+	@Parameterized.Parameter(3)
+	public boolean isVersionCheckImpossible;
+
+	@Test
+	public void isPreciseEnoughForBootstrap() {
+		assertThat( ElasticsearchDialects.isPreciseEnoughForBootstrap( version ) )
+				.isEqualTo( isPreciseEnoughForBootstrap );
+	}
+
+	@Test
+	public void isPreciseEnoughForStart() {
+		assertThat( ElasticsearchDialects.isPreciseEnoughForStart( version ) )
+				.isEqualTo( isPreciseEnoughForStart );
+	}
+
+	@Test
+	public void isVersionCheckImpossible() {
+		assertThat( ElasticsearchDialects.isVersionCheckImpossible( version ) )
+				.isEqualTo( isVersionCheckImpossible );
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/LuceneIndexWorkspace.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/LuceneIndexWorkspace.java
@@ -15,6 +15,7 @@ import org.hibernate.search.backend.lucene.work.impl.IndexManagementWork;
 import org.hibernate.search.backend.lucene.work.impl.LuceneWorkFactory;
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 
 public class LuceneIndexWorkspace implements IndexWorkspace {
 
@@ -31,12 +32,15 @@ public class LuceneIndexWorkspace implements IndexWorkspace {
 	}
 
 	@Override
-	public CompletableFuture<?> mergeSegments(OperationSubmitter operationSubmitter) {
+	public CompletableFuture<?> mergeSegments(OperationSubmitter operationSubmitter,
+			// mergeSegments is always supported
+			UnsupportedOperationBehavior ignored) {
 		return doSubmit( indexManagerContext.allManagementOrchestrators(), factory.mergeSegments(), false, operationSubmitter );
 	}
 
 	@Override
-	public CompletableFuture<?> purge(Set<String> routingKeys, OperationSubmitter operationSubmitter) {
+	public CompletableFuture<?> purge(Set<String> routingKeys, OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior) {
 		return doSubmit(
 				indexManagerContext.managementOrchestrators( routingKeys ),
 				factory.deleteAll( tenantIds, routingKeys ),
@@ -45,12 +49,16 @@ public class LuceneIndexWorkspace implements IndexWorkspace {
 	}
 
 	@Override
-	public CompletableFuture<?> flush(OperationSubmitter operationSubmitter) {
+	public CompletableFuture<?> flush(OperationSubmitter operationSubmitter,
+			// flush is always supported
+			UnsupportedOperationBehavior ignored) {
 		return doSubmit( indexManagerContext.allManagementOrchestrators(), factory.flush(), false, operationSubmitter );
 	}
 
 	@Override
-	public CompletableFuture<?> refresh(OperationSubmitter operationSubmitter) {
+	public CompletableFuture<?> refresh(OperationSubmitter operationSubmitter,
+			// refresh is always supported
+			UnsupportedOperationBehavior ignored) {
 		return doSubmit( indexManagerContext.allManagementOrchestrators(), factory.refresh(), false, operationSubmitter );
 	}
 

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -1161,7 +1161,8 @@
                         <systemPropertyVariables>
                             <org.hibernate.search.version>${project.version}</org.hibernate.search.version>
                             <org.hibernate.search.enable_performance_tests>${test.performance.enable}</org.hibernate.search.enable_performance_tests>
-                            <org.hibernate.search.integrationtest.backend.elasticsearch.version>${test.elasticsearch.distribution}:${test.elasticsearch.version}</org.hibernate.search.integrationtest.backend.elasticsearch.version>
+                            <org.hibernate.search.integrationtest.backend.elasticsearch.distribution>${test.elasticsearch.distribution}</org.hibernate.search.integrationtest.backend.elasticsearch.distribution>
+                            <org.hibernate.search.integrationtest.backend.elasticsearch.version>${test.elasticsearch.version}</org.hibernate.search.integrationtest.backend.elasticsearch.version>
                         </systemPropertyVariables>
                     </configuration>
                 </plugin>

--- a/build/parents/integrationtest/pom.xml
+++ b/build/parents/integrationtest/pom.xml
@@ -518,6 +518,32 @@
             </properties>
         </profile>
 
+        <profile>
+            <id>amazon-opensearch-serverless</id>
+            <activation>
+                <property>
+                    <name>test.elasticsearch.distribution</name>
+                    <value>amazon-opensearch-serverless</value>
+                </property>
+            </activation>
+            <properties>
+                <!-- We'll simulate testing against Amazon OpenSearch Serverless by:
+                     1. Using the Amazon OpenSearch Serverless in Hibernate Search
+                     2. Connecting to a (local) OpenSearch container running the latest version
+                 -->
+                <!-- Amazon OpenSearch Serverless doesn't use versions -->
+                <test.elasticsearch.version/>
+                <!-- We'll simulate Amazon OpenSearch Serverless with a (local)
+                     OpenSearch container running the latest version -->
+                <test.elasticsearch.run.opensearch.skip>${test.elasticsearch.run.skip}</test.elasticsearch.run.opensearch.skip>
+                <test.elasticsearch.run.elastic.skip>true</test.elasticsearch.run.elastic.skip>
+                <test.elasticsearch.run.opensearch.image.tag>${version.org.opensearch.latest}</test.elasticsearch.run.opensearch.image.tag>
+                <!-- This is just to fix docker-maven-plugin, which complains about
+                     invalid image names (missing version) even for disabled images -->
+                <test.elasticsearch.run.elastic.image.tag>${version.org.elasticsearch.latest}</test.elasticsearch.run.elastic.image.tag>
+            </properties>
+        </profile>
+
         <!-- =============================== -->
         <!-- Database profiles               -->
         <!-- =============================== -->

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -304,6 +304,7 @@
                         <openSearchCompatibleVersions>${version.org.opensearch.compatible.expected.text}</openSearchCompatibleVersions>
                         <openSearchTestedVersions>${version.org.opensearch.compatible.regularly-tested.text}</openSearchTestedVersions>
                         <amazonOpenSearchServiceUrl>https://docs.aws.amazon.com/opensearch-service/latest/developerguide</amazonOpenSearchServiceUrl>
+                        <amazonOpenSearchServerlessUrl>https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-overview.html</amazonOpenSearchServerlessUrl>
                         <wildflyUrl>https://wildfly.org/</wildflyUrl>
                         <quarkusUrl>https://quarkus.io/</quarkusUrl>
                         <springUrl>https://spring.io/</springUrl>

--- a/documentation/src/main/asciidoc/public/reference/_backend-elasticsearch.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_backend-elasticsearch.adoc
@@ -13,6 +13,8 @@ Hibernate Search's Elasticsearch backend is compatible with multiple distributio
 * <<backend-elasticsearch-compatibility-opensearch,OpenSearch clusters running version {openSearchCompatibleVersions}>>
 * <<backend-elasticsearch-compatibility-amazon-opensearch-service,Amazon OpenSearch Service clusters running version {openSearchCompatibleVersions}>>
 (requires extra configuration)
+* <<backend-elasticsearch-compatibility-amazon-opensearch-serverless,Amazon OpenSearch Serverless clusters>>
+(incubating, requires extra configuration)
 
 [TIP]
 ====
@@ -28,7 +30,8 @@ refer to the https://hibernate.org/community/compatibility-policy/#compatibility
 Where possible, the distribution and version running on your cluster will be automatically detected on startup,
 and Hibernate Search will adapt based on that.
 
-When your cluster is not available on startup,
+With <<backend-elasticsearch-compatibility-amazon-opensearch-serverless,Amazon OpenSearch Serverless>>,
+or when your cluster is not available on startup,
 you will have to configure the version Hibernate Search should expect explicitly:
 see <<backend-elasticsearch-configuration-version>> for details.
 
@@ -72,6 +75,48 @@ link:{amazonOpenSearchServiceUrl}/supported-operations.html#version_7_1[closing 
 and as a result <<mapper-orm-schema-management-manager-create-or-update,automatic schema updates>>
 (<<schema-management-concepts-update-failure,not recommended in production>>)
 <<schema-management-concepts-index-closing,will fail when trying to update analyzer definitions>>.
+
+[[backend-elasticsearch-compatibility-amazon-opensearch-serverless]]
+=== Amazon OpenSearch Serverless (incubating)
+
+include::../components/_incubating-warning.adoc[]
+
+link:{amazonOpenSearchServerlessUrl}[Amazon OpenSearch Serverless] compatibility is implemented and incubating;
+feel free to provide feedback on https://hibernate.atlassian.net/browse/HSEARCH-4867[HSEARCH-4867].
+
+However, be aware that:
+
+* Hibernate Search does not currently get tested against Amazon OpenSearch Serverless;
+see https://hibernate.atlassian.net/browse/HSEARCH-4919[HSEARCH-4919].
+* Connecting to an Amazon OpenSearch Serverless cluster
+requires <<backend-elasticsearch-configuration-aws,proprietary authentication>> that involves extra configuration.
+* Compatibility with Amazon OpenSearch Serverless must be enabled
+explicitly by <<backend-elasticsearch-configuration-version-check,setting `hibernate.search.backend.version` to `amazon-opensearch-serverless`>>.
+
+Also, link:{amazonOpenSearchServerlessUrl}[Amazon OpenSearch Serverless] has its own, specific limitations:
+
+* link:{amazonOpenSearchServiceUrl}/serverless-genref.html#serverless-operations[Closing indexes is not possible],
+and as a result <<mapper-orm-schema-management-manager-create-or-update,automatic schema updates>>
+(<<schema-management-concepts-update-failure,not recommended in production>>)
+<<schema-management-concepts-index-closing,will fail when trying to update analyzer definitions>>.
+* <<backend-elasticsearch-configuration-version-check,Distribution/version detection on startup>>
+is not possible, so it is disabled by default and cannot be enabled explicitly.
+* <<backend-elasticsearch-index-lifecycle,Minimal index status requirement>> for schema management
+is not possible, so it is disabled by default and cannot be enabled explicitly.
+* <<indexing-workspace-purge,Purging>>, <<indexing-workspace-flush,flushing>>, <<indexing-workspace-refresh,refreshing>>, or <<indexing-workspace-merge-segments,merging segments>>
+link:{amazonOpenSearchServiceUrl}/serverless-genref.html#serverless-operations[is not possible],
+so attempts to <<indexing-workspace,perform these operations explicitly>> will always fail.
+* The <<indexing-massindexer,mass indexer>> will fail if you attempt a purge on start (the default),
+because Amazon OpenSearch Serverless link:{amazonOpenSearchServiceUrl}/serverless-genref.html#serverless-operations[doesn’t support it].
+Use <<indexing-massindexer-parameters-drop-and-create-schema,`.dropAndCreateSchemaOnStart(...)`>>
+to drop the indexes on start instead.
+See https://hibernate.atlassian.net/browse/HSEARCH-4930[HSEARCH-4930].
+* The <<indexing-massindexer,mass indexer>> will skip the flush, refresh and merge-segments operations by default,
+and attempting to enable them explicitly will result in failures,
+because Amazon OpenSearch Serverless link:{amazonOpenSearchServiceUrl}/serverless-genref.html#serverless-operations[doesn’t support them].
+* The <<mapper-orm-indexing-jsr352,JSR-352 integration>> is not currently supported.
+See https://hibernate.atlassian.net/browse/HSEARCH-4929[HSEARCH-4929],
+https://hibernate.atlassian.net/browse/HSEARCH-4930[HSEARCH-4930].
 
 [[backend-elasticsearch-upgrading]]
 === [[_upgrading_elasticsearch]] Upgrading Elasticsearch
@@ -227,8 +272,9 @@ your password will be transmitted in clear text over the network.
 
 The Hibernate Search Elasticsearch backend, once configured, will work just fine in most setups.
 However, if you need to use
-<<backend-elasticsearch-compatibility-amazon-opensearch-service,Amazon OpenSearch Service>>,
-you will find it requires a proprietary authentication method:
+<<backend-elasticsearch-compatibility-amazon-opensearch-service,Amazon OpenSearch Service>>
+or <<backend-elasticsearch-compatibility-amazon-opensearch-serverless,Amazon OpenSearch Serverless>>,
+you will find they require a proprietary authentication method:
 link:{amazonOpenSearchServiceUrl}/request-signing.html[request signing].
 
 While request signing is not supported by default,
@@ -405,16 +451,29 @@ and will infer the correct behavior to adopt.
 
 You can force Hibernate Search to expect a specific version of Elasticsearch/OpenSearch by
 setting the property `hibernate.search.backend.version` to a version string
-following the format `x.y.z-qualifier` or `<distribution>:x.y.z-qualifier`, where:
+following the format `x.y.z-qualifier` or `<distribution>:x.y.z-qualifier`
+or just `<distribution>`, where:
 
-* `<distribution>` is either `elastic` or `opensearch`. Optional, defaults to `elastic`.
+* `<distribution>` is either `elastic`, `opensearch` or `amazon-opensearch-serverless`. Optional, defaults to `elastic`.
 * `x`, `y` and `z` are integers. `x` is mandatory, `y` and `z` are optional.
 * `qualifier` is a string of word characters (alphanumeric or `_`). Optional.
 
-For example, `8`, `8.0`, `8.9`, `opensearch:2.9` are all valid version strings.
+For example, `8`, `8.0`, `8.9`, `opensearch:2.9`, `amazon-opensearch-service`
+are all valid version strings.
+
+[NOTE]
+====
+<<backend-elasticsearch-compatibility-amazon-opensearch-serverless,Amazon OpenSearch Serverless>>
+is a special case as it doesn't use version numbers.
+
+When using that platform, you **must** set the version
+and it must be set to simply `amazon-opensearch-serverless`,
+without a trailing `:` or version number.
+====
 
 Hibernate Search will still query the Elasticsearch/OpenSearch cluster
 to detect the actual distribution and version of the cluster
+(except where not supported, i.e. <<backend-elasticsearch-compatibility-amazon-opensearch-serverless,Amazon OpenSearch Serverless>>),
 in order to check that the configured distribution and version match the actual ones.
 
 [[backend-elasticsearch-configuration-version-check-disabling]]
@@ -473,7 +532,9 @@ hibernate.search.backend.indexes.<index-name>.schema_management.minimal_required
 ----
 
 * `minimal_required_status` defines the minimal required status of an index before creation is considered complete.
-The default for this property is `yellow`.
+The default for this property is `yellow`,
+except on <<backend-elasticsearch-compatibility-amazon-opensearch-serverless,Amazon OpenSearch Serverless>>
+where index status checks are skipped because that platform does not support index status checks.
 * `minimal_required_status_wait_timeout` defines the maximum time to wait for this status,
 as an <<configuration-property-types,integer value>> in milliseconds.
 The default for this property is `10000`.

--- a/documentation/src/main/asciidoc/public/reference/_indexing-massindexer.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_indexing-massindexer.adoc
@@ -22,7 +22,12 @@ The `MassIndexer` takes the following approach to achieve a reasonably high thro
 
 * Indexes are purged completely when mass indexing starts.
 * Mass indexing is performed by several parallel threads,
-each loading data from the database and sending indexing requests to the indexes.
+each loading data from the database and sending indexing requests to the indexes,
+not triggering any <<concepts-commit-refresh,commit or refresh>>.
+* An implicit <<indexing-workspace-flush,flush>> (commit) and <<indexing-workspace-refresh,refresh>>
+are performed upon mass indexing completion,
+except for <<backend-elasticsearch-compatibility-amazon-opensearch-serverless,Amazon OpenSearch Serverless>>
+since it doesn't support explicit flushes or refreshes.
 
 [WARNING]
 ====
@@ -268,7 +273,7 @@ Only set this to `false` if you know the index is already empty;
 otherwise, you will end up with duplicates in the index.
 
 |`mergeSegmentsAfterPurge(boolean)`
-|`true`
+|`true` in general, `false` on <<backend-elasticsearch-compatibility-amazon-opensearch-serverless,Amazon OpenSearch Serverless>>
 |Force merging of each index into a single segment after the initial index purge, just before indexing.
 This setting has no effect if `purgeAllOnStart` is set to false.
 

--- a/documentation/src/main/asciidoc/public/reference/_indexing-massindexer.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_indexing-massindexer.adoc
@@ -160,7 +160,7 @@ i.e. simply all indexed types.
 == Running the mass indexer asynchronously
 
 It is possible to run the mass indexer asynchronously,
-because, the mass indexer does not rely on the original Hibernate ORM session.
+because it does not rely on the original Hibernate ORM session.
 When used asynchronously, the mass indexer will return a completion stage
 to track the completion of mass indexing:
 

--- a/documentation/src/main/asciidoc/public/reference/_indexing-workspace.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_indexing-workspace.adoc
@@ -44,7 +44,7 @@ without waiting for the `SearchSession` to be closed or the Hibernate ORM transa
 
 This interface offers the following methods:
 
-`purge()`::
+[[indexing-workspace-purge]]`purge()`::
 Delete all documents from indexes targeted by this workspace.
 +
 With multi-tenancy enabled, only documents of the current tenant will be removed:

--- a/documentation/src/main/asciidoc/public/reference/_schema.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_schema.adoc
@@ -252,10 +252,11 @@ those clients should be synchronized in such a way that while Hibernate Search i
 no other client needs to access the index.
 +
 Also, on <<backend-elasticsearch-compatibility-amazon-opensearch-service,Amazon OpenSearch Service>>
-running Elasticsearch (not OpenSearch) in version 7.1 or older
-link:{amazonOpenSearchServiceUrl}/supported-operations.html#version_7_1[the `_close`/`_open` operations are not supported],
+running Elasticsearch (not OpenSearch) in version 7.1 or older,
+as well as on <<backend-elasticsearch-compatibility-amazon-opensearch-serverless,Amazon OpenSearch Serverless>>,
+the `_close`/`_open` operations are not supported,
 so **the schema update will fail** when trying to update analyzer definitions.
-The only workaround is to avoid the schema update on that platform.
+The only workaround is to avoid the schema update on these platforms.
 It should be avoided in production environments regardless:
 see <<schema-management-concepts-update-failure>>.
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/layout/ElasticsearchCustomLayoutStrategyIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/layout/ElasticsearchCustomLayoutStrategyIT.java
@@ -40,7 +40,7 @@ public class ElasticsearchCustomLayoutStrategyIT {
 	public void smoke() {
 		URLEncodedString primaryIndexName = encodeName( Book.NAME + "-20171106-191900-000000000" );
 		elasticsearchClient.index( primaryIndexName, null, null )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		EntityManagerFactory entityManagerFactory = setupHelper.start()
 				.withBackendProperty(

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/gettingstarted/withhsearch/defaultanalysis/GettingStartedDefaultAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/gettingstarted/withhsearch/defaultanalysis/GettingStartedDefaultAnalysisIT.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Persistence;
 
+import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.TestConfiguration;
 import org.hibernate.search.engine.search.query.SearchResult;
 import org.hibernate.search.mapper.orm.Search;
@@ -83,6 +84,9 @@ public class GettingStartedDefaultAnalysisIT {
 				SearchSession searchSession = Search.session( entityManager ); // <1>
 
 				MassIndexer indexer = searchSession.massIndexer( Book.class ) // <2>
+						// end::manual-index[]
+						.purgeAllOnStart( BackendConfigurations.simple().supportsExplicitPurge() )
+						// tag::manual-index[]
 						.threadsToLoadObjects( 7 ); // <3>
 
 				indexer.startAndWait(); // <4>

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/AbstractHibernateOrmMassIndexingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/AbstractHibernateOrmMassIndexingIT.java
@@ -11,7 +11,6 @@ import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils
 
 import java.time.LocalDate;
 
-import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 
 import org.hibernate.search.documentation.testsupport.BackendConfigurations;
@@ -40,29 +39,16 @@ abstract class AbstractHibernateOrmMassIndexingIT {
 				.setup( Book.class, Author.class );
 		initData( entityManagerFactory );
 		with( entityManagerFactory ).runInTransaction( entityManager -> {
-			assertBookCount( entityManager, 0 );
-			assertAuthorCount( entityManager, 0 );
+			SearchSession searchSession = Search.session( entityManager );
+			assertThat( searchSession.search( Book.class )
+					.where( f -> f.matchAll() )
+					.fetchTotalHitCount() )
+					.isZero();
+			assertThat( searchSession.search( Author.class )
+					.where( f -> f.matchAll() )
+					.fetchTotalHitCount() )
+					.isZero();
 		} );
-	}
-
-	static void assertBookCount(EntityManager entityManager, int expectedCount) {
-		SearchSession searchSession = Search.session( entityManager );
-		assertThat(
-				searchSession.search( Book.class )
-						.where( f -> f.matchAll() )
-						.fetchTotalHitCount()
-		)
-				.isEqualTo( expectedCount );
-	}
-
-	protected void assertAuthorCount(EntityManager entityManager, int expectedCount) {
-		SearchSession searchSession = Search.session( entityManager );
-		assertThat(
-				searchSession.search( Author.class )
-						.where( f -> f.matchAll() )
-						.fetchTotalHitCount()
-		)
-				.isEqualTo( expectedCount );
 	}
 
 	protected void initData(EntityManagerFactory entityManagerFactory) {

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmBatchJsr352IT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmBatchJsr352IT.java
@@ -7,10 +7,6 @@
 package org.hibernate.search.documentation.mapper.orm.indexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.documentation.mapper.orm.indexing.HibernateOrmMassIndexerIT.NUMBER_OF_BOOKS;
-import static org.hibernate.search.documentation.mapper.orm.indexing.HibernateOrmMassIndexerIT.assertAuthorCount;
-import static org.hibernate.search.documentation.mapper.orm.indexing.HibernateOrmMassIndexerIT.assertBookCount;
-import static org.hibernate.search.documentation.mapper.orm.indexing.HibernateOrmMassIndexerIT.initData;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 
 import java.util.Properties;
@@ -19,36 +15,16 @@ import jakarta.batch.operations.JobOperator;
 import jakarta.batch.runtime.BatchRuntime;
 import jakarta.batch.runtime.BatchStatus;
 import jakarta.batch.runtime.JobExecution;
-import jakarta.persistence.EntityManagerFactory;
 
 import org.hibernate.search.batch.jsr352.core.massindexing.MassIndexingJob;
-import org.hibernate.search.documentation.testsupport.BackendConfigurations;
-import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
-import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class HibernateOrmBatchJsr352IT {
+public class HibernateOrmBatchJsr352IT extends AbstractHibernateOrmMassIndexingIT {
 
 	private static final int JOB_TIMEOUT_MS = 30_000;
 	private static final int THREAD_SLEEP = 1000;
-
-	@Rule
-	public DocumentationSetupHelper setupHelper = DocumentationSetupHelper.withSingleBackend(
-			BackendConfigurations.simple() );
-
-	private EntityManagerFactory entityManagerFactory;
-
-	@Before
-	public void setup() {
-		this.entityManagerFactory = setupHelper.start()
-				.withProperty( HibernateOrmMapperSettings.INDEXING_LISTENERS_ENABLED, false )
-				.setup( Book.class, Author.class );
-		initData( entityManagerFactory, HibernateOrmBatchJsr352IT::newAuthor );
-	}
 
 	@Test
 	public void simple() throws Exception {
@@ -95,7 +71,8 @@ public class HibernateOrmBatchJsr352IT {
 		} );
 	}
 
-	private static Author newAuthor(int id) {
+	@Override
+	protected Author newAuthor(int id) {
 		Author author = new Author();
 		author.setId( id );
 		author.setFirstName( "John" + id );
@@ -103,6 +80,7 @@ public class HibernateOrmBatchJsr352IT {
 		author.setLastName( "Smith" + ( id % 2 ) );
 		return author;
 	}
+
 
 	private static JobExecution waitForTermination(JobOperator jobOperator, JobExecution jobExecution, int timeoutInMs)
 			throws InterruptedException {

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmBatchJsr352IT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmBatchJsr352IT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.indexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
+import static org.junit.Assume.assumeTrue;
 
 import java.util.Properties;
 
@@ -17,14 +18,24 @@ import jakarta.batch.runtime.BatchStatus;
 import jakarta.batch.runtime.JobExecution;
 
 import org.hibernate.search.batch.jsr352.core.massindexing.MassIndexingJob;
+import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.mapper.orm.Search;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class HibernateOrmBatchJsr352IT extends AbstractHibernateOrmMassIndexingIT {
 
 	private static final int JOB_TIMEOUT_MS = 30_000;
 	private static final int THREAD_SLEEP = 1000;
+
+	@Before
+	public void checkAssumptions() {
+		assumeTrue(
+				"This test only makes sense if the backend supports explicit purge",
+				BackendConfigurations.simple().supportsExplicitPurge()
+		);
+	}
 
 	@Test
 	public void simple() throws Exception {

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.documentation.mapper.orm.indexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
+import static org.junit.Assume.assumeTrue;
 
 import java.util.Arrays;
 
@@ -227,6 +228,16 @@ public class HibernateOrmManualIndexingIT {
 			SearchWorkspace bookAndAuthorWorkspace = searchSession.workspace( Book.class, Author.class ); // <4>
 			// end::workspace-retrieval-session[]
 		} );
+	}
+
+	@Test
+	public void purge() {
+		assumeTrue( "This test only makes sense if the backend supports explicit purges",
+				BackendConfigurations.simple().supportsExplicitPurge() );
+
+		int numberOfBooks = 10;
+		EntityManagerFactory entityManagerFactory = setup( true );
+		initBooksAndAuthors( entityManagerFactory, numberOfBooks );
 
 		with( entityManagerFactory ).runNoTransaction( entityManager -> {
 			assertBookCount( entityManager, numberOfBooks );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 
+import org.hibernate.SessionFactory;
 import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
@@ -300,25 +301,27 @@ public class HibernateOrmManualIndexingIT {
 	}
 
 	private void assertBookCount(EntityManager entityManager, int expectedCount) {
-		SearchSession searchSession = Search.session( entityManager );
-		searchSession.workspace().refresh();
-		assertThat(
-				searchSession.search( Book.class )
-						.where( f -> f.matchAll() )
-						.fetchTotalHitCount()
-		)
-				.isEqualTo( expectedCount );
+		setupHelper.assertions().searchAfterIndexChanges(
+				entityManager.getEntityManagerFactory().unwrap( SessionFactory.class ),
+				() -> {
+					SearchSession searchSession = Search.session( entityManager );
+					assertThat( searchSession.search( Book.class )
+							.where( f -> f.matchAll() )
+							.fetchTotalHitCount() )
+							.isEqualTo( expectedCount );
+				} );
 	}
 
 	private void assertAuthorCount(EntityManager entityManager, int expectedCount) {
-		SearchSession searchSession = Search.session( entityManager );
-		searchSession.workspace().refresh();
-		assertThat(
-				searchSession.search( Author.class )
-						.where( f -> f.matchAll() )
-						.fetchTotalHitCount()
-		)
-				.isEqualTo( expectedCount );
+		setupHelper.assertions().searchAfterIndexChanges(
+				entityManager.getEntityManagerFactory().unwrap( SessionFactory.class ),
+				() -> {
+					SearchSession searchSession = Search.session( entityManager );
+					assertThat( searchSession.search( Author.class )
+							.where( f -> f.matchAll() )
+							.fetchTotalHitCount() )
+							.isEqualTo( expectedCount );
+				} );
 	}
 
 	private EntityManagerFactory setup(boolean automaticIndexingEnabled) {

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmMassIndexerIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmMassIndexerIT.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.documentation.mapper.orm.indexing;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
 import static org.hibernate.search.util.impl.test.FutureAssert.assertThatFuture;
@@ -14,47 +13,20 @@ import static org.hibernate.search.util.impl.test.FutureAssert.assertThatFuture;
 import java.lang.invoke.MethodHandles;
 import java.time.LocalDate;
 import java.util.concurrent.Future;
-import java.util.function.Function;
 
-import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 
-import org.hibernate.search.documentation.testsupport.BackendConfigurations;
-import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
-import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.util.common.logging.impl.Log;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class HibernateOrmMassIndexerIT {
+public class HibernateOrmMassIndexerIT extends AbstractHibernateOrmMassIndexingIT {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
-
-	static final int NUMBER_OF_BOOKS = 1000;
-	static final int INIT_DATA_TRANSACTION_SIZE = 500;
-
-	@Rule
-	public DocumentationSetupHelper setupHelper = DocumentationSetupHelper.withSingleBackend( BackendConfigurations.simple() );
-
-	private EntityManagerFactory entityManagerFactory;
-
-	@Before
-	public void setup() {
-		this.entityManagerFactory = setupHelper.start()
-				.withProperty( HibernateOrmMapperSettings.INDEXING_LISTENERS_ENABLED, false )
-				.setup( Book.class, Author.class );
-		initData( entityManagerFactory, HibernateOrmMassIndexerIT::newAuthor );
-		with( entityManagerFactory ).runNoTransaction( entityManager -> {
-			assertBookCount( entityManager, 0 );
-			assertAuthorCount( entityManager, 0 );
-		} );
-	}
 
 	@Test
 	public void simple() {
@@ -178,69 +150,5 @@ public class HibernateOrmMassIndexerIT {
 			assertBookCount( entityManager, NUMBER_OF_BOOKS );
 			assertAuthorCount( entityManager, NUMBER_OF_BOOKS );
 		} );
-	}
-
-	static void assertBookCount(EntityManager entityManager, int expectedCount) {
-		SearchSession searchSession = Search.session( entityManager );
-		assertThat(
-				searchSession.search( Book.class )
-						.where( f -> f.matchAll() )
-						.fetchTotalHitCount()
-		)
-				.isEqualTo( expectedCount );
-	}
-
-	static void assertAuthorCount(EntityManager entityManager, int expectedCount) {
-		SearchSession searchSession = Search.session( entityManager );
-		assertThat(
-				searchSession.search( Author.class )
-						.where( f -> f.matchAll() )
-						.fetchTotalHitCount()
-		)
-				.isEqualTo( expectedCount );
-	}
-
-	static void initData(EntityManagerFactory entityManagerFactory, Function<Integer, Author> authorInit) {
-		with( entityManagerFactory ).runNoTransaction( entityManager -> {
-			try {
-				int i = 0;
-				while ( i < NUMBER_OF_BOOKS ) {
-					entityManager.getTransaction().begin();
-					int end = Math.min( i + INIT_DATA_TRANSACTION_SIZE, NUMBER_OF_BOOKS );
-					for ( ; i < end; ++i ) {
-						Author author = authorInit.apply( i );
-
-						Book book = newBook( i );
-						book.setAuthor( author );
-						author.getBooks().add( book );
-
-						entityManager.persist( author );
-						entityManager.persist( book );
-					}
-					entityManager.getTransaction().commit();
-				}
-			}
-			catch (RuntimeException e) {
-				entityManager.getTransaction().rollback();
-				throw e;
-			}
-		} );
-	}
-
-	private static Book newBook(int id) {
-		Book book = new Book();
-		book.setId( id );
-		book.setTitle( "This is the title of book #" + id );
-		book.setPublicationYear( 1450 + id );
-		return book;
-	}
-
-	private static Author newAuthor(int id) {
-		Author author = new Author();
-		author.setId( id );
-		author.setFirstName( "John" + id );
-		author.setLastName( "Smith" + id );
-		author.setBirthDate( LocalDate.ofYearDay( 1450 + id, 33 ) );
-		return author;
 	}
 }

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/pojo/standalone/gettingstarted/withhsearch/customanalysis/GettingStartedCustomAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/pojo/standalone/gettingstarted/withhsearch/customanalysis/GettingStartedCustomAnalysisIT.java
@@ -106,8 +106,6 @@ public class GettingStartedCustomAnalysisIT {
 			session.indexingPlan().add( author );
 			session.indexingPlan().add( book );
 		}
-		// Make sure changes are visible
-		searchMapping.scope( Book.class ).workspace().refresh();
 
 		// tag::searching[]
 		try ( SearchSession session = searchMapping.createSession() ) {

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/pojo/standalone/gettingstarted/withhsearch/defaultanalysis/GettingStartedDefaultAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/pojo/standalone/gettingstarted/withhsearch/defaultanalysis/GettingStartedDefaultAnalysisIT.java
@@ -112,8 +112,6 @@ public class GettingStartedDefaultAnalysisIT {
 		}
 		// end::indexing[]
 		Integer bookId = 2;
-		// Make sure changes are visible
-		searchMapping.scope( Book.class ).workspace().refresh();
 
 		// tag::searching-objects[]
 		try ( SearchSession session = searchMapping.createSession() ) { // <1>
@@ -217,8 +215,6 @@ public class GettingStartedDefaultAnalysisIT {
 			session.indexingPlan().addOrUpdate( book );
 		}
 		// end::indexing-addOrUpdate[]
-		// Make sure changes are visible
-		searchMapping.scope( Book.class ).workspace().refresh();
 		try ( SearchSession session = searchMapping.createSession() ) {
 			assertThat( session.search( Book.class )
 					.select( f -> f.id( Integer.class ) )
@@ -245,8 +241,6 @@ public class GettingStartedDefaultAnalysisIT {
 			session.indexingPlan().delete( book );
 		}
 		// end::indexing-delete[]
-		// Make sure changes are visible
-		searchMapping.scope( Book.class ).workspace().refresh();
 		try ( SearchSession session = searchMapping.createSession() ) {
 			assertThat( session.search( Book.class )
 					.select( f -> f.id( Integer.class ) )

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/DocumentationSetupHelper.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/DocumentationSetupHelper.java
@@ -26,6 +26,7 @@ import org.hibernate.search.util.impl.integrationtest.common.rule.BackendSetupSt
 import org.hibernate.search.util.impl.integrationtest.common.rule.MappingSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.BackendMappingHandle;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.HibernateOrmMappingHandle;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmAssertionHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.SimpleSessionFactoryBuilder;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.multitenancy.impl.MultitenancyTestHelper;
 
@@ -108,6 +109,7 @@ public final class DocumentationSetupHelper
 	private final Boolean annotationProcessingEnabled;
 
 	private final HibernateOrmSearchMappingConfigurer defaultMappingConfigurer;
+	private final OrmAssertionHelper assertionHelper;
 
 	private DocumentationSetupHelper(BackendSetupStrategy backendSetupStrategy,
 			Boolean annotationProcessingEnabled,
@@ -115,12 +117,18 @@ public final class DocumentationSetupHelper
 		super( backendSetupStrategy );
 		this.annotationProcessingEnabled = annotationProcessingEnabled;
 		this.defaultMappingConfigurer = defaultMappingConfigurer;
+		this.assertionHelper = new OrmAssertionHelper( backendSetupStrategy );
 	}
 
 	@Override
 	public String toString() {
 		return super.toString()
 				+ ( annotationProcessingEnabled == Boolean.FALSE ? " - programmatic mapping" : "" );
+	}
+
+	@Override
+	public OrmAssertionHelper assertions() {
+		return assertionHelper;
 	}
 
 	@Override

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/TestConfiguration.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/TestConfiguration.java
@@ -60,6 +60,7 @@ public final class TestConfiguration {
 			properties.put( "hibernate.search.backend." + entry.getKey(), entry.getValue() );
 		}
 		properties.put( "hibernate.search.schema_management.strategy", "drop-and-create-and-drop" );
+		properties.put( "hibernate.search.indexing.plan.synchronization.strategy", "sync" );
 
 		return properties;
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/spi/IndexWorkspace.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/spi/IndexWorkspace.java
@@ -16,12 +16,49 @@ import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
  */
 public interface IndexWorkspace {
 
-	CompletableFuture<?> mergeSegments(OperationSubmitter operationSubmitter);
+	/**
+	 * Merge all segments of the index into a single one.
+	 * @param operationSubmitter The behavior to adopt when submitting the operation to a full queue/executor.
+	 * @param unsupportedOperationBehavior The behavior to adopt if the operation is not supported in this index.
+	 * @return A completion stage for the executed operation, or a completed stage if the operation is not supported.
+	 */
+	CompletableFuture<?> mergeSegments(OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior);
 
-	CompletableFuture<?> purge(Set<String> routingKeys, OperationSubmitter operationSubmitter);
+	/**
+	 * Delete documents that were indexed with any of the given routing keys,
+	 * or all documents if the set of routing keys is empty.
+	 *
+	 * @param routingKeys The set of routing keys.
+	 * If non-empty, only documents that were indexed with these routing keys will be deleted.
+	 * If empty, documents will be deleted regardless of their routing key.
+	 * @param operationSubmitter The behavior to adopt when submitting the operation to a full queue/executor.
+	 * @param unsupportedOperationBehavior The behavior to adopt if the operation is not supported in this index.
+	 *
+	 * @return A completion stage for the executed operation.
+	 */
+	CompletableFuture<?> purge(Set<String> routingKeys, OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior);
 
-	CompletableFuture<?> flush(OperationSubmitter operationSubmitter);
+	/**
+	 * Flush to disk the changes to the index that were not committed yet.
+	 * <p>
+	 * In the case of backends with a transaction log (Elasticsearch),
+	 * also apply operations from the transaction log that were not applied yet.
+	 * @param operationSubmitter The behavior to adopt when submitting the operation to a full queue/executor.
+	 * @param unsupportedOperationBehavior The behavior to adopt if the operation is not supported in this index.
+	 * @return A completion stage for the executed operation, or a completed stage if the operation is not supported.
+	 */
+	CompletableFuture<?> flush(OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior);
 
-	CompletableFuture<?> refresh(OperationSubmitter operationSubmitter);
+	/**
+	 * Refresh the indexes so that all changes executed so far will be visible in search queries.
+	 * @param operationSubmitter The behavior to adopt when submitting the operation to a full queue/executor.
+	 * @param unsupportedOperationBehavior The behavior to adopt if the operation is not supported in this index.
+	 * @return A completion stage for the executed operation, or a completed stage if the operation is not supported.
+	 */
+	CompletableFuture<?> refresh(OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior);
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/spi/UnsupportedOperationBehavior.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/spi/UnsupportedOperationBehavior.java
@@ -1,0 +1,12 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.backend.work.execution.spi;
+
+public enum UnsupportedOperationBehavior {
+	FAIL,
+	IGNORE;
+}

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/spi/ParseUtils.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/spi/ParseUtils.java
@@ -35,6 +35,7 @@ import java.time.format.SignStyle;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -352,7 +353,7 @@ public final class ParseUtils {
 		final String normalizedValue = value.trim().toLowerCase( Locale.ROOT );
 
 		for ( T candidate : allowedValues ) {
-			if ( stringRepresentationFunction.apply( candidate ).equals( normalizedValue ) ) {
+			if ( normalizedValue.equals( stringRepresentationFunction.apply( candidate ) ) ) {
 				return candidate;
 			}
 		}
@@ -361,6 +362,7 @@ public final class ParseUtils {
 				normalizedValue,
 				Arrays.stream( allowedValues )
 						.map( stringRepresentationFunction )
+						.filter( Objects::nonNull )
 						.collect( Collectors.toList() )
 		);
 	}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapFailureIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapFailureIT.java
@@ -7,9 +7,11 @@
 package org.hibernate.search.integrationtest.backend.elasticsearch.bootstrap;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assume.assumeTrue;
 
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchClientSpy;
+import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchTckBackendFeatures;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.reporting.FailureReportUtils;
@@ -33,6 +35,10 @@ public class ElasticsearchBootstrapFailureIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3621")
 	public void cannotConnect() {
+		assumeTrue( "This test only works if the very first request to Elasticsearch"
+				+ " is a version check, i.e. if version checks are supported",
+				ElasticsearchTckBackendFeatures.supportsVersionCheck() );
+
 		assertThatThrownBy(
 				() -> setupHelper.start()
 						.withBackendProperty(

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapIT.java
@@ -107,8 +107,8 @@ public class ElasticsearchBootstrapIT {
 						.defaultBackendContext()
 						.failure( "Invalid value for configuration property 'hibernate.search.backend.version': ''",
 								"Missing or imprecise Elasticsearch version",
-								"when configuration property 'hibernate.search.backend.version_check.enabled' is set to 'false'",
-								"the version is mandatory and must be at least as precise as 'x.y', where 'x' and 'y' are integers" )
+								"configuration property 'hibernate.search.backend.version_check.enabled' is set to 'false'",
+								"you must set the version explicitly with at least as much precision as 'x.y', where 'x' and 'y' are integers" )
 				);
 	}
 
@@ -120,7 +120,7 @@ public class ElasticsearchBootstrapIT {
 	@TestForIssue(jiraKey = "HSEARCH-3841")
 	public void noVersionCheck_incompleteVersion() {
 		ElasticsearchVersion actualVersion = ElasticsearchTestDialect.getActualVersion();
-		String versionWithMajorOnly = actualVersion.distribution() + ":" + actualVersion.major();
+		String versionWithMajorOnly = actualVersion.distribution() + ":" + actualVersion.majorOptional().getAsInt();
 
 		assertThatThrownBy(
 				() -> setupHelper.start()
@@ -146,8 +146,8 @@ public class ElasticsearchBootstrapIT {
 								"Invalid value for configuration property 'hibernate.search.backend.version': '"
 										+ versionWithMajorOnly + "'",
 								"Missing or imprecise Elasticsearch version",
-								"when configuration property 'hibernate.search.backend.version_check.enabled' is set to 'false'",
-								"the version is mandatory and must be at least as precise as 'x.y', where 'x' and 'y' are integers" )
+								"configuration property 'hibernate.search.backend.version_check.enabled' is set to 'false'",
+								"you must set the version explicitly with at least as much precision as 'x.y', where 'x' and 'y' are integers" )
 				);
 	}
 
@@ -160,7 +160,7 @@ public class ElasticsearchBootstrapIT {
 	public void noVersionCheck_completeVersion() {
 		ElasticsearchVersion actualVersion = ElasticsearchTestDialect.getActualVersion();
 		String versionWithMajorAndMinorOnly = actualVersion.distribution() + ":"
-				+ actualVersion.major() + "." + actualVersion.minor().getAsInt();
+				+ actualVersion.majorOptional().getAsInt() + "." + actualVersion.minor().getAsInt();
 
 		SearchSetupHelper.PartialSetup partialSetup = setupHelper.start()
 				.withBackendProperty(
@@ -195,9 +195,9 @@ public class ElasticsearchBootstrapIT {
 	@TestForIssue(jiraKey = "HSEARCH-4214")
 	public void noVersionCheck_versionOverrideOnStart_incompatibleVersion() {
 		ElasticsearchVersion actualVersion = ElasticsearchTestDialect.getActualVersion();
-		String versionWithMajorOnly = actualVersion.distribution() + ":" + actualVersion.major();
+		String versionWithMajorOnly = actualVersion.distribution() + ":" + actualVersion.majorOptional().getAsInt();
 		String incompatibleVersionWithMajorAndMinorOnly = actualVersion.distribution() + ":"
-				+ ( actualVersion.major() == 2 ? "42." : "2." ) + actualVersion.minor().getAsInt();
+				+ ( actualVersion.majorOptional().getAsInt() == 2 ? "42." : "2." ) + actualVersion.minor().getAsInt();
 
 		SearchSetupHelper.PartialSetup partialSetup = setupHelper.start()
 				.withBackendProperty(
@@ -242,9 +242,9 @@ public class ElasticsearchBootstrapIT {
 	@TestForIssue(jiraKey = "HSEARCH-4214")
 	public void noVersionCheck_versionOverrideOnStart_compatibleVersion() {
 		ElasticsearchVersion actualVersion = ElasticsearchTestDialect.getActualVersion();
-		String versionWithMajorOnly = actualVersion.distribution() + ":" + actualVersion.major();
+		String versionWithMajorOnly = actualVersion.distribution() + ":" + actualVersion.majorOptional().getAsInt();
 		String versionWithMajorAndMinorOnly = actualVersion.distribution() + ":"
-				+ actualVersion.major() + "." + actualVersion.minor().getAsInt();
+				+ actualVersion.majorOptional().getAsInt() + "." + actualVersion.minor().getAsInt();
 
 		SearchSetupHelper.PartialSetup partialSetup = setupHelper.start()
 				.withBackendProperty(
@@ -283,7 +283,7 @@ public class ElasticsearchBootstrapIT {
 	public void noVersionCheck_customSettingsAndMapping() {
 		ElasticsearchVersion actualVersion = ElasticsearchTestDialect.getActualVersion();
 		String versionWithMajorAndMinorOnly = actualVersion.distribution() + ":"
-				+ actualVersion.major() + "." + actualVersion.minor().getAsInt();
+				+ actualVersion.majorOptional().getAsInt() + "." + actualVersion.minor().getAsInt();
 
 		SearchSetupHelper.PartialSetup partialSetup = setupHelper.start()
 				.withBackendProperty( ElasticsearchBackendSettings.VERSION, versionWithMajorAndMinorOnly )

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/client/ElasticsearchClientFactoryImplIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/client/ElasticsearchClientFactoryImplIT.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -1172,7 +1173,8 @@ public class ElasticsearchClientFactoryImplIT {
 		return new ElasticsearchClientFactoryImpl().create( beanResolver, clientPropertySource,
 				threadPoolProvider.threadProvider(), "Client",
 				new DelegatingSimpleScheduledExecutor( timeoutExecutorService, true ),
-				GsonProvider.create( GsonBuilder::new, true )
+				GsonProvider.create( GsonBuilder::new, true ),
+				Optional.of( ElasticsearchTestDialect.getActualVersion() )
 		);
 	}
 

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/client/ElasticsearchContentLengthIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/client/ElasticsearchContentLengthIT.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
@@ -42,6 +43,7 @@ import org.hibernate.search.engine.environment.thread.impl.EmbeddedThreadProvide
 import org.hibernate.search.engine.environment.thread.impl.ThreadPoolProviderImpl;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchTckBackendHelper;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.ElasticsearchTestHostConnectionConfiguration;
+import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.ElasticsearchTestDialect;
 import org.hibernate.search.util.impl.integrationtest.common.TestConfigurationProvider;
 import org.hibernate.search.util.impl.test.annotation.PortedFromSearch5;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
@@ -219,7 +221,8 @@ public class ElasticsearchContentLengthIT {
 		return new ElasticsearchClientFactoryImpl().create( beanResolver, clientPropertySource,
 				threadPoolProvider.threadProvider(), "Client",
 				new DelegatingSimpleScheduledExecutor( timeoutExecutorService, true ),
-				GsonProvider.create( GsonBuilder::new, true ) );
+				GsonProvider.create( GsonBuilder::new, true ),
+				Optional.of( ElasticsearchTestDialect.getActualVersion() ) );
 	}
 
 	private ElasticsearchResponse doPost(ElasticsearchClient client, String path, Collection<JsonObject> bodyParts) {

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/mapping/ElasticsearchFieldAttributesIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/mapping/ElasticsearchFieldAttributesIT.java
@@ -19,6 +19,7 @@ import org.hibernate.search.engine.backend.types.Norms;
 import org.hibernate.search.engine.backend.types.TermVector;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchClientSpy;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchRequestAssertionMode;
+import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchTckBackendFeatures;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.ElasticsearchTestDialect;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappedIndex;
@@ -93,10 +94,12 @@ public class ElasticsearchFieldAttributesIT {
 
 	private void matchMapping(Consumer<IndexSchemaElement> mapping, JsonObject properties) {
 		StubMappedIndex index = StubMappedIndex.ofNonRetrievable( mapping );
-		clientSpy.expectNext(
-				ElasticsearchRequest.get().build(),
-				ElasticsearchRequestAssertionMode.STRICT
-		);
+		if ( ElasticsearchTckBackendFeatures.supportsVersionCheck() ) {
+			clientSpy.expectNext(
+					ElasticsearchRequest.get().build(),
+					ElasticsearchRequestAssertionMode.STRICT
+			);
+		}
 		clientSpy.expectNext(
 				ElasticsearchRequest.get()
 						.multiValuedPathComponent( defaultAliases( index.name() ) )

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/mapping/ElasticsearchFieldTypesIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/mapping/ElasticsearchFieldTypesIT.java
@@ -15,6 +15,7 @@ import org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchReques
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchClientSpy;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchRequestAssertionMode;
+import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchTckBackendFeatures;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.ElasticsearchTestDialect;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappedIndex;
@@ -41,10 +42,12 @@ public class ElasticsearchFieldTypesIT {
 
 	@Test
 	public void test() {
-		clientSpy.expectNext(
-				ElasticsearchRequest.get().build(),
-				ElasticsearchRequestAssertionMode.STRICT
-		);
+		if ( ElasticsearchTckBackendFeatures.supportsVersionCheck() ) {
+			clientSpy.expectNext(
+					ElasticsearchRequest.get().build(),
+					ElasticsearchRequestAssertionMode.STRICT
+			);
+		}
 		clientSpy.expectNext(
 				ElasticsearchRequest.get()
 						.multiValuedPathComponent( defaultAliases( index.name() ) )

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/mapping/ElasticsearchTypeNameMappingSchemaIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/mapping/ElasticsearchTypeNameMappingSchemaIT.java
@@ -20,6 +20,7 @@ import org.hibernate.search.backend.elasticsearch.cfg.impl.ElasticsearchBackendI
 import org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchRequest;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchClientSpy;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchRequestAssertionMode;
+import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchTckBackendFeatures;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappedIndex;
 
@@ -63,10 +64,12 @@ public class ElasticsearchTypeNameMappingSchemaIT {
 
 	@Test
 	public void schema() {
-		clientSpy.expectNext(
-				ElasticsearchRequest.get().build(),
-				ElasticsearchRequestAssertionMode.STRICT
-		);
+		if ( ElasticsearchTckBackendFeatures.supportsVersionCheck() ) {
+			clientSpy.expectNext(
+					ElasticsearchRequest.get().build(),
+					ElasticsearchRequestAssertionMode.STRICT
+			);
+		}
 		clientSpy.expectNext(
 				ElasticsearchRequest.get()
 						.multiValuedPathComponent( defaultAliases( index.name() ) )

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationAliasesIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationAliasesIT.java
@@ -64,7 +64,7 @@ public class ElasticsearchIndexSchemaManagerCreationAliasesIT {
 	@Test
 	public void success_defaultLayoutStrategy() {
 		elasticsearchClient.index( index.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		setupAndCreateIndex( null );
 
@@ -80,7 +80,7 @@ public class ElasticsearchIndexSchemaManagerCreationAliasesIT {
 	@Test
 	public void success_noAliasLayoutStrategy() {
 		elasticsearchClient.indexNoAlias( index.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		setupAndCreateIndex( "no-alias" );
 
@@ -94,7 +94,7 @@ public class ElasticsearchIndexSchemaManagerCreationAliasesIT {
 	@Test
 	public void success_customLayoutStrategy() {
 		elasticsearchClient.index( index.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		setupAndCreateIndex( new StubSingleIndexLayoutStrategy( "custom-write", "custom-read" ) );
 

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationAnalyzerIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationAnalyzerIT.java
@@ -57,7 +57,7 @@ public class ElasticsearchIndexSchemaManagerCreationAnalyzerIT {
 	@Test
 	public void success_simple() {
 		elasticSearchClient.index( mainIndex.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		setupHelper.start()
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
@@ -121,9 +121,9 @@ public class ElasticsearchIndexSchemaManagerCreationAnalyzerIT {
 	@Test
 	public void success_multiIndex() {
 		elasticSearchClient.index( mainIndex.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 		elasticSearchClient.index( otherIndex.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		setupHelper.start()
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationCustomSettingsIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationCustomSettingsIT.java
@@ -55,7 +55,7 @@ public class ElasticsearchIndexSchemaManagerCreationCustomSettingsIT {
 	@Test
 	public void success_mergeWithNoOverlapping() {
 		elasticsearchClient.index( index.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		// merge the default analysis configurer with the custom settings,
 		// there are no overlapping of their definitions
@@ -121,7 +121,7 @@ public class ElasticsearchIndexSchemaManagerCreationCustomSettingsIT {
 	@Test
 	public void success_mergeWithOverlapping() {
 		elasticsearchClient.index( index.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		// merge the default analysis configurer with the custom settings,
 		// there are some overlapping of their definitions
@@ -174,7 +174,7 @@ public class ElasticsearchIndexSchemaManagerCreationCustomSettingsIT {
 	@Test
 	public void success_onlyCustomSettings() {
 		elasticsearchClient.index( index.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		// use an empty analysis configurer,
 		// so that we have only the custom settings definitions
@@ -212,7 +212,7 @@ public class ElasticsearchIndexSchemaManagerCreationCustomSettingsIT {
 	@Test
 	public void maxResultWindow() {
 		elasticsearchClient.index( index.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		// use an empty analysis configurer,
 		// so that we have only the custom settings definitions

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationMappingBaseIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationMappingBaseIT.java
@@ -58,7 +58,7 @@ public class ElasticsearchIndexSchemaManagerCreationMappingBaseIT {
 		);
 
 		elasticSearchClient.index( index.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		setupAndCreateIndex( index );
 
@@ -82,7 +82,7 @@ public class ElasticsearchIndexSchemaManagerCreationMappingBaseIT {
 		);
 
 		elasticSearchClient.index( index.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		setupAndCreateIndex( index );
 
@@ -104,7 +104,7 @@ public class ElasticsearchIndexSchemaManagerCreationMappingBaseIT {
 		);
 
 		elasticSearchClient.index( index.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		setupAndCreateIndex( index );
 
@@ -127,7 +127,7 @@ public class ElasticsearchIndexSchemaManagerCreationMappingBaseIT {
 		);
 
 		elasticSearchClient.index( index.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		setupAndCreateIndex( index );
 
@@ -150,7 +150,7 @@ public class ElasticsearchIndexSchemaManagerCreationMappingBaseIT {
 		);
 
 		elasticSearchClient.index( index.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		setupAndCreateIndex( index );
 

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationMappingFieldTemplatesIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationMappingFieldTemplatesIT.java
@@ -63,7 +63,7 @@ public class ElasticsearchIndexSchemaManagerCreationMappingFieldTemplatesIT {
 		} );
 
 		elasticSearchClient.index( index.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		setupAndCreateIndex( index );
 
@@ -109,7 +109,7 @@ public class ElasticsearchIndexSchemaManagerCreationMappingFieldTemplatesIT {
 		} );
 
 		elasticSearchClient.index( index.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		setupAndCreateIndex( index );
 
@@ -157,7 +157,7 @@ public class ElasticsearchIndexSchemaManagerCreationMappingFieldTemplatesIT {
 		} );
 
 		elasticSearchClient.index( index.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		setupAndCreateIndex( index, Optional.of( "no-overlapping.json" ) );
 
@@ -220,7 +220,7 @@ public class ElasticsearchIndexSchemaManagerCreationMappingFieldTemplatesIT {
 		} );
 
 		elasticSearchClient.index( index.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		setupAndCreateIndex( index, Optional.of( "no-overlapping-with-templates.json" ) );
 
@@ -284,7 +284,7 @@ public class ElasticsearchIndexSchemaManagerCreationMappingFieldTemplatesIT {
 		} );
 
 		elasticSearchClient.index( index.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		setupAndCreateIndex( index, Optional.of( "no-overlapping.json" ) );
 

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationNormalizerIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationNormalizerIT.java
@@ -57,7 +57,7 @@ public class ElasticsearchIndexSchemaManagerCreationNormalizerIT {
 	@Test
 	public void success_simple() {
 		elasticSearchClient.index( mainIndex.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		setupHelper.start()
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
@@ -96,9 +96,9 @@ public class ElasticsearchIndexSchemaManagerCreationNormalizerIT {
 	@Test
 	public void success_multiIndex() {
 		elasticSearchClient.index( mainIndex.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 		elasticSearchClient.index( otherIndex.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		setupHelper.start()
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationOrPreservationIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationOrPreservationIT.java
@@ -105,7 +105,7 @@ public class ElasticsearchIndexSchemaManagerCreationOrPreservationIT {
 	@TestForIssue(jiraKey = "HSEARCH-2789")
 	public void doesNotExist() throws Exception {
 		elasticSearchClient.index( index.name() )
-				.ensureDoesNotExist().registerForCleanup();
+				.ensureDoesNotExist();
 
 		setupAndCreateIndexIfMissingOnly();
 

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerStatusCheckIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerStatusCheckIT.java
@@ -17,6 +17,7 @@ import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysis
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.backend.elasticsearch.index.IndexStatus;
+import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchTckBackendFeatures;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.common.impl.Futures;
@@ -25,6 +26,7 @@ import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappedInde
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingSchemaManagementStrategy;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,6 +58,14 @@ public class ElasticsearchIndexSchemaManagerStatusCheckIT {
 
 	public ElasticsearchIndexSchemaManagerStatusCheckIT(ElasticsearchIndexSchemaManagerOperation operation) {
 		this.operation = operation;
+	}
+
+	@Before
+	public void checkAssumptions() {
+		assumeTrue(
+				"This test only makes sense if the backend supports index status checks",
+				ElasticsearchTckBackendFeatures.supportsIndexStatusCheck()
+		);
 	}
 
 	@Test

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchClientSpy.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchClientSpy.java
@@ -6,9 +6,11 @@
  */
 package org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.hibernate.search.backend.elasticsearch.ElasticsearchVersion;
 import org.hibernate.search.backend.elasticsearch.client.impl.ElasticsearchClientFactoryImpl;
 import org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchClientFactory;
 import org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchClientImplementor;
@@ -100,11 +102,11 @@ public class ElasticsearchClientSpy implements TestRule {
 		public ElasticsearchClientImplementor create(BeanResolver beanResolver,
 				ConfigurationPropertySource propertySource,
 				ThreadProvider threadProvider, String threadNamePrefix, SimpleScheduledExecutor timeoutExecutorService,
-				GsonProvider gsonProvider) {
+				GsonProvider gsonProvider, Optional<ElasticsearchVersion> configuredVersion) {
 			createdClientCount.incrementAndGet();
 			return new SpyingElasticsearchClient( delegate.create(
 					beanResolver, propertySource, threadProvider, threadNamePrefix,
-					timeoutExecutorService, gsonProvider
+					timeoutExecutorService, gsonProvider, configuredVersion
 			) );
 		}
 	}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -13,6 +13,7 @@ import java.math.BigInteger;
 
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendFeatures;
+import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.ElasticsearchTestDialect;
 
 public class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 
@@ -203,9 +204,58 @@ public class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 		return isActualVersion(
 				// See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-operations.html#version_7_1
 				// See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-operations.html#version_7_4
-				esVersion -> !( esVersion.isAws() && esVersion.isLessThan( "7.4" ) ),
+				es -> !( es.isAws() && es.isLessThan( "7.4" ) ),
 				// See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-operations.html#version_opensearch_1.0
-				osVersion -> true
+				os -> true,
+				aoss -> false
+		);
+	}
+
+	public static boolean supportsVersionCheck() {
+		return isActualVersion(
+				es -> true,
+				os -> true,
+				aoss -> false
+		);
+	}
+
+	public static boolean supportsIndexStatusCheck() {
+		return isActualVersion(
+				es -> true,
+				os -> true,
+				aoss -> false
+		);
+	}
+
+	@Override
+	public boolean supportsExplicitPurge() {
+		return ElasticsearchTestDialect.get().supportsExplicitPurge();
+	}
+
+	@Override
+	public boolean supportsExplicitMergeSegments() {
+		return isActualVersion(
+				es -> true,
+				os -> true,
+				aoss -> false
+		);
+	}
+
+	@Override
+	public boolean supportsExplicitFlush() {
+		return isActualVersion(
+				es -> true,
+				os -> true,
+				aoss -> false
+		);
+	}
+
+	@Override
+	public boolean supportsExplicitRefresh() {
+		return isActualVersion(
+				es -> true,
+				os -> true,
+				aoss -> false
 		);
 	}
 }

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchZeroDowntimeReindexingIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchZeroDowntimeReindexingIT.java
@@ -23,6 +23,7 @@ import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrateg
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.rule.TestElasticsearchClient;
@@ -65,7 +66,7 @@ public class ElasticsearchZeroDowntimeReindexingIT {
 				DocumentRefreshStrategy.NONE,
 				OperationSubmitter.blocking()
 		).join();
-		workspace.refresh( OperationSubmitter.blocking() ).join();
+		workspace.refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
 
 		SearchQuery<DocumentReference> text1Query = index
 				.createScope().query()
@@ -102,7 +103,7 @@ public class ElasticsearchZeroDowntimeReindexingIT {
 				DocumentRefreshStrategy.NONE,
 				OperationSubmitter.blocking()
 		).join();
-		workspace.refresh( OperationSubmitter.blocking() ).join();
+		workspace.refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
 
 		// Search queries are unaffected: text == "text1"
 		assertThatQuery( text1Query ).hasTotalHitCount( 1 );

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchZeroDowntimeReindexingIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchZeroDowntimeReindexingIT.java
@@ -22,8 +22,6 @@ import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
-import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.rule.TestElasticsearchClient;
@@ -56,17 +54,15 @@ public class ElasticsearchZeroDowntimeReindexingIT {
 
 	@Test
 	public void test() {
-		IndexWorkspace workspace = index.createWorkspace();
 		IndexIndexer indexer = index.createIndexer();
 
 		indexer.add(
 				referenceProvider( "1" ),
 				document -> document.addValue( index.binding().text, "text1" ),
 				DocumentCommitStrategy.NONE,
-				DocumentRefreshStrategy.NONE,
+				DocumentRefreshStrategy.FORCE,
 				OperationSubmitter.blocking()
 		).join();
-		workspace.refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
 
 		SearchQuery<DocumentReference> text1Query = index
 				.createScope().query()
@@ -100,10 +96,9 @@ public class ElasticsearchZeroDowntimeReindexingIT {
 				referenceProvider( "1" ),
 				document -> document.addValue( index.binding().text, "text2" ),
 				DocumentCommitStrategy.NONE,
-				DocumentRefreshStrategy.NONE,
+				DocumentRefreshStrategy.FORCE,
 				OperationSubmitter.blocking()
 		).join();
-		workspace.refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
 
 		// Search queries are unaffected: text == "text1"
 		assertThatQuery( text1Query ).hasTotalHitCount( 1 );

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/index/LuceneIndexManagerIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/index/LuceneIndexManagerIT.java
@@ -17,6 +17,7 @@ import org.hibernate.search.backend.lucene.index.LuceneIndexManager;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.backend.lucene.LuceneAnalysisUtils;
@@ -95,7 +96,7 @@ public class LuceneIndexManagerIT {
 				) )
 				.join();
 
-		index.createWorkspace().flush( OperationSubmitter.blocking() ).join();
+		index.createWorkspace().flush( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
 
 		long finalSize = indexApi.computeSizeInBytes();
 		assertThat( finalSize ).isGreaterThan( 0L );
@@ -118,7 +119,7 @@ public class LuceneIndexManagerIT {
 				) )
 				.join();
 
-		index.createWorkspace().flush( OperationSubmitter.blocking() ).join();
+		index.createWorkspace().flush( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
 
 		CompletableFuture<Long> finalSizeFuture = indexApi.computeSizeInBytesAsync().toCompletableFuture();
 		await().untilAsserted( () -> assertThat( finalSizeFuture ).isCompleted() );

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/work/LuceneIndexingNestedIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/work/LuceneIndexingNestedIT.java
@@ -22,6 +22,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectF
 import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.integrationtest.backend.lucene.testsupport.util.LuceneIndexContentUtils;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
@@ -118,8 +119,12 @@ public class LuceneIndexingNestedIT {
 	public void purge() throws IOException {
 		setup( MultiTenancyStrategyName.NONE );
 
-		index.createWorkspace( sessionContext ).purge( Collections.emptySet(), OperationSubmitter.blocking() ).join();
-		index.createWorkspace( sessionContext ).refresh( OperationSubmitter.blocking() ).join();
+		index.createWorkspace( sessionContext )
+				.purge( Collections.emptySet(), OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL )
+				.join();
+		index.createWorkspace( sessionContext )
+				.refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL )
+				.join();
 
 		assertThat( countWithField( "nestedObject.field1" ) ).isEqualTo( 0 );
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/AbstractShardingRoutingKeyIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/AbstractShardingRoutingKeyIT.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendHelper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendSetupStrategy;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
@@ -134,10 +135,12 @@ public abstract class AbstractShardingRoutingKeyIT extends AbstractShardingIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3824")
 	public void purge_noRoutingKey() {
-		index.createWorkspace().purge( Collections.emptySet(), OperationSubmitter.blocking() ).join();
+		index.createWorkspace()
+				.purge( Collections.emptySet(), OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL )
+				.join();
 
 		// No routing key => all documents should be purged
-		index.createWorkspace().refresh( OperationSubmitter.blocking() ).join();
+		index.createWorkspace().refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
 		assertThatQuery( index.createScope().query().where( f -> f.matchAll() ).toQuery() )
 				.hasNoHits();
 	}
@@ -151,13 +154,16 @@ public abstract class AbstractShardingRoutingKeyIT extends AbstractShardingIT {
 		Set<String> otherRoutingKeys = new LinkedHashSet<>( routingKeys );
 		otherRoutingKeys.remove( someRoutingKey );
 
-		index.createWorkspace().purge( Collections.singleton( someRoutingKey ), OperationSubmitter.blocking() ).join();
+		index.createWorkspace()
+				.purge( Collections.singleton( someRoutingKey ), OperationSubmitter.blocking(),
+						UnsupportedOperationBehavior.FAIL )
+				.join();
 
 		/*
 		 * One routing key => all documents indexed with that routing key should be purged,
 		 * and only those documents.
 		 */
-		index.createWorkspace().refresh( OperationSubmitter.blocking() ).join();
+		index.createWorkspace().refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
 		assertThatQuery( index.createScope().query().where( f -> f.matchAll() ).toQuery() )
 				.hits().asNormalizedDocRefs()
 				.containsExactlyInAnyOrder( docRefsForRoutingKeys( otherRoutingKeys, docIdByRoutingKey ) );
@@ -172,13 +178,14 @@ public abstract class AbstractShardingRoutingKeyIT extends AbstractShardingIT {
 		Set<String> otherRoutingKeys = new LinkedHashSet<>( routingKeys );
 		otherRoutingKeys.removeAll( twoRoutingKeys );
 
-		index.createWorkspace().purge( twoRoutingKeys, OperationSubmitter.blocking() ).join();
+		index.createWorkspace().purge( twoRoutingKeys, OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL )
+				.join();
 
 		/*
 		 * Two routing keys => all documents indexed with these routing keys should be returned,
 		 * and only those documents.
 		 */
-		index.createWorkspace().refresh( OperationSubmitter.blocking() ).join();
+		index.createWorkspace().refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
 		assertThatQuery( index.createScope().query().where( f -> f.matchAll() ).toQuery() )
 				.hits().asNormalizedDocRefs()
 				.containsExactlyInAnyOrder( docRefsForRoutingKeys( otherRoutingKeys, docIdByRoutingKey ) );
@@ -187,10 +194,12 @@ public abstract class AbstractShardingRoutingKeyIT extends AbstractShardingIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3824")
 	public void purge_allRoutingKeys() {
-		index.createWorkspace().purge( routingKeys, OperationSubmitter.blocking() ).join();
+		index.createWorkspace().purge( routingKeys, OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL )
+				.join();
 
 		// All routing keys => all documents should be purged
-		index.createWorkspace().refresh( OperationSubmitter.blocking() ).join();
+		index.createWorkspace().refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL )
+				.join();
 		assertThatQuery( index.createScope().query().where( f -> f.matchAll() ).toQuery() )
 				.hasNoHits();
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/AbstractShardingRoutingKeyIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/AbstractShardingRoutingKeyIT.java
@@ -144,9 +144,8 @@ public abstract class AbstractShardingRoutingKeyIT extends AbstractShardingIT {
 				.join();
 
 		// No routing key => all documents should be purged
-		index.createWorkspace().refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
-		assertThatQuery( index.createScope().query().where( f -> f.matchAll() ).toQuery() )
-				.hasNoHits();
+		index.searchAfterIndexChanges( () -> assertThatQuery( index.query().where( f -> f.matchAll() ) )
+				.hasNoHits() );
 	}
 
 	@Test
@@ -169,10 +168,9 @@ public abstract class AbstractShardingRoutingKeyIT extends AbstractShardingIT {
 		 * One routing key => all documents indexed with that routing key should be purged,
 		 * and only those documents.
 		 */
-		index.createWorkspace().refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
-		assertThatQuery( index.createScope().query().where( f -> f.matchAll() ).toQuery() )
+		index.searchAfterIndexChanges( () -> assertThatQuery( index.query().where( f -> f.matchAll() ) )
 				.hits().asNormalizedDocRefs()
-				.containsExactlyInAnyOrder( docRefsForRoutingKeys( otherRoutingKeys, docIdByRoutingKey ) );
+				.containsExactlyInAnyOrder( docRefsForRoutingKeys( otherRoutingKeys, docIdByRoutingKey ) ) );
 	}
 
 	@Test
@@ -193,10 +191,9 @@ public abstract class AbstractShardingRoutingKeyIT extends AbstractShardingIT {
 		 * Two routing keys => all documents indexed with these routing keys should be returned,
 		 * and only those documents.
 		 */
-		index.createWorkspace().refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
-		assertThatQuery( index.createScope().query().where( f -> f.matchAll() ).toQuery() )
+		index.searchAfterIndexChanges( () -> assertThatQuery( index.query().where( f -> f.matchAll() ) )
 				.hits().asNormalizedDocRefs()
-				.containsExactlyInAnyOrder( docRefsForRoutingKeys( otherRoutingKeys, docIdByRoutingKey ) );
+				.containsExactlyInAnyOrder( docRefsForRoutingKeys( otherRoutingKeys, docIdByRoutingKey ) ) );
 	}
 
 	@Test
@@ -208,10 +205,8 @@ public abstract class AbstractShardingRoutingKeyIT extends AbstractShardingIT {
 				.join();
 
 		// All routing keys => all documents should be purged
-		index.createWorkspace().refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL )
-				.join();
-		assertThatQuery( index.createScope().query().where( f -> f.matchAll() ).toQuery() )
-				.hasNoHits();
+		index.searchAfterIndexChanges( () -> assertThatQuery( index.query().where( f -> f.matchAll() ) )
+				.hasNoHits() );
 	}
 
 	private void assumePurgeSupported() {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/ShardingHashDocumentIdIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/ShardingHashDocumentIdIT.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.test.annotation.PortedFromSearch5;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
@@ -105,10 +106,14 @@ public class ShardingHashDocumentIdIT extends AbstractShardingIT {
 		Iterator<String> iterator = docIds.iterator();
 		String someDocumentId = iterator.next();
 
-		index.createWorkspace().purge( Collections.singleton( someDocumentId ), OperationSubmitter.blocking() ).join();
+		index.createWorkspace()
+				.purge( Collections.singleton( someDocumentId ), OperationSubmitter.blocking(),
+						UnsupportedOperationBehavior.FAIL )
+				.join();
 
 		// One or more explicit routing key => no document should be purged, since no documents was indexed with that routing key.
-		index.createWorkspace().refresh( OperationSubmitter.blocking() ).join();
+		index.createWorkspace().refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL )
+				.join();
 		assertThatQuery( index.createScope().query().where( f -> f.matchAll() ).toQuery() )
 				.hits().asNormalizedDocRefs()
 				.hasSize( TOTAL_DOCUMENT_COUNT )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/ShardingHashDocumentIdIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/ShardingHashDocumentIdIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.sharding;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
+import static org.junit.Assume.assumeTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -18,6 +19,7 @@ import java.util.Map;
 
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.test.annotation.PortedFromSearch5;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
@@ -103,6 +105,8 @@ public class ShardingHashDocumentIdIT extends AbstractShardingIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3824")
 	public void purgeWithRoutingKey() {
+		assumePurgeSupported();
+
 		Iterator<String> iterator = docIds.iterator();
 		String someDocumentId = iterator.next();
 
@@ -118,6 +122,13 @@ public class ShardingHashDocumentIdIT extends AbstractShardingIT {
 				.hits().asNormalizedDocRefs()
 				.hasSize( TOTAL_DOCUMENT_COUNT )
 				.containsExactlyInAnyOrder( allDocRefs( docIdByRoutingKey ) );
+	}
+
+	private void assumePurgeSupported() {
+		assumeTrue(
+				"This test only makes sense if the backend supports explicit purge",
+				TckConfiguration.get().getBackendFeatures().supportsExplicitPurge()
+		);
 	}
 
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/ShardingHashDocumentIdIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/ShardingHashDocumentIdIT.java
@@ -116,12 +116,10 @@ public class ShardingHashDocumentIdIT extends AbstractShardingIT {
 				.join();
 
 		// One or more explicit routing key => no document should be purged, since no documents was indexed with that routing key.
-		index.createWorkspace().refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL )
-				.join();
-		assertThatQuery( index.createScope().query().where( f -> f.matchAll() ).toQuery() )
+		index.searchAfterIndexChanges( () -> assertThatQuery( index.query().where( f -> f.matchAll() ) )
 				.hits().asNormalizedDocRefs()
 				.hasSize( TOTAL_DOCUMENT_COUNT )
-				.containsExactlyInAnyOrder( allDocRefs( docIdByRoutingKey ) );
+				.containsExactlyInAnyOrder( allDocRefs( docIdByRoutingKey ) ) );
 	}
 
 	private void assumePurgeSupported() {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
@@ -7,8 +7,9 @@
 package org.hibernate.search.integrationtest.backend.tck.testsupport.util;
 
 import org.hibernate.search.engine.backend.types.ObjectStructure;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingBackendFeatures;
 
-public abstract class TckBackendFeatures {
+public abstract class TckBackendFeatures implements StubMappingBackendFeatures {
 
 	public boolean normalizesStringMissingValues() {
 		return true;
@@ -118,10 +119,15 @@ public abstract class TckBackendFeatures {
 		return true;
 	}
 
+	public boolean supportsExplicitPurge() {
+		return true;
+	}
+
 	public boolean supportsExplicitFlush() {
 		return true;
 	}
 
+	@Override
 	public boolean supportsExplicitRefresh() {
 		return true;
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
@@ -113,4 +113,17 @@ public abstract class TckBackendFeatures {
 	public boolean supportsHighlighterUnifiedPhraseMatching() {
 		return false;
 	}
+
+	public boolean supportsExplicitMergeSegments() {
+		return true;
+	}
+
+	public boolean supportsExplicitFlush() {
+		return true;
+	}
+
+	public boolean supportsExplicitRefresh() {
+		return true;
+	}
+
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
@@ -10,10 +10,6 @@ import org.hibernate.search.engine.backend.types.ObjectStructure;
 
 public abstract class TckBackendFeatures {
 
-	public boolean worksFineWithStrictAboveRangedQueriesOnDecimalScaledField() {
-		return true;
-	}
-
 	public boolean normalizesStringMissingValues() {
 		return true;
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
@@ -248,7 +248,8 @@ public class SearchSetupHelper implements TestRule {
 					? previousMapping.get().integration().restartBuilder( environment )
 					: SearchIntegration.builder( environment );
 
-			StubMappingInitiator initiator = new StubMappingInitiator( tenancyMode );
+			StubMappingInitiator initiator = new StubMappingInitiator( TckConfiguration.get().getBackendFeatures(),
+					tenancyMode );
 			mappedIndexes.forEach( initiator::add );
 			StubMappingKey mappingKey = new StubMappingKey();
 			integrationBuilder.addMappingInitiator( mappingKey, initiator );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexerIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexerIT.java
@@ -24,6 +24,7 @@ import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrateg
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.logging.impl.Log;
@@ -235,7 +236,7 @@ public class IndexIndexerIT {
 	private void refreshIfNecessary() {
 		if ( DocumentRefreshStrategy.NONE.equals( refreshStrategy ) ) {
 			IndexWorkspace workspace = index.createWorkspace();
-			workspace.refresh( OperationSubmitter.blocking() ).join();
+			workspace.refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
 		}
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexerLargeDocumentsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexerLargeDocumentsIT.java
@@ -23,6 +23,7 @@ import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentContributor;
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentReferenceProvider;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
@@ -98,7 +99,7 @@ public class IndexIndexerLargeDocumentsIT {
 
 		indexAndWait( count, valueProvider, operation );
 
-		index.createWorkspace().refresh( OperationSubmitter.blocking() ).join();
+		index.createWorkspace().refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
 
 		assertThatQuery( index.query()
 				.where( f -> f.matchAll() ) )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexerLargeDocumentsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexerLargeDocumentsIT.java
@@ -25,6 +25,7 @@ import org.hibernate.search.engine.backend.work.execution.spi.DocumentReferenceP
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
@@ -64,7 +65,13 @@ public class IndexIndexerLargeDocumentsIT {
 
 	private final SimpleMappedIndex<IndexBinding> index = SimpleMappedIndex.of( IndexBinding::new );
 
+	private final DocumentRefreshStrategy refreshStrategy;
+
 	public IndexIndexerLargeDocumentsIT() {
+		refreshStrategy = TckConfiguration.get().getBackendFeatures().supportsExplicitRefresh()
+				? DocumentRefreshStrategy.NONE
+				// This will perform poorly, but we don't have a choice.
+				: DocumentRefreshStrategy.FORCE;
 	}
 
 	@Before
@@ -99,7 +106,10 @@ public class IndexIndexerLargeDocumentsIT {
 
 		indexAndWait( count, valueProvider, operation );
 
-		index.createWorkspace().refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
+		if ( refreshStrategy == DocumentRefreshStrategy.NONE ) {
+			// If the operation itself did not refresh, do it now.
+			index.createWorkspace().refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
+		}
 
 		assertThatQuery( index.query()
 				.where( f -> f.matchAll() ) )
@@ -112,7 +122,8 @@ public class IndexIndexerLargeDocumentsIT {
 		for ( int i = 0; i < count; i++ ) {
 			final int id = i;
 			tasks[i] = operation.apply( indexer, referenceProvider( String.valueOf( id ) ),
-					document -> document.addValue( index.binding().content, valueProvider.apply( id ) ) );
+					document -> document.addValue( index.binding().content, valueProvider.apply( id ) ),
+					refreshStrategy );
 		}
 		CompletableFuture<?> future = CompletableFuture.allOf( tasks );
 		Awaitility.await().until( future::isDone );
@@ -152,22 +163,22 @@ public class IndexIndexerLargeDocumentsIT {
 		ADD {
 			@Override
 			public CompletableFuture<?> apply(IndexIndexer indexer, DocumentReferenceProvider referenceProvider,
-					DocumentContributor documentContributor) {
+					DocumentContributor documentContributor, DocumentRefreshStrategy refreshStrategy) {
 				return indexer.add( referenceProvider, documentContributor,
-						DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE, OperationSubmitter.blocking() );
+						DocumentCommitStrategy.NONE, refreshStrategy, OperationSubmitter.blocking() );
 			}
 		},
 		ADD_OR_UPDATE {
 			@Override
 			public CompletableFuture<?> apply(IndexIndexer indexer, DocumentReferenceProvider referenceProvider,
-					DocumentContributor documentContributor) {
+					DocumentContributor documentContributor, DocumentRefreshStrategy refreshStrategy) {
 				return indexer.addOrUpdate( referenceProvider, documentContributor,
-						DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE, OperationSubmitter.blocking()
+						DocumentCommitStrategy.NONE, refreshStrategy, OperationSubmitter.blocking()
 				);
 			}
 		};
 
 		public abstract CompletableFuture<?> apply(IndexIndexer indexer, DocumentReferenceProvider referenceProvider,
-				DocumentContributor documentContributor);
+				DocumentContributor documentContributor, DocumentRefreshStrategy refreshStrategy);
 	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceFlushIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceFlushIT.java
@@ -10,6 +10,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendAccessor;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappedIndex;
 
@@ -22,7 +23,7 @@ public class IndexWorkspaceFlushIT extends AbstractIndexWorkspaceSimpleOperation
 
 	@Override
 	protected CompletableFuture<?> executeAsync(IndexWorkspace workspace) {
-		return workspace.flush( OperationSubmitter.rejecting() );
+		return workspace.flush( OperationSubmitter.rejecting(), UnsupportedOperationBehavior.FAIL );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceFlushIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceFlushIT.java
@@ -6,15 +6,27 @@
  */
 package org.hibernate.search.integrationtest.backend.tck.work;
 
+import static org.junit.Assume.assumeTrue;
+
 import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendAccessor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappedIndex;
 
+import org.junit.Before;
+
 public class IndexWorkspaceFlushIT extends AbstractIndexWorkspaceSimpleOperationIT {
+	@Before
+	public void checkAssumptions() {
+		assumeTrue(
+				"This test only makes sense if the backend supports explicit flush",
+				TckConfiguration.get().getBackendFeatures().supportsExplicitFlush()
+		);
+	}
 
 	@Override
 	protected void ensureOperationsFail(TckBackendAccessor accessor, String indexName) {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceIT.java
@@ -16,6 +16,7 @@ import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendHelper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
@@ -28,7 +29,10 @@ import org.junit.Test;
 
 /**
  * Verify that the work executor operations:
- * {@link IndexWorkspace#mergeSegments(OperationSubmitter)}, {@link IndexWorkspace#purge(java.util.Set, OperationSubmitter)}, {@link IndexWorkspace#flush(OperationSubmitter)}, {@link IndexWorkspace#refresh(OperationSubmitter)}
+ * {@link IndexWorkspace#mergeSegments(OperationSubmitter, UnsupportedOperationBehavior)},
+ * {@link IndexWorkspace#purge(java.util.Set, OperationSubmitter, UnsupportedOperationBehavior)},
+ * {@link IndexWorkspace#flush(OperationSubmitter, UnsupportedOperationBehavior)},
+ * {@link IndexWorkspace#refresh(OperationSubmitter, UnsupportedOperationBehavior)}
  * work properly, in every backends.
  */
 public class IndexWorkspaceIT {
@@ -60,16 +64,17 @@ public class IndexWorkspaceIT {
 		IndexWorkspace workspace = index.createWorkspace();
 		createBookIndexes( noTenantSessionContext );
 
-		workspace.refresh( OperationSubmitter.blocking() ).join();
+		workspace.refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
 		assertBookNumberIsEqualsTo( NUMBER_OF_BOOKS, noTenantSessionContext );
 
-		workspace.mergeSegments( OperationSubmitter.blocking() ).join();
+		workspace.mergeSegments( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
 		assertBookNumberIsEqualsTo( NUMBER_OF_BOOKS, noTenantSessionContext );
 
 		// purge without providing a tenant
-		workspace.purge( Collections.emptySet(), OperationSubmitter.blocking() ).join();
-		workspace.flush( OperationSubmitter.blocking() ).join();
-		workspace.refresh( OperationSubmitter.blocking() ).join();
+		workspace.purge( Collections.emptySet(), OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL )
+				.join();
+		workspace.flush( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
+		workspace.refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
 
 		assertBookNumberIsEqualsTo( 0, noTenantSessionContext );
 	}
@@ -85,18 +90,19 @@ public class IndexWorkspaceIT {
 
 		createBookIndexes( tenant1SessionContext );
 		createBookIndexes( tenant2SessionContext );
-		workspace.refresh( OperationSubmitter.blocking() ).join();
+		workspace.refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
 
 		assertBookNumberIsEqualsTo( NUMBER_OF_BOOKS, tenant1SessionContext );
 		assertBookNumberIsEqualsTo( NUMBER_OF_BOOKS, tenant2SessionContext );
 
-		workspace.mergeSegments( OperationSubmitter.blocking() ).join();
+		workspace.mergeSegments( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
 		assertBookNumberIsEqualsTo( NUMBER_OF_BOOKS, tenant1SessionContext );
 		assertBookNumberIsEqualsTo( NUMBER_OF_BOOKS, tenant2SessionContext );
 
-		workspace.purge( Collections.emptySet(), OperationSubmitter.blocking() ).join();
-		workspace.flush( OperationSubmitter.blocking() ).join();
-		workspace.refresh( OperationSubmitter.blocking() ).join();
+		workspace.purge( Collections.emptySet(), OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL )
+				.join();
+		workspace.flush( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
+		workspace.refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
 
 		// check that only TENANT_1 is affected by the purge
 		assertBookNumberIsEqualsTo( 0, tenant1SessionContext );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.integrationtest.backend.tck.work;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.documentProvider;
+import static org.junit.Assume.assumeTrue;
 
 import java.util.Collections;
 
@@ -19,6 +20,7 @@ import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendHelper;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubSession;
@@ -52,7 +54,14 @@ public class IndexWorkspaceIT {
 	private final SimpleMappedIndex<IndexBinding> index = SimpleMappedIndex.of( IndexBinding::new );
 
 	@Before
-	public void initSessionContexts() {
+	public void checkAssumptions() {
+		assumeTrue(
+				"This test only makes sense if the backend supports explicit purge, mergeSegments, flush and refresh",
+				TckConfiguration.get().getBackendFeatures().supportsExplicitPurge()
+						&& TckConfiguration.get().getBackendFeatures().supportsExplicitMergeSegments()
+						&& TckConfiguration.get().getBackendFeatures().supportsExplicitFlush()
+						&& TckConfiguration.get().getBackendFeatures().supportsExplicitRefresh()
+		);
 	}
 
 	@Test

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceMergeSegmentsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceMergeSegmentsIT.java
@@ -10,6 +10,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendAccessor;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappedIndex;
 
@@ -22,7 +23,7 @@ public class IndexWorkspaceMergeSegmentsIT extends AbstractIndexWorkspaceSimpleO
 
 	@Override
 	protected CompletableFuture<?> executeAsync(IndexWorkspace workspace) {
-		return workspace.mergeSegments( OperationSubmitter.rejecting() );
+		return workspace.mergeSegments( OperationSubmitter.rejecting(), UnsupportedOperationBehavior.FAIL );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceMergeSegmentsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceMergeSegmentsIT.java
@@ -6,15 +6,28 @@
  */
 package org.hibernate.search.integrationtest.backend.tck.work;
 
+import static org.junit.Assume.assumeTrue;
+
 import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendAccessor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappedIndex;
 
+import org.junit.Before;
+
 public class IndexWorkspaceMergeSegmentsIT extends AbstractIndexWorkspaceSimpleOperationIT {
+
+	@Before
+	public void checkAssumptions() {
+		assumeTrue(
+				"This test only makes sense if the backend supports explicit mergeSegments",
+				TckConfiguration.get().getBackendFeatures().supportsExplicitMergeSegments()
+		);
+	}
 
 	@Override
 	protected void ensureOperationsFail(TckBackendAccessor accessor, String indexName) {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspacePurgeIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspacePurgeIT.java
@@ -13,6 +13,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendAccessor;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappedIndex;
 
@@ -25,19 +26,20 @@ public class IndexWorkspacePurgeIT extends AbstractIndexWorkspaceSimpleOperation
 
 	@Override
 	protected CompletableFuture<?> executeAsync(IndexWorkspace workspace) {
-		return workspace.purge( Collections.emptySet(), OperationSubmitter.rejecting() );
+		return workspace.purge( Collections.emptySet(), OperationSubmitter.rejecting(),
+				UnsupportedOperationBehavior.FAIL );
 	}
 
 	@Override
 	protected void afterInitData(StubMappedIndex index) {
 		// Make sure to flush the index, otherwise the test won't fail as expected with Lucene,
 		// probably because the index writer optimizes purges when changes are not committed yet.
-		index.createWorkspace().flush( OperationSubmitter.blocking() ).join();
+		index.createWorkspace().flush( OperationSubmitter.blocking(), UnsupportedOperationBehavior.IGNORE ).join();
 	}
 
 	@Override
 	protected void assertPreconditions(StubMappedIndex index) {
-		index.createWorkspace().refresh( OperationSubmitter.blocking() ).join();
+		index.createWorkspace().refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
 		long count = index.createScope().query().where( f -> f.matchAll() )
 				.fetchTotalHitCount();
 		assertThat( count ).isGreaterThan( 0 );
@@ -45,7 +47,7 @@ public class IndexWorkspacePurgeIT extends AbstractIndexWorkspaceSimpleOperation
 
 	@Override
 	protected void assertSuccess(StubMappedIndex index) {
-		index.createWorkspace().refresh( OperationSubmitter.blocking() ).join();
+		index.createWorkspace().refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
 		long count = index.createScope().query().where( f -> f.matchAll() )
 				.fetchTotalHitCount();
 		assertThat( count ).isEqualTo( 0 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspacePurgeIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspacePurgeIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.work;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
@@ -17,7 +18,17 @@ import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperati
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendAccessor;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappedIndex;
 
+import org.junit.Before;
+
 public class IndexWorkspacePurgeIT extends AbstractIndexWorkspaceSimpleOperationIT {
+
+	@Before
+	public void checkAssumptions() {
+		assumeTrue(
+				"This test only makes sense if the backend supports explicit purge",
+				TckConfiguration.get().getBackendFeatures().supportsExplicitPurge()
+		);
+	}
 
 	@Override
 	protected void ensureOperationsFail(TckBackendAccessor accessor, String indexName) {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspacePurgeIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspacePurgeIT.java
@@ -16,6 +16,7 @@ import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendAccessor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappedIndex;
 
 import org.junit.Before;
@@ -43,24 +44,26 @@ public class IndexWorkspacePurgeIT extends AbstractIndexWorkspaceSimpleOperation
 
 	@Override
 	protected void afterInitData(StubMappedIndex index) {
-		// Make sure to flush the index, otherwise the test won't fail as expected with Lucene,
-		// probably because the index writer optimizes purges when changes are not committed yet.
-		index.createWorkspace().flush( OperationSubmitter.blocking(), UnsupportedOperationBehavior.IGNORE ).join();
+		if ( TckConfiguration.get().getBackendFeatures().supportsExplicitFlush() ) {
+			// Make sure to flush the index, otherwise the test won't fail as expected with Lucene,
+			// probably because the index writer optimizes purges when changes are not committed yet.
+			index.createWorkspace().flush( OperationSubmitter.blocking(), UnsupportedOperationBehavior.IGNORE ).join();
+		}
 	}
 
 	@Override
 	protected void assertPreconditions(StubMappedIndex index) {
-		index.createWorkspace().refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
-		long count = index.createScope().query().where( f -> f.matchAll() )
-				.fetchTotalHitCount();
-		assertThat( count ).isGreaterThan( 0 );
+		index.searchAfterIndexChanges( () -> {
+			assertThat( index.query().where( f -> f.matchAll() ).fetchTotalHitCount() )
+					.isGreaterThan( 0 );
+		} );
 	}
 
 	@Override
 	protected void assertSuccess(StubMappedIndex index) {
-		index.createWorkspace().refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
-		long count = index.createScope().query().where( f -> f.matchAll() )
-				.fetchTotalHitCount();
-		assertThat( count ).isEqualTo( 0 );
+		index.searchAfterIndexChanges( () -> {
+			assertThat( index.query().where( f -> f.matchAll() ).fetchTotalHitCount() )
+					.isEqualTo( 0 );
+		} );
 	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceRefreshIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceRefreshIT.java
@@ -12,6 +12,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendAccessor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappedIndex;
@@ -29,7 +30,7 @@ public class IndexWorkspaceRefreshIT extends AbstractIndexWorkspaceSimpleOperati
 
 	@Override
 	protected CompletableFuture<?> executeAsync(IndexWorkspace workspace) {
-		return workspace.refresh( OperationSubmitter.rejecting() );
+		return workspace.refresh( OperationSubmitter.rejecting(), UnsupportedOperationBehavior.FAIL );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceRefreshIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceRefreshIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.work;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -14,13 +15,24 @@ import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendAccessor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappedIndex;
+
+import org.junit.Before;
 
 public class IndexWorkspaceRefreshIT extends AbstractIndexWorkspaceSimpleOperationIT {
 
 	public IndexWorkspaceRefreshIT() {
 		super( new SearchSetupHelper( helper -> helper.createRarePeriodicRefreshBackendSetupStrategy() ) );
+	}
+
+	@Before
+	public void checkAssumptions() {
+		assumeTrue(
+				"This test only makes sense if the backend supports explicit refresh",
+				TckConfiguration.get().getBackendFeatures().supportsExplicitRefresh()
+		);
 	}
 
 	@Override

--- a/integrationtest/mapper/orm-batch-jsr352/pom.xml
+++ b/integrationtest/mapper/orm-batch-jsr352/pom.xml
@@ -132,6 +132,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
+                            <skip>${test.elasticsearch.skip}</skip>
                             <reportNameSuffix>${surefire.reportNameSuffix}-elasticsearch-jbatch</reportNameSuffix>
                             <classpathDependencyExcludes>
                                 <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-lucene</classpathDependencyExclude>
@@ -151,6 +152,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
+                            <skip>${test.elasticsearch.skip}</skip>
                             <reportNameSuffix>${surefire.reportNameSuffix}-elasticsearch-jberet</reportNameSuffix>
                             <classpathDependencyExcludes>
                                 <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-lucene</classpathDependencyExclude>
@@ -178,6 +180,26 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>amazon-opensearch-serverless</id>
+            <activation>
+                <property>
+                    <name>test.elasticsearch.distribution</name>
+                    <value>amazon-opensearch-serverless</value>
+                </property>
+            </activation>
+            <properties>
+                <!-- The JSR-352 job executes a purge on startup and thus cannot
+                     work with Amazon OpenSearch Serverless (which doesn't support purge/delete-by-query).
+                     See https://hibernate.atlassian.net/browse/HSEARCH-4929,
+                     https://hibernate.atlassian.net/browse/HSEARCH-4930
+                 -->
+                <test.elasticsearch.skip>true</test.elasticsearch.skip>
+            </properties>
+        </profile>
+    </profiles>
 
 </project>
 

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/massindexing/MassIndexingManualSchemaManagementIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/massindexing/MassIndexingManualSchemaManagementIT.java
@@ -81,9 +81,10 @@ public class MassIndexingManualSchemaManagementIT {
 			catch (InterruptedException e) {
 				fail( "Unexpected InterruptedException: " + e.getMessage() );
 			}
-			assertThat( BookCreatorUtils.documentsCount( entityManagerFactory ) ).isEqualTo( NUMBER_OF_BOOKS );
-		}
-		);
+			setupHelper.assertions().searchAfterIndexChangesAndPotentialRefresh( () ->
+					assertThat( BookCreatorUtils.documentsCount( entityManagerFactory ) )
+							.isEqualTo( NUMBER_OF_BOOKS ) );
+		} );
 	}
 
 	@Test
@@ -102,8 +103,9 @@ public class MassIndexingManualSchemaManagementIT {
 			catch (InterruptedException e) {
 				fail( "Unexpected InterruptedException: " + e.getMessage() );
 			}
-			assertThat( BookCreatorUtils.documentsCount( entityManagerFactory ) ).isEqualTo( NUMBER_OF_BOOKS );
-		}
-		);
+			setupHelper.assertions().searchAfterIndexChangesAndPotentialRefresh( () ->
+					assertThat( BookCreatorUtils.documentsCount( entityManagerFactory ) )
+							.isEqualTo( NUMBER_OF_BOOKS ) );
+		} );
 	}
 }

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/massindexing/MassIndexingManualSchemaManagementIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/massindexing/MassIndexingManualSchemaManagementIT.java
@@ -96,7 +96,7 @@ public class MassIndexingManualSchemaManagementIT {
 			assertThat( BookCreatorUtils.documentsCount( entityManagerFactory ) ).isZero();
 
 			MassIndexer indexer = Search.session( entityManager ).massIndexer()
-					.dropAndCreateSchemaOnStart( true );
+					.purgeAllOnStart( false );
 			try {
 				indexer.startAndWait();
 			}

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/massindexing/MassIndexingMonitorIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/massindexing/MassIndexingMonitorIT.java
@@ -108,7 +108,9 @@ public class MassIndexingMonitorIT {
 			catch (InterruptedException e) {
 				fail( "Unexpected InterruptedException: " + e.getMessage() );
 			}
-			assertThat( BookCreatorUtils.documentsCount( entityManagerFactory ) ).isEqualTo( NUMBER_OF_BOOKS );
+			setupHelper.assertions().searchAfterIndexChangesAndPotentialRefresh(
+					() -> assertThat( BookCreatorUtils.documentsCount( entityManagerFactory ) )
+							.isEqualTo( NUMBER_OF_BOOKS ) );
 		}
 		);
 

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/AbstractBackendHolder.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/AbstractBackendHolder.java
@@ -23,6 +23,7 @@ import org.hibernate.search.engine.common.spi.SearchIntegrationPartialBuildState
 import org.hibernate.search.engine.tenancy.spi.TenancyMode;
 import org.hibernate.search.integrationtest.performance.backend.base.testsupport.filesystem.TemporaryFileHolder;
 import org.hibernate.search.util.common.impl.SuppressingCloser;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingBackendFeatures;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingImpl;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingInitiator;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingKey;
@@ -68,7 +69,8 @@ public abstract class AbstractBackendHolder {
 		SearchIntegration.Builder integrationBuilder =
 				SearchIntegration.builder( environment );
 
-		StubMappingInitiator initiator = new StubMappingInitiator( TenancyMode.SINGLE_TENANCY );
+		StubMappingInitiator initiator = new StubMappingInitiator( new StubMappingBackendFeatures() { },
+				TenancyMode.SINGLE_TENANCY );
 		StubMappingKey mappingKey = new StubMappingKey();
 		integrationBuilder.addMappingInitiator( mappingKey, initiator );
 

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/IndexInitializer.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/IndexInitializer.java
@@ -19,6 +19,7 @@ import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrateg
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.integrationtest.performance.backend.base.testsupport.dataset.Dataset;
 import org.hibernate.search.integrationtest.performance.backend.base.testsupport.dataset.DatasetHolder;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils;
@@ -80,7 +81,7 @@ public class IndexInitializer {
 			futures.add( future );
 		} );
 		CompletableFuture.allOf( futures.toArray( new CompletableFuture[0] ) ).join();
-		workspace.flush( OperationSubmitter.blocking() ).join();
+		workspace.flush( OperationSubmitter.blocking(), UnsupportedOperationBehavior.IGNORE ).join();
 
 		log( index, " ... added " + futures.size() + " documents to the index." );
 	}
@@ -89,7 +90,7 @@ public class IndexInitializer {
 		log( index, "Starting index initialization..." );
 		log( index, "Purging..." );
 		IndexWorkspace workspace = index.createWorkspace();
-		workspace.purge( Collections.emptySet(), OperationSubmitter.blocking() ).join();
+		workspace.purge( Collections.emptySet(), OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ).join();
 		log( index, "Finished purge." );
 
 		addToIndex( index, idStream );

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchDocumentRepositoryImpl.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchDocumentRepositoryImpl.java
@@ -20,7 +20,6 @@ import org.hibernate.search.integrationtest.showcase.library.model.BookMedium;
 import org.hibernate.search.integrationtest.showcase.library.model.Document;
 import org.hibernate.search.integrationtest.showcase.library.model.LibraryServiceOption;
 import org.hibernate.search.mapper.orm.Search;
-import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -150,9 +149,9 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 
 	@Override
 	public void purge() {
-		SearchWorkspace workspace = Search.session( entityManager ).workspace( Document.class );
-		workspace.purge();
-		workspace.flush();
-		workspace.refresh();
+		// This is faster than a workspace(...).purge(),
+		// and works even on Amazon OpenSearch Serverless.
+		Search.session( entityManager ).schemaManager( Document.class )
+				.dropAndCreate();
 	}
 }

--- a/integrationtest/v5migrationhelper/engine/pom.xml
+++ b/integrationtest/v5migrationhelper/engine/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>hibernate-search-util-internal-integrationtest-v5migrationhelper</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-mapper-pojo-standalone</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integrationtest/v5migrationhelper/engine/src/test/java/org/hibernate/search/testsupport/junit/V5MigrationHelperEngineSetupHelper.java
+++ b/integrationtest/v5migrationhelper/engine/src/test/java/org/hibernate/search/testsupport/junit/V5MigrationHelperEngineSetupHelper.java
@@ -24,6 +24,7 @@ import org.hibernate.search.util.common.impl.CollectionHelper;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendSetupStrategy;
 import org.hibernate.search.util.impl.integrationtest.common.rule.MappingSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.BackendMappingHandle;
+import org.hibernate.search.util.impl.integrationtest.mapper.pojo.standalone.StandalonePojoAssertionHelper;
 
 public final class V5MigrationHelperEngineSetupHelper
 		extends
@@ -38,8 +39,16 @@ public final class V5MigrationHelperEngineSetupHelper
 		);
 	}
 
+	private final StandalonePojoAssertionHelper assertionHelper;
+
 	private V5MigrationHelperEngineSetupHelper(BackendSetupStrategy backendSetupStrategy) {
 		super( backendSetupStrategy );
+		this.assertionHelper = new StandalonePojoAssertionHelper( backendSetupStrategy );
+	}
+
+	@Override
+	public StandalonePojoAssertionHelper assertions() {
+		return assertionHelper;
 	}
 
 	@Override

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/testsupport/V5MigrationHelperJPASetupHelper.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/testsupport/V5MigrationHelperJPASetupHelper.java
@@ -24,6 +24,7 @@ import org.hibernate.search.util.impl.integrationtest.common.rule.BackendSetupSt
 import org.hibernate.search.util.impl.integrationtest.common.rule.MappingSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.BackendMappingHandle;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.HibernateOrmMappingHandle;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmAssertionHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.SimpleEntityManagerFactoryBuilder;
 
 public final class V5MigrationHelperJPASetupHelper
@@ -39,8 +40,16 @@ public final class V5MigrationHelperJPASetupHelper
 		);
 	}
 
+	private final OrmAssertionHelper assertionHelper;
+
 	private V5MigrationHelperJPASetupHelper(BackendSetupStrategy backendSetupStrategy) {
 		super( backendSetupStrategy );
+		this.assertionHelper = new OrmAssertionHelper( backendSetupStrategy );
+	}
+
+	@Override
+	public OrmAssertionHelper assertions() {
+		return assertionHelper;
 	}
 
 	@Override

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/testsupport/V5MigrationHelperOrmSetupHelper.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/testsupport/V5MigrationHelperOrmSetupHelper.java
@@ -24,6 +24,7 @@ import org.hibernate.search.util.impl.integrationtest.common.rule.BackendSetupSt
 import org.hibernate.search.util.impl.integrationtest.common.rule.MappingSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.BackendMappingHandle;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.HibernateOrmMappingHandle;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmAssertionHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.SimpleSessionFactoryBuilder;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.multitenancy.impl.MultitenancyTestHelper;
 
@@ -40,8 +41,16 @@ public final class V5MigrationHelperOrmSetupHelper
 		);
 	}
 
+	private final OrmAssertionHelper assertionHelper;
+
 	private V5MigrationHelperOrmSetupHelper(BackendSetupStrategy backendSetupStrategy) {
 		super( backendSetupStrategy );
+		this.assertionHelper = new OrmAssertionHelper( backendSetupStrategy );
+	}
+
+	@Override
+	public OrmAssertionHelper assertions() {
+		return assertionHelper;
 	}
 
 	@Override

--- a/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/logging/impl/Log.java
+++ b/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/logging/impl/Log.java
@@ -87,12 +87,6 @@ public interface Log extends BasicLogger {
 	)
 	void analyzeIndexProgress(String progress);
 
-	@LogMessage(level = Level.INFO)
-	@Message(id = ID_OFFSET + 15,
-			value = "Merging index segments for all entities ..."
-	)
-	void startMergeSegments();
-
 	@LogMessage(level = Level.DEBUG)
 	@Message(id = ID_OFFSET + 17,
 			value = "Checkpoint reached. Sending checkpoint ID to batch runtime... (entity='%1$s', checkpointInfo='%2$s')"

--- a/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/massindexing/step/afterchunk/impl/AfterChunkBatchlet.java
+++ b/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/massindexing/step/afterchunk/impl/AfterChunkBatchlet.java
@@ -19,6 +19,7 @@ import org.hibernate.search.batch.jsr352.core.massindexing.MassIndexingJobParame
 import org.hibernate.search.batch.jsr352.core.massindexing.impl.JobContextData;
 import org.hibernate.search.batch.jsr352.core.massindexing.util.impl.SerializationUtil;
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.spi.BatchMappingContext;
 import org.hibernate.search.mapper.pojo.work.spi.PojoScopeWorkspace;
@@ -53,7 +54,9 @@ public class AfterChunkBatchlet extends AbstractBatchlet {
 			EntityManagerFactory emf = jobData.getEntityManagerFactory();
 			BatchMappingContext mappingContext = (BatchMappingContext) Search.mapping( emf );
 			PojoScopeWorkspace workspace = mappingContext.scope( Object.class ).pojoWorkspace( tenantId );
-			Futures.unwrappedExceptionJoin( workspace.mergeSegments( OperationSubmitter.blocking() ) );
+			Futures.unwrappedExceptionJoin( workspace.mergeSegments( OperationSubmitter.blocking(),
+					serializedMergeSegmentsOnFinish != null ? UnsupportedOperationBehavior.FAIL
+							: UnsupportedOperationBehavior.IGNORE ) );
 		}
 		return null;
 	}

--- a/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/massindexing/step/impl/EntityWriter.java
+++ b/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/massindexing/step/impl/EntityWriter.java
@@ -27,6 +27,7 @@ import org.hibernate.search.batch.jsr352.core.massindexing.util.impl.MassIndexin
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.mapping.SearchMapping;
 import org.hibernate.search.mapper.orm.spi.BatchMappingContext;
@@ -113,7 +114,10 @@ public class EntityWriter extends AbstractItemWriter {
 			 * which is necessary because the runtime will perform a checkpoint
 			 * just after we return from this method.
 			 */
-			Futures.unwrappedExceptionJoin( workspace.flush( OperationSubmitter.blocking() ) );
+			Futures.unwrappedExceptionJoin( workspace.flush( OperationSubmitter.blocking(),
+					// If not supported, we're on Amazon OpenSearch Serverless,
+					// and in this case purge writes are safe even without a flush.
+					UnsupportedOperationBehavior.IGNORE ) );
 		}
 
 		// update work count

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapping.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapping.java
@@ -48,7 +48,6 @@ import org.hibernate.search.mapper.orm.model.impl.HibernateOrmRawTypeIdentifierR
 import org.hibernate.search.mapper.orm.reporting.impl.HibernateOrmMappingHints;
 import org.hibernate.search.mapper.orm.schema.management.SchemaManagementStrategyName;
 import org.hibernate.search.mapper.orm.schema.management.impl.SchemaManagementListener;
-import org.hibernate.search.mapper.orm.scope.SearchScope;
 import org.hibernate.search.mapper.orm.scope.impl.HibernateOrmScopeIndexedTypeContext;
 import org.hibernate.search.mapper.orm.scope.impl.HibernateOrmScopeMappingContext;
 import org.hibernate.search.mapper.orm.scope.impl.HibernateOrmScopeSessionContext;
@@ -227,12 +226,22 @@ public class HibernateOrmMapping extends AbstractPojoMappingImplementor<Hibernat
 	}
 
 	@Override
-	public <T> SearchScope<T> scope(Collection<? extends Class<? extends T>> types) {
+	public <T> SearchScopeImpl<T> scope(Class<T> type) {
+		return scope( Collections.singleton( type ) );
+	}
+
+	@Override
+	public <T> SearchScopeImpl<T> scope(Class<T> expectedSuperType, String entityName) {
+		return scope( expectedSuperType, Collections.singleton( entityName ) );
+	}
+
+	@Override
+	public <T> SearchScopeImpl<T> scope(Collection<? extends Class<? extends T>> types) {
 		return createScope( types );
 	}
 
 	@Override
-	public <T> SearchScope<T> scope(Class<T> expectedSuperType, Collection<String> entityNames) {
+	public <T> SearchScopeImpl<T> scope(Class<T> expectedSuperType, Collection<String> entityNames) {
 		return createScope( expectedSuperType, entityNames );
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/MassIndexer.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/MassIndexer.java
@@ -79,7 +79,7 @@ public interface MassIndexer {
 	/**
 	 * Merges each index into a single segment after the initial index purge, just before indexing.
 	 * <p>
-	 * Defaults to {@code true}.
+	 * Defaults to {@code true} for indexes that support it, {@code false} for other indexes.
 	 * <p>
 	 * This setting has no effect if {@code purgeAllOnStart} is set to false.
 	 * @param enable {@code true} to enable this operation, {@code false} to disable it.

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/scope/impl/SearchScopeImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/scope/impl/SearchScopeImpl.java
@@ -27,15 +27,17 @@ import org.hibernate.search.mapper.orm.schema.management.SearchSchemaManager;
 import org.hibernate.search.mapper.orm.schema.management.impl.SearchSchemaManagerImpl;
 import org.hibernate.search.mapper.orm.scope.SearchScope;
 import org.hibernate.search.mapper.orm.search.loading.dsl.SearchLoadingOptionsStep;
+import org.hibernate.search.mapper.orm.spi.BatchScopeContext;
 import org.hibernate.search.mapper.orm.tenancy.spi.TenancyConfiguration;
 import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 import org.hibernate.search.mapper.orm.work.impl.SearchWorkspaceImpl;
 import org.hibernate.search.mapper.pojo.massindexing.spi.PojoMassIndexer;
 import org.hibernate.search.mapper.pojo.schema.management.spi.PojoScopeSchemaManager;
 import org.hibernate.search.mapper.pojo.scope.spi.PojoScopeDelegate;
+import org.hibernate.search.mapper.pojo.work.spi.PojoScopeWorkspace;
 
 @SuppressWarnings("deprecation")
-public class SearchScopeImpl<E> implements SearchScope<E> {
+public class SearchScopeImpl<E> implements SearchScope<E>, BatchScopeContext<E> {
 
 	private final HibernateOrmScopeMappingContext mappingContext;
 	private final TenancyConfiguration tenancyConfiguration;
@@ -96,12 +98,17 @@ public class SearchScopeImpl<E> implements SearchScope<E> {
 
 	@Override
 	public SearchWorkspace workspace() {
-		return workspace( (String) null );
+		return workspace( null );
 	}
 
 	@Override
 	public SearchWorkspace workspace(String tenantId) {
-		return new SearchWorkspaceImpl( delegate.workspace( tenantId ) );
+		return new SearchWorkspaceImpl( pojoWorkspace( tenantId ) );
+	}
+
+	@Override
+	public PojoScopeWorkspace pojoWorkspace(String tenantId) {
+		return delegate.workspace( tenantId );
 	}
 
 	@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/spi/BatchMappingContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/spi/BatchMappingContext.java
@@ -14,4 +14,8 @@ public interface BatchMappingContext {
 
 	BatchSessionContext sessionContext(EntityManager entityManager);
 
+	<T> BatchScopeContext<T> scope(Class<T> expectedSuperType);
+
+	<T> BatchScopeContext<T> scope(Class<T> expectedSuperType, String entityName);
+
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/spi/BatchScopeContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/spi/BatchScopeContext.java
@@ -1,0 +1,15 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.orm.spi;
+
+import org.hibernate.search.mapper.pojo.work.spi.PojoScopeWorkspace;
+
+public interface BatchScopeContext<T> {
+
+	PojoScopeWorkspace pojoWorkspace(String tenantId);
+
+}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchWorkspaceImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchWorkspaceImpl.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 import org.hibernate.search.mapper.pojo.work.spi.PojoScopeWorkspace;
 import org.hibernate.search.util.common.impl.Futures;
@@ -24,12 +25,13 @@ public class SearchWorkspaceImpl implements SearchWorkspace {
 
 	@Override
 	public void mergeSegments() {
-		Futures.unwrappedExceptionJoin( delegate.mergeSegments( OperationSubmitter.blocking() ) );
+		Futures.unwrappedExceptionJoin(
+				delegate.mergeSegments( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ) );
 	}
 
 	@Override
 	public CompletableFuture<?> mergeSegmentsAsync() {
-		return delegate.mergeSegments( OperationSubmitter.rejecting() );
+		return delegate.mergeSegments( OperationSubmitter.rejecting(), UnsupportedOperationBehavior.FAIL );
 	}
 
 	@Override
@@ -44,31 +46,32 @@ public class SearchWorkspaceImpl implements SearchWorkspace {
 
 	@Override
 	public void purge(Set<String> routingKeys) {
-		Futures.unwrappedExceptionJoin( delegate.purge( routingKeys, OperationSubmitter.blocking() ) );
+		Futures.unwrappedExceptionJoin(
+				delegate.purge( routingKeys, OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ) );
 	}
 
 	@Override
 	public CompletableFuture<?> purgeAsync(Set<String> routingKeys) {
-		return delegate.purge( routingKeys, OperationSubmitter.rejecting() );
+		return delegate.purge( routingKeys, OperationSubmitter.rejecting(), UnsupportedOperationBehavior.FAIL );
 	}
 
 	@Override
 	public void flush() {
-		Futures.unwrappedExceptionJoin( delegate.flush( OperationSubmitter.blocking() ) );
+		Futures.unwrappedExceptionJoin( delegate.flush( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ) );
 	}
 
 	@Override
 	public CompletableFuture<?> flushAsync() {
-		return delegate.flush( OperationSubmitter.rejecting() );
+		return delegate.flush( OperationSubmitter.rejecting(), UnsupportedOperationBehavior.FAIL );
 	}
 
 	@Override
 	public void refresh() {
-		Futures.unwrappedExceptionJoin( delegate.refresh( OperationSubmitter.blocking() ) );
+		Futures.unwrappedExceptionJoin( delegate.refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ) );
 	}
 
 	@Override
 	public CompletableFuture<?> refreshAsync() {
-		return delegate.refresh( OperationSubmitter.rejecting() );
+		return delegate.refresh( OperationSubmitter.rejecting(), UnsupportedOperationBehavior.FAIL );
 	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoDefaultMassIndexer.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoDefaultMassIndexer.java
@@ -57,10 +57,10 @@ public class PojoDefaultMassIndexer implements PojoMassIndexer {
 	// default settings defined here:
 	private int typesToIndexInParallel = 1;
 	private int documentBuilderThreads = 6;
-	private boolean mergeSegmentsOnFinish = false;
+	private Boolean mergeSegmentsOnFinish;
 	private Boolean dropAndCreateSchemaOnStart;
 	private Boolean purgeAtStart;
-	private boolean mergeSegmentsAfterPurge = true;
+	private Boolean mergeSegmentsAfterPurge;
 	private Long failureFloodingThreshold = null;
 
 	private MassIndexingFailureHandler failureHandler;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoScopeWorkspaceImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoScopeWorkspaceImpl.java
@@ -10,12 +10,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.BiFunction;
 
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.mapper.pojo.scope.spi.PojoScopeMappingContext;
 import org.hibernate.search.mapper.pojo.work.spi.PojoScopeWorkspace;
+import org.hibernate.search.util.common.function.TriFunction;
 
 public class PojoScopeWorkspaceImpl implements PojoScopeWorkspace {
 
@@ -30,36 +31,41 @@ public class PojoScopeWorkspaceImpl implements PojoScopeWorkspace {
 	}
 
 	@Override
-	public CompletableFuture<?> mergeSegments(OperationSubmitter operationSubmitter) {
-		return doOperationOnTypes( IndexWorkspace::mergeSegments, operationSubmitter );
+	public CompletableFuture<?> mergeSegments(OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior) {
+		return doOperationOnTypes( IndexWorkspace::mergeSegments, operationSubmitter, unsupportedOperationBehavior );
 	}
 
 	@Override
-	public CompletableFuture<?> purge(Set<String> routingKeys, OperationSubmitter operationSubmitter) {
-		return doOperationOnTypes( (indexWorkspace, submitter) -> indexWorkspace.purge( routingKeys, submitter ),
-				operationSubmitter );
+	public CompletableFuture<?> purge(Set<String> routingKeys, OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior) {
+		return doOperationOnTypes(
+				(indexWorkspace, submitter, unsupportedBehavior) ->
+						indexWorkspace.purge( routingKeys, submitter, unsupportedBehavior ),
+				operationSubmitter, unsupportedOperationBehavior );
 	}
 
 	@Override
-	public CompletableFuture<?> flush(OperationSubmitter operationSubmitter) {
-		return doOperationOnTypes( IndexWorkspace::flush, operationSubmitter );
+	public CompletableFuture<?> flush(OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior) {
+		return doOperationOnTypes( IndexWorkspace::flush, operationSubmitter, unsupportedOperationBehavior );
 	}
 
 	@Override
-	public CompletableFuture<?> refresh(OperationSubmitter operationSubmitter) {
-		return doOperationOnTypes( IndexWorkspace::refresh, operationSubmitter );
+	public CompletableFuture<?> refresh(OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior) {
+		return doOperationOnTypes( IndexWorkspace::refresh, operationSubmitter, unsupportedOperationBehavior );
 	}
 
 	private CompletableFuture<?> doOperationOnTypes(
-			BiFunction<IndexWorkspace,
-					OperationSubmitter,
-					CompletableFuture<?>> operation,
-			OperationSubmitter operationSubmitter) {
+			TriFunction<IndexWorkspace, OperationSubmitter, UnsupportedOperationBehavior, CompletableFuture<?>> operation,
+			OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior) {
 		CompletableFuture<?>[] futures = new CompletableFuture<?>[delegates.size()];
 		int typeCounter = 0;
 
 		for ( IndexWorkspace delegate : delegates ) {
-			futures[typeCounter++] = operation.apply( delegate, operationSubmitter );
+			futures[typeCounter++] = operation.apply( delegate, operationSubmitter, unsupportedOperationBehavior );
 		}
 
 		// TODO HSEARCH-3110 use a FailureHandler here?

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoScopeWorkspace.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoScopeWorkspace.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 
 public interface PojoScopeWorkspace {
 
@@ -18,27 +19,51 @@ public interface PojoScopeWorkspace {
 		return mergeSegments( OperationSubmitter.blocking() );
 	}
 
-	CompletableFuture<?> mergeSegments(OperationSubmitter operationSubmitter);
+	@Deprecated
+	default CompletableFuture<?> mergeSegments(OperationSubmitter operationSubmitter) {
+		return mergeSegments( operationSubmitter, UnsupportedOperationBehavior.FAIL );
+	}
+
+	CompletableFuture<?> mergeSegments(OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior);
 
 	@Deprecated
 	default CompletableFuture<?> purge(Set<String> routingKeys) {
 		return purge( routingKeys, OperationSubmitter.blocking() );
 	}
 
-	CompletableFuture<?> purge(Set<String> routingKeys, OperationSubmitter operationSubmitter);
+	@Deprecated
+	default CompletableFuture<?> purge(Set<String> routingKeys, OperationSubmitter operationSubmitter) {
+		return purge( routingKeys, operationSubmitter, UnsupportedOperationBehavior.FAIL );
+	}
+
+	CompletableFuture<?> purge(Set<String> routingKeys, OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior);
 
 	@Deprecated
 	default CompletableFuture<?> flush() {
 		return flush( OperationSubmitter.blocking() );
 	}
 
-	CompletableFuture<?> flush(OperationSubmitter operationSubmitter);
+	@Deprecated
+	default CompletableFuture<?> flush(OperationSubmitter operationSubmitter) {
+		return flush( operationSubmitter, UnsupportedOperationBehavior.FAIL );
+	}
+
+	CompletableFuture<?> flush(OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior);
 
 	@Deprecated
 	default CompletableFuture<?> refresh() {
 		return refresh( OperationSubmitter.blocking() );
 	}
 
-	CompletableFuture<?> refresh(OperationSubmitter operationSubmitter);
+	@Deprecated
+	default CompletableFuture<?> refresh(OperationSubmitter operationSubmitter) {
+		return refresh( operationSubmitter, UnsupportedOperationBehavior.FAIL );
+	}
+
+	CompletableFuture<?> refresh(OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior);
 
 }

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/massindexing/MassIndexer.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/massindexing/MassIndexer.java
@@ -63,7 +63,7 @@ public interface MassIndexer {
 	/**
 	 * Merges each index into a single segment after the initial index purge, just before indexing.
 	 * <p>
-	 * Defaults to {@code true}.
+	 * Defaults to {@code true} for indexes that support it, {@code false} for other indexes.
 	 * <p>
 	 * This setting has no effect if {@code purgeAllOnStart} is set to false.
 	 * @param enable {@code true} to enable this operation, {@code false} to disable it.

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/work/impl/SearchWorkspaceImpl.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/work/impl/SearchWorkspaceImpl.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.mapper.pojo.standalone.work.SearchWorkspace;
 import org.hibernate.search.mapper.pojo.work.spi.PojoScopeWorkspace;
 import org.hibernate.search.util.common.impl.Futures;
@@ -24,12 +25,13 @@ public class SearchWorkspaceImpl implements SearchWorkspace {
 
 	@Override
 	public void mergeSegments() {
-		Futures.unwrappedExceptionJoin( delegate.mergeSegments( OperationSubmitter.blocking() ) );
+		Futures.unwrappedExceptionJoin(
+				delegate.mergeSegments( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ) );
 	}
 
 	@Override
 	public CompletableFuture<?> mergeSegmentsAsync() {
-		return delegate.mergeSegments( OperationSubmitter.rejecting() );
+		return delegate.mergeSegments( OperationSubmitter.rejecting(), UnsupportedOperationBehavior.FAIL );
 	}
 
 	@Override
@@ -44,31 +46,32 @@ public class SearchWorkspaceImpl implements SearchWorkspace {
 
 	@Override
 	public void purge(Set<String> routingKeys) {
-		Futures.unwrappedExceptionJoin( delegate.purge( routingKeys, OperationSubmitter.blocking() ) );
+		Futures.unwrappedExceptionJoin(
+				delegate.purge( routingKeys, OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ) );
 	}
 
 	@Override
 	public CompletableFuture<?> purgeAsync(Set<String> routingKeys) {
-		return delegate.purge( routingKeys, OperationSubmitter.rejecting() );
+		return delegate.purge( routingKeys, OperationSubmitter.rejecting(), UnsupportedOperationBehavior.FAIL );
 	}
 
 	@Override
 	public void flush() {
-		Futures.unwrappedExceptionJoin( delegate.flush( OperationSubmitter.blocking() ) );
+		Futures.unwrappedExceptionJoin( delegate.flush( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ) );
 	}
 
 	@Override
 	public CompletableFuture<?> flushAsync() {
-		return delegate.flush( OperationSubmitter.rejecting() );
+		return delegate.flush( OperationSubmitter.rejecting(), UnsupportedOperationBehavior.FAIL );
 	}
 
 	@Override
 	public void refresh() {
-		Futures.unwrappedExceptionJoin( delegate.refresh( OperationSubmitter.blocking() ) );
+		Futures.unwrappedExceptionJoin( delegate.refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ) );
 	}
 
 	@Override
 	public CompletableFuture<?> refreshAsync() {
-		return delegate.refresh( OperationSubmitter.rejecting() );
+		return delegate.refresh( OperationSubmitter.rejecting(), UnsupportedOperationBehavior.FAIL );
 	}
 }

--- a/util/common/src/main/java/org/hibernate/search/util/common/annotation/Incubating.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/annotation/Incubating.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.util.common.annotation;
 
+import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.CLASS;
@@ -28,7 +29,7 @@ import java.lang.annotation.Target;
  * @author Gunnar Morling
  */
 @Documented
-@Target({ TYPE, METHOD })
+@Target({ TYPE, METHOD, FIELD })
 @Retention(CLASS)
 public @interface Incubating {
 }

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchBackendConfiguration.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchBackendConfiguration.java
@@ -8,29 +8,14 @@ package org.hibernate.search.util.impl.integrationtest.backend.elasticsearch;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Optional;
 
-import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.rule.TestElasticsearchClient;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration;
 
-import org.junit.rules.TestRule;
-
 public class ElasticsearchBackendConfiguration extends BackendConfiguration {
-
-	protected final TestElasticsearchClient testElasticsearchClient = new TestElasticsearchClient();
 
 	@Override
 	public String toString() {
 		return "elasticsearch";
-	}
-
-	@Override
-	public Optional<TestRule> testRule() {
-		return Optional.of( testElasticsearchClient );
-	}
-
-	public TestElasticsearchClient testElasticsearchClient() {
-		return testElasticsearchClient;
 	}
 
 	@Override

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchBackendConfiguration.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchBackendConfiguration.java
@@ -25,6 +25,10 @@ public class ElasticsearchBackendConfiguration extends BackendConfiguration {
 		Map<String, String> properties = new LinkedHashMap<>();
 		properties.put( "log.json_pretty_printing", "true" );
 		ElasticsearchTestHostConnectionConfiguration.get().addToBackendProperties( properties );
+		if ( ElasticsearchDistributionName.AMAZON_OPENSEARCH_SERVERLESS.equals( ElasticsearchTestDialect.getActualVersion().distribution() ) ) {
+			// The distribution/version cannot be detected on Amazon OpenSearch Serverless
+			properties.put( "version", ElasticsearchTestDialect.getActualVersion().toString() );
+		}
 		return properties;
 	}
 

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchBackendConfiguration.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchBackendConfiguration.java
@@ -9,6 +9,8 @@ package org.hibernate.search.util.impl.integrationtest.backend.elasticsearch;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.hibernate.search.backend.elasticsearch.ElasticsearchDistributionName;
+import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.ElasticsearchTestDialect;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration;
 
 public class ElasticsearchBackendConfiguration extends BackendConfiguration {
@@ -25,4 +27,11 @@ public class ElasticsearchBackendConfiguration extends BackendConfiguration {
 		ElasticsearchTestHostConnectionConfiguration.get().addToBackendProperties( properties );
 		return properties;
 	}
+
+	@Override
+	public boolean supportsExplicitPurge() {
+		return !ElasticsearchDistributionName.AMAZON_OPENSEARCH_SERVERLESS
+				.equals( ElasticsearchTestDialect.getActualVersion().distribution() );
+	}
+
 }

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchBackendConfiguration.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchBackendConfiguration.java
@@ -34,4 +34,10 @@ public class ElasticsearchBackendConfiguration extends BackendConfiguration {
 				.equals( ElasticsearchTestDialect.getActualVersion().distribution() );
 	}
 
+	@Override
+	public boolean supportsExplicitRefresh() {
+		return !ElasticsearchDistributionName.AMAZON_OPENSEARCH_SERVERLESS
+				.equals( ElasticsearchTestDialect.getActualVersion().distribution() );
+	}
+
 }

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/rule/TestElasticsearchClient.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/rule/TestElasticsearchClient.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
@@ -497,7 +498,8 @@ public class TestElasticsearchClient implements TestRule, Closeable {
 						timeoutExecutorService,
 						threadPoolProvider.isScheduledExecutorBlocking()
 				),
-				GsonProvider.create( GsonBuilder::new, true )
+				GsonProvider.create( GsonBuilder::new, true ),
+				Optional.of( ElasticsearchTestDialect.getActualVersion() )
 		);
 	}
 

--- a/util/internal/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/ElasticsearchTestDialectVersionTest.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/ElasticsearchTestDialectVersionTest.java
@@ -19,11 +19,13 @@ public class ElasticsearchTestDialectVersionTest {
 
 	@BeforeClass
 	public static void beforeClass() {
-		System.setProperty( "org.hibernate.search.integrationtest.backend.elasticsearch.version", "elastic:1.1.1" );
+		System.setProperty( "org.hibernate.search.integrationtest.backend.elasticsearch.distribution", "elastic" );
+		System.setProperty( "org.hibernate.search.integrationtest.backend.elasticsearch.version", "1.1.1" );
 	}
 
 	@AfterClass
 	public static void afterClass() {
+		System.clearProperty( "org.hibernate.search.integrationtest.backend.elasticsearch.distribution" );
 		System.clearProperty( "org.hibernate.search.integrationtest.backend.elasticsearch.version" );
 	}
 

--- a/util/internal/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/ElasticsearchTestDialectVersionTest.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/ElasticsearchTestDialectVersionTest.java
@@ -35,7 +35,8 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "elastic:6.7.0" ),
 						es -> es.isBetween( "6.7", "6.9" ),
-						os -> false
+						os -> false,
+						aoss -> false
 				)
 		).isTrue();
 
@@ -43,7 +44,8 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "elastic:1.1.1" ),
 						es -> es.isBetween( "1.0.1", "1.1.2" ),
-						os -> false
+						os -> false,
+						aoss -> false
 				)
 		).isTrue();
 
@@ -51,7 +53,8 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "elastic:1.1.1" ),
 						es -> es.isBetween( "1.1.1", "1.1.2" ),
-						os -> false
+						os -> false,
+						aoss -> false
 				)
 		).isTrue();
 
@@ -59,7 +62,8 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "elastic:1.1.2" ),
 						es -> es.isBetween( "1.1.1", "1.1.2" ),
-						os -> false
+						os -> false,
+						aoss -> false
 				)
 		).isTrue();
 
@@ -67,7 +71,8 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "elastic:2.2.2" ),
 						es -> es.isBetween( "1.1", "2.2" ),
-						os -> false
+						os -> false,
+						aoss -> false
 				)
 		).isTrue();
 
@@ -75,7 +80,8 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "elastic:2.2.2" ),
 						es -> es.isBetween( "1", "2" ),
-						os -> false
+						os -> false,
+						aoss -> false
 				)
 		).isTrue();
 	}
@@ -86,7 +92,8 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "elastic:1.1.1" ),
 						es -> false,
-						os -> true
+						os -> true,
+						aoss -> true
 				)
 		).isFalse();
 
@@ -94,7 +101,17 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "opensearch:1.1.1" ),
 						es -> true,
-						os -> false
+						os -> false,
+						aoss -> true
+				)
+		).isFalse();
+
+		assertThat(
+				isVersion(
+						ElasticsearchVersion.of( "amazon-opensearch-serverless" ),
+						es -> true,
+						os -> true,
+						aoss -> false
 				)
 		).isFalse();
 
@@ -102,7 +119,8 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "elastic:1.1.1" ),
 						es -> true,
-						os -> false
+						os -> false,
+						aoss -> false
 				)
 		).isTrue();
 
@@ -110,7 +128,17 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "opensearch:1.1.1" ),
 						es -> false,
-						os -> true
+						os -> true,
+						aoss -> false
+				)
+		).isTrue();
+
+		assertThat(
+				isVersion(
+						ElasticsearchVersion.of( "amazon-opensearch-serverless" ),
+						es -> false,
+						os -> false,
+						aoss -> true
 				)
 		).isTrue();
 	}
@@ -121,7 +149,8 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "elastic:1.1.1" ),
 						es -> es.isMatching( "1.1.2" ),
-						os -> true
+						os -> true,
+						aoss -> true
 				)
 		).isFalse();
 
@@ -129,7 +158,8 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "elastic:1.1.1" ),
 						es -> es.isMatching( "1.1.1" ),
-						os -> false
+						os -> false,
+						aoss -> false
 				)
 		).isTrue();
 
@@ -137,7 +167,8 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "elastic:1.1.1" ),
 						es -> es.isMatching( "1.1" ),
-						os -> false
+						os -> false,
+						aoss -> false
 				)
 		).isTrue();
 	}
@@ -148,7 +179,8 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "elastic:1.1.2" ),
 						es -> es.isAtMost( "1.1.1" ),
-						os -> true
+						os -> true,
+						aoss -> true
 				)
 		).isFalse();
 
@@ -156,7 +188,8 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "opensearch:1.1.1" ),
 						es -> true,
-						os -> os.isAtMost( "1.1.0" )
+						os -> os.isAtMost( "1.1.0" ),
+						aoss -> true
 				)
 		).isFalse();
 
@@ -164,7 +197,8 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "elastic:1.1.1" ),
 						es -> es.isAtMost( "1.1.1" ),
-						os -> false
+						os -> false,
+						aoss -> false
 				)
 		).isTrue();
 
@@ -172,7 +206,8 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "elastic:1.0.1" ),
 						es -> es.isAtMost( "1.1.1" ),
-						os -> false
+						os -> false,
+						aoss -> false
 				)
 		).isTrue();
 	}
@@ -183,7 +218,8 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "elastic:1.1.1" ),
 						es -> es.isLessThan( "1.1.2" ),
-						os -> false
+						os -> false,
+						aoss -> false
 				)
 		).isTrue();
 
@@ -191,7 +227,8 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "opensearch:1.1.1" ),
 						es -> true,
-						os -> os.isLessThan( "1.1.0" )
+						os -> os.isLessThan( "1.1.0" ),
+						aoss -> true
 				)
 		).isFalse();
 
@@ -199,7 +236,8 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "elastic:1.1" ),
 						es -> es.isLessThan( "1.1.0" ),
-						os -> true
+						os -> true,
+						aoss -> true
 				)
 		).isFalse();
 
@@ -207,7 +245,8 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "elastic:1.1.1" ),
 						es -> es.isLessThan( "1.0.1" ),
-						os -> true
+						os -> true,
+						aoss -> true
 				)
 		).isFalse();
 
@@ -215,9 +254,53 @@ public class ElasticsearchTestDialectVersionTest {
 				isVersion(
 						ElasticsearchVersion.of( "elastic:1.0.1" ),
 						es -> es.isLessThan( "1.1.1" ),
-						os -> false
+						os -> false,
+						aoss -> false
 				)
 		).isTrue();
+	}
+
+	@Test
+	public void amazonOpenSearchServerless_defaultToOpenSearchPredicate() {
+		ElasticsearchVersion version = ElasticsearchVersion.of( "amazon-opensearch-serverless" );
+		assertThat( isVersion(
+				version,
+				es -> true,
+				os -> os.isAtMost( "2.0" ),
+				null
+		) ).isFalse();
+		assertThat( isVersion(
+				version,
+				es -> false,
+				os -> !os.isAtMost( "2.0" ),
+				null
+		) ).isTrue();
+
+		assertThat( isVersion(
+				version,
+				es -> true,
+				os -> os.isLessThan( "2.0" ),
+				null
+		) ).isFalse();
+		assertThat( isVersion(
+				version,
+				es -> false,
+				os -> !os.isLessThan( "2.0" ),
+				null
+		) ).isTrue();
+
+		assertThat( isVersion(
+				version,
+				es -> true,
+				os -> os.isBetween( "2.0", "2.5" ),
+				null
+		) ).isFalse();
+		assertThat( isVersion(
+				version,
+				es -> false,
+				os -> !os.isBetween( "2.0", "2.5" ),
+				null
+		) ).isTrue();
 	}
 
 }

--- a/util/internal/integrationtest/backend/lucene/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/lucene/LuceneBackendConfiguration.java
+++ b/util/internal/integrationtest/backend/lucene/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/lucene/LuceneBackendConfiguration.java
@@ -28,4 +28,9 @@ public class LuceneBackendConfiguration extends BackendConfiguration {
 		return properties;
 	}
 
+	@Override
+	public boolean supportsExplicitPurge() {
+		return true;
+	}
+
 }

--- a/util/internal/integrationtest/backend/lucene/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/lucene/LuceneBackendConfiguration.java
+++ b/util/internal/integrationtest/backend/lucene/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/lucene/LuceneBackendConfiguration.java
@@ -33,4 +33,9 @@ public class LuceneBackendConfiguration extends BackendConfiguration {
 		return true;
 	}
 
+	@Override
+	public boolean supportsExplicitRefresh() {
+		return true;
+	}
+
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/assertion/MappingAssertionHelper.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/assertion/MappingAssertionHelper.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.integrationtest.common.assertion;
+
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendSetupStrategy;
+
+import org.awaitility.Awaitility;
+
+public abstract class MappingAssertionHelper<E> {
+
+	private final boolean supportsExplicitRefresh;
+
+	protected MappingAssertionHelper(BackendConfiguration backendConfiguration) {
+		this.supportsExplicitRefresh = backendConfiguration.supportsExplicitRefresh();
+	}
+
+	protected MappingAssertionHelper(BackendSetupStrategy backendSetupStrategy) {
+		this.supportsExplicitRefresh = backendSetupStrategy.supportsExplicitRefresh();
+	}
+
+	public void searchAfterIndexChanges(E entryPoint, Runnable assertion) {
+		if ( supportsExplicitRefresh ) {
+			doRefresh( entryPoint );
+		}
+		searchAfterIndexChangesAndPotentialRefresh( assertion );
+	}
+
+	protected abstract void doRefresh(E entryPoint);
+
+	public void searchAfterIndexChangesAndPotentialRefresh(Runnable assertion) {
+		if ( supportsExplicitRefresh ) {
+			// The refresh actually occurred: we can run the assertion now.
+			assertion.run();
+		}
+		else {
+			// The refresh did not actually occur: we cannot expect the assertion to succeed immediately.
+			// This will lead to potentially long (~1s) waits,
+			// but we don't have a choice since we can't do an explicit refresh.
+			// Also, this will only work for assertions that don't pass before changes,
+			// but do pass afterward.
+			// Things like "checking we still have the same state" may produce false positives.
+			Awaitility.await().untilAsserted( assertion::run );
+		}
+	}
+
+
+}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/ActualBackendSetupStrategy.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/ActualBackendSetupStrategy.java
@@ -73,4 +73,9 @@ class ActualBackendSetupStrategy implements BackendSetupStrategy {
 		}
 		return setupContext;
 	}
+
+	@Override
+	public boolean supportsExplicitRefresh() {
+		return allConfigurations.stream().allMatch( BackendConfiguration::supportsExplicitRefresh );
+	}
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendConfiguration.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendConfiguration.java
@@ -80,4 +80,6 @@ public abstract class BackendConfiguration {
 
 	public abstract boolean supportsExplicitPurge();
 
+	public abstract boolean supportsExplicitRefresh();
+
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendConfiguration.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendConfiguration.java
@@ -78,4 +78,6 @@ public abstract class BackendConfiguration {
 
 	public abstract Map<String, String> rawBackendProperties();
 
+	public abstract boolean supportsExplicitPurge();
+
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMockSetupStrategy.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMockSetupStrategy.java
@@ -35,4 +35,9 @@ class BackendMockSetupStrategy implements BackendSetupStrategy {
 		}
 		return setupContext;
 	}
+
+	@Override
+	public boolean supportsExplicitRefresh() {
+		return true;
+	}
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendSetupStrategy.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendSetupStrategy.java
@@ -26,6 +26,8 @@ public interface BackendSetupStrategy {
 			TestConfigurationProvider configurationProvider,
 			CompletionStage<BackendMappingHandle> mappingHandlePromise);
 
+	boolean supportsExplicitRefresh();
+
 	static BackendSetupStrategy withSingleBackendMock(BackendMock defaultBackendMock) {
 		return new BackendMockSetupStrategy( defaultBackendMock, Collections.emptyMap() );
 	}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/MappingSetupHelper.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/MappingSetupHelper.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 import org.hibernate.search.engine.cfg.EngineSettings;
 import org.hibernate.search.util.common.impl.Closer;
 import org.hibernate.search.util.impl.integrationtest.common.TestConfigurationProvider;
+import org.hibernate.search.util.impl.integrationtest.common.assertion.MappingAssertionHelper;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.BackendMappingHandle;
 
 import org.junit.rules.RuleChain;
@@ -48,6 +49,8 @@ public abstract class MappingSetupHelper<C extends MappingSetupHelper<C, B, BC, 
 	public String toString() {
 		return backendSetupStrategy.toString();
 	}
+
+	public abstract MappingAssertionHelper<? super R> assertions();
 
 	public C start() {
 		C setupContext = createSetupContext();

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexWorkspace.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexWorkspace.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.StubBackendBehavior;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.StubIndexScaleWork;
 
@@ -27,7 +28,8 @@ class StubIndexWorkspace implements IndexWorkspace {
 	}
 
 	@Override
-	public CompletableFuture<?> mergeSegments(OperationSubmitter operationSubmitter) {
+	public CompletableFuture<?> mergeSegments(OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior) {
 		StubIndexScaleWork work = StubIndexScaleWork.builder( StubIndexScaleWork.Type.MERGE_SEGMENTS )
 				// In a real-world backend the operation would cross tenants,
 				// because that doesn't matter,
@@ -39,7 +41,8 @@ class StubIndexWorkspace implements IndexWorkspace {
 	}
 
 	@Override
-	public CompletableFuture<?> purge(Set<String> routingKeys, OperationSubmitter operationSubmitter) {
+	public CompletableFuture<?> purge(Set<String> routingKeys, OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior) {
 		StubIndexScaleWork work = StubIndexScaleWork.builder( StubIndexScaleWork.Type.PURGE )
 				.tenantIdentifiers( tenantIdentifiers )
 				.routingKeys( routingKeys )
@@ -48,7 +51,8 @@ class StubIndexWorkspace implements IndexWorkspace {
 	}
 
 	@Override
-	public CompletableFuture<?> flush(OperationSubmitter operationSubmitter) {
+	public CompletableFuture<?> flush(OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior) {
 		StubIndexScaleWork work = StubIndexScaleWork.builder( StubIndexScaleWork.Type.FLUSH )
 				// In a real-world backend the operation would cross tenants,
 				// because that doesn't matter,
@@ -60,7 +64,8 @@ class StubIndexWorkspace implements IndexWorkspace {
 	}
 
 	@Override
-	public CompletableFuture<?> refresh(OperationSubmitter operationSubmitter) {
+	public CompletableFuture<?> refresh(OperationSubmitter operationSubmitter,
+			UnsupportedOperationBehavior unsupportedOperationBehavior) {
 		StubIndexScaleWork work = StubIndexScaleWork.builder( StubIndexScaleWork.Type.REFRESH )
 				// In a real-world backend the operation would cross tenants,
 				// because that doesn't matter,

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmAssertionHelper.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmAssertionHelper.java
@@ -1,0 +1,24 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.integrationtest.mapper.orm;
+
+import jakarta.persistence.EntityManagerFactory;
+
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.util.impl.integrationtest.common.assertion.MappingAssertionHelper;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendSetupStrategy;
+
+public class OrmAssertionHelper extends MappingAssertionHelper<EntityManagerFactory> {
+	public OrmAssertionHelper(BackendSetupStrategy backendSetupStrategy) {
+		super( backendSetupStrategy );
+	}
+
+	@Override
+	protected void doRefresh(EntityManagerFactory entryPoint) {
+		Search.mapping( entryPoint ).scope( Object.class ).workspace().refresh();
+	}
+}

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmSetupHelper.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmSetupHelper.java
@@ -104,6 +104,7 @@ public final class OrmSetupHelper
 
 	private final Collection<BackendMock> backendMocks;
 	private final SchemaManagementStrategyName schemaManagementStrategyName;
+	private final OrmAssertionHelper assertionHelper;
 	private CoordinationStrategyExpectations coordinationStrategyExpectations =
 			DEFAULT_COORDINATION_STRATEGY_EXPECTATIONS;
 
@@ -112,11 +113,17 @@ public final class OrmSetupHelper
 		super( backendSetupStrategy );
 		this.backendMocks = backendMocks;
 		this.schemaManagementStrategyName = schemaManagementStrategyName;
+		this.assertionHelper = new OrmAssertionHelper( backendSetupStrategy );
 	}
 
 	public OrmSetupHelper coordinationStrategy(CoordinationStrategyExpectations coordinationStrategyExpectations) {
 		this.coordinationStrategyExpectations = coordinationStrategyExpectations;
 		return this;
+	}
+
+	@Override
+	public OrmAssertionHelper assertions() {
+		return assertionHelper;
 	}
 
 	public boolean areEntitiesProcessedInSession() {

--- a/util/internal/integrationtest/mapper/pojo-standalone/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/pojo/standalone/StandalonePojoAssertionHelper.java
+++ b/util/internal/integrationtest/mapper/pojo-standalone/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/pojo/standalone/StandalonePojoAssertionHelper.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.integrationtest.mapper.pojo.standalone;
+
+import org.hibernate.search.mapper.pojo.standalone.mapping.SearchMapping;
+import org.hibernate.search.util.impl.integrationtest.common.assertion.MappingAssertionHelper;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendSetupStrategy;
+
+public class StandalonePojoAssertionHelper extends MappingAssertionHelper<SearchMapping> {
+	public StandalonePojoAssertionHelper(BackendConfiguration backendConfiguration) {
+		super( backendConfiguration );
+	}
+
+	public StandalonePojoAssertionHelper(BackendSetupStrategy backendSetupStrategy) {
+		super( backendSetupStrategy );
+	}
+
+	@Override
+	protected void doRefresh(SearchMapping entryPoint) {
+		entryPoint.scope( Object.class ).workspace().refresh();
+	}
+}

--- a/util/internal/integrationtest/mapper/pojo-standalone/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/pojo/standalone/StandalonePojoMappingSetupHelper.java
+++ b/util/internal/integrationtest/mapper/pojo-standalone/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/pojo/standalone/StandalonePojoMappingSetupHelper.java
@@ -73,6 +73,7 @@ public final class StandalonePojoMappingSetupHelper
 
 	private final MethodHandles.Lookup lookup;
 	private final SchemaManagementStrategyName schemaManagementStrategyName;
+	private final StandalonePojoAssertionHelper assertionHelper;
 
 	private ReindexOnUpdate defaultReindexOnUpdate;
 
@@ -81,11 +82,17 @@ public final class StandalonePojoMappingSetupHelper
 		super( backendSetupStrategy );
 		this.lookup = lookup;
 		this.schemaManagementStrategyName = schemaManagementStrategyName;
+		this.assertionHelper = new StandalonePojoAssertionHelper( backendSetupStrategy );
 	}
 
 	public StandalonePojoMappingSetupHelper disableAssociationReindexing() {
 		this.defaultReindexOnUpdate = ReindexOnUpdate.SHALLOW;
 		return this;
+	}
+
+	@Override
+	public StandalonePojoAssertionHelper assertions() {
+		return assertionHelper;
 	}
 
 	@Override

--- a/util/internal/integrationtest/mapper/stub/pom.xml
+++ b/util/internal/integrationtest/mapper/stub/pom.xml
@@ -24,6 +24,10 @@
             <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-engine</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/BulkIndexer.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/BulkIndexer.java
@@ -24,6 +24,7 @@ import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentContributor;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
+import org.hibernate.search.engine.backend.work.execution.spi.UnsupportedOperationBehavior;
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexManager;
 import org.hibernate.search.util.common.impl.Futures;
 
@@ -124,7 +125,8 @@ public class BulkIndexer {
 					mappingContext,
 					asSetIgnoreNull( tenantId )
 			);
-			future = future.thenCompose( ignored -> workspace.refresh( OperationSubmitter.blocking() ) );
+			future = future.thenCompose( ignored ->
+					workspace.refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ) );
 		}
 		return future;
 	}

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMapper.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMapper.java
@@ -35,6 +35,7 @@ class StubMapper implements Mapper<StubMappingPartialBuildState>, IndexedEntityB
 	private final ContextualFailureCollector failureCollector;
 	private final TypeMetadataContributorProvider<StubMappedIndex> contributorProvider;
 
+	private final StubMappingBackendFeatures backendFeatures;
 	private final TenancyMode tenancyMode;
 
 	private final Map<StubTypeModel, MappedIndexManagerBuilder> indexManagerBuilders = new HashMap<>();
@@ -42,9 +43,11 @@ class StubMapper implements Mapper<StubMappingPartialBuildState>, IndexedEntityB
 
 	StubMapper(MappingBuildContext buildContext,
 			TypeMetadataContributorProvider<StubMappedIndex> contributorProvider,
+			StubMappingBackendFeatures backendFeatures,
 			TenancyMode tenancyMode) {
 		this.failureCollector = buildContext.failureCollector();
 		this.contributorProvider = contributorProvider;
+		this.backendFeatures = backendFeatures;
 		this.tenancyMode = tenancyMode;
 	}
 
@@ -134,7 +137,7 @@ class StubMapper implements Mapper<StubMappingPartialBuildState>, IndexedEntityB
 			throw new MappingAbortedException();
 		}
 
-		return new StubMappingPartialBuildState( mappedIndexesByTypeIdentifier );
+		return new StubMappingPartialBuildState( backendFeatures, mappedIndexesByTypeIdentifier );
 	}
 
 	@Override

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingBackendFeatures.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingBackendFeatures.java
@@ -1,0 +1,15 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.integrationtest.mapper.stub;
+
+public interface StubMappingBackendFeatures {
+
+	default boolean supportsExplicitRefresh() {
+		return true;
+	}
+
+}

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingImpl.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingImpl.java
@@ -30,6 +30,7 @@ import org.hibernate.search.util.common.impl.Futures;
 public class StubMappingImpl
 		implements StubMapping, MappingImplementor<StubMappingImpl>, EntityReferenceFactory {
 
+	private final StubMappingBackendFeatures backendFeatures;
 	private final Map<String, StubMappedIndex> mappedIndexesByTypeIdentifier;
 	private final StubMappingSchemaManagementStrategy schemaManagementStrategy;
 
@@ -39,8 +40,10 @@ public class StubMappingImpl
 
 	StubMappingFixture fixture = new StubMappingFixture( this );
 
-	StubMappingImpl(Map<String, StubMappedIndex> mappedIndexesByTypeIdentifier,
+	StubMappingImpl(StubMappingBackendFeatures backendFeatures,
+			Map<String, StubMappedIndex> mappedIndexesByTypeIdentifier,
 			StubMappingSchemaManagementStrategy schemaManagementStrategy) {
+		this.backendFeatures = backendFeatures;
 		this.mappedIndexesByTypeIdentifier = mappedIndexesByTypeIdentifier;
 		this.schemaManagementStrategy = schemaManagementStrategy;
 		this.toDocumentFieldValueConvertContext = new ToDocumentValueConvertContextImpl( this );
@@ -52,6 +55,10 @@ public class StubMappingImpl
 			closer.push( SearchIntegration::close, integrationHandle, SearchIntegration.Handle::getOrNull );
 			integrationHandle = null;
 		}
+	}
+
+	StubMappingBackendFeatures backendFeatures() {
+		return backendFeatures;
 	}
 
 	@Override

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingInitiator.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingInitiator.java
@@ -18,10 +18,12 @@ import org.hibernate.search.engine.tenancy.spi.TenancyMode;
 
 public class StubMappingInitiator implements MappingInitiator<StubMappedIndex, StubMappingPartialBuildState> {
 
+	private final StubMappingBackendFeatures backendFeatures;
 	private final TenancyMode tenancyMode;
 	private final List<StubMappedIndex> mappedIndexes = new ArrayList<>();
 
-	public StubMappingInitiator(TenancyMode tenancyMode) {
+	public StubMappingInitiator(StubMappingBackendFeatures backendFeatures, TenancyMode tenancyMode) {
+		this.backendFeatures = backendFeatures;
 		this.tenancyMode = tenancyMode;
 	}
 
@@ -40,7 +42,7 @@ public class StubMappingInitiator implements MappingInitiator<StubMappedIndex, S
 	@Override
 	public Mapper<StubMappingPartialBuildState> createMapper(MappingBuildContext buildContext,
 			TypeMetadataContributorProvider<StubMappedIndex> contributorProvider) {
-		return new StubMapper( buildContext, contributorProvider, tenancyMode );
+		return new StubMapper( buildContext, contributorProvider, backendFeatures, tenancyMode );
 	}
 
 }

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingPartialBuildState.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingPartialBuildState.java
@@ -12,9 +12,12 @@ import org.hibernate.search.engine.mapper.mapping.building.spi.MappingPartialBui
 
 public class StubMappingPartialBuildState implements MappingPartialBuildState {
 
+	private final StubMappingBackendFeatures backendFeatures;
 	private final Map<String, StubMappedIndex> mappedIndexesByTypeIdentifier;
 
-	StubMappingPartialBuildState(Map<String, StubMappedIndex> mappedIndexesByTypeIdentifier) {
+	StubMappingPartialBuildState(StubMappingBackendFeatures backendFeatures,
+			Map<String, StubMappedIndex> mappedIndexesByTypeIdentifier) {
+		this.backendFeatures = backendFeatures;
 		this.mappedIndexesByTypeIdentifier = mappedIndexesByTypeIdentifier;
 	}
 
@@ -24,7 +27,7 @@ public class StubMappingPartialBuildState implements MappingPartialBuildState {
 	}
 
 	public StubMappingImpl finalizeMapping(StubMappingSchemaManagementStrategy schemaManagementStrategy) {
-		StubMappingImpl mapping = new StubMappingImpl( mappedIndexesByTypeIdentifier,
+		StubMappingImpl mapping = new StubMappingImpl( backendFeatures, mappedIndexesByTypeIdentifier,
 				schemaManagementStrategy );
 		for ( StubMappedIndex index : mappedIndexesByTypeIdentifier.values() ) {
 			index.onMappingCreated( mapping );


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4867

~~Based on #3672 , which must be merged first.~~ => Done

In short, this overcomes all problems reported by RiVogel in the Jira issue, but the tests just use a local OpenSearch instance because of problems setting up an Amazon OpenSearch Serverless cluster (see https://hibernate.atlassian.net/browse/HSEARCH-4919).

So, we really can't consider this working now, but at least it's there for anyone to try and we will eventually be able to get to testing and perfecting it (see https://hibernate.atlassian.net/browse/HSEARCH-4919).

There are a few limitations, but I think they are acceptable.

@marko-bekhta I'd recommend reviewing commit by commits, and skipping the commits that are strictly about tests, because they are uninteresting and not even critical (since we don't test against Amazon OpenSearch Serverless at the moment).