### PR TITLE
HSEARCH-4989 Use a different property to skip JQAssistant analysis of some modules

### DIFF
--- a/build/config/pom.xml
+++ b/build/config/pom.xml
@@ -19,7 +19,7 @@
     <description>Hibernate Search common build configuration files</description>
 
     <properties>
-        <jqassistant.skip>true</jqassistant.skip>
+        <jqassistant.maven.module.skip>true</jqassistant.maven.module.skip>
 
         <!--
             This module generates the rules used in the Checkstyle and ForbiddenAPIs plugins,

--- a/build/enforcer/pom.xml
+++ b/build/enforcer/pom.xml
@@ -30,7 +30,7 @@
         <format.skip>true</format.skip>
 
         <deploy.skip>true</deploy.skip>
-        <jqassistant.skip>true</jqassistant.skip>
+        <jqassistant.maven.module.skip>true</jqassistant.maven.module.skip>
     </properties>
 
     <dependencies>

--- a/build/reports/pom.xml
+++ b/build/reports/pom.xml
@@ -22,12 +22,6 @@
 
     <properties>
         <!--
-             Do NOT skip jqassistant: we want to execute analysis here so as to fail the build if anything is wrong.
-             Reminder: jqassistant only executes analysis in the last module of the build,
-             so if we skip it in the last module, it just won't execute analysis... ever.
-         -->
-        <jqassistant.skip>false</jqassistant.skip>
-        <!--
         Disable the dependency convergence rule, because the dependencies of various integration tests do not converge
         -->
         <enforcer.dependencyconvergence.skip>true</enforcer.dependencyconvergence.skip>

--- a/integrationtest/v5migrationhelper/engine/pom.xml
+++ b/integrationtest/v5migrationhelper/engine/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <!-- This is based on legacy code and there are plenty of problems that we don't care to fix -->
-        <jqassistant.skip>true</jqassistant.skip>
+        <jqassistant.maven.module.skip>true</jqassistant.maven.module.skip>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <sonar.skip>true</sonar.skip>
     </properties>

--- a/integrationtest/v5migrationhelper/orm/pom.xml
+++ b/integrationtest/v5migrationhelper/orm/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <!-- This is based on legacy code and there are plenty of problems that we don't care to fix -->
-        <jqassistant.skip>true</jqassistant.skip>
+        <jqassistant.maven.module.skip>true</jqassistant.maven.module.skip>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <sonar.skip>true</sonar.skip>
 

--- a/util/internal/integrationtest/v5migrationhelper/pom.xml
+++ b/util/internal/integrationtest/v5migrationhelper/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <!-- This is based on legacy code and there are plenty of problems that we don't care to fix -->
-        <jqassistant.skip>true</jqassistant.skip>
+        <jqassistant.maven.module.skip>true</jqassistant.maven.module.skip>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <sonar.skip>true</sonar.skip>
     </properties>

--- a/v5migrationhelper/engine/pom.xml
+++ b/v5migrationhelper/engine/pom.xml
@@ -25,7 +25,7 @@
         <java.module.name>org.hibernate.search.v5migrationhelper.engine</java.module.name>
 
         <!-- This is based on legacy code and there are plenty of problems that we don't care to fix -->
-        <jqassistant.skip>true</jqassistant.skip>
+        <jqassistant.maven.module.skip>true</jqassistant.maven.module.skip>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <sonar.skip>true</sonar.skip>
     </properties>

--- a/v5migrationhelper/orm/pom.xml
+++ b/v5migrationhelper/orm/pom.xml
@@ -25,7 +25,7 @@
         <java.module.name>org.hibernate.search.v5migrationhelper.orm</java.module.name>
 
         <!-- This is based on legacy code and there are plenty of problems that we don't care to fix -->
-        <jqassistant.skip>true</jqassistant.skip>
+        <jqassistant.maven.module.skip>true</jqassistant.maven.module.skip>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <sonar.skip>true</sonar.skip>
     </properties>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4989

The problem was coming from how the plugin decides if it is the last module in the execution run ... it expects to encounter all the modules, even those that skip plugin execution... but it still wants to see them as "executed" which never happens 😃 ...
using this other property `jqassistant.maven.module.skip` allows skipping the analysis of the module, which makes the plugin happy and it manages to correctly figure out when to run the analysis..

I have also looked into the rule for nested static class ... but the info is not there. from what it seems ASM does not add a static modifier to the descriptor and that field is never set to true in the generated DB, there's also no other info that can be used to cover that sooo I've just added another check into the filter in the JUnit upgrade PR...