### PR TITLE
HSEARCH-4914 Handle transaction deadlocks more gracefully when retrieving outbox events (especially on CockroachDB)

### DIFF
--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxEventLoader.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxEventLoader.java
@@ -53,10 +53,11 @@ final class OutboxEventLoader implements ToStringTreeAppendable {
 		if ( dialect.supportsSkipLocked() ) {
 			lockOptions = new LockOptions( LockMode.UPGRADE_SKIPLOCKED );
 		}
-		// If SKIP_LOCKED is not supported, we just do basic locking and hope for the best
+		// If LockMode.UPGRADE_SKIPLOCKED is not supported, we just do basic locking and hope for the best
 		// (in particular we hope for transaction deadlocks to be detected by the database and result in a failure,
 		// so that we can try again later).
-		// HSEARCH-4634: CockroachDB doesn't support SKIP_LOCKED (https://github.com/cockroachdb/cockroach/issues/40476?version=v22.1),
+		// HSEARCH-4634: CockroachDB doesn't support LockMode.UPGRADE_SKIPLOCKED
+		// (https://github.com/cockroachdb/cockroach/issues/40476?version=v22.1),
 		// but fortunately it doesn't suffer from lock escalation,
 		// so as long as we target a distinct set of events in each processor (we do),
 		// locking shouldn't trigger any deadlocks.
@@ -88,7 +89,7 @@ final class OutboxEventLoader implements ToStringTreeAppendable {
 		catch (OptimisticLockException lockException) {
 			// Don't be fooled by the exception type, this is actually a *pessimistic* lock failure.
 			// It can happen with some databases (Mariadb before 10.6, perhaps others) that do not support
-			// skipping locked rows (see LockOptions.SKIP_LOCKED).
+			// skipping locked rows (see LockOptions.UPGRADE_SKIPLOCKED).
 			// If that happens, we will just log something and try again later.
 			// See also https://jira.mariadb.org/browse/MDEV-13115
 			log.outboxEventProcessorUnableToLock( processorName, lockException );

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxEventLoader.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxEventLoader.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import jakarta.persistence.OptimisticLockException;
+import jakarta.persistence.PessimisticLockException;
 
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
@@ -86,8 +87,8 @@ final class OutboxEventLoader implements ToStringTreeAppendable {
 			query.setLockOptions( lockOptions );
 			return query.getResultList();
 		}
-		catch (OptimisticLockException lockException) {
-			// Don't be fooled by the exception type, this is actually a *pessimistic* lock failure.
+		catch (PessimisticLockException | OptimisticLockException lockException) {
+			// Note OptimisticLockException is sometimes (always?) thrown to indicate a *pessimistic* lock failure.
 			// It can happen with some databases (Mariadb before 10.6, perhaps others) that do not support
 			// skipping locked rows (see LockOptions.UPGRADE_SKIPLOCKED).
 			// If that happens, we will just log something and try again later.

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingEventProcessor.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/event/impl/OutboxPollingEventProcessor.java
@@ -18,6 +18,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.persistence.OptimisticLockException;
+import jakarta.persistence.PessimisticLockException;
 
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.search.engine.backend.orchestration.spi.SingletonTask;
@@ -286,8 +287,8 @@ public final class OutboxPollingEventProcessor implements ToStringTreeAppendable
 							return;
 						}
 					}
-					catch (OptimisticLockException lockException) {
-						// Don't be fooled by the exception type, this is actually a *pessimistic* lock failure.
+					catch (PessimisticLockException | OptimisticLockException lockException) {
+						// Note OptimisticLockException is sometimes (always?) thrown to indicate a *pessimistic* lock failure.
 						// It can happen with some databases (CockroachDB in particular, perhaps others)
 						// that treat transaction failures as a matter of course that applications should deal with.
 						// See also https://www.cockroachlabs.com/docs/v23.1/transaction-retry-error-reference.html

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/logging/impl/Log.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/logging/impl/Log.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import jakarta.persistence.OptimisticLockException;
+import jakarta.persistence.PersistenceException;
 
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.Agent;
 import org.hibernate.search.mapper.orm.coordination.outboxpolling.cluster.impl.AgentReference;
@@ -86,7 +86,7 @@ public interface Log extends BasicLogger {
 
 	@LogMessage(level = DEBUG)
 	@Message(id = ID_OFFSET + 11, value = "'%1$s' failed to obtain a lock on events to update/delete; will try again later.")
-	void outboxEventProcessorUnableToLock(String name, @Cause OptimisticLockException lockException);
+	void outboxEventProcessorUnableToLock(String name, @Cause PersistenceException lockException);
 
 	@Message(id = ID_OFFSET + 12, value = "Unable to serialize OutboxEvent payload with Avro: %1$s")
 	SearchException unableToSerializeOutboxEventPayloadWithAvro(String causeMessage, @Cause Throwable cause);
@@ -209,6 +209,6 @@ public interface Log extends BasicLogger {
 			// Warning: we check that this message does NOT appear in logs in some tests.
 			// If you update this message, make sure to also update OutboxPollingAutomaticIndexingConcurrencyIT.
 			value = "'%1$s' failed to retrieve events to process due to a locking failure; will try again later.")
-	void eventProcessorFindEventsUnableToLock(String name, @Cause OptimisticLockException lockException);
+	void eventProcessorFindEventsUnableToLock(String name, @Cause PersistenceException lockException);
 
 }

--- a/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/logging/impl/Log.java
+++ b/mapper/orm-coordination-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/coordination/outboxpolling/logging/impl/Log.java
@@ -85,7 +85,7 @@ public interface Log extends BasicLogger {
 	void eventProcessorDisabled(String tenantId);
 
 	@LogMessage(level = DEBUG)
-	@Message(id = ID_OFFSET + 11, value = "'%1$s' failed to obtain a lock on events to process; will try again later.")
+	@Message(id = ID_OFFSET + 11, value = "'%1$s' failed to obtain a lock on events to update/delete; will try again later.")
 	void outboxEventProcessorUnableToLock(String name, @Cause OptimisticLockException lockException);
 
 	@Message(id = ID_OFFSET + 12, value = "Unable to serialize OutboxEvent payload with Avro: %1$s")
@@ -203,5 +203,12 @@ public interface Log extends BasicLogger {
 			value = "Configuration property `%1$s` is deprecated and will be removed in the future versions of Hibernate Search."
 					+ " This property is only to help with the schema migration and should not be used as a long term solution.")
 	void usingDeprecatedPayloadTypeConfigurationProperty(String configurationProperty);
+
+	@LogMessage(level = DEBUG)
+	@Message(id = ID_OFFSET + 34,
+			// Warning: we check that this message does NOT appear in logs in some tests.
+			// If you update this message, make sure to also update OutboxPollingAutomaticIndexingConcurrencyIT.
+			value = "'%1$s' failed to retrieve events to process due to a locking failure; will try again later.")
+	void eventProcessorFindEventsUnableToLock(String name, @Cause OptimisticLockException lockException);
 
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4914

Essentially I'm giving up on avoiding deadlocks on CockroachDB. We'll retry instead, and will just avoid reporting errors.