### PR TITLE
HSEARCH-4943 Add migration to update id column types

### DIFF
--- a/documentation/src/main/asciidoc/migration/index.adoc
+++ b/documentation/src/main/asciidoc/migration/index.adoc
@@ -112,6 +112,173 @@ Keep in mind that these properties are temporary, to help with the migration,
 and will be removed in the future versions of Hibernate Search.
 ====
 
+If you were using Hibernate Search 6.2 with Hibernate ORM 5, i.e. using regular Hibernate Search artifacts and not `-orm6`/`-jakarta` ones
+this upgrade will also mean the upgrade of Hibernate ORM to 6.3. Doing so will lead to a potential type mismatch when using Hibernate ORM's schema validation.
+To prevent that, `id` column types can be updated from `varchar` to `char` where applicable.
+You can find suggested migration scripts for the tested databases below:
+
+.Postgresql:
+[,sql]
+----
+-- change outbox event `id` column type to char:
+alter table hsearch_outbox_event
+    alter column id TYPE char(36);
+
+-- change agent `id` column type to char:
+alter table hsearch_agent
+    alter column id TYPE char(36);
+----
+
+.CockroachDB:
+[,sql]
+----
+-- change outbox event `id` column type to char:
+-- altering type directly is not supported: https://go.crdb.dev/issue-v/47636/v22.1
+alter table hsearch_outbox_event
+    add tmp char(36);
+update hsearch_outbox_event
+set tmp = id
+where 1 = 1;
+alter table hsearch_outbox_event
+    alter column tmp set not null;
+alter table hsearch_outbox_event
+    alter primary key using columns (tmp);
+alter table hsearch_outbox_event
+    drop column id;
+alter table hsearch_outbox_event
+    rename column tmp to id;
+
+-- change agent `id` column type to char:
+alter table hsearch_agent
+    add tmp char(36);
+update hsearch_agent
+set tmp = id
+where 1 = 1;
+alter table hsearch_agent
+    alter column tmp set not null;
+alter table hsearch_agent
+    alter primary key using columns (tmp);
+alter table hsearch_agent
+    drop column id;
+alter table hsearch_agent
+    rename column tmp to id;
+----
+
+.MySQL:
+[,sql]
+----
+-- change outbox event `id` column type to char:
+alter table hsearch_outbox_event
+    modify column id char(36);
+
+-- change agent `id` column type to char:
+alter table hsearch_agent
+    modify column id char(36);
+----
+
+.MariaDB:
+[,sql]
+----
+-- change outbox event `id` column type to char:
+alter table hsearch_outbox_event
+    modify column id char(36);
+
+-- change agent `id` column type to char:
+alter table hsearch_agent
+    modify column id char(36);
+----
+
+.DB2:
+[,sql]
+----
+-- change outbox event `id` column type to char:
+alter table hsearch_outbox_event
+    drop primary key;
+alter table hsearch_outbox_event
+    alter column id set data type char(36);
+-- make this call if the adding constraint fails:
+call sysproc.admin_cmd('reorg table hsearch_outbox_event');
+alter table hsearch_outbox_event
+    add constraint hsearch_outbox_event_pkey primary key (id);
+
+-- change agent `id` column type to char:
+alter table hsearch_agent
+    drop primary key;
+alter table hsearch_agent
+    alter column id set data type char(36);
+-- make this call if the adding constraint fails:
+call sysproc.admin_cmd('reorg table hsearch_agent');
+alter table hsearch_agent
+    add constraint hsearch_agent_pkey primary key (id);
+----
+
+.Oracle:
+[,sql]
+----
+-- change outbox event `id` column type to char:
+alter table hsearch_outbox_event
+    add tmp char(36);
+update hsearch_outbox_event
+set tmp = id
+where 1 = 1;
+alter table hsearch_outbox_event
+    modify tmp not null;
+alter table hsearch_outbox_event
+    drop column id;
+alter table hsearch_outbox_event
+    rename column tmp to id;
+alter table hsearch_outbox_event
+    add constraint hsearch_outbox_event_pkey primary key (id);
+
+-- change agent `id` column type to char:
+alter table hsearch_agent
+alter table hsearch_agent
+    add tmp char(36);
+update hsearch_agent
+set tmp = id
+where 1 = 1;
+alter table hsearch_agent
+    modify tmp not null;
+alter table hsearch_agent
+    drop column id;
+alter table hsearch_agent
+    rename column tmp to id;
+alter table hsearch_agent
+    add constraint hsearch_agent_pkey primary key (id);
+----
+
+.MSSQL:
+[,sql]
+----
+-- change publox event `id` column type to char:
+alter table hsearch_outbox_event
+    drop constraint if exists hsearch_outbox_event_pkey;
+alter table hsearch_outbox_event
+    alter column id binary(16) not null;
+alter table hsearch_outbox_event
+    add constraint hsearch_outbox_event_pkey primary key (id);
+
+-- change agent `id` column type to char:
+alter table hsearch_agent
+    drop constraint if exists hsearch_agent_pkey;
+alter table hsearch_agent
+    alter column id binary(16) not null;
+alter table hsearch_agent
+    add constraint hsearch_agent_pkey primary key (id);
+----
+
+.H2:
+[,sql]
+----
+-- change outbox event `id` column type to char:
+alter table hsearch_outbox_event
+    alter column id char(36) not null;
+
+-- change agent `id` column type to char:
+alter table hsearch_agent
+    alter column id char(36) not null;
+----
+
 [[configuration]]
 == Configuration changes
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4943

I guess since there can be these differences we could also give users these migration scripts if they'd want to make schema validation work ok... 😃 