### PR TITLE
Backport of HSEARCH-5041 to 7.0 - Test against latest OpenSearch 1.3.14

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -245,7 +245,7 @@ stage('Configure') {
 					// --------------------------------------------
 					// OpenSearch
 					// Not testing 1.0 - 1.2 as these versions are EOL'ed.
-					new LocalOpenSearchBuildEnvironment(version: '1.3.13', condition: TestCondition.AFTER_MERGE),
+					new LocalOpenSearchBuildEnvironment(version: '1.3.14', condition: TestCondition.AFTER_MERGE),
 					// See https://opensearch.org/lines/1x.html for a list of all 1.x versions
 					new LocalOpenSearchBuildEnvironment(version: '2.0.1', condition: TestCondition.ON_DEMAND),
 					new LocalOpenSearchBuildEnvironment(version: '2.1.0', condition: TestCondition.ON_DEMAND),


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5041