### PR TITLE
HSEARCH-4947 Make sure that nested jars can be read on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,10 @@ jobs:
           # We can't start Linux containers on GitHub Actions' Windows VMs,
           # so we can't run Elasticsearch tests.
           # See https://github.com/actions/runner-images/issues/1143#issuecomment-972929995
+          # For some reason docker-maven-plugin will error out with "All pipe instances are busy"
+          # on GitHub Actions' Windows VMs (when using Bash?),
+          # so we also explicitly disable docker-maven-plugin.
+          # See https://github.com/fabric8io/docker-maven-plugin/issues/548#issuecomment-255477600
           - {
             name: "Windows JDK 17",
             runs-on: 'windows-latest',
@@ -71,7 +75,7 @@ jobs:
               version: 17
             },
             maven: {
-              args: '-Dtest.elasticsearch.skip=true'
+              args: '-Dtest.elasticsearch.skip=true -Dtest.containers.run.skip=true'
             }
           }
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,13 +56,22 @@ jobs:
             runs-on: 'ubuntu-latest',
             java: {
               version: 17
+            },
+            maven: {
+              args: ''
             }
           }
+          # We can't start Linux containers on GitHub Actions' Windows VMs,
+          # so we can't run Elasticsearch tests.
+          # See https://github.com/actions/runner-images/issues/1143#issuecomment-972929995
           - {
             name: "Windows JDK 17",
             runs-on: 'windows-latest',
             java: {
               version: 17
+            },
+            maven: {
+              args: '-Dtest.elasticsearch.skip=true'
             }
           }
     steps:
@@ -91,10 +100,12 @@ jobs:
       - name: Docker cleanup
         run: ./ci/docker-cleanup.sh
       - name: Building code and running unit tests and basic checks
-        run: ./mvnw $MAVEN_ARGS install -Pjqassistant -Pdist -Pci-sources-check -DskipITs
+        run: |
+          ./mvnw $MAVEN_ARGS ${{ matrix.os.maven.args }} install \
+          -Pjqassistant -Pdist -Pci-sources-check -DskipITs
       - name: Running integration tests in the default environment
         run: |
-          ./mvnw $MAVEN_ARGS verify \
+          ./mvnw $MAVEN_ARGS ${{ matrix.os.maven.args }} verify \
           -DskipSurefireTests -Pskip-checks -Pci-rebuild \
           ${{ github.event.pull_request.base.ref && format('-Dincremental -Dgib.referenceBranch=refs/remotes/origin/{0}', github.event.pull_request.base.ref) || '' }}
       - name: Docker cleanup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,13 @@ concurrency:
   group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'hibernate/hibernate-search' }}
 
+defaults:
+  run:
+    shell: bash
+
 env:
   MAVEN_ARGS: "-e -B --settings .github/mvn-settings.xml --fail-at-end"
+
 jobs:
   build:
     name: ${{matrix.os.name}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,11 +117,21 @@ jobs:
         run: ./ci/docker-cleanup.sh
       - name: Omit produced artifacts from build cache
         run: rm -r ~/.m2/repository/org/hibernate/search
+      # Workaround for https://github.com/actions/upload-artifact/issues/240
+      - name: List build reports to upload (if build failed)
+        if: ${{ failure() || cancelled() }}
+        # The weird syntax is because we're setting a multiline environment variable
+        # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
+        run: |
+          {
+            echo 'buildReportPaths<<EOF'
+            find . -path '**/*-reports'
+            echo EOF
+          } >> "$GITHUB_ENV"
       - name: Upload build reports (if build failed)
         uses: actions/upload-artifact@v3
         if: ${{ failure() || cancelled() }}
         with:
-          name: ${{ format('build-reports-{0}', github.job) }}
-          path: |
-            ./**/*-reports/
-          retention-days: 2
+          name: ${{ format('build-reports-{0}', matrix.os.name ) }}
+          path: ${{ env.buildReportPaths }}
+          retention-days: 7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,8 +223,8 @@ and run unit tests and integration tests.
 ```
 
 Note: on Windows, you will need a Docker install able to run Linux containers.
-If you don't have that, you can skip the Elasticsearch tests:
-`./mvnw clean install -Dtest.elasticsearch.skip=true`.
+If you don't have that, you can skip the Elasticsearch tests and all container startups:
+`./mvnw clean install -Dtest.elasticsearch.skip=true -Dtest.containers.run.skip=true`.
 
 Note: the produced JARs are compatible with Java 8 and later,
 regardless of the JDK used to build Hibernate Search.
@@ -344,6 +344,12 @@ you can skip all Elasticsearch tests (and thus the Elasticsearch container start
 
 ```bash
 ./mvnw clean install -Dtest.elasticsearch.skip=true
+```
+
+On Windows, you might need to also skip all docker container features:
+
+```bash
+./mvnw clean install -Dtest.elasticsearch.skip=true -Dtest.containers.run.skip=true
 ```
 
 Alternatively, you can prevent the build from launching an Elasticsearch server automatically

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,6 +222,10 @@ and run unit tests and integration tests.
 ./mvnw clean install
 ```
 
+Note: on Windows, you will need a Docker install able to run Linux containers.
+If you don't have that, you can skip the Elasticsearch tests:
+`./mvnw clean install -Dtest.elasticsearch.skip=true`.
+
 Note: the produced JARs are compatible with Java 8 and later,
 regardless of the JDK used to build Hibernate Search.
 
@@ -302,6 +306,17 @@ Or more simply, if the newer JDK you want to test against is newer than 17 and i
 ./mvnw clean install -Djava-version.test.release=18
 ```
 
+### Lucene
+
+The Lucene integration tests do not, by themselves,
+require any external setup.
+
+If you are not interested in Lucene integration tests (e.g. you only want to test Elasticsearch),
+you can skip all Lucene tests with:
+
+```bash
+./mvnw clean install -Dtest.lucene.skip=true
+```
 ### Elasticsearch
 
 The Elasticsearch integration tests run against one single version of Elasticsearch at a time,
@@ -323,6 +338,13 @@ Please note that Elasticsearch [distributions starting with version 7.11 are not
 For available versions of [OpenSearch](https://www.opensearch.org/) distribution see [DockerHub](https://hub.docker.com/r/opensearchproject/opensearch/tags).
 
 For Amazon OpenSearch Serverless, the version must be unset (set to an empty string).
+
+When necessary (e.g. you don't have Docker, or are on Windows and can't run Linux containers),
+you can skip all Elasticsearch tests (and thus the Elasticsearch container startup) with:
+
+```bash
+./mvnw clean install -Dtest.elasticsearch.skip=true
+```
 
 Alternatively, you can prevent the build from launching an Elasticsearch server automatically
 and run Elasticsearch-related tests against your own server using the

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -183,17 +183,27 @@
         <!-- Containers executions tests properties -->
         <test.containers.run.skip>false</test.containers.run.skip>
 
+        <!-- Lucene tests properties -->
+
+        <!-- To skip all Lucene tests from the CLI -->
+        <test.lucene.skip>false</test.lucene.skip>
+
         <!-- Elasticsearch tests properties -->
+
+        <!-- To skip all Elasticsearch tests from the CLI -->
+        <test.elasticsearch.skip>false</test.elasticsearch.skip>
 
         <!-- Control how an Elasticsearch instance is run automatically during tests -->
         <!-- By default, the plugin is not skipped, but each container (elastic, opensearch, etc.) is skipped;
              Maven profiles will re-enable the right container depending on configuration.
           -->
         <test.elasticsearch.run.skip>true</test.elasticsearch.run.skip>
-
-        <!-- If an external connection url is defined this property will be true -->
-        <!-- See elasticsearch-run and elasticsearch-do-not-run profiles -->
-        <test.elasticsearch.connection.uris.defined></test.elasticsearch.connection.uris.defined>
+        <!-- This is set to true automatically when the Elasticsearch instance should not be started
+             even for modules that include Elasticsearch tests,
+             be it because Elasticsearch tests are disabled
+             or because an Elasticsearch instance is provided externally.
+             See elasticsearch-run, elasticsearch-test-skip and elasticsearch-do-not-run profiles -->
+        <test.elasticsearch.run.skip.forRelevantModules>false</test.elasticsearch.run.skip.forRelevantModules>
 
         <!--
              These properties are transparently passed as system properties to integration tests,

--- a/build/parents/integrationtest/pom.xml
+++ b/build/parents/integrationtest/pom.xml
@@ -467,7 +467,6 @@
             </activation>
             <properties>
                 <test.elasticsearch.connection.uris>http://localhost:9200</test.elasticsearch.connection.uris>
-                <test.elasticsearch.connection.uris.defined>false</test.elasticsearch.connection.uris.defined>
             </properties>
         </profile>
         <!-- Profile enabled when an Elasticsearch instance must NOT be run by Maven -->
@@ -480,7 +479,21 @@
                 </property>
             </activation>
             <properties>
-                <test.elasticsearch.connection.uris.defined>true</test.elasticsearch.connection.uris.defined>
+                <test.elasticsearch.run.skip.forRelevantModules>true</test.elasticsearch.run.skip.forRelevantModules>
+            </properties>
+        </profile>
+        <!-- Profile enabled when Elasticsearch tests are skipped -->
+        <profile>
+            <id>elasticsearch-test-skip</id>
+            <activation>
+                <!-- Activate if test.elasticsearch.connection.uris has been defined explicitly -->
+                <property>
+                    <name>test.elasticsearch.skip</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <test.elasticsearch.run.skip.forRelevantModules>true</test.elasticsearch.run.skip.forRelevantModules>
             </properties>
         </profile>
 

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -20,7 +20,7 @@
     <description>Hibernate Search reference documentation</description>
 
     <properties>
-        <test.elasticsearch.run.skip>${test.elasticsearch.connection.uris.defined}</test.elasticsearch.run.skip>
+        <test.elasticsearch.run.skip>${test.elasticsearch.run.skip.forRelevantModules}</test.elasticsearch.run.skip>
         <test.database.run.skip>false</test.database.run.skip>
 
         <asciidoctor.base-output-dir>${project.build.directory}/asciidoctor/</asciidoctor.base-output-dir>
@@ -128,6 +128,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
+                            <skip>${test.lucene.skip}</skip>
                             <reportNameSuffix>${surefire.reportNameSuffix}-lucene</reportNameSuffix>
                             <classpathDependencyExcludes>
                                 <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-elasticsearch</classpathDependencyExclude>
@@ -146,6 +147,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
+                            <skip>${test.elasticsearch.skip}</skip>
                             <reportNameSuffix>${surefire.reportNameSuffix}-elasticsearch</reportNameSuffix>
                             <classpathDependencyExcludes>
                                 <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-lucene</classpathDependencyExclude>

--- a/integrationtest/backend/elasticsearch/pom.xml
+++ b/integrationtest/backend/elasticsearch/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <surefire.module>elasticsearch</surefire.module>
 
-        <test.elasticsearch.run.skip>${test.elasticsearch.connection.uris.defined}</test.elasticsearch.run.skip>
+        <test.elasticsearch.run.skip>${test.elasticsearch.run.skip.forRelevantModules}</test.elasticsearch.run.skip>
     </properties>
 
     <dependencies>
@@ -72,6 +72,7 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
+                            <skip>${test.elasticsearch.skip}</skip>
                             <!-- WARNING: When using <dependenciesToScan>, be sure to set the Maven property surefire.module -->
                             <dependenciesToScan>
                                 <dependency>${project.groupId}:hibernate-search-integrationtest-backend-tck</dependency>

--- a/integrationtest/backend/lucene/pom.xml
+++ b/integrationtest/backend/lucene/pom.xml
@@ -52,6 +52,7 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
+                            <skip>${test.lucene.skip}</skip>
                             <!-- WARNING: When using <dependenciesToScan>, be sure to set the Maven property surefire.module -->
                             <dependenciesToScan>
                                 <dependency>${project.groupId}:hibernate-search-integrationtest-backend-tck</dependency>

--- a/integrationtest/java/modules/orm-coordination-outbox-polling-elasticsearch/pom.xml
+++ b/integrationtest/java/modules/orm-coordination-outbox-polling-elasticsearch/pom.xml
@@ -17,7 +17,7 @@
     <description>Hibernate Search integration tests for Java 11+ modules</description>
 
     <properties>
-        <test.elasticsearch.run.skip>${test.elasticsearch.connection.uris.defined}</test.elasticsearch.run.skip>
+        <test.elasticsearch.run.skip>${test.elasticsearch.run.skip.forRelevantModules}</test.elasticsearch.run.skip>
         <test.database.run.skip>false</test.database.run.skip>
 
         <maven.compiler.release>11</maven.compiler.release>
@@ -89,6 +89,9 @@
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
+                        <configuration>
+                            <skip>${test.elasticsearch.skip}</skip>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/integrationtest/java/modules/orm-elasticsearch/pom.xml
+++ b/integrationtest/java/modules/orm-elasticsearch/pom.xml
@@ -17,7 +17,7 @@
     <description>Hibernate Search integration tests for Java 11+ modules</description>
 
     <properties>
-        <test.elasticsearch.run.skip>${test.elasticsearch.connection.uris.defined}</test.elasticsearch.run.skip>
+        <test.elasticsearch.run.skip>${test.elasticsearch.run.skip.forRelevantModules}</test.elasticsearch.run.skip>
         <test.database.run.skip>false</test.database.run.skip>
 
         <maven.compiler.release>11</maven.compiler.release>
@@ -71,6 +71,9 @@
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
+                        <configuration>
+                            <skip>${test.elasticsearch.skip}</skip>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/integrationtest/java/modules/orm-lucene/pom.xml
+++ b/integrationtest/java/modules/orm-lucene/pom.xml
@@ -66,6 +66,9 @@
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
+                        <configuration>
+                            <skip>${test.lucene.skip}</skip>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/integrationtest/java/modules/pojo-standalone-elasticsearch/pom.xml
+++ b/integrationtest/java/modules/pojo-standalone-elasticsearch/pom.xml
@@ -17,7 +17,7 @@
     <description>Hibernate Search integration tests for Java 11+ modules</description>
 
     <properties>
-        <test.elasticsearch.run.skip>${test.elasticsearch.connection.uris.defined}</test.elasticsearch.run.skip>
+        <test.elasticsearch.run.skip>${test.elasticsearch.run.skip.forRelevantModules}</test.elasticsearch.run.skip>
         <test.database.run.skip>false</test.database.run.skip>
 
         <maven.compiler.release>11</maven.compiler.release>
@@ -63,6 +63,9 @@
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
+                        <configuration>
+                            <skip>${test.elasticsearch.skip}</skip>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/integrationtest/java/modules/pojo-standalone-lucene/pom.xml
+++ b/integrationtest/java/modules/pojo-standalone-lucene/pom.xml
@@ -58,6 +58,9 @@
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
+                        <configuration>
+                            <skip>${test.lucene.skip}</skip>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/integrationtest/mapper/orm-batch-jsr352/pom.xml
+++ b/integrationtest/mapper/orm-batch-jsr352/pom.xml
@@ -13,7 +13,7 @@
     <description>Hibernate Search integration tests for the Batch JSR-352 integration</description>
 
     <properties>
-        <test.elasticsearch.run.skip>${test.elasticsearch.connection.uris.defined}</test.elasticsearch.run.skip>
+        <test.elasticsearch.run.skip>${test.elasticsearch.run.skip.forRelevantModules}</test.elasticsearch.run.skip>
         <test.database.run.skip>false</test.database.run.skip>
 
         <surefire.jvm.args.module>

--- a/integrationtest/mapper/orm-coordination-outbox-polling/pom.xml
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/pom.xml
@@ -111,4 +111,19 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <properties>
+                <!-- For some reason these outbox-polling tests don't seem to work on Windows -->
+                <skipITs>true</skipITs>
+            </properties>
+        </profile>
+    </profiles>
+
 </project>

--- a/integrationtest/mapper/orm-coordination-outbox-polling/pom.xml
+++ b/integrationtest/mapper/orm-coordination-outbox-polling/pom.xml
@@ -78,9 +78,9 @@
                             </dependenciesToScan>
                             <includes>
                                 <!-- Include all tests from this module -->
-                                <include>%regex[org/hibernate/search/integrationtest/mapper/orm/coordination/outboxpolling/.*IT\.class]</include>
+                                <include>%regex[org[/\\]hibernate[/\\]search[/\\]integrationtest[/\\]mapper[/\\]orm[/\\]coordination[/\\]outboxpolling[/\\].*IT\.class]</include>
                                 <!-- Include tests from integrationtest-mapper-orm that are related to automatic indexing -->
-                                <include>%regex[org/hibernate/search/integrationtest/mapper/orm/automaticindexing/.*IT\.class]</include>
+                                <include>%regex[org[/\\]hibernate[/\\]search[/\\]integrationtest[/\\]mapper[/\\]orm[/\\]automaticindexing[/\\].*IT\.class]</include>
                             </includes>
                             <excludes>
                                 <!-- Exclude tests from integrationtest-mapper-orm that just cannot work with the outbox polling strategy: -->

--- a/integrationtest/mapper/orm-realbackend/pom.xml
+++ b/integrationtest/mapper/orm-realbackend/pom.xml
@@ -124,8 +124,6 @@
                             <reportNameSuffix>${surefire.reportNameSuffix}-multiplebackends</reportNameSuffix>
                             <includes>
                                 <include>org.hibernate.search.integrationtest.mapper.orm.realbackend.bootstrap.BackendTypeAutoDetectMultipleBackendTypesInClasspathIT</include>
-                                <include>org.hibernate.search.integrationtest.mapper.orm.realbackend.schema.management.ElasticsearchSchemaManagerExporterIT</include>
-                                <include>org.hibernate.search.integrationtest.mapper.orm.realbackend.schema.management.LuceneSchemaManagerExporterIT</include>
                             </includes>
                         </configuration>
                     </execution>

--- a/integrationtest/mapper/orm-realbackend/pom.xml
+++ b/integrationtest/mapper/orm-realbackend/pom.xml
@@ -13,8 +13,11 @@
     <description>Hibernate Search integration tests for the Hibernate ORM mapper with a real (non-mock) backend</description>
 
     <properties>
-        <test.elasticsearch.run.skip>${test.elasticsearch.connection.uris.defined}</test.elasticsearch.run.skip>
+        <test.elasticsearch.run.skip>${test.elasticsearch.run.skip.forRelevantModules}</test.elasticsearch.run.skip>
         <test.database.run.skip>false</test.database.run.skip>
+
+        <!-- See profiles below -->
+        <test.multiplebackends.skip>false</test.multiplebackends.skip>
     </properties>
 
     <dependencies>
@@ -77,6 +80,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
+                            <skip>${test.lucene.skip}</skip>
                             <reportNameSuffix>${surefire.reportNameSuffix}-lucene</reportNameSuffix>
                             <classpathDependencyExcludes>
                                 <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-elasticsearch</classpathDependencyExclude>
@@ -96,6 +100,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
+                            <skip>${test.elasticsearch.skip}</skip>
                             <reportNameSuffix>${surefire.reportNameSuffix}-elasticsearch</reportNameSuffix>
                             <classpathDependencyExcludes>
                                 <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-lucene</classpathDependencyExclude>
@@ -115,6 +120,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
+                            <skip>${test.multiplebackends.skip}</skip>
                             <reportNameSuffix>${surefire.reportNameSuffix}-multiplebackends</reportNameSuffix>
                             <includes>
                                 <include>org.hibernate.search.integrationtest.mapper.orm.realbackend.bootstrap.BackendTypeAutoDetectMultipleBackendTypesInClasspathIT</include>
@@ -138,5 +144,31 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>skipLuceneTests</id>
+            <activation>
+                <property>
+                    <name>test.lucene.skip</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <test.multiplebackends.skip>true</test.multiplebackends.skip>
+            </properties>
+        </profile>
+        <profile>
+            <id>skipElasticsearchTests</id>
+            <activation>
+                <property>
+                    <name>test.elasticsearch.skip</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <test.multiplebackends.skip>true</test.multiplebackends.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>
 

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/schema/management/ElasticsearchSchemaManagerExporterIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/schema/management/ElasticsearchSchemaManagerExporterIT.java
@@ -14,15 +14,18 @@ import static org.junit.Assume.assumeFalse;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import jakarta.persistence.EntityManagerFactory;
 
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
 import org.hibernate.search.integrationtest.mapper.orm.realbackend.testsupport.BackendConfigurations;
 import org.hibernate.search.integrationtest.mapper.orm.realbackend.util.Article;
 import org.hibernate.search.integrationtest.mapper.orm.realbackend.util.Book;
 import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.ElasticsearchTestDialect;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 
@@ -35,7 +38,10 @@ public class ElasticsearchSchemaManagerExporterIT {
 	@Rule
 	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 	@Rule
-	public OrmSetupHelper setupHelper = OrmSetupHelper.withSingleBackend( BackendConfigurations.simple() );
+	public OrmSetupHelper setupHelper = OrmSetupHelper.withMultipleBackends(
+			BackendConfigurations.simple(),
+			Map.of( Article.BACKEND_NAME, BackendConfigurations.simple() )
+	);
 
 	private EntityManagerFactory entityManagerFactory;
 
@@ -51,15 +57,11 @@ public class ElasticsearchSchemaManagerExporterIT {
 		String version = ElasticsearchTestDialect.getActualVersion().toString();
 		entityManagerFactory = setupHelper.start()
 				// so that we don't try to do anything with the schema and allow to run without ES being up:
-				.withProperty( "hibernate.search.schema_management.strategy", "none" )
-
-				.withProperty( "hibernate.search.backend.type", "elasticsearch" )
-				.withProperty( "hibernate.search.backend.version_check.enabled", false )
-				.withProperty( "hibernate.search.backend.version", version )
-
-				.withProperty( "hibernate.search.backends." + Article.BACKEND_NAME + ".type", "elasticsearch" )
-				.withProperty( "hibernate.search.backends." + Article.BACKEND_NAME + ".version_check.enabled", false )
-				.withProperty( "hibernate.search.backends." + Article.BACKEND_NAME + ".version", version )
+				.withProperty( HibernateOrmMapperSettings.SCHEMA_MANAGEMENT_STRATEGY, "none" )
+				.withBackendProperty( ElasticsearchBackendSettings.VERSION_CHECK_ENABLED, false )
+				.withBackendProperty( ElasticsearchBackendSettings.VERSION, version )
+				.withBackendProperty( Article.BACKEND_NAME, ElasticsearchBackendSettings.VERSION_CHECK_ENABLED, false )
+				.withBackendProperty( Article.BACKEND_NAME, ElasticsearchBackendSettings.VERSION, version )
 				.setup( Book.class, Article.class );
 
 		Path directory = temporaryFolder.newFolder().toPath();

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/schema/management/LuceneSchemaManagerExporterIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/schema/management/LuceneSchemaManagerExporterIT.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -31,17 +32,16 @@ public class LuceneSchemaManagerExporterIT {
 	@Rule
 	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 	@Rule
-	public OrmSetupHelper setupHelper = OrmSetupHelper.withSingleBackend( BackendConfigurations.simple() );
+	public OrmSetupHelper setupHelper = OrmSetupHelper.withMultipleBackends(
+			BackendConfigurations.simple(),
+			Map.of( Article.BACKEND_NAME, BackendConfigurations.simple() )
+	);
 
 	private EntityManagerFactory entityManagerFactory;
 
 	@Test
 	public void lucene() throws IOException {
-		entityManagerFactory = setupHelper.start()
-				.withProperty( "hibernate.search.backend.type", "lucene" )
-
-				.withProperty( "hibernate.search.backends." + Article.BACKEND_NAME + ".type", "lucene" )
-				.setup( Book.class, Article.class );
+		entityManagerFactory = setupHelper.start().setup( Book.class, Article.class );
 
 		Path directory = temporaryFolder.newFolder().toPath();
 		Search.mapping( entityManagerFactory ).scope( Object.class ).schemaManager().exportExpectedSchema( directory );

--- a/integrationtest/mapper/orm-spring-uberjar/application/pom.xml
+++ b/integrationtest/mapper/orm-spring-uberjar/application/pom.xml
@@ -68,7 +68,6 @@
         </dependency>
     </dependencies>
 
-
     <build>
         <plugins>
             <plugin>
@@ -123,5 +122,20 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>skipLuceneTests</id>
+            <activation>
+                <property>
+                    <name>test.lucene.skip</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <failsafe.spring.skip>true</failsafe.spring.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>
 

--- a/integrationtest/mapper/pojo-standalone-realbackend/pom.xml
+++ b/integrationtest/mapper/pojo-standalone-realbackend/pom.xml
@@ -13,7 +13,7 @@
     <description>Hibernate Search integration tests for the POJO Standalone mapper with a real (non-mock) backend</description>
 
     <properties>
-        <test.elasticsearch.run.skip>${test.elasticsearch.connection.uris.defined}</test.elasticsearch.run.skip>
+        <test.elasticsearch.run.skip>${test.elasticsearch.run.skip.forRelevantModules}</test.elasticsearch.run.skip>
     </properties>
 
     <dependencies>
@@ -63,6 +63,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
+                            <skip>${test.lucene.skip}</skip>
                             <reportNameSuffix>${surefire.reportNameSuffix}-lucene</reportNameSuffix>
                             <classpathDependencyExcludes>
                                 <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-elasticsearch</classpathDependencyExclude>
@@ -81,6 +82,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
+                            <skip>${test.elasticsearch.skip}</skip>
                             <reportNameSuffix>${surefire.reportNameSuffix}-elasticsearch</reportNameSuffix>
                             <classpathDependencyExcludes>
                                 <classpathDependencyExclude>org.hibernate.search:hibernate-search-backend-lucene</classpathDependencyExclude>

--- a/integrationtest/performance/backend/elasticsearch/pom.xml
+++ b/integrationtest/performance/backend/elasticsearch/pom.xml
@@ -137,4 +137,19 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <properties>
+                <!-- For some reason these performance tests don't seem to work on Windows -->
+                <test.elasticsearch.skip>true</test.elasticsearch.skip>
+            </properties>
+        </profile>
+    </profiles>
+
 </project>

--- a/integrationtest/performance/backend/elasticsearch/pom.xml
+++ b/integrationtest/performance/backend/elasticsearch/pom.xml
@@ -22,7 +22,7 @@
         <!-- We don't want to use a Jacoco agent here, and we don't want to rely on these tests for coverage either -->
         <jacoco.skip>true</jacoco.skip>
 
-        <test.elasticsearch.run.skip>${test.elasticsearch.connection.uris.defined}</test.elasticsearch.run.skip>
+        <test.elasticsearch.run.skip>${test.elasticsearch.run.skip.forRelevantModules}</test.elasticsearch.run.skip>
     </properties>
 
     <dependencies>
@@ -59,6 +59,9 @@
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
+                        <configuration>
+                            <skip>${test.elasticsearch.skip}</skip>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/integrationtest/performance/backend/lucene/pom.xml
+++ b/integrationtest/performance/backend/lucene/pom.xml
@@ -127,4 +127,19 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <properties>
+                <!-- For some reason these performance tests don't seem to work on Windows -->
+                <test.lucene.skip>true</test.lucene.skip>
+            </properties>
+        </profile>
+    </profiles>
+
 </project>

--- a/integrationtest/performance/backend/lucene/pom.xml
+++ b/integrationtest/performance/backend/lucene/pom.xml
@@ -53,6 +53,9 @@
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
+                        <configuration>
+                            <skip>${test.lucene.skip}</skip>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/integrationtest/showcase/library/pom.xml
+++ b/integrationtest/showcase/library/pom.xml
@@ -13,7 +13,7 @@
     <description>Hibernate Search showcase based on the ORM and Elasticsearch integrations, using libraries and books as business objects</description>
 
     <properties>
-        <test.elasticsearch.run.skip>${test.elasticsearch.connection.uris.defined}</test.elasticsearch.run.skip>
+        <test.elasticsearch.run.skip>${test.elasticsearch.run.skip.forRelevantModules}</test.elasticsearch.run.skip>
         <test.database.run.skip>false</test.database.run.skip>
 
         <!--
@@ -194,6 +194,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
+                            <skip>${test.lucene.skip}</skip>
                             <reportNameSuffix>${surefire.reportNameSuffix}-lucene</reportNameSuffix>
                             <systemPropertyVariables>
                                 <!-- See TestActiveProfilesResolver -->
@@ -207,6 +208,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
+                            <skip>${test.elasticsearch.skip}</skip>
                             <reportNameSuffix>${surefire.reportNameSuffix}-elasticsearch</reportNameSuffix>
                             <systemPropertyVariables>
                                 <!-- See TestActiveProfilesResolver -->

--- a/integrationtest/v5migrationhelper/engine/pom.xml
+++ b/integrationtest/v5migrationhelper/engine/pom.xml
@@ -78,6 +78,7 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
+                            <skip>${test.lucene.skip}</skip>
                             <includes>
                                 <include>**/*IT.java</include>
                                 <!--

--- a/integrationtest/v5migrationhelper/orm/pom.xml
+++ b/integrationtest/v5migrationhelper/orm/pom.xml
@@ -89,6 +89,7 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
+                            <skip>${test.lucene.skip}</skip>
                             <includes>
                                 <include>**/*IT.java</include>
                                 <!--

--- a/util/common/src/main/java/org/hibernate/search/util/common/jar/impl/CodeSource.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/jar/impl/CodeSource.java
@@ -150,7 +150,7 @@ class CodeSource implements Closeable {
 				else {
 					// The URI points to a regular file, so hopefully an actual JAR file.
 					// We'll try to open a ZIP filesystem to work on the contents of the JAR file.
-					URI jarUri = new URI( "jar:file", null, path.toString(), null );
+					URI jarUri = new URI( "jar:file", null, path.toUri().getPath(), null );
 					tryInitJarFileSystem( jarUri );
 				}
 			}

--- a/util/common/src/test/java/org/hibernate/search/util/common/jar/impl/CodeSourceTest.java
+++ b/util/common/src/test/java/org/hibernate/search/util/common/jar/impl/CodeSourceTest.java
@@ -51,13 +51,14 @@ public class CodeSourceTest {
 			addSimpleClass( root );
 		} );
 
-		try ( URLClassLoader isolatedClassLoader = createIsolatedClassLoader( dirPath.toUri().toURL() ) ) {
+		URL dirPathUrl = dirPath.toUri().toURL();
+		try ( URLClassLoader isolatedClassLoader = createIsolatedClassLoader( dirPathUrl ) ) {
 			Class<?> classInIsolatedClassLoader = isolatedClassLoader.loadClass( SimpleClass.class.getName() );
 
 			// Check preconditions: this is the situation that we want to test.
 			URL location = classInIsolatedClassLoader.getProtectionDomain().getCodeSource().getLocation();
 			assertThat( location.getProtocol() ).isEqualTo( "file" );
-			assertThat( location.toExternalForm() ).contains( dirPath.toString() );
+			assertThat( location.toExternalForm() ).contains( dirPathUrl.toString() );
 
 			// Check that the JAR can be opened and that we can access other files within it
 			try ( CodeSource codeSource = new CodeSource( location ) ) {
@@ -86,13 +87,14 @@ public class CodeSourceTest {
 			addSimpleClass( root );
 		} );
 
-		try ( URLClassLoader isolatedClassLoader = createIsolatedClassLoader( jarPath.toUri().toURL() ) ) {
+		URL jarPathUrl = jarPath.toUri().toURL();
+		try ( URLClassLoader isolatedClassLoader = createIsolatedClassLoader( jarPathUrl ) ) {
 			Class<?> classInIsolatedClassLoader = isolatedClassLoader.loadClass( SimpleClass.class.getName() );
 
 			// Check preconditions: this is the situation that we want to test.
 			URL location = classInIsolatedClassLoader.getProtectionDomain().getCodeSource().getLocation();
 			assertThat( location.getProtocol() ).isEqualTo( "file" );
-			assertThat( location.toExternalForm() ).contains( jarPath.toString() );
+			assertThat( location.toExternalForm() ).contains( jarPathUrl.toString() );
 
 			// Check that the JAR can be opened and that we can access other files within it
 			try ( CodeSource codeSource = new CodeSource( location ) ) {
@@ -130,7 +132,7 @@ public class CodeSourceTest {
 			URL location = classInIsolatedClassLoader.getProtectionDomain().getCodeSource().getLocation();
 			// For some reason the "jar" scheme gets replaced with "file"
 			assertThat( location.getProtocol() ).isEqualTo( "file" );
-			assertThat( location.toExternalForm() ).contains( jarPath.toString() );
+			assertThat( location.toExternalForm() ).contains( jarPath.toUri().toURL().toString() );
 
 			// Check that the JAR can be opened and that we can access other files within it
 			try ( CodeSource codeSource = new CodeSource( location ) ) {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4947

The idea here is that since we are trying to construct a URI then we should construct it from the URI 😃 
Since in the case of Linux `Path` path would have the same `/` that is needed for a URI, but then in Windows, it'll be `\`, and URI construction won't work...
And the same is about the test updates; the changes are to make the asserts compare the URIs rather than Path vs URI

I've reverted the ORM version to 6.2 series to test the spring boot uberjar module -- the tests passed with these changes.