### PR TITLE
HSEARCH-4992 Bump software.amazon.awssdk:auth from 2.20.2 to 2.21.1

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -77,7 +77,7 @@
         <version.org.opensearch.latest>2.10.0</version.org.opensearch.latest>
 
         <version.com.google.code.gson>2.9.1</version.com.google.code.gson>
-        <version.software.amazon.awssdk>2.20.2</version.software.amazon.awssdk>
+        <version.software.amazon.awssdk>2.21.1</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, by Avro, by the AWS SDK and in tests (wiremock, ...) -->
         <version.com.fasterxml.jackson>2.15.2</version.com.fasterxml.jackson>
         <!-- slf4j: used by the AWS SDK -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4992

Bumps software.amazon.awssdk:auth from 2.20.2 to 2.21.1.

---
updated-dependencies:
- dependency-name: software.amazon.awssdk:auth dependency-type: direct:production update-type: version-update:semver-minor ...
