### PR TITLE
HSEARCH-4902 Follow-up: fix weird URLs in flattened POMs and use flattenMode

### DIFF
--- a/bom/public/pom.xml
+++ b/bom/public/pom.xml
@@ -95,6 +95,14 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
+                <configuration>
+                    <!-- Keep dependency management -->
+                    <flattenMode>bom</flattenMode>
+                    <pomElements>
+                        <!-- But not properties, they are not useful in a bom -->
+                        <properties>remove</properties>
+                    </pomElements>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/build/parents/public/pom.xml
+++ b/build/parents/public/pom.xml
@@ -29,12 +29,6 @@
         <deploy.skip>true</deploy.skip>
         <!-- This will make sure the build fails if we forget to set <deploy.skip>false</deploy.skip> in a child module -->
         <enforcer.publicModuleIsDeployedRule.skip>false</enforcer.publicModuleIsDeployedRule.skip>
-        <!--
-            POMs of public modules will be flattened and will include the list of dependencies
-            with resolved versions.
-            Thus, there's no need for dependency management sections in these POMs.
-        -->
-        <flatten-maven-plugin.dependencyManagement.action>remove</flatten-maven-plugin.dependencyManagement.action>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -602,16 +602,9 @@
                     <version>${version.flatten-maven-plugin}</version>
                     <configuration>
                         <outputDirectory>${project.build.directory}</outputDirectory>
-                        <flattenMode>bom</flattenMode>
-                        <pomElements>
-                            <!-- Specific modules can decide what to do about the dependency management section -->
-                            <dependencyManagement>${flatten-maven-plugin.dependencyManagement.action}</dependencyManagement>
-                            <!--
-                                We don't want to show any properties in the BOM/POMs.
-                                The properties we need will be resolved, others have no value for the users of the BOM/POMs.
-                             -->
-                            <properties>remove</properties>
-                        </pomElements>
+                        <!-- Keep things like url, inceptionYear, authors...
+                             everything that's required by the OSSRH Maven repository -->
+                        <flattenMode>ossrh</flattenMode>
                     </configuration>
                     <executions>
                         <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,11 @@
  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
   -->
+<!-- child.project.url.inherit.append.path is weird but necessary to have correct URLs in flattened POMs,
+     see XSD for more info. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
+         child.project.url.inherit.append.path="false">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.hibernate.search</groupId>
@@ -26,7 +29,11 @@
         <url>https://hibernate.atlassian.net/browse/HSEARCH</url>
     </issueManagement>
 
-    <scm>
+    <!-- The various child.*.append.path are weird but necessary to have correct URLs in flattened POMs,
+         see XSD for more info. -->
+    <scm child.scm.connection.inherit.append.path="false"
+         child.scm.developerConnection.inherit.append.path="false"
+         child.scm.url.inherit.append.path="false">
         <connection>scm:git:git://github.com/hibernate/hibernate-search.git</connection>
         <developerConnection>scm:git:git@github.com:hibernate/hibernate-search.git</developerConnection>
         <url>http://github.com/hibernate/hibernate-search</url>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4902

Follows up on #3603

This avoids weird URLs we're getting right now in flattened POMs:

```xml
<url>
http://hibernate.org/search/build/parents/hibernate-search-parent-build/hibernate-search-parent-public/hibernate-search-engine/
</url>
```

```xml
<scm>
<connection>
scm:git:git://github.com/hibernate/hibernate-search.git/build/parents/hibernate-search-parent-build/hibernate-search-parent-public/hibernate-search-engine
</connection>
<developerConnection>
scm:git:git@github.com:hibernate/hibernate-search.git/build/parents/hibernate-search-parent-build/hibernate-search-parent-public/hibernate-search-engine
</developerConnection>
<url>
http://github.com/hibernate/hibernate-search/build/parents/hibernate-search-parent-build/hibernate-search-parent-public/hibernate-search-engine
</url>
</scm>
```

Turns out it affects `mvn help:effective-pom` as well, and is actually a Maven feature. Go figure.

I also made a minor change to use `flattenMode` more appropriately, but that shouldn't change the end result.