### PR TITLE
HSEARCH-4941 Upgrade to Elasticsearch client 8.9.2 and test against Elasticsearch 8.9.2 / HSEARCH-4942 Test against latest Elasticsearch 7.17.13

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -228,7 +228,7 @@ stage('Configure') {
 					// so we don't test them
 					// See https://hibernate.atlassian.net/browse/HSEARCH-4340
 					new LocalElasticsearchBuildEnvironment(version: '7.16.3', condition: TestCondition.ON_DEMAND),
-					new LocalElasticsearchBuildEnvironment(version: '7.17.12', condition: TestCondition.AFTER_MERGE),
+					new LocalElasticsearchBuildEnvironment(version: '7.17.13', condition: TestCondition.AFTER_MERGE),
 					// Not testing 8.0 because we know there are problems in 8.0.1 (see https://hibernate.atlassian.net/browse/HSEARCH-4497)
 					// Not testing 8.1-8.6 to make the build quicker.
 					new LocalElasticsearchBuildEnvironment(version: '8.1.3', condition: TestCondition.ON_DEMAND),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -239,7 +239,7 @@ stage('Configure') {
 					new LocalElasticsearchBuildEnvironment(version: '8.6.2', condition: TestCondition.ON_DEMAND),
 					new LocalElasticsearchBuildEnvironment(version: '8.7.1', condition: TestCondition.ON_DEMAND),
 					new LocalElasticsearchBuildEnvironment(version: '8.8.2', condition: TestCondition.ON_DEMAND),
-					new LocalElasticsearchBuildEnvironment(version: '8.9.1', condition: TestCondition.BEFORE_MERGE, isDefault: true),
+					new LocalElasticsearchBuildEnvironment(version: '8.9.2', condition: TestCondition.BEFORE_MERGE, isDefault: true),
 
 					// --------------------------------------------
 					// OpenSearch

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -46,7 +46,7 @@
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.5+ -->
         <!-- NOTE: when updating this version check if the Jackson version is still aligned. -->
-        <version.org.elasticsearch.client>8.9.1</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>8.9.2</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-8.4) becomes the default. -->

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -161,7 +161,7 @@ public class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 		// https://github.com/elastic/elasticsearch/issues/91246
 		// Hopefully this will get fixed in a future version.
 		return isActualVersion(
-				esVersion -> !esVersion.isBetween( "7.17.7", "7.17" ) && !esVersion.isBetween( "8.5.0", "8.9.1" ),
+				esVersion -> !esVersion.isBetween( "7.17.7", "7.17" ) && !esVersion.isBetween( "8.5.0", "8.9.2" ),
 				osVersion -> true
 		);
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -372,7 +372,7 @@
 
         <!-- Container images for various integration tests -->
         <!-- The latest version of Elasticsearch tested against by default -->
-        <version.org.elasticsearch.latest>8.9.1</version.org.elasticsearch.latest>
+        <version.org.elasticsearch.latest>8.9.2</version.org.elasticsearch.latest>
         <test.elasticsearch.version>${version.org.elasticsearch.latest}</test.elasticsearch.version>
 
         <test.elasticsearch.run.elastic.skip>true</test.elasticsearch.run.elastic.skip>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4941
https://hibernate.atlassian.net/browse/HSEARCH-4942