### PR TITLE
HSEARCH-4983 Concurrency issues in Lucene IndexAccessor/IndexWriterProvider may lead to LockObtainFailedException: Lock held by this virtual machine

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/writer/impl/IndexWriterProvider.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/writer/impl/IndexWriterProvider.java
@@ -71,9 +71,15 @@ public class IndexWriterProvider {
 	 * Should be used when stopping the index.
 	 */
 	public void clear() throws IOException {
-		IndexWriterDelegatorImpl indexWriterDelegator = currentWriter.getAndSet( null );
-		if ( indexWriterDelegator != null ) {
-			indexWriterDelegator.close();
+		currentWriterModificationLock.lock();
+		try {
+			IndexWriterDelegatorImpl indexWriterDelegator = currentWriter.getAndSet( null );
+			if ( indexWriterDelegator != null ) {
+				indexWriterDelegator.close();
+			}
+		}
+		finally {
+			currentWriterModificationLock.unlock();
 		}
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4983
