### PR TITLE
[WIP] Lucene 10 SNAPSHOT upgrade

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/docvalues/impl/JoiningTextMultiValuesSource.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/docvalues/impl/JoiningTextMultiValuesSource.java
@@ -35,7 +35,7 @@ public abstract class JoiningTextMultiValuesSource extends TextMultiValuesSource
 
 	protected final NestedDocsProvider nestedDocsProvider;
 
-	public JoiningTextMultiValuesSource(NestedDocsProvider nestedDocsProvider) {
+	protected JoiningTextMultiValuesSource(NestedDocsProvider nestedDocsProvider) {
 		this.nestedDocsProvider = nestedDocsProvider;
 	}
 
@@ -84,15 +84,12 @@ public abstract class JoiningTextMultiValuesSource extends TextMultiValuesSource
 					return hasNextValue();
 				}
 
-				currentParentDoc = parentDoc;
-				nextOrd = NO_MORE_ORDS; // To be set in the next call to hasNextValue()
-
 				return childDocsWithValues.advanceExactParent( parentDoc );
 			}
 
 			@Override
 			public boolean hasNextValue() throws IOException {
-				if ( nextOrd != NO_MORE_ORDS ) {
+				if ( super.hasNextValue() ) {
 					return true;
 				}
 
@@ -101,7 +98,6 @@ public abstract class JoiningTextMultiValuesSource extends TextMultiValuesSource
 					return true;
 				}
 				else {
-					nextOrd = NO_MORE_ORDS;
 					return false;
 				}
 			}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/docvalues/impl/TextMultiValues.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/docvalues/impl/TextMultiValues.java
@@ -22,8 +22,6 @@ import org.apache.lucene.index.SortedSetDocValues;
  */
 public abstract class TextMultiValues {
 
-	protected static final long NO_MORE_ORDS = -1L;
-
 	/**
 	 * Sole constructor. (For invocation by subclass
 	 * constructors, typically implicit.)
@@ -91,6 +89,8 @@ public abstract class TextMultiValues {
 
 		protected final SortedSetDocValues values;
 		protected long nextOrd;
+		protected int docValueCount = 0;
+		protected int currentDocIndex = 0;
 
 		DocValuesTextMultiValues(SortedSetDocValues values) {
 			this.values = values;
@@ -99,20 +99,25 @@ public abstract class TextMultiValues {
 		@Override
 		public boolean advanceExact(int doc) throws IOException {
 			boolean found = values.advanceExact( doc );
-			nextOrd = found ? values.nextOrd() : NO_MORE_ORDS;
+			if ( found ) {
+				nextOrd = values.nextOrd();
+				docValueCount = values.docValueCount();
+				currentDocIndex = 0;
+			}
 			return found;
 		}
 
 		@Override
 		public boolean hasNextValue() throws IOException {
-			return nextOrd != NO_MORE_ORDS;
+			return currentDocIndex < docValueCount;
 		}
 
 		@Override
 		public long nextOrd() throws IOException {
-			long result = nextOrd;
+			currentDocIndex++;
+			long previousOrd = nextOrd;
 			nextOrd = values.nextOrd();
-			return result;
+			return previousOrd;
 		}
 
 		@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextRegexpPredicate.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextRegexpPredicate.java
@@ -73,9 +73,6 @@ public class LuceneTextRegexpPredicate extends AbstractLuceneLeafSingleFieldPred
 
 		for ( RegexpQueryFlag operation : flags ) {
 			switch ( operation ) {
-				case COMPLEMENT:
-					flag |= RegExp.COMPLEMENT;
-					break;
 				case INTERVAL:
 					flag |= RegExp.INTERVAL;
 					break;

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -30,7 +30,7 @@
 
         <!-- >>> Lucene -->
         <!-- When upgrading Lucene, make sure to align the dependency to com.carrotsearch.hppc (see below) -->
-        <version.org.apache.lucene>9.7.0</version.org.apache.lucene>
+        <version.org.apache.lucene>10.0.0-SNAPSHOT</version.org.apache.lucene>
         <javadoc.org.apache.lucene.tag>${parsed-version.org.apache.lucene.majorVersion}_${parsed-version.org.apache.lucene.minorVersion}_${parsed-version.org.apache.lucene.incrementalVersion}</javadoc.org.apache.lucene.tag>
         <javadoc.org.apache.lucene.core.url>https://lucene.apache.org/core/${javadoc.org.apache.lucene.tag}/core/</javadoc.org.apache.lucene.core.url>
         <javadoc.org.apache.lucene.analyzers-common.url>https://lucene.apache.org/core/${javadoc.org.apache.lucene.tag}/analyzers-common/</javadoc.org.apache.lucene.analyzers-common.url>

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
@@ -894,7 +894,7 @@ public class PredicateDslIT {
 			hits = searchSession.search( Book.class )
 					.where( f -> f.regexp().field( "description" )
 							.matching( "r@t" )
-							.flags( RegexpQueryFlag.ANY_STRING, RegexpQueryFlag.COMPLEMENT )
+							.flags( RegexpQueryFlag.ANY_STRING )
 					)
 					.fetchHits( 20 );
 			// end::regexp-flags[]

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/LuceneTckBackendFeatures.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/LuceneTckBackendFeatures.java
@@ -58,4 +58,9 @@ class LuceneTckBackendFeatures extends TckBackendFeatures {
 	public boolean supportsHighlighterUnifiedPhraseMatching() {
 		return true;
 	}
+
+	@Override
+	public boolean supportsComplementRegexFlag() {
+		return false;
+	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/RegexpPredicateSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/RegexpPredicateSpecificsIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.predicate;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
+import static org.junit.Assume.assumeTrue;
 
 import java.util.Collections;
 import java.util.function.Function;
@@ -164,6 +165,10 @@ public class RegexpPredicateSpecificsIT {
 
 	@Test
 	public void flag_complement() {
+		assumeTrue(
+				"Lucene 10 does not have a `COMPLEMENT` flag. ",
+				TckConfiguration.get().getBackendFeatures().supportsComplementRegexFlag()
+		);
 		StubMappingScope scope = index.createScope();
 		String absoluteFieldPath = index.binding().complementField.relativeFieldName;
 
@@ -207,6 +212,10 @@ public class RegexpPredicateSpecificsIT {
 
 	@Test
 	public void flag_interval() {
+		assumeTrue(
+				"Lucene 10 does not have a `COMPLEMENT` flag. ",
+				TckConfiguration.get().getBackendFeatures().supportsComplementRegexFlag()
+		);
 		StubMappingScope scope = index.createScope();
 		String absoluteFieldPath = index.binding().intervalField.relativeFieldName;
 
@@ -235,7 +244,7 @@ public class RegexpPredicateSpecificsIT {
 		assertThatQuery( scope.query()
 				.where( f -> f.regexp().field( absoluteFieldPath )
 						.matching( TEXT_INTERVAL )
-						.flags( RegexpQueryFlag.COMPLEMENT, RegexpQueryFlag.INTERVAL, RegexpQueryFlag.ANY_STRING )
+						.flags( RegexpQueryFlag.INTERVAL, RegexpQueryFlag.ANY_STRING )
 				) )
 				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_2 );
 
@@ -243,7 +252,7 @@ public class RegexpPredicateSpecificsIT {
 		assertThatQuery( scope.query()
 				.where( f -> f.regexp().field( absoluteFieldPath )
 						.matching( TEXT_INTERVAL )
-						.flags( RegexpQueryFlag.COMPLEMENT, RegexpQueryFlag.INTERSECTION, RegexpQueryFlag.ANY_STRING )
+						.flags( RegexpQueryFlag.INTERSECTION, RegexpQueryFlag.ANY_STRING )
 				) )
 				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
 	}
@@ -278,7 +287,7 @@ public class RegexpPredicateSpecificsIT {
 		assertThatQuery( scope.query()
 				.where( f -> f.regexp().field( absoluteFieldPath )
 						.matching( TEXT_INTERSECTION )
-						.flags( RegexpQueryFlag.COMPLEMENT, RegexpQueryFlag.INTERVAL, RegexpQueryFlag.INTERSECTION )
+						.flags( RegexpQueryFlag.INTERVAL, RegexpQueryFlag.INTERSECTION )
 				) )
 				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1, DOCUMENT_2 );
 
@@ -286,7 +295,7 @@ public class RegexpPredicateSpecificsIT {
 		assertThatQuery( scope.query()
 				.where( f -> f.regexp().field( absoluteFieldPath )
 						.matching( TEXT_INTERSECTION )
-						.flags( RegexpQueryFlag.COMPLEMENT, RegexpQueryFlag.INTERVAL, RegexpQueryFlag.ANY_STRING )
+						.flags( RegexpQueryFlag.INTERVAL, RegexpQueryFlag.ANY_STRING )
 				) )
 				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
 	}
@@ -329,7 +338,7 @@ public class RegexpPredicateSpecificsIT {
 		assertThatQuery( scope.query()
 				.where( f -> f.regexp().field( absoluteFieldPath )
 						.matching( TEXT_ANYSTRING )
-						.flags( RegexpQueryFlag.COMPLEMENT, RegexpQueryFlag.INTERVAL, RegexpQueryFlag.INTERSECTION )
+						.flags( RegexpQueryFlag.INTERVAL, RegexpQueryFlag.INTERSECTION )
 				) )
 				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
@@ -132,4 +132,8 @@ public abstract class TckBackendFeatures implements StubMappingBackendFeatures {
 		return true;
 	}
 
+	public boolean supportsComplementRegexFlag() {
+		return true;
+	}
+
 }

--- a/util/internal/integrationtest/backend/lucene/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/lucene/directory/TrackingDirectory.java
+++ b/util/internal/integrationtest/backend/lucene/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/lucene/directory/TrackingDirectory.java
@@ -76,8 +76,8 @@ class TrackingDirectory extends BaseDirectory {
 	}
 
 	@Override
-	public ChecksumIndexInput openChecksumInput(String name, IOContext context) throws IOException {
-		return new TrackingChecksumIndexInput( delegate.openChecksumInput( name, context ), tracker );
+	public ChecksumIndexInput openChecksumInput(String name) throws IOException {
+		return new TrackingChecksumIndexInput( delegate.openChecksumInput( name ), tracker );
 	}
 
 	@Override


### PR DESCRIPTION
Apparently, deprecating Lucene's constant `NO_MORE_ORDS` wasn't just for fun on their side 😄.
In Lucene 10 stored set doc values wouldn't return -1 when they are "finished"... For example `SingletonSortedSetDocValues` would just always return the ord it has leading to a never-ending loop, others can end up throwing some exceptions...

I've tested the patched  `DocValuesTextMultiValues` and `JoiningTextMultiValuesSource` on main with Lucene 9 and it passed the TCK tests. I think it probably would be better to make these in the main, and let it be a part of Search 7.0.

Then as for the missing `RegexpQueryFlag.COMPLEMENT` counterpart in Lucene ... I've removed it from Lucene backend, but left it as is in the tests and Search enum until we decide how we want to treat that option in general...