### PR TITLE
Update Groovy script to list required test containers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -967,7 +967,7 @@
                                         }
                                     }
                                     // Exclude images from non-dockerhub repositories
-                                    new File('${containerImagesListFile}').append( images.findAll{ref -> !(ref ==~ /^(?!((.*\.)?docker\.io))[\w\d\.]+\/[\w\d\.]+\/[\w\d\.]+(:.+)?$/)}.join('\n') + '\n' )
+                                    new File('${containerImagesListFile}').append( images.join('\n') + '\n' )
                                 ]]></script>
                             </configuration>
                         </execution>


### PR DESCRIPTION
to work with non-docker-io registries (e.g. db2/mssql)

Right now, these won't be prefetched. It should still work out ok in the end as they can be downloaded without docker auth. But let's fetch them the same as we are doing for other  containters.