### PR TITLE
Bump the build-dependencies group with 8 updates

### DIFF
--- a/build/container/ryuk.Dockerfile
+++ b/build/container/ryuk.Dockerfile
@@ -4,4 +4,4 @@
 # IMPORTANT! When updating the version for Ryuk in this Dockerfile,
 # make sure to update `TESTCONTAINERS_RYUK_CONTAINER_IMAGE` env variable set as part of maven-failsafe-plugin configuration.
 #
-FROM docker.io/testcontainers/ryuk:0.5.1
+FROM docker.io/testcontainers/ryuk:0.6.0

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -1207,7 +1207,7 @@
                     <configuration>
                         <environmentVariables>
                             <!-- Just to be sure that we are pulling/using the Ryuk from docker.io -->
-                            <TESTCONTAINERS_RYUK_CONTAINER_IMAGE>docker.io/testcontainers/ryuk:0.5.1</TESTCONTAINERS_RYUK_CONTAINER_IMAGE>
+                            <TESTCONTAINERS_RYUK_CONTAINER_IMAGE>docker.io/testcontainers/ryuk:0.6.0</TESTCONTAINERS_RYUK_CONTAINER_IMAGE>
                             <!--
                                 Startup checks might want to test whether the images can be pulled (e.g. see `tinyimage.container.image` config property).
                                 To prevent that and speedup the startup a bit the checks are disabled.


### PR DESCRIPTION
Based on https://github.com/hibernate/hibernate-search/pull/3890

Bumps the build-dependencies group with 8 updates:

| Package | From | To |
| --- | --- | --- |
| [org.asciidoctor:asciidoctorj](https://github.com/asciidoctor/asciidoctorj) | `2.5.10` | `2.5.11` | | [org.asciidoctor:asciidoctorj-pdf](https://github.com/asciidoctor/asciidoctorj-pdf) | `2.3.9` | `2.3.10` | | [org.codehaus.plexus:plexus-compiler-api](https://github.com/codehaus-plexus/plexus-compiler) | `2.14.1` | `2.14.2` | | [org.codehaus.plexus:plexus-compiler-manager](https://github.com/codehaus-plexus/plexus-compiler) | `2.14.1` | `2.14.2` | | org.codehaus.plexus:plexus-compiler-eclipse | `2.14.1` | `2.14.2` | | [org.apache.maven.plugins:maven-compiler-plugin](https://github.com/apache/maven-compiler-plugin) | `3.11.0` | `3.12.1` | | [com.buschmais.jqassistant:jqassistant-maven-plugin](https://github.com/jqassistant/jqa-maven-plugin) | `2.0.9` | `2.0.10` | | [org.assertj:assertj-core](https://github.com/assertj/assertj) | `3.24.2` | `3.25.0` |

Updates `org.asciidoctor:asciidoctorj` from 2.5.10 to 2.5.11
- [Release notes](https://github.com/asciidoctor/asciidoctorj/releases)
- [Changelog](https://github.com/asciidoctor/asciidoctorj/blob/main/CHANGELOG.adoc)
- [Commits](https://github.com/asciidoctor/asciidoctorj/compare/v2.5.10...v2.5.11)

Updates `org.asciidoctor:asciidoctorj-pdf` from 2.3.9 to 2.3.10
- [Release notes](https://github.com/asciidoctor/asciidoctorj-pdf/releases)
- [Changelog](https://github.com/asciidoctor/asciidoctorj-pdf/blob/main/CHANGELOG.adoc)
- [Commits](https://github.com/asciidoctor/asciidoctorj-pdf/compare/v2.3.9...v2.3.10)

Updates `org.codehaus.plexus:plexus-compiler-api` from 2.14.1 to 2.14.2
- [Release notes](https://github.com/codehaus-plexus/plexus-compiler/releases)
- [Commits](https://github.com/codehaus-plexus/plexus-compiler/compare/plexus-compiler-2.14.1...plexus-compiler-2.14.2)

Updates `org.codehaus.plexus:plexus-compiler-manager` from 2.14.1 to 2.14.2
- [Release notes](https://github.com/codehaus-plexus/plexus-compiler/releases)
- [Commits](https://github.com/codehaus-plexus/plexus-compiler/compare/plexus-compiler-2.14.1...plexus-compiler-2.14.2)

Updates `org.codehaus.plexus:plexus-compiler-eclipse` from 2.14.1 to 2.14.2

Updates `org.apache.maven.plugins:maven-compiler-plugin` from 3.11.0 to 3.12.1
- [Release notes](https://github.com/apache/maven-compiler-plugin/releases)
- [Commits](https://github.com/apache/maven-compiler-plugin/compare/maven-compiler-plugin-3.11.0...maven-compiler-plugin-3.12.1)

Updates `com.buschmais.jqassistant:jqassistant-maven-plugin` from 2.0.9 to 2.0.10
- [Commits](https://github.com/jqassistant/jqa-maven-plugin/compare/REL-2.0.9...REL-2.0.10)

Updates `org.assertj:assertj-core` from 3.24.2 to 3.25.0
- [Release notes](https://github.com/assertj/assertj/releases)
- [Commits](https://github.com/assertj/assertj/compare/assertj-build-3.24.2...assertj-build-3.25.0)

---
updated-dependencies:
- dependency-name: org.asciidoctor:asciidoctorj dependency-type: direct:production update-type: version-update:semver-patch dependency-group: build-dependencies
- dependency-name: org.asciidoctor:asciidoctorj-pdf dependency-type: direct:production update-type: version-update:semver-patch dependency-group: build-dependencies
- dependency-name: org.codehaus.plexus:plexus-compiler-api dependency-type: direct:production update-type: version-update:semver-patch dependency-group: build-dependencies
- dependency-name: org.codehaus.plexus:plexus-compiler-manager dependency-type: direct:production update-type: version-update:semver-patch dependency-group: build-dependencies
- dependency-name: org.codehaus.plexus:plexus-compiler-eclipse dependency-type: direct:production update-type: version-update:semver-patch dependency-group: build-dependencies
- dependency-name: org.apache.maven.plugins:maven-compiler-plugin dependency-type: direct:production update-type: version-update:semver-minor dependency-group: build-dependencies
- dependency-name: com.buschmais.jqassistant:jqassistant-maven-plugin dependency-type: direct:production update-type: version-update:semver-patch dependency-group: build-dependencies
- dependency-name: org.assertj:assertj-core dependency-type: direct:production update-type: version-update:semver-minor dependency-group: build-dependencies ...

<!--
Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HSEARCH.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HSEARCH-<digits>`).
-->