### PR TITLE
HSEARCH-4920 Follow-up: Don't pre-pull images from elastic docker registry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -989,7 +989,8 @@
                                     if ( isFalseString( '${test.database.run.cockroachdb.skip}' ) ) {
                                         images += '${test.database.run.cockroachdb.image.name}:${test.database.run.cockroachdb.image.tag}'
                                     }
-                                    new File('${containerImagesListFile}').append( images.join('\n') + '\n' )
+                                    // Exclude images from non-dockerhub repositories
+                                    new File('${containerImagesListFile}').append( images.findAll{ref -> !(ref ==~ /^(?!((.*\.)?docker\.io))[\w\d\.]+\/[\w\d\.]+\/[\w\d\.]+(:.+)?$/)}.join('\n') + '\n' )
                                 ]]></script>
                             </configuration>
                         </execution>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4920

I'd expect something along these lines to work: we iterate over various docker registries, and if the image cannot be pulled, it is added for an attempt to be pulled from the next registry and so on...
I've added the exact change with a different registry order to the main Jenkins file so we can test it in the PR..