### PR TITLE
Remove unnecessary line in the migration script

### DIFF
--- a/documentation/src/main/asciidoc/migration/index.adoc
+++ b/documentation/src/main/asciidoc/migration/index.adoc
@@ -253,7 +253,6 @@ alter table hsearch_outbox_event
 
 -- change agent `id` column type to char:
 alter table hsearch_agent
-alter table hsearch_agent
     add tmp char(36);
 update hsearch_agent
 set tmp = id


### PR DESCRIPTION
Noticed this when was creating a similar script for another PR in 7.1