### PR TITLE
Followup: HSEARCH-4674 Change dependabot configuration for databases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,6 @@ registries:
     username: ${{secrets.DOCKERHUB_USERNAME}}
     password: ${{secrets.DOCKERHUB_TOKEN}}
     replaces-base: true
-  ibm:
-    type: docker-registry
-    url: https://icr.io
 updates:
   - package-ecosystem: "maven"
     directory: "/"
@@ -112,7 +109,6 @@ updates:
   - package-ecosystem: "docker"
     registries:
       - dockerhub
-      - ibm
     # For dependabot to find Docker files they all should be in the same directory.
     # Dependabot is picking any files that has `dockerfile` in them.
     #

--- a/build/container/database/mssql.Dockerfile
+++ b/build/container/database/mssql.Dockerfile
@@ -1,3 +1,3 @@
 # MS SQL Server
 # See https://hub.docker.com/_/microsoft-mssql-server
-FROM docker.io/mcr.microsoft.com/mssql/server:2022-CU9-ubuntu-20.04
+FROM mcr.microsoft.com/mssql/server:2022-CU9-ubuntu-20.04


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4674

empty or `""` empty strings didn't work , but from the logs it looks like it can figure it out without any additional configs:

```
updater | 2023/11/08 10:43:01 INFO <job_746926390> Checking if db2_community/db2 11.5.8.0 needs updating
  proxy | 2023/11/08 10:43:02 [108] GET https://icr.io:443/v2/db2_community/db2/tags/list
  proxy | 2023/11/08 10:43:02 [108] 200 https://icr.io:443/v2/db2_community/db2/tags/list
  proxy | 2023/11/08 10:43:02 [110] HEAD https://icr.io:443/v2/db2_community/db2/manifests/latest
  proxy | 2023/11/08 10:43:02 [110] 200 https://icr.io:443/v2/db2_community/db2/manifests/latest
  proxy | 2023/11/08 10:43:02 [112] HEAD https://icr.io:443/v2/db2_community/db2/manifests/11.5.8.0
  proxy | 2023/11/08 10:43:02 [112] 200 https://icr.io:443/v2/db2_community/db2/manifests/11.5.8.0
updater | 2023/11/08 10:43:02 INFO <job_746926390> Latest version is 11.5.8.0
updater | 2023/11/08 10:43:02 INFO <job_746926390> No update needed for db2_community/db2 11.5.8.0
```

Also, I've noticed that there are RHEL builds for MSSQL: https://mcr.microsoft.com/en-us/product/mssql/rhel/server/tags
Do we want to switch to those or stay on Ubuntu ones?