### PR TITLE
Remove update dependencies job throttling

### DIFF
--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -107,8 +107,7 @@ pipeline {
 	options {
 		buildDiscarder logRotator(daysToKeepStr: '10', numToKeepStr: '3')
 		disableConcurrentBuilds(abortPrevious: true)
-		// Run at most twice per week, to preserve CI workers for more urgent tasks.
-		rateLimitBuilds(throttle: [count: 2, durationName: 'week', userBoost: true])
+		overrideIndexTriggers(false)
 	}
 	stages {
 		// This allows testing the original (unpatched) artifacts,
@@ -142,7 +141,10 @@ pipeline {
 						}
 						script {
 							dir('hibernate-orm-local-copy') {
-								sh "git clone ${params.ORM_REPOSITORY} --depth 1 --branch ${params.ORM_BRANCH} --single-branch ."
+								// We may get either an http or an ssh repository URLs.
+								// Since this job can work correctly only with an http URL we will try to adapt the ssh url if we spot one:
+								def repositoryUrl = params.ORM_REPOSITORY ==~ /^git@github\.com:.+$/ ? params.ORM_REPOSITORY.replace("git@github.com:", "https://github.com/") : params.ORM_REPOSITORY
+								sh "git clone ${repositoryUrl} --depth 1 --branch ${params.ORM_BRANCH} --single-branch ."
 								sh "./gradlew publishToMavenLocal -x test -Dmaven.repo.local=${env.WORKSPACE_TMP}/.m2repository"
 							}
 							dir(env.WORKSPACE_TMP + '/.m2repository') {


### PR DESCRIPTION
Here's an ORM job triggering the Search dependency update job and waiting for the results: https://ci.hibernate.org/blue/organizations/jenkins/hibernate-orm-personal-marko/detail/ci%2Fadd-hibernate-search-tests-to-build-test/15/pipeline/

I've tried `git` `checkout` as well as `git clone -c 'core.sshCommand=ssh -v ...` for cloning a repo using an ssh URL, but with no luck... it looks like git wasn't able to find the known_hosts that would contain the keys we had on CI... Hence I've just adapted the job to "convert" the URL instead 🙈 🙈 🙈 
I'll backport to 6.2 once we merge the changes to main and then update the ORM PR so it can actually trigger the correct build 😃 