### PR TITLE
HSEARCH-4920 Add CI jobs to test against the latest version of Lucene/Elasticsearch

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -1344,6 +1344,22 @@
                         <updatePolicy>always</updatePolicy>
                     </snapshots>
                 </repository>
+                <repository>
+                    <id>apache-snapshots</id>
+                    <url>https://repository.apache.org/content/groups/snapshots</url>
+                    <layout>default</layout>
+                    <releases>
+                        <!-- versions-maven-plugin will ignore this repo, even for snapshots,
+                             unless we enable releases.
+                             This is most likely a bug. -->
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </snapshots>
+                </repository>
             </repositories>
         </profile>
 

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -1162,7 +1162,6 @@
                             <org.hibernate.search.version>${project.version}</org.hibernate.search.version>
                             <org.hibernate.search.enable_performance_tests>${test.performance.enable}</org.hibernate.search.enable_performance_tests>
                             <org.hibernate.search.integrationtest.backend.elasticsearch.distribution>${test.elasticsearch.distribution}</org.hibernate.search.integrationtest.backend.elasticsearch.distribution>
-                            <org.hibernate.search.integrationtest.backend.elasticsearch.version>${test.elasticsearch.version}</org.hibernate.search.integrationtest.backend.elasticsearch.version>
                         </systemPropertyVariables>
                     </configuration>
                 </plugin>

--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -20,6 +20,16 @@ Map settings() {
 					updateProperties: ['version.org.hibernate.orm'],
 					onlyRunTestDependingOn: ['hibernate-search-mapper-orm']
 			]
+		case 'lucene9':
+			return [
+					updateProperties: ['version.org.apache.lucene'],
+					onlyRunTestDependingOn: ['hibernate-search-backend-lucene'],
+			]
+		case 'lucene10':
+			return [
+					updateProperties: ['version.org.apache.lucene'],
+					onlyRunTestDependingOn: ['hibernate-search-backend-lucene'],
+			]
 		default:
 			return [:]
 	}
@@ -117,7 +127,7 @@ pipeline {
 					axis {
 						name 'DEPENDENCY_UPDATE_NAME'
 						// NOTE: Remember to update the settings() method above when changing this.
-						values 'orm6.2', 'orm6.3'
+						values 'orm6.2', 'orm6.3', 'lucene9', 'lucene10'
 					}
 				}
 				stages {

--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -30,6 +30,14 @@ Map settings() {
 					updateProperties: ['version.org.apache.lucene'],
 					onlyRunTestDependingOn: ['hibernate-search-backend-lucene'],
 			]
+		case 'elasticsearch-latest':
+			return [
+					// There are no properties to update in this case.
+					updateProperties: [],
+					onlyRunTestDependingOn: ['hibernate-search-backend-elasticsearch'],
+					// We want to use the snapshot version of an image from the ES registry since that's where they are publishing their snapshots.
+					additionalMavenArgs: '-Dtest.elasticsearch.run.elastic.image.name=docker.elastic.co/elasticsearch/elasticsearch -Dtest.elasticsearch.run.elastic.image.tag=master-SNAPSHOT'
+			]
 		default:
 			return [:]
 	}
@@ -127,7 +135,7 @@ pipeline {
 					axis {
 						name 'DEPENDENCY_UPDATE_NAME'
 						// NOTE: Remember to update the settings() method above when changing this.
-						values 'orm6.2', 'orm6.3', 'lucene9', 'lucene10'
+						values 'orm6.2', 'orm6.3', 'lucene9', 'lucene10', 'elasticsearch-latest'
 					}
 				}
 				stages {

--- a/ci/dependency-update/rules-lucene10.xml
+++ b/ci/dependency-update/rules-lucene10.xml
@@ -1,0 +1,9 @@
+<ruleset comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+  <ignoreVersions>
+    <!-- Restrict allowed versions to a particular major/range-of-minors, because forbidding major/minor upgrades
+         in the version-maven-plugin configuration doesn't always work for some reason. -->
+    <ignoreVersion type="regex">(?!10\.\d+\.).*</ignoreVersion>
+  </ignoreVersions>
+</ruleset>

--- a/ci/dependency-update/rules-lucene9.xml
+++ b/ci/dependency-update/rules-lucene9.xml
@@ -1,0 +1,9 @@
+<ruleset comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+  <ignoreVersions>
+    <!-- Restrict allowed versions to a particular major/range-of-minors, because forbidding major/minor upgrades
+         in the version-maven-plugin configuration doesn't always work for some reason. -->
+    <ignoreVersion type="regex">(?!9\.([8-9]|\d{2,})\.).*</ignoreVersion>
+  </ignoreVersions>
+</ruleset>

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -200,6 +200,14 @@ public class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 		);
 	}
 
+	@Override
+	public boolean supportsHighlighterUnifiedPhraseMatching() {
+		return isActualVersion(
+				esVersion -> !esVersion.isLessThan( "8.10" ),
+				osVersion -> false
+		);
+	}
+
 	public static boolean supportsIndexClosingAndOpening() {
 		return isActualVersion(
 				// See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-operations.html#version_7_1

--- a/util/internal/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/ElasticsearchTestDialectVersionTest.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/ElasticsearchTestDialectVersionTest.java
@@ -11,23 +11,9 @@ import static org.hibernate.search.util.impl.integrationtest.backend.elasticsear
 
 import org.hibernate.search.backend.elasticsearch.ElasticsearchVersion;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class ElasticsearchTestDialectVersionTest {
-
-	@BeforeClass
-	public static void beforeClass() {
-		System.setProperty( "org.hibernate.search.integrationtest.backend.elasticsearch.distribution", "elastic" );
-		System.setProperty( "org.hibernate.search.integrationtest.backend.elasticsearch.version", "1.1.1" );
-	}
-
-	@AfterClass
-	public static void afterClass() {
-		System.clearProperty( "org.hibernate.search.integrationtest.backend.elasticsearch.distribution" );
-		System.clearProperty( "org.hibernate.search.integrationtest.backend.elasticsearch.version" );
-	}
 
 	@Test
 	public void isBetween() {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4920

I haven't found if there are snapshots for ES/OS images, so I haven't added anything for them...
As for the Lucene upgrade, I thought we could run the upgrade tests for the current 9 series as well as for the upcoming 10. 