### PR TITLE
HSEARCH-4987 Upgrade -orm6 artifacts to Hibernate ORM 6.2.12.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,7 +277,7 @@
         <version.jakarta.xml.bind.orm5>3.0.1</version.jakarta.xml.bind.orm5>
 
         <!-- >>> ORM 6 with Jakarta Persistence -->
-        <version.org.hibernate.orm>6.2.11.Final</version.org.hibernate.orm>
+        <version.org.hibernate.orm>6.2.12.Final</version.org.hibernate.orm>
         <javadoc.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/javadocs/</javadoc.org.hibernate.orm.url>
         <documentation.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/userguide/html_single/Hibernate_User_Guide.html</documentation.org.hibernate.orm.url>
         <!-- These version must be kept in sync with the version of the dependency in Hibernate ORM 6.


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4987

I assume it's okay just to reuse the same ticket since we haven't released this yet. I'll update the JIRA description.