### PR TITLE
HSEARCH-4996 Bump version.org.jberet from 2.1.2.Final to 2.1.3.Final

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -105,7 +105,7 @@
 
         <!-- >>> Jakarta Batch -->
         <version.jakarta.batch>2.1.1</version.jakarta.batch>
-        <version.org.jberet>2.1.2.Final</version.org.jberet>
+        <version.org.jberet>2.1.3.Final</version.org.jberet>
 
         <!-- >>> Java EE/Jakarta EE dependencies -->
         <!-- This is used to generate a link to the Jakarta EE javadoc -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4996

Bumps `version.org.jberet` from 2.1.2.Final to 2.1.3.Final.

Updates `org.jberet:jberet-core` from 2.1.2.Final to 2.1.3.Final
- [Release notes](https://github.com/jberet/jsr352/releases)
- [Commits](https://github.com/jberet/jsr352/compare/2.1.2.Final...2.1.3.Final)

Updates `org.jberet:jberet-se` from 2.1.2.Final to 2.1.3.Final
- [Release notes](https://github.com/jberet/jsr352/releases)
- [Commits](https://github.com/jberet/jsr352/compare/2.1.2.Final...2.1.3.Final)

---
updated-dependencies:
- dependency-name: org.jberet:jberet-core dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.jberet:jberet-se dependency-type: direct:production update-type: version-update:semver-patch ...
