### PR TITLE
Change when the default attach-javadocs execution runs

### DIFF
--- a/build/parents/public/pom.xml
+++ b/build/parents/public/pom.xml
@@ -297,6 +297,17 @@
                                 </goals>
                                 <phase>process-resources</phase>
                             </execution>
+                            <execution>
+                                <!--
+                                    This is the default name of an execution that is added automatically if release profile is enabled.
+                                    We want to "override" it so that we can control when it is actually executed.
+                                 -->
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <phase>${javadoc.generate.jar.phase}</phase>
+                            </execution>
                         </executions>
                     </plugin>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,8 @@
         <!-- Overridden in profiles to disable the plugin (which doesn't have a 'skip' property...) -->
         <injection-plugin.phase>compile</injection-plugin.phase>
 
+        <javadoc.generate.jar.phase>none</javadoc.generate.jar.phase>
+
         <!-- Test settings -->
 
         <!-- Properties overridden in profiles to disable certain tests that only work with specific Java versions -->
@@ -1392,6 +1394,10 @@
                     <value>true</value>
                 </property>
             </activation>
+            <properties>
+                <!-- We want this execution to happen before moditect (which executes at package phase) -->
+                <javadoc.generate.jar.phase>prepare-package</javadoc.generate.jar.phase>
+            </properties>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
- to prevent it from running after moditect, which causes issues otherwise

The other moditect goal (that we've talked about over Zulip) doesn't work for us since that one generates a java file for an already built jar ... so that somewhat does not meet our needs 😃 
I have tested this javadoc generation when a module has a module-info.java file in the root and it worked ok... 
I have also tried to add sources via `build-helper-maven-plugin` since moditect generates the file into target dir... but then the build was failing as the generated file was missing a "require" for jboss-logging-annotations ... 