### PR TITLE
HSEARCH-5002 Document dropped compatibility with older Elasticsearch/OpenSearch versions and Hibernate ORM 6.3 upgrade in migration guide

### DIFF
--- a/documentation/src/main/asciidoc/migration/index.adoc
+++ b/documentation/src/main/asciidoc/migration/index.adoc
@@ -38,20 +38,34 @@ and only then to later versions (which will be significantly easier).
 [[requirements]]
 == Requirements
 
-Hibernate Search {hibernateSearchVersion} now:
+Hibernate Search {hibernateSearchVersion} now requires:
 
-- is using JDK 11 as the baseline.
-- is based on Lucene 9 for its Lucene backend.
-- requires using Hibernate ORM versions from the 6.2.x family.
+- JDK 11 or later;
+- Lucene 9 for its Lucene backend;
+- Elasticsearch 7.10+ or OpenSearch 1.3+ for its Elasticsearch backend;
+- Hibernate ORM 6.3.x for the Hibernate ORM integration.
 
-When migrating from previous versions of Hibernate Search
+Regarding the Hibernate ORM requirements, when migrating from previous versions of Hibernate Search:
 
-- If you were using Hibernate ORM 6.2 and your corresponding Hibernate Search dependencies included references
-to artifacts ending with `-orm6` (e.g. `hibernate-search-mapper-orm-orm6`) just remove the `-orm6` suffix
-(e.g. use `hibernate-search-mapper-orm` instead) when you upgrade to this version of Hibernate Search.
-- If you were using previous Hibernate ORM versions (e.g. Hibernate ORM 5.6), you would need to migrate to Hibernate ORM 6.2 first
+If your application uses Hibernate ORM 6.3::
+Your Hibernate Search dependencies include references
+to artifacts ending with `-orm6` (e.g. `hibernate-search-mapper-orm-orm6`).
++
+Just remove the `-orm6` suffix from the dependency coordinates
+(e.g. use `hibernate-search-mapper-orm` instead)
+when you upgrade to this version of Hibernate Search.
+If your application uses Hibernate ORM 6.2::
+You need to https://github.com/hibernate/hibernate-orm/blob/6.3/migration-guide.adoc[migrate to Hibernate ORM 6.3] first
 before upgrading to this version of Hibernate Search.
-See https://github.com/hibernate/hibernate-orm/wiki/Migration-Guides/[Hibernate ORM migration guides].
++
+Then follow the instructions for "If your application uses Hibernate ORM 6.3" above.
+If your application uses Hibernate ORM 5.6::
+You need to migrate to Hibernate ORM 6.3 first
+before upgrading to this version of Hibernate Search;
+see https://github.com/hibernate/hibernate-orm/wiki/Migration-Guides/[Hibernate ORM migration guides]
+and https://docs.jboss.org/hibernate/search/6.2/reference/en-US/html_single/#other-integrations-orm6[this guide for using Hibernate ORM 6.x with Hibernate Search 6.2].
++
+Then follow the instructions for "If your application uses Hibernate ORM 6.3" above.
 
 [[artifact-changes]]
 == Artifact changes


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5002
