### PR TITLE
Follow-up: HSEARCH-4944 Update ORM6 patch to not use an array in a `@SkipForDialect`

### DIFF
--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -29,7 +29,9 @@ Map settings() {
 		case 'orm6.3':
 			return [
 					updateProperties: ['version.org.hibernate.orm'],
-					onlyRunTestDependingOn: ['hibernate-search-mapper-orm-orm6']
+					onlyRunTestDependingOn: ['hibernate-search-mapper-orm-orm6'],
+					// we need to recompile this module since it has incompatible return type and will result in a build error:
+					additionalMavenArgs: '-pl :hibernate-search-util-internal-integrationtest'
 			]
 		case 'orm6-in-main-code':
 			return [

--- a/orm6/integrationtest/v5migrationhelper/orm/ant-src-changes.patch
+++ b/orm6/integrationtest/v5migrationhelper/orm/ant-src-changes.patch
@@ -1,5 +1,5 @@
 diff --git a/test/java/org/hibernate/search/test/configuration/LobTest.java b/test/java/org/hibernate/search/test/configuration/LobTest.java
-index 1820470ca3..6eec8d5d83 100644
+index 1820470ca3..3ac74481e4 100644
 --- a/test/java/org/hibernate/search/test/configuration/LobTest.java
 +++ b/test/java/org/hibernate/search/test/configuration/LobTest.java
 @@ -17,8 +17,7 @@
@@ -17,7 +17,7 @@ index 1820470ca3..6eec8d5d83 100644
  
  	@Test
 -	@SkipForDialect(value = { SybaseASE15Dialect.class, Sybase11Dialect.class },
-+	@SkipForDialect(value = { SybaseDialect.class },
++	@SkipForDialect(value = SybaseDialect.class,
  			comment = "Sybase does not support @Lob")
  	public void testCreateIndexSearchEntityWithLobField() {
  		// create and index


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4944