### PR TITLE
Skip Elasticsearch tests on ALL Lucene dependency-update jobs

### DIFF
--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -22,6 +22,7 @@ Map settings() {
 			return [
 					updateProperties: ['version.org.apache.lucene'],
 					onlyRunTestDependingOn: ['hibernate-search-backend-lucene'],
+					additionalMavenArgs: '-Dtest.elasticsearch.skip=true'
 			]
 		case 'lucene9':
 			return [


### PR DESCRIPTION
E.g. in Jakarta Batch integration modules where we have one failsafe execution per backend.

@marko-bekhta FYI