### PR TITLE
HSEARCH-4986 Mapping partitions fails in Jakarta Batch mass indexing job for some JDBC drivers (DB2, MSSQL, ...)

### DIFF
--- a/integrationtest/mapper/orm-jakarta-batch/src/test/java/org/hibernate/search/integrationtest/jakarta/batch/component/HibernateSearchPartitionMapperComponentIT.java
+++ b/integrationtest/mapper/orm-jakarta-batch/src/test/java/org/hibernate/search/integrationtest/jakarta/batch/component/HibernateSearchPartitionMapperComponentIT.java
@@ -78,13 +78,11 @@ public class HibernateSearchPartitionMapperComponentIT {
 			}
 		} );
 
-		final String fetchSize = String.valueOf( 200 * 1000 );
 		final String maxThreads = String.valueOf( 1 );
 		final String rowsPerPartition = String.valueOf( 3 );
 
 		mockedJobContext = mock( JobContext.class );
 		partitionMapper = new HibernateSearchPartitionMapper(
-				fetchSize,
 				null, null,
 				maxThreads,
 				null,
@@ -153,7 +151,9 @@ public class HibernateSearchPartitionMapperComponentIT {
 			}
 		}
 
-		// No data => 0 partition
-		assertEquals( 0, compGroupPartitions );
+		// Did not find anything in the ResultSet at index "rowsPerPartition"
+		// => 1 partition covering the whole range.
+		// We'll notice there is no data later, when reading IDs to reindex.
+		assertEquals( 1, compGroupPartitions );
 	}
 }

--- a/mapper/orm-jakarta-batch/core/src/main/java/org/hibernate/search/jakarta/batch/core/massindexing/step/impl/HibernateSearchPartitionMapper.java
+++ b/mapper/orm-jakarta-batch/core/src/main/java/org/hibernate/search/jakarta/batch/core/massindexing/step/impl/HibernateSearchPartitionMapper.java
@@ -218,10 +218,14 @@ public class HibernateSearchPartitionMapper implements PartitionMapper {
 			 * The scroll results are originally positioned *before* the first element,
 			 * so we need to scroll rowsPerPartition + 1 positions to advanced to the
 			 * upper bound of the first partition, whereas for the next partitions
-			 * we only need to advance rowsPerPartition positions.
-			 * This handle the special case of the first partition.
+			 * we need to advance `rowsPerPartition` positions.
+			 * The call to scroll.next() handles the special case of the first partition,
+			 * as well as the special case where there is no data to index.
 			 */
-			scroll.next();
+			if ( !scroll.next() ) {
+				// Nothing to be indexed.
+				return partitionUnits;
+			}
 
 			while ( scroll.scroll( rowsPerPartition ) ) {
 				lowerID = upperID;

--- a/mapper/orm-jakarta-batch/core/src/main/java/org/hibernate/search/jakarta/batch/core/massindexing/step/impl/HibernateSearchPartitionMapper.java
+++ b/mapper/orm-jakarta-batch/core/src/main/java/org/hibernate/search/jakarta/batch/core/massindexing/step/impl/HibernateSearchPartitionMapper.java
@@ -8,6 +8,7 @@ package org.hibernate.search.jakarta.batch.core.massindexing.step.impl;
 
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
@@ -165,7 +166,7 @@ public class HibernateSearchPartitionMapper implements PartitionMapper {
 				);
 			}
 
-			log.infof( "Partitions: %s", (Object) props );
+			log.debugf( "Partitions: %s", Arrays.toString( props ) );
 
 			PartitionPlan partitionPlan = new PartitionPlanImpl();
 			partitionPlan.setPartitionProperties( props );

--- a/mapper/orm-jakarta-batch/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
+++ b/mapper/orm-jakarta-batch/core/src/main/resources/META-INF/batch-jobs/hibernate-search-mass-indexing.xml
@@ -91,7 +91,6 @@
             <mapper ref="org.hibernate.search.jakarta.batch.core.massindexing.step.impl.HibernateSearchPartitionMapper">
                 <properties>
                     <property name="tenantId" value="#{jobParameters['tenantId']}" />
-                    <property name="idFetchSize" value="#{jobParameters['idFetchSize']}" />
                     <property name="reindexOnlyHql" value="#{jobParameters['reindexOnlyHql']}" />
                     <property name="reindexOnlyParameters" value="#{jobParameters['reindexOnlyParameters']}" />
                     <property name="maxThreads" value="#{jobParameters['maxThreads']}" />


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4986

I had to completely give up on using scrolls for partition mapping, see commit messages.

We'll still use scrolls during mass indexing to load IDs though, that doesn't change.