### PR TITLE
HSEARCH-4933 Follow-up: Fix incorrect bytebuddy changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2710,6 +2710,11 @@
                 </property>
             </activation>
             <properties>
+                <!-- We need net.bytebuddy.experimental=true to make BytecodeEnhancementIT and mockito-based tests pass -->
+                <surefire.jvm.args.java-version>
+                    -Djdk.attach.allowAttachSelf=true
+                    -Dnet.bytebuddy.experimental=true
+                </surefire.jvm.args.java-version>
                 <!-- Spring isn't ready for JDK21 yet -->
                 <failsafe.spring.skip>true</failsafe.spring.skip>
                 <!-- impsort-maven-plugin doesn't work with JDK21 yet -->

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
         <version.jakarta.interceptor-api>2.0.1</version.jakarta.interceptor-api>
         <version.jakarta.enterprise>3.0.1</version.jakarta.enterprise>
         <version.jakarta.xml.bind>4.0.0</version.jakarta.xml.bind>
-        <version.net.bytebuddy.orm6>1.12.22</version.net.bytebuddy.orm6>
+        <version.net.bytebuddy.orm6>1.14.7</version.net.bytebuddy.orm6>
 
         <!-- >>> JSR 352 -->
         <version.javax.batch>1.0.1</version.javax.batch>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4933

I used the wrong version of bytebuddy and forgot that we also need to test against ORM 5, where we still need `net.bytebuddy.experimental=true` on Java 21...