### PR TITLE
Enable code formatting plugin in default build

### DIFF
--- a/backend/elasticsearch-aws/src/main/java/org/hibernate/search/backend/elasticsearch/aws/impl/ElasticsearchAwsHttpClientConfigurer.java
+++ b/backend/elasticsearch-aws/src/main/java/org/hibernate/search/backend/elasticsearch/aws/impl/ElasticsearchAwsHttpClientConfigurer.java
@@ -86,7 +86,8 @@ public class ElasticsearchAwsHttpClientConfigurer implements ElasticsearchHttpCl
 		log.debugf( "AWS request signing is enabled [region = '%s', service = '%s', credentialsProvider = '%s'].",
 				region, service, credentialsProvider );
 
-		AwsSigningRequestInterceptor signingInterceptor = new AwsSigningRequestInterceptor( region, service, credentialsProvider );
+		AwsSigningRequestInterceptor signingInterceptor =
+				new AwsSigningRequestInterceptor( region, service, credentialsProvider );
 
 		context.clientBuilder().addInterceptorLast( signingInterceptor );
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -822,7 +822,8 @@ public interface Log extends BasicLogger {
 	SearchException unableToFetchElasticsearchVersion(String versionConfigPropertyKey,
 			ElasticsearchVersion expectedAWSOpenSearchServerlessVersion);
 
-	@Message(id = ID_OFFSET + 174, value = "Cannot check the Elasticsearch version because the targeted Elasticsearch distribution '%s' does not expose its version.")
+	@Message(id = ID_OFFSET + 174,
+			value = "Cannot check the Elasticsearch version because the targeted Elasticsearch distribution '%s' does not expose its version.")
 	SearchException cannotCheckElasticsearchVersion(ElasticsearchDistributionName distributionName);
 
 	@Message(id = ID_OFFSET + 175,
@@ -832,8 +833,9 @@ public interface Log extends BasicLogger {
 	SearchException unexpectedAwsOpenSearchServerlessVersion(ElasticsearchVersion configuredVersion,
 			ElasticsearchVersion expectedAWSOpenSearchServerlessVersion);
 
-	@Message(id = ID_OFFSET + 176, value = "Cannot execute '%s' because Amazon OpenSearch Serverless does not support this operation."
-			+ " Either avoid this operation or switch to another Elasticsearch/OpenSearch distribution.")
+	@Message(id = ID_OFFSET + 176,
+			value = "Cannot execute '%s' because Amazon OpenSearch Serverless does not support this operation."
+					+ " Either avoid this operation or switch to another Elasticsearch/OpenSearch distribution.")
 	SearchException cannotExecuteOperationOnAmazonOpenSearchServerless(String operation);
 
 	@Message(id = ID_OFFSET + 177, value = "The targeted Elasticsearch cluster does not expose index status,"

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchVersionTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchVersionTest.java
@@ -208,7 +208,8 @@ public class ElasticsearchVersionTest {
 
 	@Test
 	public void exactMatch_amazonOpensearchServerless() {
-		assertMatch( "amazon-opensearch-serverless", ElasticsearchDistributionName.AMAZON_OPENSEARCH_SERVERLESS, null ).isTrue();
+		assertMatch( "amazon-opensearch-serverless", ElasticsearchDistributionName.AMAZON_OPENSEARCH_SERVERLESS, null )
+				.isTrue();
 	}
 
 	@Test

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmMassIndexerIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmMassIndexerIT.java
@@ -68,7 +68,7 @@ public class HibernateOrmMassIndexerIT extends AbstractHibernateOrmMassIndexingI
 				massIndexer.type( Author.class ).reindexOnly( "e.birthDate < :birthDate" ) // <4>
 						.param( "birthDate", LocalDate.ofYearDay( 2100, 77 ) ); // <5>
 				// end::reindexOnly[]
-				if ( ! BackendConfigurations.simple().supportsExplicitPurge() ) {
+				if ( !BackendConfigurations.simple().supportsExplicitPurge() ) {
 					massIndexer.purgeAllOnStart( false );
 				}
 				// tag::reindexOnly[]

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapIT.java
@@ -227,7 +227,7 @@ public class ElasticsearchBootstrapIT {
 					+ actualVersion.majorOptional().getAsInt();
 			incompatibleConfiguredVersionOnBackendStart = actualVersion.distribution() + ":"
 					+ ( actualVersion.majorOptional().getAsInt() == 2 ? "42." : "2." ) + actualVersion.minor()
-					.getAsInt();
+							.getAsInt();
 		}
 		else {
 			// This should only happen when testing Amazon OpenSearch Serverless
@@ -264,7 +264,8 @@ public class ElasticsearchBootstrapIT {
 										+ incompatibleConfiguredVersionOnBackendStart + "'",
 								"Incompatible Elasticsearch version:"
 										+ " version '" + incompatibleConfiguredVersionOnBackendStart
-										+ "' does not match version '" + configuredVersionOnBackendCreation + "' that was provided"
+										+ "' does not match version '" + configuredVersionOnBackendCreation
+										+ "' that was provided"
 										+ " when the backend was created.",
 								"You can provide a more precise version on startup,"
 										+ " but you cannot override the version that was provided when the backend was created." )
@@ -376,7 +377,8 @@ public class ElasticsearchBootstrapIT {
 	private void checkAmazonOpenSearchServerless() {
 		ElasticsearchVersion actualVersion = ElasticsearchTestDialect.getActualVersion();
 		if ( actualVersion.distribution() != ElasticsearchDistributionName.AMAZON_OPENSEARCH_SERVERLESS ) {
-			throw new IllegalStateException( "Unexpected actual Elasticsearch version: " + actualVersion + ". Tests are buggy?" );
+			throw new IllegalStateException(
+					"Unexpected actual Elasticsearch version: " + actualVersion + ". Tests are buggy?" );
 		}
 	}
 

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/massindexing/MassIndexingManualSchemaManagementIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/massindexing/MassIndexingManualSchemaManagementIT.java
@@ -81,8 +81,8 @@ public class MassIndexingManualSchemaManagementIT {
 			catch (InterruptedException e) {
 				fail( "Unexpected InterruptedException: " + e.getMessage() );
 			}
-			setupHelper.assertions().searchAfterIndexChangesAndPotentialRefresh( () ->
-					assertThat( BookCreatorUtils.documentsCount( entityManagerFactory ) )
+			setupHelper.assertions().searchAfterIndexChangesAndPotentialRefresh(
+					() -> assertThat( BookCreatorUtils.documentsCount( entityManagerFactory ) )
 							.isEqualTo( NUMBER_OF_BOOKS ) );
 		} );
 	}
@@ -103,8 +103,8 @@ public class MassIndexingManualSchemaManagementIT {
 			catch (InterruptedException e) {
 				fail( "Unexpected InterruptedException: " + e.getMessage() );
 			}
-			setupHelper.assertions().searchAfterIndexChangesAndPotentialRefresh( () ->
-					assertThat( BookCreatorUtils.documentsCount( entityManagerFactory ) )
+			setupHelper.assertions().searchAfterIndexChangesAndPotentialRefresh(
+					() -> assertThat( BookCreatorUtils.documentsCount( entityManagerFactory ) )
 							.isEqualTo( NUMBER_OF_BOOKS ) );
 		} );
 	}

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/AbstractBackendHolder.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/AbstractBackendHolder.java
@@ -69,7 +69,7 @@ public abstract class AbstractBackendHolder {
 		SearchIntegration.Builder integrationBuilder =
 				SearchIntegration.builder( environment );
 
-		StubMappingInitiator initiator = new StubMappingInitiator( new StubMappingBackendFeatures() { },
+		StubMappingInitiator initiator = new StubMappingInitiator( new StubMappingBackendFeatures() {},
 				TenancyMode.SINGLE_TENANCY );
 		StubMappingKey mappingKey = new StubMappingKey();
 		integrationBuilder.addMappingInitiator( mappingKey, initiator );

--- a/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/massindexing/step/afterchunk/impl/AfterChunkBatchlet.java
+++ b/mapper/orm-batch-jsr352/core/src/main/java/org/hibernate/search/batch/jsr352/core/massindexing/step/afterchunk/impl/AfterChunkBatchlet.java
@@ -55,7 +55,8 @@ public class AfterChunkBatchlet extends AbstractBatchlet {
 			BatchMappingContext mappingContext = (BatchMappingContext) Search.mapping( emf );
 			PojoScopeWorkspace workspace = mappingContext.scope( Object.class ).pojoWorkspace( tenantId );
 			Futures.unwrappedExceptionJoin( workspace.mergeSegments( OperationSubmitter.blocking(),
-					serializedMergeSegmentsOnFinish != null ? UnsupportedOperationBehavior.FAIL
+					serializedMergeSegmentsOnFinish != null
+							? UnsupportedOperationBehavior.FAIL
 							: UnsupportedOperationBehavior.IGNORE ) );
 		}
 		return null;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoScopeWorkspaceImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoScopeWorkspaceImpl.java
@@ -40,8 +40,8 @@ public class PojoScopeWorkspaceImpl implements PojoScopeWorkspace {
 	public CompletableFuture<?> purge(Set<String> routingKeys, OperationSubmitter operationSubmitter,
 			UnsupportedOperationBehavior unsupportedOperationBehavior) {
 		return doOperationOnTypes(
-				(indexWorkspace, submitter, unsupportedBehavior) ->
-						indexWorkspace.purge( routingKeys, submitter, unsupportedBehavior ),
+				(indexWorkspace, submitter, unsupportedBehavior) -> indexWorkspace.purge( routingKeys, submitter,
+						unsupportedBehavior ),
 				operationSubmitter, unsupportedOperationBehavior );
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -1048,6 +1048,15 @@
                         <skip>${format.skip}</skip>
                         <removeTrailingWhitespace>true</removeTrailingWhitespace>
                     </configuration>
+                    <executions>
+                        <execution>
+                            <id>code-formatting</id>
+                            <goals>
+                                <goal>${goal.formatter-maven-plugin}</goal>
+                            </goals>
+                            <phase>process-sources</phase>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.eclipse.sisu</groupId>

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchBackendConfiguration.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchBackendConfiguration.java
@@ -25,7 +25,8 @@ public class ElasticsearchBackendConfiguration extends BackendConfiguration {
 		Map<String, String> properties = new LinkedHashMap<>();
 		properties.put( "log.json_pretty_printing", "true" );
 		ElasticsearchTestHostConnectionConfiguration.get().addToBackendProperties( properties );
-		if ( ElasticsearchDistributionName.AMAZON_OPENSEARCH_SERVERLESS.equals( ElasticsearchTestDialect.getActualVersion().distribution() ) ) {
+		if ( ElasticsearchDistributionName.AMAZON_OPENSEARCH_SERVERLESS
+				.equals( ElasticsearchTestDialect.getActualVersion().distribution() ) ) {
 			// The distribution/version cannot be detected on Amazon OpenSearch Serverless
 			properties.put( "version", ElasticsearchTestDialect.getActualVersion().toString() );
 		}

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/BulkIndexer.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/BulkIndexer.java
@@ -128,8 +128,8 @@ public class BulkIndexer {
 					mappingContext,
 					asSetIgnoreNull( tenantId )
 			);
-			future = future.thenCompose( ignored ->
-					workspace.refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ) );
+			future = future.thenCompose(
+					ignored -> workspace.refresh( OperationSubmitter.blocking(), UnsupportedOperationBehavior.FAIL ) );
 		}
 		return future;
 	}


### PR DESCRIPTION
- add an execution for a formatter plugin
- reformat the project with an enabled plugin


Seems like with all the plugins moved around we've lost the execution of the formatter plugin 🙈 