### PR TITLE
[Hibernate Search 6.2] HSEARCH-4944 Recompile util module to make the ORM6.2 upgrade work correctly

### DIFF
--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -25,6 +25,9 @@ Map settings() {
 			return [
 					updateProperties: ['version.org.hibernate.orm'],
 					onlyRunTestDependingOn: ['hibernate-search-mapper-orm-orm6']
+					// we need to recompile this module since it has incompatible return type and will result in a build error.
+					// Note: we *must* rebuild the `-orm6` artifact (not the regular one), since that's where the orm6 upgrade is applied:
+					additionalMavenArgs: '-pl :hibernate-search-util-internal-integrationtest-mapper-orm-orm6'
 			]
 		case 'orm6.3':
 			return [


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4944

I suppose with the next ORM upgrade, we can remove these additional build args as the changes will be in the main artifact already ...