### PR TITLE
Backport HSEARCH-4985 to branch 6.2 - Fix heading level of documentation section "Explicitly altering a whole index"

### DIFF
--- a/documentation/src/main/asciidoc/public/reference/_indexing-workspace.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_indexing-workspace.adoc
@@ -1,5 +1,5 @@
 [[indexing-workspace]]
-== [[mapper-orm-indexing-manual-largescale]] Explicitly altering a whole index
+= [[mapper-orm-indexing-manual-largescale]] Explicitly altering a whole index
 
 Some index operations are not about a specific entity/document,
 but rather about a large number of documents, possibly all of them.


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4985
