### PR TITLE
Enable Spring tests on JDK 22

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -167,6 +167,7 @@
         <version.org.google.guava>32.1.2-jre</version.org.google.guava>
 
         <!-- >>> Spring integration tests -->
+        <!-- When updating Spring Boot check if it supports JDK23 and enable testing with it if so (see testWithJdk23 profile). -->
         <version.org.springframework.boot>3.2.0</version.org.springframework.boot>
         <!-- Spring Boot 3 Atomikos starter and related libs version: -->
         <version.com.atomikos>6.0.0</version.com.atomikos>

--- a/pom.xml
+++ b/pom.xml
@@ -1476,8 +1476,6 @@
                     -Djdk.attach.allowAttachSelf=true
                     -Dnet.bytebuddy.experimental=true
                 </surefire.jvm.args.java-version>
-                <!-- Spring Boot 3 isn't ready for JDK22 yet -->
-                <failsafe.spring.skip>true</failsafe.spring.skip>
                 <!-- impsort-maven-plugin doesn't work with JDK22 yet -->
                 <format.skip>true</format.skip>
             </properties>


### PR DESCRIPTION
I've just checked that the tests now compile and run OK with JDK 22. For JDK 23 it is:

```
Caused by: java.io.IOException: ASM ClassReader failed to parse class file - probably due to a new Java class file version that isn't supported yet: file [/home/marko/development/projects/opensource/hibernate-search/integrationtest/mapper/orm-spring/target/test-classes/org/hibernate/search/integrationtest/spring/transaction/TransactionIT$HelperService$MakeRollbackException.class]
	at org.springframework.core.type.classreading.SimpleMetadataReader.getClassReader(SimpleMetadataReader.java:59)
	at org.springframework.core.type.classreading.SimpleMetadataReader.<init>(SimpleMetadataReader.java:48)
	at org.springframework.core.type.classreading.SimpleMetadataReaderFactory.getMetadataReader(SimpleMetadataReaderFactory.java:103)
	at org.springframework.core.type.classreading.CachingMetadataReaderFactory.getMetadataReader(CachingMetadataReaderFactory.java:122)
	at org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider.scanCandidateComponents(ClassPathScanningCandidateComponentProvider.java:456)
	... 42 more
Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 67
	at org.springframework.asm.ClassReader.<init>(ClassReader.java:199)
	at org.springframework.asm.ClassReader.<init>(ClassReader.java:180)
	at org.springframework.asm.ClassReader.<init>(ClassReader.java:166)
	at org.springframework.asm.ClassReader.<init>(ClassReader.java:287)
	at org.springframework.core.type.classreading.SimpleMetadataReader.getClassReader(SimpleMetadataReader.java:56)
	... 46 more
```
so I've added a note to the Spring Boot version for us to check when we do the next Spring update