### PR TITLE
Backport HSEARCH-4946 + HSEARCH-4958 + HSEARCH-4967 to branch 6.2 - Upgrade to Elasticsearch client 8.10.2 and test against Elasticsearch 8.10.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -254,7 +254,7 @@ stage('Configure') {
 					new EsLocalBuildEnvironment(version: '8.7.1', condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(version: '8.8.2', condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(version: '8.9.2', condition: TestCondition.ON_DEMAND),
-					new EsLocalBuildEnvironment(version: '8.10.1', condition: TestCondition.BEFORE_MERGE, isDefault: true),
+					new EsLocalBuildEnvironment(version: '8.10.2', condition: TestCondition.BEFORE_MERGE, isDefault: true),
 
 					// --------------------------------------------
 					// OpenSearch

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -253,7 +253,8 @@ stage('Configure') {
 					new EsLocalBuildEnvironment(version: '8.6.2', condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(version: '8.7.1', condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(version: '8.8.2', condition: TestCondition.ON_DEMAND),
-					new EsLocalBuildEnvironment(version: '8.9.2', condition: TestCondition.BEFORE_MERGE, isDefault: true),
+					new EsLocalBuildEnvironment(version: '8.9.2', condition: TestCondition.ON_DEMAND),
+					new EsLocalBuildEnvironment(version: '8.10.0', condition: TestCondition.BEFORE_MERGE, isDefault: true),
 
 					// --------------------------------------------
 					// OpenSearch

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -254,7 +254,7 @@ stage('Configure') {
 					new EsLocalBuildEnvironment(version: '8.7.1', condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(version: '8.8.2', condition: TestCondition.ON_DEMAND),
 					new EsLocalBuildEnvironment(version: '8.9.2', condition: TestCondition.ON_DEMAND),
-					new EsLocalBuildEnvironment(version: '8.10.0', condition: TestCondition.BEFORE_MERGE, isDefault: true),
+					new EsLocalBuildEnvironment(version: '8.10.1', condition: TestCondition.BEFORE_MERGE, isDefault: true),
 
 					// --------------------------------------------
 					// OpenSearch

--- a/build/container/elasticsearch/env-8.10.properties
+++ b/build/container/elasticsearch/env-8.10.properties
@@ -1,0 +1,10 @@
+# Disable some features that are not needed in our tests and just slow down startup
+cluster.deprecation_indexing.enabled=false
+indices.lifecycle.history_index_enabled=false
+slm.history_index_enabled=false
+stack.templates.enabled=false
+xpack.ent_search.enabled=false
+xpack.ml.enabled=false
+xpack.monitoring.templates.enabled=false
+xpack.profiling.enabled=false
+xpack.watcher.enabled=false

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -272,7 +272,7 @@ class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 		// https://github.com/elastic/elasticsearch/issues/91246
 		// Hopefully this will get fixed in a future version.
 		return isActualVersion(
-				esVersion -> !esVersion.isBetween( "7.17.7", "7.17" ) && !esVersion.isBetween( "8.5.0", "8.10.0" ),
+				esVersion -> !esVersion.isBetween( "7.17.7", "7.17" ) && !esVersion.isBetween( "8.5.0", "8.10.1" ),
 				osVersion -> true
 		);
 	}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -272,7 +272,7 @@ class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 		// https://github.com/elastic/elasticsearch/issues/91246
 		// Hopefully this will get fixed in a future version.
 		return isActualVersion(
-				esVersion -> !esVersion.isBetween( "7.17.7", "7.17" ) && !esVersion.isBetween( "8.5.0", "8.10.1" ),
+				esVersion -> !esVersion.isBetween( "7.17.7", "7.17" ) && !esVersion.isBetween( "8.5.0", "8.10.2" ),
 				osVersion -> true
 		);
 	}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -272,7 +272,7 @@ class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 		// https://github.com/elastic/elasticsearch/issues/91246
 		// Hopefully this will get fixed in a future version.
 		return isActualVersion(
-				esVersion -> !esVersion.isBetween( "7.17.7", "7.17" ) && !esVersion.isBetween( "8.5.0", "8.9.2" ),
+				esVersion -> !esVersion.isBetween( "7.17.7", "7.17" ) && !esVersion.isBetween( "8.5.0", "8.10.0" ),
 				osVersion -> true
 		);
 	}
@@ -308,6 +308,14 @@ class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 		return isActualVersion(
 				esVersion -> !esVersion.isBetween( "7.15", "8.3" ),
 				osVersion -> true
+		);
+	}
+
+	@Override
+	public boolean supportsHighlighterUnifiedPhraseMatching() {
+		return isActualVersion(
+				esVersion -> !esVersion.isAtMost( "8.9" ),
+				osVersion -> false
 		);
 	}
 }

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/LuceneTckBackendFeatures.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/LuceneTckBackendFeatures.java
@@ -54,4 +54,8 @@ class LuceneTckBackendFeatures extends TckBackendFeatures {
 		return false;
 	}
 
+	@Override
+	public boolean supportsHighlighterUnifiedPhraseMatching() {
+		return false;
+	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/highlight/HighlighterUnifiedIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/highlight/HighlighterUnifiedIT.java
@@ -45,7 +45,7 @@ public class HighlighterUnifiedIT extends AbstractHighlighterIT {
 
 	@Override
 	protected boolean supportsPhraseMatching() {
-		return false;
+		return TckConfiguration.get().getBackendFeatures().supportsHighlighterUnifiedPhraseMatching();
 	}
 
 	@Test

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
@@ -142,4 +142,8 @@ public abstract class TckBackendFeatures {
 	public boolean supportsHighlighterPlainOrderByScoreMultivaluedField() {
 		return true;
 	}
+
+	public boolean supportsHighlighterUnifiedPhraseMatching() {
+		return true;
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.5+ -->
-        <version.org.elasticsearch.client>8.10.1</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>8.10.2</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-8.4) becomes the default. -->

--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.5+ -->
-        <version.org.elasticsearch.client>8.9.2</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>8.10.0</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-8.4) becomes the default. -->

--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
         <version.org.elasticsearch.compatible.not-regularly-tested.text>7.0 or 8.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest version of Elasticsearch tested against by default -->
-        <version.org.elasticsearch.latest>8.10.1</version.org.elasticsearch.latest>
+        <version.org.elasticsearch.latest>8.10.2</version.org.elasticsearch.latest>
         <!-- The versions of OpenSearch advertised as compatible with Hibernate Search -->
         <!-- Make sure to only mention tested versions here -->
         <version.org.opensearch.compatible.regularly-tested.text>1.3 or 2.9</version.org.opensearch.compatible.regularly-tested.text>

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
         <!-- The versions of Elasticsearch advertised as compatible with Hibernate Search -->
         <!-- Make sure to only mention tested versions here -->
         <!-- Make sure that 7.10 stays explicitly mentioned here, because that's the last open-source version -->
-        <version.org.elasticsearch.compatible.regularly-tested.text>5.6, 6.8, 7.10, 7.17 or 8.9</version.org.elasticsearch.compatible.regularly-tested.text>
+        <version.org.elasticsearch.compatible.regularly-tested.text>5.6, 6.8, 7.10, 7.17 or 8.10</version.org.elasticsearch.compatible.regularly-tested.text>
         <!-- These are the versions same as above, but pointing only to the major part (used in compatibility section of ES backend documentation
           as versions that Hibernate Search is compatible with. -->
         <!-- NOTE: Adding new major versions would require to update the compatibility table in `backend-elasticsearch-compatibility` section of `backend-elasticsearch.asciidoc`. -->
@@ -227,7 +227,7 @@
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
         <version.org.elasticsearch.compatible.not-regularly-tested.text>7.0 or 8.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest version of Elasticsearch tested against by default -->
-        <version.org.elasticsearch.latest>8.9.2</version.org.elasticsearch.latest>
+        <version.org.elasticsearch.latest>8.10.0</version.org.elasticsearch.latest>
         <!-- The versions of OpenSearch advertised as compatible with Hibernate Search -->
         <!-- Make sure to only mention tested versions here -->
         <version.org.opensearch.compatible.regularly-tested.text>1.3 or 2.9</version.org.opensearch.compatible.regularly-tested.text>

--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
         <version.org.elasticsearch.compatible.not-regularly-tested.text>7.0 or 8.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest version of Elasticsearch tested against by default -->
-        <version.org.elasticsearch.latest>8.10.0</version.org.elasticsearch.latest>
+        <version.org.elasticsearch.latest>8.10.1</version.org.elasticsearch.latest>
         <!-- The versions of OpenSearch advertised as compatible with Hibernate Search -->
         <!-- Make sure to only mention tested versions here -->
         <version.org.opensearch.compatible.regularly-tested.text>1.3 or 2.9</version.org.opensearch.compatible.regularly-tested.text>

--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.5+ -->
-        <version.org.elasticsearch.client>8.10.0</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>8.10.1</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
              to make sure the corresponding profile (e.g. elasticsearch-8.4) becomes the default. -->


### PR DESCRIPTION
* [HSEARCH-4967](https://hibernate.atlassian.net/browse/HSEARCH-4967): Upgrade to Elasticsearch client 8.10.2 and test against Elasticsearch 8.10.2
* [HSEARCH-4958](https://hibernate.atlassian.net/browse/HSEARCH-4958): Upgrade to Elasticsearch client 8.10.1 and test against Elasticsearch 8.10.1
* [HSEARCH-4946](https://hibernate.atlassian.net/browse/HSEARCH-4946): Upgrade to Elasticsearch client 8.10.0 and test against Elasticsearch 8.10.0

@marko-bekhta Yes, I know, I said previously it wasn't worth it. But seeing the list of issues in the 6.2.2 release made me realize I was just dumb to force 6.2 users to get a warning as soon as they try to use the latest Elasticsearch (8.10). Especially since the client upgrade doesn't change anything, so integrators can certainly stick to the client in version 8.9.

[HSEARCH-4967]: https://hibernate.atlassian.net/browse/HSEARCH-4967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HSEARCH-4958]: https://hibernate.atlassian.net/browse/HSEARCH-4958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HSEARCH-4946]: https://hibernate.atlassian.net/browse/HSEARCH-4946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ