### PR TITLE
[Backport to 6.1] HSEARCH-4944 Adjust tests to address ORM changes

### DIFF
--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -30,7 +30,9 @@ Map settings() {
 		case 'orm6.2':
 			return [
 					updateProperties: ['version.org.hibernate.orm'],
-					onlyRunTestDependingOn: ['hibernate-search-mapper-orm-orm6']
+					onlyRunTestDependingOn: ['hibernate-search-mapper-orm-orm6'],
+					// we need to recompile this module since it has incompatible return type and will result in a build error:
+					additionalMavenArgs: '-pl :hibernate-search-util-internal-integrationtest-mapper-orm'
 			]
 		default:
 			return [:]

--- a/orm6/integrationtest/v5migrationhelper/orm/ant-src-changes.patch
+++ b/orm6/integrationtest/v5migrationhelper/orm/ant-src-changes.patch
@@ -5,7 +5,7 @@ index fc90c71105..eb45ab96a2 100644
 @@ -17,8 +17,7 @@
  import org.hibernate.Session;
  import org.hibernate.Transaction;
- 
+
 -import org.hibernate.dialect.Sybase11Dialect;
 -import org.hibernate.dialect.SybaseASE15Dialect;
 +import org.hibernate.dialect.SybaseDialect;
@@ -17,7 +17,7 @@ index fc90c71105..eb45ab96a2 100644
  
  	@Test
 -	@SkipForDialect(value = { SybaseASE15Dialect.class, Sybase11Dialect.class },
-+	@SkipForDialect(value = { SybaseDialect.class },
++	@SkipForDialect(value = SybaseDialect.class,
  			comment = "Sybase does not support @Lob")
  	public void testCreateIndexSearchEntityWithLobField() {
  		// create and index


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4944

I don't see a `wip/6.1/dependency-update/orm6-in-main-code` ... so I didn't upgrade the wip branch for patches ...