### PR TITLE
HSEARCH-4924 Follow-up: fix Sonar execution (hopefully)

### DIFF
--- a/ci/list-dependent-integration-tests.sh
+++ b/ci/list-dependent-integration-tests.sh
@@ -13,7 +13,7 @@ IFS="," COMMA_SEPARATED_TESTED_ARTIFACT_IDS="$*"
 TESTED_ARTIFACT_IDS_REGEXP="(\Q$(echo "$*" | perl -pe 's/,/\\E|\\Q/g')\E)"
 
 {
-	./mvnw -Pdist dependency:list -pl :hibernate-search-parent-integrationtest -am -amd -DincludeArtifactIds="$COMMA_SEPARATED_TESTED_ARTIFACT_IDS"
+	./mvnw dependency:list -pl :hibernate-search-parent-integrationtest -am -amd -DincludeArtifactIds="$COMMA_SEPARATED_TESTED_ARTIFACT_IDS"
 } \
 	| perl -0777 -pe "s/(hibernate-search-.*) ---(\n(?!.*Building).*)*\n.*:$TESTED_ARTIFACT_IDS_REGEXP:jar:/\nMATCH:\$1\n/g" \
 	| perl -ne 'print if s/MATCH:(.*)/:$1/g' \

--- a/pom.xml
+++ b/pom.xml
@@ -1856,6 +1856,9 @@
                                 Use [/\\] for path separators because of Windows.
                             -->
                             <excludePathsMatching>[/\\][^/\\]*\.(md|txt)|[/\\]\..*|[/\\].*[/\\]README\.(md|txt)|[/\\]ci[/\\]dependency-update[/\\].*</excludePathsMatching>
+                            <!-- The reports module always needs to be built, otherwise we don't generate
+                                 some important reports like coverage reports -->
+                            <forceBuildModules>hibernate-search-reports</forceBuildModules>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4924

I ended up always enabling the "pre-build", because it's simpler, possibly useful (I'd rather have formatting checks fail fast) and I don't expect it to impact non-incrementl builds too much (at worst we'll build integration tests twice, so will waste 3-4 minutes on a 1h build...)