### PR TITLE
[DO NOT MERGE] HSEARCH-5010 Upgrade to Lucene 9.9-SNAPSHOT

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/comparator/impl/DoubleValuesSourceComparator.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/comparator/impl/DoubleValuesSourceComparator.java
@@ -13,6 +13,7 @@ import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.DoubleMultiVa
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.search.LeafFieldComparator;
+import org.apache.lucene.search.Pruning;
 import org.apache.lucene.search.comparators.DoubleComparator;
 
 public class DoubleValuesSourceComparator extends DoubleComparator {
@@ -20,8 +21,8 @@ public class DoubleValuesSourceComparator extends DoubleComparator {
 	private final DoubleMultiValuesToSingleValuesSource source;
 
 	public DoubleValuesSourceComparator(int numHits, String field, Double missingValue, boolean reversed,
-			boolean enableSkipping, DoubleMultiValuesToSingleValuesSource source) {
-		super( numHits, field, missingValue, reversed, enableSkipping );
+			Pruning pruning, DoubleMultiValuesToSingleValuesSource source) {
+		super( numHits, field, missingValue, reversed, pruning );
 		this.source = source;
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/comparator/impl/FloatValuesSourceComparator.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/comparator/impl/FloatValuesSourceComparator.java
@@ -13,15 +13,16 @@ import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.DoubleMultiVa
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.search.LeafFieldComparator;
+import org.apache.lucene.search.Pruning;
 import org.apache.lucene.search.comparators.FloatComparator;
 
 public class FloatValuesSourceComparator extends FloatComparator {
 
 	private final DoubleMultiValuesToSingleValuesSource source;
 
-	public FloatValuesSourceComparator(int numHits, String field, Float missingValue, boolean reversed, boolean enableSkipping,
+	public FloatValuesSourceComparator(int numHits, String field, Float missingValue, boolean reversed, Pruning pruning,
 			DoubleMultiValuesToSingleValuesSource source) {
-		super( numHits, field, missingValue, reversed, enableSkipping );
+		super( numHits, field, missingValue, reversed, pruning );
 		this.source = source;
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/comparator/impl/IntValuesSourceComparator.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/comparator/impl/IntValuesSourceComparator.java
@@ -13,15 +13,16 @@ import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.LongMultiValu
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.search.LeafFieldComparator;
+import org.apache.lucene.search.Pruning;
 import org.apache.lucene.search.comparators.IntComparator;
 
 public class IntValuesSourceComparator extends IntComparator {
 
 	private final LongMultiValuesToSingleValuesSource source;
 
-	public IntValuesSourceComparator(int numHits, String field, Integer missingValue, boolean reversed, boolean enableSkipping,
+	public IntValuesSourceComparator(int numHits, String field, Integer missingValue, boolean reversed, Pruning pruning,
 			LongMultiValuesToSingleValuesSource source) {
-		super( numHits, field, missingValue, reversed, enableSkipping );
+		super( numHits, field, missingValue, reversed, pruning );
 		this.source = source;
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/comparator/impl/LongValuesSourceComparator.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/comparator/impl/LongValuesSourceComparator.java
@@ -13,15 +13,16 @@ import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.LongMultiValu
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.search.LeafFieldComparator;
+import org.apache.lucene.search.Pruning;
 import org.apache.lucene.search.comparators.LongComparator;
 
 public class LongValuesSourceComparator extends LongComparator {
 
 	private final LongMultiValuesToSingleValuesSource source;
 
-	public LongValuesSourceComparator(int numHits, String field, Long missingValue, boolean reversed, boolean enableSkipping,
+	public LongValuesSourceComparator(int numHits, String field, Long missingValue, boolean reversed, Pruning pruning,
 			LongMultiValuesToSingleValuesSource source) {
-		super( numHits, field, missingValue, reversed, enableSkipping );
+		super( numHits, field, missingValue, reversed, pruning );
 		this.source = source;
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/lowlevel/impl/LuceneDoubleDomain.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/lowlevel/impl/LuceneDoubleDomain.java
@@ -26,6 +26,7 @@ import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.FieldComparator;
+import org.apache.lucene.search.Pruning;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.NumericUtils;
 
@@ -129,11 +130,11 @@ public class LuceneDoubleDomain implements LuceneNumericDomain<Double> {
 
 	@Override
 	public FieldComparator<Double> createFieldComparator(String fieldName, int numHits,
-			Double missingValue, boolean reversed, boolean enableSkipping, MultiValueMode multiValueMode,
+			Double missingValue, boolean reversed, Pruning pruning, MultiValueMode multiValueMode,
 			NestedDocsProvider nestedDocsProvider) {
 		DoubleMultiValuesToSingleValuesSource source = DoubleMultiValuesToSingleValuesSource
 				.fromDoubleField( fieldName, multiValueMode, nestedDocsProvider );
-		return new DoubleValuesSourceComparator( numHits, fieldName, missingValue, reversed, enableSkipping, source );
+		return new DoubleValuesSourceComparator( numHits, fieldName, missingValue, reversed, pruning, source );
 	}
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/lowlevel/impl/LuceneFloatDomain.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/lowlevel/impl/LuceneFloatDomain.java
@@ -26,6 +26,7 @@ import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.FieldComparator;
+import org.apache.lucene.search.Pruning;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.NumericUtils;
 
@@ -129,11 +130,11 @@ public class LuceneFloatDomain implements LuceneNumericDomain<Float> {
 
 	@Override
 	public FieldComparator<Float> createFieldComparator(String fieldName, int numHits,
-			Float missingValue, boolean reversed, boolean enableSkipping, MultiValueMode multiValueMode,
+			Float missingValue, boolean reversed, Pruning pruning, MultiValueMode multiValueMode,
 			NestedDocsProvider nestedDocsProvider) {
 		DoubleMultiValuesToSingleValuesSource source =
 				DoubleMultiValuesToSingleValuesSource.fromFloatField( fieldName, multiValueMode, nestedDocsProvider );
-		return new FloatValuesSourceComparator( numHits, fieldName, missingValue, reversed, enableSkipping, source );
+		return new FloatValuesSourceComparator( numHits, fieldName, missingValue, reversed, pruning, source );
 	}
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/lowlevel/impl/LuceneIntegerDomain.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/lowlevel/impl/LuceneIntegerDomain.java
@@ -26,6 +26,7 @@ import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.FieldComparator;
+import org.apache.lucene.search.Pruning;
 import org.apache.lucene.search.Query;
 
 public class LuceneIntegerDomain implements LuceneNumericDomain<Integer> {
@@ -122,10 +123,10 @@ public class LuceneIntegerDomain implements LuceneNumericDomain<Integer> {
 
 	@Override
 	public FieldComparator<Integer> createFieldComparator(String fieldName, int numHits,
-			Integer missingValue, boolean reversed, boolean enableSkipping, MultiValueMode multiValueMode,
+			Integer missingValue, boolean reversed, Pruning pruning, MultiValueMode multiValueMode,
 			NestedDocsProvider nestedDocsProvider) {
 		LongMultiValuesToSingleValuesSource source =
 				LongMultiValuesToSingleValuesSource.fromIntField( fieldName, multiValueMode, nestedDocsProvider );
-		return new IntValuesSourceComparator( numHits, fieldName, missingValue, reversed, enableSkipping, source );
+		return new IntValuesSourceComparator( numHits, fieldName, missingValue, reversed, pruning, source );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/lowlevel/impl/LuceneLongDomain.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/lowlevel/impl/LuceneLongDomain.java
@@ -26,6 +26,7 @@ import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.FieldComparator;
+import org.apache.lucene.search.Pruning;
 import org.apache.lucene.search.Query;
 
 public class LuceneLongDomain implements LuceneNumericDomain<Long> {
@@ -122,10 +123,10 @@ public class LuceneLongDomain implements LuceneNumericDomain<Long> {
 
 	@Override
 	public FieldComparator<Long> createFieldComparator(String fieldName, int numHits,
-			Long missingValue, boolean reversed, boolean enableSkipping, MultiValueMode multiValueMode,
+			Long missingValue, boolean reversed, Pruning pruning, MultiValueMode multiValueMode,
 			NestedDocsProvider nestedDocsProvider) {
 		LongMultiValuesToSingleValuesSource source =
 				LongMultiValuesToSingleValuesSource.fromLongField( fieldName, multiValueMode, nestedDocsProvider );
-		return new LongValuesSourceComparator( numHits, fieldName, missingValue, reversed, enableSkipping, source );
+		return new LongValuesSourceComparator( numHits, fieldName, missingValue, reversed, pruning, source );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/lowlevel/impl/LuceneNumericDomain.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/lowlevel/impl/LuceneNumericDomain.java
@@ -18,6 +18,7 @@ import org.apache.lucene.facet.Facets;
 import org.apache.lucene.facet.FacetsCollector;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.FieldComparator;
+import org.apache.lucene.search.Pruning;
 import org.apache.lucene.search.Query;
 
 public interface LuceneNumericDomain<E extends Number> {
@@ -54,6 +55,6 @@ public interface LuceneNumericDomain<E extends Number> {
 	IndexableField createSortedDocValuesField(String absoluteFieldPath, E numericValue);
 
 	FieldComparator<E> createFieldComparator(String absoluteFieldPath, int numHits,
-			E missingValue, boolean reversed, boolean enableSkipping, MultiValueMode multiValueMode,
+			E missingValue, boolean reversed, Pruning pruning, MultiValueMode multiValueMode,
 			NestedDocsProvider nestedDocsProvider);
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/comparatorsource/impl/LuceneGeoPointDistanceComparatorSource.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/comparatorsource/impl/LuceneGeoPointDistanceComparatorSource.java
@@ -12,6 +12,7 @@ import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.MultiValueMod
 import org.hibernate.search.engine.spatial.GeoPoint;
 
 import org.apache.lucene.search.FieldComparator;
+import org.apache.lucene.search.Pruning;
 import org.apache.lucene.search.Query;
 
 public class LuceneGeoPointDistanceComparatorSource extends LuceneFieldComparatorSource {
@@ -29,11 +30,11 @@ public class LuceneGeoPointDistanceComparatorSource extends LuceneFieldComparato
 	}
 
 	@Override
-	public FieldComparator<?> newComparator(String fieldname, int numHits, boolean enableSkipping, boolean reversed) {
+	public FieldComparator<?> newComparator(String fieldname, int numHits, Pruning pruning, boolean reversed) {
 		GeoPointDistanceMultiValuesToSingleValuesSource source = new GeoPointDistanceMultiValuesToSingleValuesSource(
 				fieldname, mode, nestedDocsProvider, center
 		);
 		// forcing to not skipping documents
-		return new DoubleValuesSourceComparator( numHits, fieldname, missingValue, reversed, false, source );
+		return new DoubleValuesSourceComparator( numHits, fieldname, missingValue, reversed, Pruning.NONE, source );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/comparatorsource/impl/LuceneNumericFieldComparatorSource.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/comparatorsource/impl/LuceneNumericFieldComparatorSource.java
@@ -10,6 +10,7 @@ import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.MultiValueMod
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneNumericDomain;
 
 import org.apache.lucene.search.FieldComparator;
+import org.apache.lucene.search.Pruning;
 import org.apache.lucene.search.Query;
 
 public class LuceneNumericFieldComparatorSource<E extends Number> extends LuceneFieldComparatorSource {
@@ -27,8 +28,8 @@ public class LuceneNumericFieldComparatorSource<E extends Number> extends Lucene
 	}
 
 	@Override
-	public FieldComparator<?> newComparator(String fieldname, int numHits, boolean enableSkipping, boolean reversed) {
-		return numericDomain.createFieldComparator( fieldname, numHits, missingValue, reversed, enableSkipping,
+	public FieldComparator<?> newComparator(String fieldname, int numHits, Pruning pruning, boolean reversed) {
+		return numericDomain.createFieldComparator( fieldname, numHits, missingValue, reversed, pruning,
 				sortMode, nestedDocsProvider );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/comparatorsource/impl/LuceneTextFieldComparatorSource.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/comparatorsource/impl/LuceneTextFieldComparatorSource.java
@@ -16,6 +16,7 @@ import org.hibernate.search.backend.lucene.types.sort.impl.SortMissingValue;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.search.FieldComparator;
+import org.apache.lucene.search.Pruning;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.comparators.TermOrdValComparator;
 import org.apache.lucene.util.BytesRef;
@@ -33,7 +34,7 @@ public class LuceneTextFieldComparatorSource extends LuceneFieldComparatorSource
 	}
 
 	@Override
-	public FieldComparator<?> newComparator(String fieldname, int numHits, boolean enableSkipping, boolean reversed) {
+	public FieldComparator<?> newComparator(String fieldname, int numHits, Pruning pruning, boolean reversed) {
 		final boolean considerMissingHighest;
 		if ( SortMissingValue.MISSING_LOWEST.equals( missingValue ) ) {
 			considerMissingHighest = false;
@@ -53,7 +54,7 @@ public class LuceneTextFieldComparatorSource extends LuceneFieldComparatorSource
 				TextMultiValuesToSingleValuesSource.fromField( fieldname, multiValueMode, nestedDocsProvider );
 
 		// forcing to not skipping documents
-		return new TermOrdValComparator( numHits, fieldname, considerMissingHighest, reversed, false ) {
+		return new TermOrdValComparator( numHits, fieldname, considerMissingHighest, reversed, Pruning.NONE ) {
 			@Override
 			protected SortedDocValues getSortedDocValues(LeafReaderContext context, String field) throws IOException {
 				SortedDocValues sortedDocValues = source.getValues( context );

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -30,7 +30,7 @@
 
         <!-- >>> Lucene -->
         <!-- When upgrading Lucene, make sure to align the dependency to com.carrotsearch.hppc (see below) -->
-        <version.org.apache.lucene>9.8.0</version.org.apache.lucene>
+        <version.org.apache.lucene>9.9.0-SNAPSHOT</version.org.apache.lucene>
         <javadoc.org.apache.lucene.tag>${parsed-version.org.apache.lucene.majorVersion}_${parsed-version.org.apache.lucene.minorVersion}_${parsed-version.org.apache.lucene.incrementalVersion}</javadoc.org.apache.lucene.tag>
         <javadoc.org.apache.lucene.core.url>https://lucene.apache.org/core/${javadoc.org.apache.lucene.tag}/core/</javadoc.org.apache.lucene.core.url>
         <javadoc.org.apache.lucene.analyzers-common.url>https://lucene.apache.org/core/${javadoc.org.apache.lucene.tag}/analyzers-common/</javadoc.org.apache.lucene.analyzers-common.url>

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/query/sorting/SortTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/query/sorting/SortTest.java
@@ -47,6 +47,7 @@ import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.search.FieldComparatorSource;
 import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Pruning;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SimpleFieldComparator;
 import org.apache.lucene.search.Sort;
@@ -485,7 +486,7 @@ class SortTest extends SearchTestBase {
 
 	public static class SumFieldComparatorSource extends FieldComparatorSource {
 		@Override
-		public FieldComparator<?> newComparator(String fieldName, int numHits, boolean enableSkipping, boolean reversed) {
+		public FieldComparator<?> newComparator(String fieldName, int numHits, Pruning pruning, boolean reversed) {
 			return new SumFieldComparator( numHits, "num1", "num2" );
 		}
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5010

Yeah, it was a change in the signature, now the skipping has more control:

```java
/** Controls {@link LeafFieldComparator} how to skip documents */
public enum Pruning {
  /** Not allowed to skip documents. */
  NONE,
  /**
   * Allowed to skip documents that compare strictly better than the top value, or strictly worse
   * than the bottom value.
   */
  GREATER_THAN,
  /**
   * Allowed to skip documents that compare better than the top value, or worse than or equal to the
   * bottom value.
   */
  GREATER_THAN_OR_EQUAL_TO
}
```

Should I just push this branch to the main repo and create a similar one for `lucene10` ?