### PR TITLE
HSEARCH-4924 Follow-up: ensure Jacoco coverage numbers are correct in default build + speed up some Maven executions on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -380,7 +380,7 @@ stage('Default build') {
 		withMavenWorkspace(mavenSettingsConfig: deploySnapshot ? helper.configuration.file.deployment.maven.settingsId : null) {
 			String commonMavenArgs = """ \
 					--fail-at-end \
-					-Pdist -Pcoverage \
+					-Pcoverage \
 					${toTestJdkArg(environments.content.jdk.default)} \
 			"""
 
@@ -388,9 +388,9 @@ stage('Default build') {
 			sh """ \
 					mvn \
 					${commonMavenArgs} \
+					-Pdist \
 					-Pjqassistant -Pci-sources-check \
 					-DskipITs \
-					${toTestJdkArg(environments.content.jdk.default)} \
 					clean \
 					${deploySnapshot ? "\
 							deploy \

--- a/build/enforcer/src/main/java/org/hibernate/search/build/enforcer/DependenciesIncludeAllTestCoverageModulesRule.java
+++ b/build/enforcer/src/main/java/org/hibernate/search/build/enforcer/DependenciesIncludeAllTestCoverageModulesRule.java
@@ -1,0 +1,79 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.build.enforcer;
+
+import static org.hibernate.search.build.enforcer.MavenProjectUtils.isAnyParentIntegrationTestParent;
+import static org.hibernate.search.build.enforcer.MavenProjectUtils.isAnyParentPublicParent;
+import static org.hibernate.search.build.enforcer.MavenProjectUtils.isProjectJacocoSkipped;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.project.MavenProject;
+
+@Named("dependenciesIncludeAllTestCoverageModules") // rule name - must start with lowercase character
+public class DependenciesIncludeAllTestCoverageModulesRule extends AbstractEnforcerRule {
+
+	// Inject needed Maven components
+	@Inject
+	private MavenSession session;
+
+	/**
+	 * Specify the test modules that will be ignored.
+	 */
+	private List<String> excludes = null;
+
+	public void execute() throws EnforcerRuleException {
+		Map<String, Dependency> dependencies = session.getCurrentProject()
+				.getDependencies()
+				.stream()
+				.collect( Collectors.toMap( Dependency::getArtifactId, Function.identity() ) );
+
+		List<String> problems = new ArrayList<>();
+
+		for ( MavenProject project : session.getAllProjects() ) {
+			if ( project.getArtifactId().equals( session.getCurrentProject().getArtifactId() ) ) {
+				// We don't expect a project to depend on itself.
+				continue;
+			}
+			if ( excludes != null && excludes.contains( project.getArtifactId() ) ) {
+				continue;
+			}
+			if ( !"jar".equals( project.getPackaging() ) ) {
+				// We don't care about non-JAR modules (those don't have any tests)
+				continue;
+			}
+			if ( !isAnyParentPublicParent( project ) && !isAnyParentIntegrationTestParent( project ) ) {
+				// We don't care about non-public, non-IT modules
+				continue;
+			}
+			if ( isProjectJacocoSkipped( project ) ) {
+				// We don't care about modules whose coverage gets ignored
+				continue;
+			}
+			if ( dependencies.remove( project.getArtifactId() ) == null ) {
+				// The project is NOT in the dependencies
+				problems.add( "`" + project.getGroupId() + ":" + project.getArtifactId()
+						+ "` is missing from the 'dependencies' section." );
+			}
+		}
+
+		if ( !problems.isEmpty() ) {
+			throw new EnforcerRuleException( String.join( ";\n", problems ) );
+		}
+	}
+}

--- a/build/enforcer/src/main/java/org/hibernate/search/build/enforcer/MavenProjectUtils.java
+++ b/build/enforcer/src/main/java/org/hibernate/search/build/enforcer/MavenProjectUtils.java
@@ -11,6 +11,7 @@ import org.apache.maven.project.MavenProject;
 public class MavenProjectUtils {
 
 	public static final String HIBERNATE_SEARCH_PARENT_PUBLIC = "hibernate-search-parent-public";
+	public static final String HIBERNATE_SEARCH_PARENT_INTEGRATION_TEST = "hibernate-search-parent-integrationtest";
 	public static final String DEPLOY_SKIP = "deploy.skip";
 
 	private MavenProjectUtils() {
@@ -22,8 +23,19 @@ public class MavenProjectUtils {
 						|| isAnyParentPublicParent( project.getParent() ) );
 	}
 
+	public static boolean isAnyParentIntegrationTestParent(MavenProject project) {
+		return project.hasParent()
+				&& ( HIBERNATE_SEARCH_PARENT_INTEGRATION_TEST.equals( project.getParent().getArtifactId() )
+				|| isAnyParentIntegrationTestParent( project.getParent() ) );
+	}
+
 	public static boolean isProjectDeploySkipped(MavenProject project) {
 		return Boolean.TRUE.toString()
 				.equals( project.getProperties().getOrDefault( DEPLOY_SKIP, Boolean.FALSE ).toString() );
+	}
+
+	public static boolean isProjectJacocoSkipped(MavenProject project) {
+		return Boolean.TRUE.toString()
+				.equals( project.getProperties().getOrDefault( "jacoco.skip", Boolean.FALSE ).toString() );
 	}
 }

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -629,6 +629,36 @@
                 <artifactId>hibernate-search-integrationtest-mapper-orm-batch-jsr352</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-spring-repackaged-application</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-java-modules-orm-coordination-outbox-polling-elasticsearch</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-java-modules-orm-elasticsearch</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-java-modules-orm-lucene</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-java-modules-pojo-standalone-elasticsearch</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-java-modules-pojo-standalone-lucene</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <!-- Test -->
             <dependency>

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -1283,6 +1283,7 @@
             <properties>
                 <!-- Skip parts of the build that may fail but don't matter when testing upgrades -->
                 <checkstyle.skip>true</checkstyle.skip>
+                <format.skip>true</format.skip>
                 <maven.javadoc.skip>true</maven.javadoc.skip>
                 <javadoc.download.phase>none</javadoc.download.phase>
                 <enforcer.dependencyconvergence.skip>true</enforcer.dependencyconvergence.skip>

--- a/build/reports/pom.xml
+++ b/build/reports/pom.xml
@@ -105,6 +105,11 @@
         </dependency>
         <dependency>
             <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-integrationtest-mapper-orm-spring</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-integrationtest-mapper-orm-envers</artifactId>
             <scope>test</scope>
         </dependency>
@@ -116,6 +121,11 @@
         <dependency>
             <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-integrationtest-mapper-pojo-standalone-realbackend</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-integrationtest-showcase-library</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -140,6 +150,11 @@
         </dependency>
         <dependency>
             <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-integrationtest-spring-repackaged-application</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-documentation</artifactId>
             <scope>test</scope>
         </dependency>
@@ -147,6 +162,41 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-dependencies-rules</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <dependenciesIncludeAllTestCoverageModules>
+                                    <excludes>
+                                        <!-- These modules are legacy and we don't care about test coverage. -->
+                                        <exclude>hibernate-search-v5migrationhelper-engine</exclude>
+                                        <exclude>hibernate-search-v5migrationhelper-orm</exclude>
+                                        <!-- These modules do not actually contain code to be covered or test executions,
+                                             they are basically false positives. -->
+                                        <exclude>hibernate-search-integrationtest-backend-tck</exclude>
+                                        <exclude>hibernate-search-integrationtest-performance-backend-base</exclude>
+                                        <exclude>hibernate-search-integrationtest-spring-repackaged-model</exclude>
+                                    </excludes>
+                                </dependenciesIncludeAllTestCoverageModules>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.hibernate.search</groupId>
+                        <artifactId>hibernate-search-build-enforcer</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
             <!--
                 Hack to deploy in the "reports" module without deploying the "reports" module itself.
                 The default lifecycle bindings of the plugin is to "stage locally" every artifact throughout
@@ -202,6 +252,45 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <!--
+                We want to keep these module path tests within their own profile,
+                so we can easily exclude building them all in some scenarios like eclipse compiler profile etc.
+             -->
+            <id>javaModuleITs</id>
+            <activation>
+                <!-- Hack to activate by default, except when explicitly disabled -->
+                <jdk>[11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.hibernate.search</groupId>
+                    <artifactId>hibernate-search-integrationtest-java-modules-orm-coordination-outbox-polling-elasticsearch</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hibernate.search</groupId>
+                    <artifactId>hibernate-search-integrationtest-java-modules-orm-elasticsearch</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hibernate.search</groupId>
+                    <artifactId>hibernate-search-integrationtest-java-modules-orm-lucene</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hibernate.search</groupId>
+                    <artifactId>hibernate-search-integrationtest-java-modules-pojo-standalone-elasticsearch</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hibernate.search</groupId>
+                    <artifactId>hibernate-search-integrationtest-java-modules-pojo-standalone-lucene</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -44,14 +44,6 @@
             <plugin>
                 <groupId>org.jboss.maven.plugins</groupId>
                 <artifactId>maven-injection-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>bytecode</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <bytecodeInjections>
                         <bytecodeInjection>

--- a/integrationtest/performance/backend/elasticsearch/pom.xml
+++ b/integrationtest/performance/backend/elasticsearch/pom.xml
@@ -19,6 +19,9 @@
     <description>Performance tests for the Elasticsearch backend</description>
 
     <properties>
+        <!-- We don't want to use a Jacoco agent here, and we don't want to rely on these tests for coverage either -->
+        <jacoco.skip>true</jacoco.skip>
+
         <test.elasticsearch.run.skip>${test.elasticsearch.connection.uris.defined}</test.elasticsearch.run.skip>
     </properties>
 

--- a/integrationtest/performance/backend/lucene/pom.xml
+++ b/integrationtest/performance/backend/lucene/pom.xml
@@ -18,6 +18,11 @@
     <name>Hibernate Search ITs - Performance - Backend - Lucene</name>
     <description>Performance tests for the Lucene backend</description>
 
+    <properties>
+        <!-- We don't want to use a Jacoco agent here, and we don't want to rely on these tests for coverage either -->
+        <jacoco.skip>true</jacoco.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.hibernate.search</groupId>

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -53,6 +53,7 @@
              -->
             <id>javaModuleITs</id>
             <activation>
+                <!-- Hack to activate by default, except when explicitly disabled -->
                 <jdk>[11,)</jdk>
             </activation>
             <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -349,6 +349,9 @@
         -->
         <flatten-maven-plugin.dependencyManagement.action>resolve</flatten-maven-plugin.dependencyManagement.action>
 
+        <!-- Overridden in profiles to disable the plugin (which doesn't have a 'skip' property...) -->
+        <injection-plugin.phase>compile</injection-plugin.phase>
+
         <!-- Test settings -->
 
         <!-- Properties overridden in profiles to disable certain tests that only work with specific Java versions -->
@@ -640,6 +643,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>${version.resources.plugin}</version>
+                    <configuration>
+                        <!-- Don't overwrite existing files if the destination files are newer.
+                             Necessary to avoid rebuilding JARs when executing Maven twice,
+                             which has dramatic cascading effects as it leads to recompiling
+                             sources for all depending projects. -->
+                        <overwrite>false</overwrite>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -772,6 +782,14 @@
                     <groupId>org.jboss.maven.plugins</groupId>
                     <artifactId>maven-injection-plugin</artifactId>
                     <version>${version.maven.injection.plugin}</version>
+                    <executions>
+                        <execution>
+                            <phase>${injection-plugin.phase}</phase>
+                            <goals>
+                                <goal>bytecode</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>io.smallrye</groupId>
@@ -1377,6 +1395,16 @@
         </profile>
 
         <profile>
+            <id>skip-checks</id>
+            <properties>
+                <enforcer.skip>true</enforcer.skip>
+                <checkstyle.skip>true</checkstyle.skip>
+                <format.skip>true</format.skip>
+                <forbiddenapis.skip>true</forbiddenapis.skip>
+            </properties>
+        </profile>
+
+        <profile>
             <id>testWithJdkSpecifiedExplicitly</id>
             <activation>
                 <property>
@@ -1685,6 +1713,40 @@
                 <goal.impsort-maven-plugin>check</goal.impsort-maven-plugin>
                 <goal.formatter-maven-plugin>validate</goal.formatter-maven-plugin>
             </properties>
+        </profile>
+
+        <!-- A profile for CI when we've already built the whole tree but for some reason need
+             to run Maven again, preferably without cleaning.
+             Useful for example when we do `mvn clean verify -DskipITs` then `mvn verify -Dincremental`;
+             the second execution needs this profile to fix a few things.
+         -->
+        <profile>
+            <id>ci-rebuild</id>
+            <properties>
+                <!-- Don't inject code again if we already did a full build (we only do this in the engine).
+                     Necessary to avoid rebuilding JARs when executing Maven twice,
+                     which has dramatic cascading effects as it leads to recompiling
+                     sources for all depending projects. -->
+                <injection-plugin.phase>none</injection-plugin.phase>
+                <!-- Once we've already built the main modules, we don't need to run Moditect a second time,
+                     and doing so will actually lead to errors because Moditect worries about overwriting
+                     module-info.class files. -->
+                <moditect.skip>true</moditect.skip>
+            </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <configuration>
+                                <!-- This is to skip Surefire without skipping Failsafe -->
+                                <skipTests>true</skipTests >
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
         </profile>
 
         <profile>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4924

Test coverage is currently at 0 on Maven because the modules that contain classes that we need coverage numbers for *must* be included in the "default build - second round" that runs ITs. Otherwise the Jacoco execution will not report coverage for the corresponding classes.

This fixes that, and a bit more.