### PR TITLE
HSEARCH-5024 Adjust the CodeSource to be able to handle the new URL structure of the nested jars from Spring

### DIFF
--- a/orm6/integrationtest/mapper/orm-spring-uberjar/application/ant-src-changes.patch
+++ b/orm6/integrationtest/mapper/orm-spring-uberjar/application/ant-src-changes.patch
@@ -1,0 +1,53 @@
+diff --git a/test/java/org/hibernate/search/integrationtest/spring/repackaged/application/RepackagedApplicationIT.java b/integrationtest/mapper/orm-spring-uberjar/application/src/test/java/org/hibernate/search/integrationtest/spring/repackaged/application/RepackagedApplicationIT.java
+--- a/test/java/org/hibernate/search/integrationtest/spring/repackaged/application/RepackagedApplicationIT.java
++++ b/test/java/org/hibernate/search/integrationtest/spring/repackaged/application/RepackagedApplicationIT.java
+@@ -15,6 +15,7 @@
+ import java.nio.file.Path;
+ import java.nio.file.Paths;
+ import java.util.jar.JarEntry;
++import java.util.jar.JarFile;
+
+ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ProjectionConstructor;
+ import org.hibernate.search.util.common.SearchException;
+@@ -32,7 +33,8 @@
+
+ import acme.org.hibernate.search.integrationtest.spring.repackaged.model.MyEntity;
+ import acme.org.hibernate.search.integrationtest.spring.repackaged.model.MyProjection;
+-import org.springframework.boot.loader.jar.JarFile;
++import org.springframework.boot.loader.net.protocol.Handlers;
++import org.springframework.boot.loader.net.protocol.jar.JarUrl;
+
+ /**
+  * This test is NOT a @SpringBootTest:
+@@ -83,9 +85,9 @@
+ 	@Test
+ 	public void canReadJar() throws Exception {
+ 		try ( JarFile outerJar = new JarFile( repackedJarPath.toFile() ) ) {
+-			for ( JarEntry jarEntry : outerJar ) {
++			for ( JarEntry jarEntry : outerJar.stream().toList() ) {
+ 				if ( jarEntry.getName().contains( "hibernate-search-integrationtest-spring-repackaged-model" ) ) {
+-					URL innerJarURL = outerJar.getNestedJarFile( jarEntry ).getUrl();
++					URL innerJarURL = innerJarUrl( jarEntry );
+
+ 					try ( URLClassLoader isolatedClassLoader = new URLClassLoader( new URL[] { innerJarURL }, null ) ) {
+ 						Class<?> classInIsolatedClassLoader = isolatedClassLoader.loadClass( MyEntity.class.getName() );
+@@ -106,8 +106,7 @@
+ 							classInfo = index.getClassByName( DotName.createSimple( MyProjection.class.getName() ) );
+ 							assertThat( classInfo ).isNotNull();
+ 							assertThat(
+-									classInfo.annotations()
+-											.get( DotName.createSimple( ProjectionConstructor.class.getName() ) ) )
++									classInfo.annotations( DotName.createSimple( ProjectionConstructor.class.getName() ) ) )
+ 									.isNotNull();
+ 							name = classInfo.field( "name" );
+ 							assertThat( name ).isNotNull();
+@@ -130,4 +132,9 @@
+ 			}
+ 		}
+ 	}
++
++	URL innerJarUrl(JarEntry jarEntry) {
++		Handlers.register();
++		return JarUrl.create( repackedJarPath.toFile(), jarEntry );
++	}
+ }

--- a/orm6/integrationtest/mapper/orm-spring-uberjar/application/pom.xml
+++ b/orm6/integrationtest/mapper/orm-spring-uberjar/application/pom.xml
@@ -1,0 +1,135 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-integrationtest-spring-repackaged-orm6</artifactId>
+        <version>6.2.3-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-integrationtest-spring-repackaged-application-orm6</artifactId>
+
+    <name>Hibernate Search ITs - Spring Repackaged JAR Application - ORM6</name>
+
+    <properties>
+        <transform.original.pathFromRoot>integrationtest/mapper/orm-spring-uberjar/application</transform.original.pathFromRoot>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-integrationtest-spring-repackaged-model-orm6</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm-orm6</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-backend-lucene</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <exclusions>
+                <!-- Using JBoss Logging -->
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <!-- Using JBoss Logging -->
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-loader</artifactId>
+            <version>${version.org.springframework.boot}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-mapper-orm-orm6</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${version.org.springframework.boot}</version>
+                <executions>
+                    <execution>
+                        <id>repackage</id>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <outputDirectory>${project.build.directory}</outputDirectory>
+                    <finalName>app-repackaged</finalName>
+                    <mainClass>
+                        org.hibernate.search.integrationtest.spring.repackaged.application.Application
+                    </mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skip>${failsafe.spring.skip}</skip>
+                    <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+                    <environmentVariables>
+                        <!--
+                             The test settings add a different suffix to this value for each test execution.
+                             We can't add this suffix (${random.uuid}) here due to IDEA limitations:
+                             IDEA just ignores this environment variable if it finds a reference to an unknown property
+                             such as "${random.uuid}".
+                         -->
+                        <LUCENE_ROOT_PATH>${project.build.directory}/test-indexes/</LUCENE_ROOT_PATH>
+                    </environmentVariables>
+                    <systemPropertyVariables>
+                        <test.launcher-command>${java-version.test.launcher}</test.launcher-command>
+                        <test.repackaged-jar-path>${project.build.directory}/app-repackaged.jar</test.repackaged-jar-path>
+                    </systemPropertyVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>it</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/orm6/integrationtest/mapper/orm-spring-uberjar/model/pom.xml
+++ b/orm6/integrationtest/mapper/orm-spring-uberjar/model/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-integrationtest-spring-repackaged-orm6</artifactId>
+        <version>6.2.3-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-integrationtest-spring-repackaged-model-orm6</artifactId>
+
+    <name>Hibernate Search ITs - Spring Repackaged JAR Model - ORM6</name>
+
+    <properties>
+        <transform.original.pathFromRoot>integrationtest/mapper/orm-spring-uberjar/model</transform.original.pathFromRoot>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm-orm6</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+

--- a/orm6/integrationtest/mapper/orm-spring-uberjar/pom.xml
+++ b/orm6/integrationtest/mapper/orm-spring-uberjar/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-integrationtest-orm6</artifactId>
+        <version>6.2.3-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-integrationtest-spring-repackaged-orm6</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Hibernate Search ITs - Spring Repackaged JAR</name>
+    <description>Testing if Hibernate Search will start correctly inside a Spring's repackaged jar</description>
+
+    <modules>
+        <module>model</module>
+        <module>application</module>
+    </modules>
+
+    <properties>
+        <!--
+            Remove Hibernate system properties from parent settings:
+            They are supposed to be handled by the spring.datasource subsystem
+            and not by the Hibernate internal pool!
+            See also the failsafe configuration.
+         -->
+        <failsafe.jvm.args.hibernate-orm></failsafe.jvm.args.hibernate-orm>
+        <version.org.springframework.boot>3.2.0</version.org.springframework.boot>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${version.org.springframework.boot}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- The Spring BOM uses a version of bytebuddy that's too old for Mockito to work correctly -->
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${version.net.bytebuddy}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy-agent</artifactId>
+                <version>${version.net.bytebuddy}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>
+

--- a/orm6/integrationtest/pom.xml
+++ b/orm6/integrationtest/pom.xml
@@ -38,6 +38,18 @@
                 <module>java/modules/orm-coordination-outbox-polling-elasticsearch</module>
             </modules>
         </profile>
+        <profile>
+            <id>springITs</id>
+            <activation>
+                <property>
+                    <name>java-version.test.release</name>
+                    <value>!8</value>
+                </property>
+            </activation>
+            <modules>
+                <module>mapper/orm-spring-uberjar</module>
+            </modules>
+        </profile>
     </profiles>
 </project>
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5024

for 6.2 we didn't update spring integration tests, and they are still based on 2.7. Update would mean Jakarta, java17 and probably more, So I don't think we want to bump the version for the main build ... I've added a copy of the repackaged app to orm6 modules so we can still test the compatibility a bit.