### PR TITLE
Address build errors in Jenkinsfile for update job

### DIFF
--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -7,44 +7,46 @@
 
 @Library('hibernate-jenkins-pipeline-helpers@1.5') _
 
-def configurations = [
-		'jandex3'          :
-				[
-						onlyRunTestDependingOn: ['hibernate-search-mapper-pojo-base'],
-						// Need to rebuild this module in order to insert the Jandex 3 dependency in tests
-						additionalMavenArgs   : '-pl :hibernate-search-util-internal-test-common'
-				],
-		'orm5.6'           :
-				[
-						updateProperties      : ['version.org.hibernate'],
-						onlyRunTestDependingOn: ['hibernate-search-mapper-orm', 'hibernate-search-mapper-orm-jakarta']
-				],
-		'orm6.2'           :
-				[
-						updateProperties      : ['version.org.hibernate.orm'],
-						onlyRunTestDependingOn: ['hibernate-search-mapper-orm-orm6'],
-						// we need to recompile this module since it has incompatible return type and will result in a build error.
-						// Note: we *must* rebuild the `-orm6` artifact (not the regular one), since that's where the orm6 upgrade is applied:
-						additionalMavenArgs   : '-pl :hibernate-search-util-internal-integrationtest-mapper-orm-orm6',
-						skipSourceModifiedCheck: true
-				],
-		'orm6.3'           :
-				[
-						updateProperties      : ['version.org.hibernate.orm'],
-						onlyRunTestDependingOn: ['hibernate-search-mapper-orm-orm6'],
-						// we need to recompile this module since it has incompatible return type and will result in a build error.
-						// Note: we *must* rebuild the `-orm6` artifact (not the regular one), since that's where the orm6 upgrade is applied:
-						additionalMavenArgs   : '-pl :hibernate-search-util-internal-integrationtest-mapper-orm-orm6'
-				],
-		'orm6-in-main-code':
-				[
-						updateProperties: ['version.org.hibernate.orm']
-						// In this case we'll rebuild and test everything.
-				]
-]
-
+// NOTE: Remember to update the matrix axes below when adding/removing entries here.
+// Also make sure to update the parameters in the parameters {} section of the pipeline.
 Map settings() {
-	return configurations.getOrDefault(env.DEPENDENCY_UPDATE_NAME, [:])
+	switch (env.DEPENDENCY_UPDATE_NAME) {
+		case 'jandex3':
+			return [
+					onlyRunTestDependingOn: ['hibernate-search-mapper-pojo-base'],
+					// Need to rebuild this module in order to insert the Jandex 3 dependency in tests
+					additionalMavenArgs: '-pl :hibernate-search-util-internal-test-common'
+			]
+		case 'orm5.6':
+			return [
+					updateProperties      : ['version.org.hibernate'],
+					onlyRunTestDependingOn: ['hibernate-search-mapper-orm', 'hibernate-search-mapper-orm-jakarta']
+			]
+		case 'orm6.2':
+			return [
+					updateProperties       : ['version.org.hibernate.orm'],
+					onlyRunTestDependingOn : ['hibernate-search-mapper-orm-orm6'],
+					// we need to recompile this module since it has incompatible return type and will result in a build error.
+					// Note: we *must* rebuild the `-orm6` artifact (not the regular one), since that's where the orm6 upgrade is applied:
+					additionalMavenArgs    : '-pl :hibernate-search-util-internal-integrationtest-mapper-orm-orm6',
+					skipSourceModifiedCheck: true
+			]
+		case 'orm6.3':
+			return [
+					updateProperties      : ['version.org.hibernate.orm'],
+					onlyRunTestDependingOn: ['hibernate-search-mapper-orm-orm6'],
+					// we need to recompile this module since it has incompatible return type and will result in a build error.
+					// Note: we *must* rebuild the `-orm6` artifact (not the regular one), since that's where the orm6 upgrade is applied:
+					additionalMavenArgs   : '-pl :hibernate-search-util-internal-integrationtest-mapper-orm-orm6'
+			]
+		case 'orm6-in-main-code':
+			return [
+					updateProperties: ['version.org.hibernate.orm']
+					// In this case we'll rebuild and test everything.
+			]
+		default:
+			return [:]
+	}
 }
 
 // Perform authenticated pulls of container images, to avoid failure due to download throttling on dockerhub.
@@ -91,8 +93,10 @@ pipeline {
 		cron '@weekly'
 	}
 	parameters {
-		choice(name: 'UPDATE_JOB', choices: ['all'] + configurations.keySet() as String[], defaultValue: 'all', description: 'Select which update jobs to run. `All` will include all configured update jobs.')
-		string(name: 'ORM_REPOSITORY', defaultValue: '', description: 'Git URL to Hibernate ORM repository. If provided, Hibernate ORM will be built locally. Works only in pair with ORM_BRANCH.')
+		// choice parameter doesn't have a default, but the first value should be treated as a default, if it wasn't specified manually.
+		// Make sure tp update axis and settings() when adding new choice parameter.
+		choice(name: 'UPDATE_JOB', choices: ['all', 'jandex3', 'orm5.6', 'orm6.2', 'orm6.3', 'orm6-in-main-code'], description: 'Select which update jobs to run. `All` will include all configured update jobs.')
+		string(name: 'ORM_REPOSITORY', defaultValue: '', description: 'Git URL to Hibernate ORM repository. If provided, Hibernate ORM will be built locally. Works only in pair with ORM_BRANCH. Provide an http repository URL rather than an ssh one.')
 		string(name: 'ORM_BRANCH', defaultValue: '', description: 'Hibernate ORM branch to build from. If provided, Hibernate ORM will be built locally. Works only in pair with ORM_REPOSITORY.')
 	}
 	options {
@@ -113,18 +117,45 @@ pipeline {
 			post {
 				cleanup {
 					sh 'ci/docker-cleanup.sh'
+					dir('hibernate-orm-local-copy') {
+						deleteDir()
+					}
 				}
 			}
-			steps {
-				// The timeout cannot be in stage options, because that would
-				// include the time needed to provision a node.
-				timeout(time: 30, unit: 'MINUTES') {
-					withMavenWorkspace {
-						sh """ \
+			stages {
+				stage('Build Hibernate ORM') {
+					when {
+						expression {
+							return params.ORM_REPOSITORY?.trim() || params.ORM_BRANCH?.trim()
+						}
+					}
+					steps {
+						script {
+							if (!params.ORM_REPOSITORY?.trim() || !params.ORM_BRANCH?.trim()) {
+								error "Both ORM_REPOSITORY and ORM_BRANCH must be not blank if a local build of Hibernate ORM is required. Repository: [${params.ORM_REPOSITORY}], branch: [${params.ORM_BRANCH}]."
+							}
+						}
+						script {
+							dir('hibernate-orm-local-copy') {
+								sh "git clone ${params.ORM_REPOSITORY} --depth 1 --branch ${params.ORM_BRANCH} --single-branch ."
+								sh "./gradlew publishToMavenLocal -x test -Dmaven.repo.local=${env.WORKSPACE_TMP}/.m2repository"
+							}
+						}
+					}
+				}
+				stage('Build Hibernate Search') {
+					steps {
+						// The timeout cannot be in stage options, because that would
+						// include the time needed to provision a node.
+						timeout(time: 30, unit: 'MINUTES') {
+							withMavenWorkspace {
+								sh """ \
 							mvn clean install -U -Pdist -DskipTests \
 						"""
-						dir(env.WORKSPACE_TMP + '/.m2repository') {
-							stash name: 'original-build-result', includes:"org/hibernate/search/**"
+								dir(env.WORKSPACE_TMP + '/.m2repository') {
+									stash name: 'original-build-result', includes: "org/hibernate/**"
+								}
+							}
 						}
 					}
 				}
@@ -143,68 +174,61 @@ pipeline {
 				axes {
 					axis {
 						name 'DEPENDENCY_UPDATE_NAME'
-						values params.UPDATE_JOB == 'all' ? configurations.keySet() as String[] : params.UPDATE_JOB
+						// NOTE: Remember to update the settings() method above when changing this.
+						// And also add a new choice parameter in the parameters {} section of the pipeline
+						values 'jandex3', 'orm5.6', 'orm6.2', 'orm6.3', 'orm6-in-main-code'
 					}
 				}
 				stages {
-					stage('Init') {
-						steps {
-							sh 'ci/docker-cleanup.sh'
-							dir(env.WORKSPACE_TMP + '/.m2repository') {
-								unstash name: 'original-build-result'
+					stage('Build') {
+						when {
+							expression {
+								return params.UPDATE_JOB?.trim() == 'all' || params.UPDATE_JOB?.trim() == env.DEPENDENCY_UPDATE_NAME
 							}
-							withMavenWorkspace {
-								script {
-									env[qualify('ADDITIONAL_MAVEN_ARGS')] = settings().additionalMavenArgs ?: ''
-									if (settings().onlyRunTestDependingOn) {
-										env[qualify('ADDITIONAL_MAVEN_ARGS')] += ' -pl ' + sh(script: "./ci/list-dependent-integration-tests.sh ${settings().onlyRunTestDependingOn.join(' ')}", returnStdout: true).trim()
+						}
+						stages {
+							stage('Init') {
+								steps {
+									sh 'ci/docker-cleanup.sh'
+									dir(env.WORKSPACE_TMP + '/.m2repository') {
+										unstash name: 'original-build-result'
+									}
+									withMavenWorkspace {
+										script {
+											env[qualify('ADDITIONAL_MAVEN_ARGS')] = settings().additionalMavenArgs ?: ''
+											if (settings().onlyRunTestDependingOn) {
+												env[qualify('ADDITIONAL_MAVEN_ARGS')] += ' -pl ' + sh(script: "./ci/list-dependent-integration-tests.sh ${settings().onlyRunTestDependingOn.join(' ')}", returnStdout: true).trim()
+											}
+										}
 									}
 								}
 							}
-						}
-					}
-					stage('Build Hibernate ORM') {
-						when {
-							expression {
-								return params.ORM_REPOSITORY?.trim() || params.ORM_BRANCH?.trim()
-							}
-						}
-						steps {
-							if (!params.ORM_REPOSITORY?.trim() || !params.ORM_BRANCH?.trim()) {
-								error "Both ORM_REPOSITORY and ORM_BRANCH must be not blank if a local build of Hibernate ORM is required. Repository: [${params.ORM_REPOSITORY}], branch: [${params.ORM_BRANCH}]."
-							}
-							script {
-								sh "git clone ${params.ORM_REPOSITORY} --depth 1 --branch ${params.ORM_BRANCH} --single-branch ${env.WORKSPACE_TMP}/hibernate-orm-local-copy"
-							}
-							script {
-								sh "${env.WORKSPACE_TMP}/hibernate-orm-local-copy/gradlew publishToMavenLocal -x test"
-							}
-						}
-					}
-					stage('Update dependency') {
-						steps {
-							withMavenWorkspace {
-								sh "ci/dependency-update/perform-update.sh ${env.DEPENDENCY_UPDATE_NAME} '${settings().updateProperties?.join(",") ?: ''}'"
-							}
-							script {
-								if (!settings().skipSourceModifiedCheck && 0 != sh(script: "git diff origin/${BRANCH_NAME} | grep -q '.'", returnStatus: true)) {
-									error "This job does not seem to update any dependency; perhaps it is misconfigured? The source code has not been updated, neither by merging a WIP branch nor by updating version properties."
+							stage('Update dependency') {
+								steps {
+									withMavenWorkspace {
+										sh "ci/dependency-update/perform-update.sh ${env.DEPENDENCY_UPDATE_NAME} '${settings().updateProperties?.join(",") ?: ''}'"
+									}
+									script {
+										if (!settings().skipSourceModifiedCheck && 0 != sh(script: "git diff origin/${BRANCH_NAME} | grep -q '.'", returnStatus: true)) {
+											error "This job does not seem to update any dependency; perhaps it is misconfigured? The source code has not been updated, neither by merging a WIP branch nor by updating version properties."
+										}
+									}
 								}
 							}
-						}
-					}
-					stage('Test') {
-						options {
-							timeout(time: 1, unit: 'HOURS')
-						}
-						steps {
-							withMavenWorkspace {
-								pullContainerImages()
-								sh """ \
+							stage('Test') {
+								options {
+									timeout(time: 1, unit: 'HOURS')
+								}
+								steps {
+									withMavenWorkspace {
+										pullContainerImages()
+										sh """ \
 									mvn clean install -U -Pdependency-update -Pdist -Dsurefire.environment=${normalize(env.DEPENDENCY_UPDATE_NAME)} \
 									--fail-at-end \
 									${env[qualify('ADDITIONAL_MAVEN_ARGS')]} \
 								"""
+									}
+								}
 							}
 						}
 					}


### PR DESCRIPTION
https://ci.hibernate.org/blue/organizations/jenkins/hibernate-search-personal-marko/detail/build%2Fupdate-update-job/22/pipeline/11

that's a 6.2 run with the backports from Christian's repository.
I've reverted the configuration map, since CI was complaining that it cannot find the variable, then I've moved the ORM build to the same stage as pre-building Search so that all necessary jars are stashed. 
Dependency update worked looking at the logs:
```

-        <version.org.hibernate.orm>6.2.13.Final</version.org.hibernate.orm>

+        <version.org.hibernate.orm>6.2.14-SNAPSHOT</version.org.hibernate.orm>
```

I also had to add the dir cleanup, as otherwise, cloning of ORM was failing. 

Sorry for the formatting; it's because of an additional `stage('Build') {` that has a condition 🙈 .

Also cloning ORM with an ssh link fails, while using an HTTPS one works ok (I've added it to the comment on the job parameter, but just wanted to mention it here as well 😃)