### PR TITLE
HSEARCH-5034 Allow passing BeanReference<? extends T> when registering beans to BeanConfigurationContext

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/environment/bean/TypeBeanReference.java
+++ b/engine/src/main/java/org/hibernate/search/engine/environment/bean/TypeBeanReference.java
@@ -36,6 +36,7 @@ class TypeBeanReference<T> implements BeanReference<T> {
 			return (BeanReference<? extends U>) this;
 		}
 		else {
+			// We don't know the concrete type of returned beans, so we'll have to check upon retrieval
 			return BeanReference.super.asSubTypeOf( expectedType );
 		}
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/environment/bean/impl/BeanConfigurationContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/environment/bean/impl/BeanConfigurationContextImpl.java
@@ -18,14 +18,14 @@ final class BeanConfigurationContextImpl implements BeanConfigurationContext {
 	private final Map<Class<?>, BeanReferenceRegistryForType<?>> configuredBeans = new HashMap<>();
 
 	@Override
-	public <T> void define(Class<T> exposedType, BeanReference<T> reference) {
+	public <T> void define(Class<T> exposedType, BeanReference<? extends T> reference) {
 		Contracts.assertNotNull( exposedType, "exposedType" );
 		Contracts.assertNotNull( reference, "reference" );
 		configuredBeans( exposedType ).add( reference );
 	}
 
 	@Override
-	public <T> void define(Class<T> exposedType, String name, BeanReference<T> reference) {
+	public <T> void define(Class<T> exposedType, String name, BeanReference<? extends T> reference) {
 		Contracts.assertNotNull( exposedType, "exposedType" );
 		Contracts.assertNotNull( name, "name" );
 		Contracts.assertNotNull( reference, "reference" );

--- a/engine/src/main/java/org/hibernate/search/engine/environment/bean/impl/BeanReferenceRegistryForType.java
+++ b/engine/src/main/java/org/hibernate/search/engine/environment/bean/impl/BeanReferenceRegistryForType.java
@@ -61,17 +61,19 @@ public class BeanReferenceRegistryForType<T> {
 		return named.get( name );
 	}
 
-	void add(BeanReference<T> reference) {
-		all.add( reference );
+	@SuppressWarnings("unchecked") // Safe cast from BeanReference<? extends T> to BeanReference<T> as BeanReference is covariant in T
+	void add(BeanReference<? extends T> reference) {
+		all.add( (BeanReference<T>) reference );
 	}
 
-	void add(String name, BeanReference<T> reference) {
-		Object previous = named.putIfAbsent( name, reference );
+	@SuppressWarnings("unchecked") // Safe cast from BeanReference<? extends T> to BeanReference<T> as BeanReference is covariant in T
+	void add(String name, BeanReference<? extends T> reference) {
+		Object previous = named.putIfAbsent( name, (BeanReference<T>) reference );
 		if ( previous != null ) {
 			throw new AssertionFailure( String.format( Locale.ROOT,
 					"Duplicate bean references for name '%1$s': %2$s, %3$s",
 					name, previous, reference ) );
 		}
-		all.add( reference );
+		all.add( (BeanReference<T>) reference );
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/environment/bean/spi/BeanConfigurationContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/environment/bean/spi/BeanConfigurationContext.java
@@ -24,7 +24,7 @@ public interface BeanConfigurationContext {
 	 * provided that reference is not {@code BeanReference.of( exposedType )} (which would create a cycle).
 	 * @param <T> The exposed type of the bean.
 	 */
-	<T> void define(Class<T> exposedType, BeanReference<T> reference);
+	<T> void define(Class<T> exposedType, BeanReference<? extends T> reference);
 
 	/**
 	 * Define a way to resolve a bean referenced by its {@code exposedType} and {@code name}.
@@ -40,6 +40,6 @@ public interface BeanConfigurationContext {
 	 * provided that reference is not {@code BeanReference.of( exposedType, name )} (which would create a cycle).
 	 * @param <T> The exposed type of the bean.
 	 */
-	<T> void define(Class<T> exposedType, String name, BeanReference<T> reference);
+	<T> void define(Class<T> exposedType, String name, BeanReference<? extends T> reference);
 
 }

--- a/engine/src/test/java/org/hibernate/search/engine/environment/bean/impl/BeanResolverImplBaseTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/environment/bean/impl/BeanResolverImplBaseTest.java
@@ -65,11 +65,11 @@ class BeanResolverImplBaseTest {
 	@Mock
 	private BeanReference<RoleType> roleInternalBean1FactoryMock;
 	@Mock
-	private BeanReference<RoleType> roleInternalBean2FactoryMock;
+	private BeanReference<InternalType3> roleInternalBean2FactoryMock;
 	@Mock
 	private BeanReference<RoleType> roleInternalBean3FactoryMock;
 	@Mock
-	private BeanReference<RoleType> roleInternalBean4FactoryMock;
+	private BeanReference<InternalType3> roleInternalBean4FactoryMock;
 
 	private BeanResolver beanResolver;
 
@@ -436,9 +436,9 @@ class BeanResolverImplBaseTest {
 	@Test
 	void resolveRole() {
 		BeanHolder<RoleType> beanHolder1 = BeanHolder.of( new InternalType3() );
-		BeanHolder<RoleType> beanHolder2 = BeanHolder.of( new InternalType3() );
+		BeanHolder<InternalType3> beanHolder2 = BeanHolder.of( new InternalType3() );
 		BeanHolder<RoleType> beanHolder3 = BeanHolder.of( new InternalType3() );
-		BeanHolder<RoleType> beanHolder4 = BeanHolder.of( new InternalType3() );
+		BeanHolder<InternalType3> beanHolder4 = BeanHolder.of( new InternalType3() );
 
 		// resolveRole
 		when( roleInternalBean1FactoryMock.resolve( any() ) ).thenReturn( beanHolder1 );


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5034
