### PR TITLE
HSEARCH-5038 Align vector similarity naming between backends / HSEARCH-5056 Rename VectorField#beamWidth / VectorField#maxConnections to align with Elasticsearch/OpenSearch naming

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -23,6 +23,7 @@ import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 import org.hibernate.search.engine.backend.scope.spi.IndexScopeBuilder;
 import org.hibernate.search.engine.backend.types.Highlightable;
 import org.hibernate.search.engine.backend.types.TermVector;
+import org.hibernate.search.engine.backend.types.VectorSimilarity;
 import org.hibernate.search.engine.logging.spi.AggregationKeyFormatter;
 import org.hibernate.search.engine.search.aggregation.AggregationKey;
 import org.hibernate.search.engine.search.aggregation.SearchAggregation;
@@ -888,4 +889,9 @@ public interface Log extends BasicLogger {
 			value = "An OpenSearch distribution does not allow specifying the `required minimum similarity` option. "
 					+ "This option is only applicable to an Elastic distribution of an Elasticsearch backend.")
 	SearchException knnRequiredMinimumSimilarityUnsupportedOption();
+
+	@Message(id = ID_OFFSET + 188,
+			value = "The OpenSearch distribution does not allow using %1$s as a space type for a Lucene engine."
+					+ " Try using a different similarity type and refer to the OpenSearch documentation for more details.")
+	SearchException vectorSimilarityNotSupportedByOpenSearchBackend(VectorSimilarity vectorSimilarity);
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/AbstractElasticsearchVectorFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/AbstractElasticsearchVectorFieldCodec.java
@@ -19,16 +19,16 @@ public abstract class AbstractElasticsearchVectorFieldCodec<F> implements Elasti
 
 	private final VectorSimilarity similarity;
 	private final int dimension;
-	private final Integer maxConnections;
-	private final Integer beamWidth;
+	private final Integer m;
+	private final Integer efConstruction;
 	private final F indexNullAs;
 
 	protected AbstractElasticsearchVectorFieldCodec(VectorSimilarity similarity, int dimension,
-			Integer maxConnections, Integer beamWidth, F indexNullAs) {
+			Integer m, Integer efConstruction, F indexNullAs) {
 		this.similarity = similarity;
 		this.dimension = dimension;
-		this.maxConnections = maxConnections;
-		this.beamWidth = beamWidth;
+		this.m = m;
+		this.efConstruction = efConstruction;
 		this.indexNullAs = indexNullAs;
 	}
 
@@ -72,8 +72,8 @@ public abstract class AbstractElasticsearchVectorFieldCodec<F> implements Elasti
 		AbstractElasticsearchVectorFieldCodec<?> that = (AbstractElasticsearchVectorFieldCodec<?>) other;
 		return dimension == that.dimension
 				&& Objects.equals( similarity, that.similarity )
-				&& Objects.equals( maxConnections, that.maxConnections )
-				&& Objects.equals( beamWidth, that.beamWidth );
+				&& Objects.equals( m, that.m )
+				&& Objects.equals( efConstruction, that.efConstruction );
 	}
 
 	@Override
@@ -86,8 +86,8 @@ public abstract class AbstractElasticsearchVectorFieldCodec<F> implements Elasti
 		return getClass().getSimpleName() + "{" +
 				"vectorSimilarity=" + similarity +
 				", dimension=" + dimension +
-				", beamWidth=" + beamWidth +
-				", maxConnection=" + maxConnections +
+				", efConstruction=" + efConstruction +
+				", m=" + m +
 				'}';
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchByteVectorFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchByteVectorFieldCodec.java
@@ -12,9 +12,9 @@ import com.google.gson.JsonArray;
 
 public class ElasticsearchByteVectorFieldCodec extends AbstractElasticsearchVectorFieldCodec<byte[]> {
 
-	public ElasticsearchByteVectorFieldCodec(VectorSimilarity similarity, int dimension, Integer maxConnections,
-			Integer beamWidth, byte[] indexNullAs) {
-		super( similarity, dimension, maxConnections, beamWidth, indexNullAs );
+	public ElasticsearchByteVectorFieldCodec(VectorSimilarity similarity, int dimension, Integer m,
+			Integer efConstruction, byte[] indexNullAs) {
+		super( similarity, dimension, m, efConstruction, indexNullAs );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchFloatVectorFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchFloatVectorFieldCodec.java
@@ -12,9 +12,9 @@ import com.google.gson.JsonArray;
 
 public class ElasticsearchFloatVectorFieldCodec extends AbstractElasticsearchVectorFieldCodec<float[]> {
 
-	public ElasticsearchFloatVectorFieldCodec(VectorSimilarity similarity, int dimension, Integer maxConnections,
-			Integer beamWidth, float[] indexNullAs) {
-		super( similarity, dimension, maxConnections, beamWidth, indexNullAs );
+	public ElasticsearchFloatVectorFieldCodec(VectorSimilarity similarity, int dimension, Integer m,
+			Integer efConstruction, float[] indexNullAs) {
+		super( similarity, dimension, m, efConstruction, indexNullAs );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/AbstractElasticsearchVectorFieldTypeOptionsStep.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/AbstractElasticsearchVectorFieldTypeOptionsStep.java
@@ -35,8 +35,8 @@ abstract class AbstractElasticsearchVectorFieldTypeOptionsStep<
 
 	protected VectorSimilarity vectorSimilarity = VectorSimilarity.DEFAULT;
 	protected Integer dimension;
-	protected Integer beamWidth;
-	protected Integer maxConnections;
+	protected Integer efConstruction;
+	protected Integer m;
 	protected F indexNullAs;
 	private Projectable projectable = Projectable.DEFAULT;
 	private Searchable searchable = Searchable.DEFAULT;
@@ -72,14 +72,14 @@ abstract class AbstractElasticsearchVectorFieldTypeOptionsStep<
 	}
 
 	@Override
-	public S beamWidth(int beamWidth) {
-		this.beamWidth = beamWidth;
+	public S efConstruction(int efConstruction) {
+		this.efConstruction = efConstruction;
 		return thisAsS();
 	}
 
 	@Override
-	public S maxConnections(int maxConnections) {
-		this.maxConnections = maxConnections;
+	public S m(int m) {
+		this.m = m;
 		return thisAsS();
 	}
 
@@ -104,7 +104,7 @@ abstract class AbstractElasticsearchVectorFieldTypeOptionsStep<
 		mappingContributor.contribute( mapping, this );
 
 		AbstractElasticsearchVectorFieldCodec<F> codec =
-				createCodec( vectorSimilarity, dimension, maxConnections, beamWidth, indexNullAs );
+				createCodec( vectorSimilarity, dimension, m, efConstruction, indexNullAs );
 		builder.codec( codec );
 		if ( resolvedSearchable ) {
 			builder.searchable( true );
@@ -123,7 +123,7 @@ abstract class AbstractElasticsearchVectorFieldTypeOptionsStep<
 	}
 
 	protected abstract AbstractElasticsearchVectorFieldCodec<F> createCodec(VectorSimilarity vectorSimilarity, int dimension,
-			Integer maxConnections, Integer beamWidth, F indexNullAs);
+			Integer m, Integer efConstruction, F indexNullAs);
 
 	protected static boolean resolveDefault(Projectable projectable) {
 		switch ( projectable ) {
@@ -168,12 +168,12 @@ abstract class AbstractElasticsearchVectorFieldTypeOptionsStep<
 	}
 
 	@Override
-	public Integer beamWidth() {
-		return beamWidth;
+	public Integer efConstruction() {
+		return efConstruction;
 	}
 
 	@Override
-	public Integer maxConnections() {
-		return maxConnections;
+	public Integer m() {
+		return m;
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchByteVectorFieldTypeOptionsStep.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchByteVectorFieldTypeOptionsStep.java
@@ -22,8 +22,8 @@ class ElasticsearchByteVectorFieldTypeOptionsStep
 
 	@Override
 	protected AbstractElasticsearchVectorFieldCodec<byte[]> createCodec(VectorSimilarity vectorSimilarity,
-			int dimension, Integer maxConnections, Integer beamWidth, byte[] indexNullAs) {
-		return new ElasticsearchByteVectorFieldCodec( vectorSimilarity, dimension, maxConnections, beamWidth, indexNullAs );
+			int dimension, Integer m, Integer efConstruction, byte[] indexNullAs) {
+		return new ElasticsearchByteVectorFieldCodec( vectorSimilarity, dimension, m, efConstruction, indexNullAs );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchFloatVectorFieldTypeOptionsStep.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchFloatVectorFieldTypeOptionsStep.java
@@ -28,8 +28,8 @@ class ElasticsearchFloatVectorFieldTypeOptionsStep
 
 	@Override
 	protected AbstractElasticsearchVectorFieldCodec<float[]> createCodec(VectorSimilarity similarity, int dimension,
-			Integer maxConnections, Integer beamWidth, float[] indexNullAs) {
-		return new ElasticsearchFloatVectorFieldCodec( similarity, dimension, maxConnections, beamWidth, indexNullAs );
+			Integer m, Integer efConstruction, float[] indexNullAs) {
+		return new ElasticsearchFloatVectorFieldCodec( similarity, dimension, m, efConstruction, indexNullAs );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/mapping/impl/Elasticsearch8VectorFieldTypeMappingContributor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/mapping/impl/Elasticsearch8VectorFieldTypeMappingContributor.java
@@ -25,14 +25,14 @@ public class Elasticsearch8VectorFieldTypeMappingContributor implements Elastics
 		if ( resolvedVectorSimilarity != null ) {
 			mapping.setSimilarity( resolvedVectorSimilarity );
 		}
-		if ( context.maxConnections() != null || context.beamWidth() != null ) {
+		if ( context.m() != null || context.efConstruction() != null ) {
 			ElasticsearchDenseVectorIndexOptions indexOptions = new ElasticsearchDenseVectorIndexOptions();
 			indexOptions.setType( "hnsw" );
-			if ( context.maxConnections() != null ) {
-				indexOptions.setM( context.maxConnections() );
+			if ( context.m() != null ) {
+				indexOptions.setM( context.m() );
 			}
-			if ( context.beamWidth() != null ) {
-				indexOptions.setEfConstruction( context.beamWidth() );
+			if ( context.efConstruction() != null ) {
+				indexOptions.setEfConstruction( context.efConstruction() );
 			}
 			mapping.setIndexOptions( indexOptions );
 		}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/mapping/impl/Elasticsearch8VectorFieldTypeMappingContributor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/mapping/impl/Elasticsearch8VectorFieldTypeMappingContributor.java
@@ -50,10 +50,12 @@ public class Elasticsearch8VectorFieldTypeMappingContributor implements Elastics
 				return null;
 			case L2:
 				return "l2_norm";
-			case INNER_PRODUCT:
+			case DOT_PRODUCT:
 				return "dot_product";
 			case COSINE:
 				return "cosine";
+			case MAX_INNER_PRODUCT:
+				return "max_inner_product";
 			default:
 				throw new AssertionFailure( "Unexpected value for Similarity: " + vectorSimilarity );
 		}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/mapping/impl/ElasticsearchVectorFieldTypeMappingContributor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/mapping/impl/ElasticsearchVectorFieldTypeMappingContributor.java
@@ -23,9 +23,9 @@ public interface ElasticsearchVectorFieldTypeMappingContributor {
 
 		int dimension();
 
-		Integer beamWidth();
+		Integer efConstruction();
 
-		Integer maxConnections();
+		Integer m();
 
 		boolean searchable();
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/mapping/impl/OpenSearch2VectorFieldTypeMappingContributor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/mapping/impl/OpenSearch2VectorFieldTypeMappingContributor.java
@@ -44,13 +44,13 @@ public class OpenSearch2VectorFieldTypeMappingContributor implements Elasticsear
 		if ( resolvedVectorSimilarity != null ) {
 			method.setSpaceType( resolvedVectorSimilarity );
 		}
-		if ( context.maxConnections() != null || context.beamWidth() != null ) {
+		if ( context.m() != null || context.efConstruction() != null ) {
 			OpenSearchVectorTypeMethod.Parameters parameters = new OpenSearchVectorTypeMethod.Parameters();
-			if ( context.maxConnections() != null ) {
-				parameters.setM( context.maxConnections() );
+			if ( context.m() != null ) {
+				parameters.setM( context.m() );
 			}
-			if ( context.beamWidth() != null ) {
-				parameters.setEfConstruction( context.beamWidth() );
+			if ( context.efConstruction() != null ) {
+				parameters.setEfConstruction( context.efConstruction() );
 			}
 			method.setParameters( parameters );
 		}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/mapping/impl/OpenSearch2VectorFieldTypeMappingContributor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/mapping/impl/OpenSearch2VectorFieldTypeMappingContributor.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.search.backend.elasticsearch.types.mapping.impl;
 
+import java.lang.invoke.MethodHandles;
+
+import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.DataTypes;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.OpenSearchVectorTypeMethod;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.PropertyMapping;
@@ -14,8 +17,11 @@ import org.hibernate.search.backend.elasticsearch.types.impl.ElasticsearchIndexV
 import org.hibernate.search.engine.backend.types.VectorSimilarity;
 import org.hibernate.search.engine.search.predicate.spi.PredicateTypeKeys;
 import org.hibernate.search.util.common.AssertionFailure;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 public class OpenSearch2VectorFieldTypeMappingContributor implements ElasticsearchVectorFieldTypeMappingContributor {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private static final String BYTE_TYPE = "BYTE";
 
@@ -64,12 +70,12 @@ public class OpenSearch2VectorFieldTypeMappingContributor implements Elasticsear
 				return null;
 			case L2:
 				return "l2";
-			case INNER_PRODUCT:
-				// TODO: figure out what's actually supported: innerproduct/l1/linf all throw exceptions ...
-				//   see HSEARCH-5038
-				return "l2";
 			case COSINE:
 				return "cosinesimil";
+			case DOT_PRODUCT:
+			case MAX_INNER_PRODUCT:
+				throw log.vectorSimilarityNotSupportedByOpenSearchBackend( vectorSimilarity );
+
 			default:
 				throw new AssertionFailure( "Unexpected value for Similarity: " + vectorSimilarity );
 		}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/codec/impl/HibernateSearchKnnVectorsFormat.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/codec/impl/HibernateSearchKnnVectorsFormat.java
@@ -28,23 +28,23 @@ public class HibernateSearchKnnVectorsFormat extends KnnVectorsFormat {
 	}
 
 	private final KnnVectorsFormat delegate;
-	private final int maxConnection;
+	private final int m;
 
-	private final int beamWidth;
+	private final int efConstruction;
 
 	public HibernateSearchKnnVectorsFormat() {
 		this( DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH );
 	}
 
-	public HibernateSearchKnnVectorsFormat(int maxConnection, int beamWidth) {
-		this( new Lucene99HnswVectorsFormat( maxConnection, beamWidth ), maxConnection, beamWidth );
+	public HibernateSearchKnnVectorsFormat(int m, int efConstruction) {
+		this( new Lucene99HnswVectorsFormat( m, efConstruction ), m, efConstruction );
 	}
 
-	public HibernateSearchKnnVectorsFormat(KnnVectorsFormat delegate, int maxConnection, int beamWidth) {
+	public HibernateSearchKnnVectorsFormat(KnnVectorsFormat delegate, int m, int efConstruction) {
 		super( delegate.getName() );
 		this.delegate = delegate;
-		this.maxConnection = maxConnection;
-		this.beamWidth = beamWidth;
+		this.m = m;
+		this.efConstruction = efConstruction;
 	}
 
 	@Override
@@ -76,19 +76,19 @@ public class HibernateSearchKnnVectorsFormat extends KnnVectorsFormat {
 			return false;
 		}
 		HibernateSearchKnnVectorsFormat that = (HibernateSearchKnnVectorsFormat) o;
-		return maxConnection == that.maxConnection && beamWidth == that.beamWidth;
+		return m == that.m && efConstruction == that.efConstruction;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash( maxConnection, beamWidth );
+		return Objects.hash( m, efConstruction );
 	}
 
 	@Override
 	public String toString() {
 		return "HibernateSearchKnnVectorsFormat{" +
-				"maxConnection=" + maxConnection +
-				", beamWidth=" + beamWidth +
+				"m=" + m +
+				", efConstruction=" + efConstruction +
 				'}';
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/AbstractLuceneVectorFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/AbstractLuceneVectorFieldCodec.java
@@ -79,7 +79,7 @@ public abstract class AbstractLuceneVectorFieldCodec<F> implements LuceneVectorF
 
 		return dimension == other.dimension
 				&& vectorSimilarity == other.vectorSimilarity
-				// to check beam width and max connections:
+				// to check ef construction and m
 				&& Objects.equals( knnVectorsFormat, other.knnVectorsFormat );
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneVectorFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneVectorFieldCodec.java
@@ -18,7 +18,7 @@ public interface LuceneVectorFieldCodec<F> extends LuceneStandardFieldCodec<F, b
 
 	/**
 	 * Custom {@link KnnVectorsFormat knn vector format} that will be used in {@link org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat}
-	 * and can for example define custom {@code beamWidth} or {@code maxConnections} or even provide a completely custom implementation (needs to be registered via ServiceLoader mechanism).
+	 * and can for example define custom {@code efConstruction} or {@code m} or even provide a completely custom implementation (needs to be registered via ServiceLoader mechanism).
 	 */
 	KnnVectorsFormat knnVectorFormat();
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/AbstractLuceneVectorFieldTypeOptionsStep.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/AbstractLuceneVectorFieldTypeOptionsStep.java
@@ -146,10 +146,12 @@ abstract class AbstractLuceneVectorFieldTypeOptionsStep<S extends AbstractLucene
 			case DEFAULT:
 			case L2:
 				return VectorSimilarityFunction.EUCLIDEAN;
-			case INNER_PRODUCT:
+			case DOT_PRODUCT:
 				return VectorSimilarityFunction.DOT_PRODUCT;
 			case COSINE:
 				return VectorSimilarityFunction.COSINE;
+			case MAX_INNER_PRODUCT:
+				return VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT;
 			default:
 				throw new AssertionFailure( "Unexpected value for Similarity: " + vectorSimilarity );
 		}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/AbstractLuceneVectorFieldTypeOptionsStep.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/AbstractLuceneVectorFieldTypeOptionsStep.java
@@ -44,7 +44,7 @@ abstract class AbstractLuceneVectorFieldTypeOptionsStep<S extends AbstractLucene
 
 	protected VectorSimilarity vectorSimilarity = VectorSimilarity.DEFAULT;
 	protected Integer dimension;
-	protected int beamWidth = MAX_MAX_CONNECTIONS;
+	protected int beamWidth = 512;
 	protected int maxConnections = 16;
 	private Projectable projectable = Projectable.DEFAULT;
 	private Searchable searchable = Searchable.DEFAULT;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/AbstractLuceneVectorFieldTypeOptionsStep.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/AbstractLuceneVectorFieldTypeOptionsStep.java
@@ -39,13 +39,13 @@ abstract class AbstractLuceneVectorFieldTypeOptionsStep<S extends AbstractLucene
 		implements LuceneVectorFieldTypeOptionsStep<S, F> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
-	private static final int MAX_BEAM_WIDTH = 3200;
-	private static final int MAX_MAX_CONNECTIONS = 512;
+	private static final int MAX_EF_CONSTRUCTION = 3200;
+	private static final int MAX_M = 512;
 
 	protected VectorSimilarity vectorSimilarity = VectorSimilarity.DEFAULT;
 	protected Integer dimension;
-	protected int beamWidth = 512;
-	protected int maxConnections = 16;
+	protected int efConstruction = 512;
+	protected int m = 16;
 	private Projectable projectable = Projectable.DEFAULT;
 	private Searchable searchable = Searchable.DEFAULT;
 	private F indexNullAsValue = null;
@@ -73,20 +73,20 @@ abstract class AbstractLuceneVectorFieldTypeOptionsStep<S extends AbstractLucene
 	}
 
 	@Override
-	public S beamWidth(int beamWidth) {
-		if ( beamWidth < 1 || beamWidth > MAX_BEAM_WIDTH ) {
-			throw log.vectorPropertyUnsupportedValue( "beamWidth", beamWidth, MAX_BEAM_WIDTH );
+	public S efConstruction(int efConstruction) {
+		if ( efConstruction < 1 || efConstruction > MAX_EF_CONSTRUCTION ) {
+			throw log.vectorPropertyUnsupportedValue( "efConstruction", efConstruction, MAX_EF_CONSTRUCTION );
 		}
-		this.beamWidth = beamWidth;
+		this.efConstruction = efConstruction;
 		return thisAsS();
 	}
 
 	@Override
-	public S maxConnections(int maxConnections) {
-		if ( maxConnections < 1 || maxConnections > MAX_MAX_CONNECTIONS ) {
-			throw log.vectorPropertyUnsupportedValue( "maxConnections", maxConnections, MAX_MAX_CONNECTIONS );
+	public S m(int m) {
+		if ( m < 1 || m > MAX_M ) {
+			throw log.vectorPropertyUnsupportedValue( "m", m, MAX_M );
 		}
-		this.maxConnections = maxConnections;
+		this.m = m;
 		return thisAsS();
 	}
 
@@ -118,7 +118,7 @@ abstract class AbstractLuceneVectorFieldTypeOptionsStep<S extends AbstractLucene
 		Storage storage = resolvedProjectable ? Storage.ENABLED : Storage.DISABLED;
 
 		AbstractLuceneVectorFieldCodec<F> codec = createCodec( resolvedVectorSimilarity, dimension, storage, indexing,
-				indexNullAsValue, new HibernateSearchKnnVectorsFormat( maxConnections, beamWidth )
+				indexNullAsValue, new HibernateSearchKnnVectorsFormat( m, efConstruction )
 		);
 		builder.codec( codec );
 		if ( resolvedSearchable ) {

--- a/documentation/src/main/asciidoc/public/reference/_mapping-directfieldmapping.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_mapping-directfieldmapping.adoc
@@ -381,8 +381,8 @@ Only available on `@VectorField`.
 |===============
 |Value|Definition
 |`VectorSimilarity.L2`|An L2 (Euclidean) norm, that is a sensible default for most scenarios.
-Distance between vectors `x` and `y` is calculated as latexmath:[d(x,y) = \sum_{i=1}^{n} (x_i - y_i)^2 ]
-and the score function is latexmath:[s = \frac{1}{1+d}]
+Distance between vectors `x` and `y` is calculated as latexmath:[d(x,y) = \sqrt{\sum_{i=1}^{n} (x_i - y_i)^2 } ]
+and the score function is latexmath:[s = \frac{1}{1+d*d}]
 |`VectorSimilarity.DOT_PRODUCT`|Inner product (dot product in particular).
 Distance between vectors `x` and `y` is calculated as latexmath:[d(x,y) = \sum_{i=1}^{n} x_i \cdot y_i ]
 and the score function is latexmath:[s = \frac{1}{1+d}]

--- a/documentation/src/main/asciidoc/public/reference/_mapping-directfieldmapping.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_mapping-directfieldmapping.adoc
@@ -144,8 +144,8 @@ size match this dimension.
 +
 Besides that, vector fields allow optionally configuring
 the <<mapping-directfieldmapping-vectorSimilarity,similarity function>> used during search,
-the <<mapping-directfieldmapping-beamWidth,beam width>>
-and the <<mapping-directfieldmapping-maxConnections,maximum connections>> used during indexing.
+<<mapping-directfieldmapping-efConstruction,`efConstruction`>>
+and <<mapping-directfieldmapping-m,`m`>> used during indexing.
 +
 WARNING: Vector fields, on the contrary to the other field types, disable the container extraction by default
 Manually setting the <<mapping-directfieldmapping-extraction,extraction>> to `DEFAULT` will result in an exception.
@@ -418,18 +418,18 @@ d+1 & \text{otherwise}
 |`MAX_INNER_PRODUCT`| `MAXIMUM_INNER_PRODUCT`| `max_inner_product`   | currently *not supported* by OpenSearch and will result in an exception.
 |===============
 
-[[mapping-directfieldmapping-beamWidth]] `beamWidth`::
+[[mapping-directfieldmapping-efConstruction]] `efConstruction`::
 +
 include::../components/_incubating-warning.adoc[]
 +
-Beam width is the size of the dynamic list used during k-NN graph creation. It affects how vectors are stored.
+`efConstruction` is the size of the dynamic list used during k-NN graph creation. It affects how vectors are stored.
 Higher values lead to a more accurate graph but slower indexing speed.
 +
 Default value is backend-specific.
 +
 Only available on `@VectorField`.
 
-[[mapping-directfieldmapping-maxConnections]] `maxConnections`::
+[[mapping-directfieldmapping-m]] `m`::
 +
 include::../components/_incubating-warning.adoc[]
 +

--- a/documentation/src/main/asciidoc/public/reference/_mapping-directfieldmapping.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_mapping-directfieldmapping.adoc
@@ -383,7 +383,7 @@ Only available on `@VectorField`.
 |`VectorSimilarity.L2`|An L2 (Euclidean) norm, that is a sensible default for most scenarios.
 Distance between vectors `x` and `y` is calculated as latexmath:[d(x,y) = \sum_{i=1}^{n} (x_i - y_i)^2 ]
 and the score function is latexmath:[s = \frac{1}{1+d}]
-|`VectorSimilarity.INNER_PRODUCT`|Inner product (dot product in particular).
+|`VectorSimilarity.DOT_PRODUCT`|Inner product (dot product in particular).
 Distance between vectors `x` and `y` is calculated as latexmath:[d(x,y) = \sum_{i=1}^{n} x_i \cdot y_i ]
 and the score function is latexmath:[s = \frac{1}{1+d}]
 
@@ -398,7 +398,24 @@ while byte vectors should simply all have the same norm.
 |`VectorSimilarity.COSINE`|Cosine similarity.
 Distance between vectors `x` and `y` is calculated as latexmath:[d(x,y) = \frac{1 - \sum_{i=1} ^{n} x_i \cdot y_i }{ \sqrt{ \sum_{i=1} ^{n} x_i^2 } \sqrt{ \sum_{i=1} ^{n} y_i^2 }} ]
 and the score function is latexmath:[s = \frac{1}{1+d}]
+|`VectorSimilarity.MAX_INNER_PRODUCT`|Similar to a dot product similarity, but does not require vector normalization.
+Distance between vectors `x` and `y` is calculated as latexmath:[d(x,y) = \sum_{i=1}^{n} x_i \cdot y_i ]
+and the score function is latexmath:[s = \begin{cases}
+\frac{1}{1-d} & \text{if d < 0}\\
+d+1 & \text{otherwise}
+\end{cases} ]
 |`VectorSimilarity.DEFAULT`|Use the backend-specific default. For the <<backend-lucene, Lucene backend>> an `L2` similarity is used.
+|===============
++
+.How the vector similarity matches to a backend-specific value
+[cols=",,,",options="header"]
+|===============
+|Hibernate Search Value|Lucene Backend |Elasticsearch Backend|Elasticsearch Backend (OpenSearch distribution)
+|`DEFAULT`          | `EUCLIDEAN`            | Elasticsearch default | OpenSearch default.
+|`L2`               | `EUCLIDEAN`            | `l2_norm`             | `l2`
+|`DOT_PRODUCT`      | `DOT_PRODUCT`          | `dot_product`         | currently *not supported* by OpenSearch and will result in an exception.
+|`COSINE`           | `COSINE`               | `cosine`              | `cosinesimil`
+|`MAX_INNER_PRODUCT`| `MAXIMUM_INNER_PRODUCT`| `max_inner_product`   | currently *not supported* by OpenSearch and will result in an exception.
 |===============
 
 [[mapping-directfieldmapping-beamWidth]] `beamWidth`::

--- a/engine/src/main/java/org/hibernate/search/engine/backend/types/VectorSimilarity.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/types/VectorSimilarity.java
@@ -10,6 +10,8 @@ import org.hibernate.search.util.common.annotation.Incubating;
 
 /**
  * Defines a function to calculate the vector similarity, i.e. distance between two vectors.
+ * <p>
+ * Note, some backends or their distributions may not support all of available similarity options.
  */
 @Incubating
 public enum VectorSimilarity {
@@ -30,10 +32,17 @@ public enum VectorSimilarity {
 	 * Floating point vectors must be <a href="https://en.wikipedia.org/wiki/Unit_vector">normalized to be of unit length</a>,
 	 * while byte vectors should simply all have the same norm.
 	 */
-	INNER_PRODUCT,
+	DOT_PRODUCT,
 	/**
 	 * Cosine similarity. Distance is calculated as {@code d(x,y) = 1 - \sum_(i=1) ^(n) x_i*y_i / ( \sqrt( \sum_(i=1) ^(n) x_i^2 ) \sqrt( \sum_(i=1) ^(n) y_i^2 ) },
 	 * similarity function is {@code s = 1 / (1+d) }, but may differ between backends.
 	 */
-	COSINE;
+	COSINE,
+
+	/**
+	 * Similar to {@link VectorSimilarity#DOT_PRODUCT} but does not require vector normalization.
+	 * Distance is calculated as {@code d(x,y) = \sum_(i=1) ^(n) (x_i - y_i)^2 }
+	 * and similarity function is {@code d < 0 ? s = 1 / (1 - d)  : s = d + 1}
+	 */
+	MAX_INNER_PRODUCT;
 }

--- a/engine/src/main/java/org/hibernate/search/engine/backend/types/dsl/VectorFieldTypeOptionsStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/types/dsl/VectorFieldTypeOptionsStep.java
@@ -26,16 +26,16 @@ public interface VectorFieldTypeOptionsStep<S extends VectorFieldTypeOptionsStep
 	S vectorSimilarity(VectorSimilarity vectorSimilarity);
 
 	/**
-	 * @param beamWidth Defines the size of the dynamic list used during k-NN graph creation.
+	 * @param efConstruction Defines the size of the dynamic list used during k-NN graph creation.
 	 * @return {@code this}, for method chaining.
 	 */
-	S beamWidth(int beamWidth);
+	S efConstruction(int efConstruction);
 
 	/**
-	 * @param maxConnections Defines the number of neighbors each node will be connected to in the HNSW graph.
+	 * @param m Defines the number of neighbors each node will be connected to in the HNSW graph.
 	 * @return {@code this}, for method chaining.
 	 */
-	S maxConnections(int maxConnections);
+	S m(int m);
 
 	/**
 	 * @param dimension The number of dimensions (array length) of vectors to be indexed.

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerValidationMappingBaseIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerValidationMappingBaseIT.java
@@ -417,8 +417,8 @@ class ElasticsearchIndexSchemaManagerValidationMappingBaseIT {
 		);
 		StubMappedIndex index = StubMappedIndex.ofNonRetrievable( root -> {
 			root.field( "vector",
-					f -> f.asFloatVector().dimension( 50 ).vectorSimilarity( VectorSimilarity.L2 ).maxConnections( 2 )
-							.beamWidth( 10 ) )
+					f -> f.asFloatVector().dimension( 50 ).vectorSimilarity( VectorSimilarity.L2 ).m( 2 )
+							.efConstruction( 10 ) )
 					.toReference();
 		} );
 
@@ -581,8 +581,8 @@ class ElasticsearchIndexSchemaManagerValidationMappingBaseIT {
 				"These tests only make sense for a backend where Vector Search is supported and implemented."
 		);
 		StubMappedIndex index = StubMappedIndex.ofNonRetrievable( root -> {
-			root.field( "vectorB", f -> f.asByteVector().dimension( 2 ).beamWidth( 2 ).maxConnections( 20 ) ).toReference();
-			root.field( "vectorF", f -> f.asFloatVector().dimension( 2 ).beamWidth( 5 ).maxConnections( 50 ) ).toReference();
+			root.field( "vectorB", f -> f.asByteVector().dimension( 2 ).efConstruction( 2 ).m( 20 ) ).toReference();
+			root.field( "vectorF", f -> f.asFloatVector().dimension( 2 ).efConstruction( 5 ).m( 50 ) ).toReference();
 		} );
 
 		elasticSearchClient.index( index.name() ).deleteAndCreate();

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/ElasticsearchKnnPredicateSpecificsIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/ElasticsearchKnnPredicateSpecificsIT.java
@@ -300,7 +300,7 @@ class ElasticsearchKnnPredicateSpecificsIT {
 			parking = root.field( "parking", f -> f.asBoolean().projectable( Projectable.YES ) ).toReference();
 			rating = root.field( "rating", f -> f.asInteger().projectable( Projectable.YES ) ).toReference();
 			location = root.field( "location", f -> f.asFloatVector().dimension( 2 ).projectable( Projectable.YES )
-					.maxConnections( 16 ).beamWidth( 100 ).vectorSimilarity( VectorSimilarity.L2 ) ).toReference();
+					.m( 16 ).efConstruction( 100 ).vectorSimilarity( VectorSimilarity.L2 ) ).toReference();
 			IndexSchemaObjectField nested = root.objectField( "object", ObjectStructure.NESTED );
 			object = nested.toReference();
 			nestedParking = nested.field( "nestedParking", f -> f.asBoolean().aggregable( Aggregable.YES ) ).toReference();

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -11,6 +11,7 @@ import static org.hibernate.search.util.impl.integrationtest.backend.elasticsear
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
+import org.hibernate.search.engine.backend.types.VectorSimilarity;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendFeatures;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.ElasticsearchTestDialect;
@@ -280,5 +281,20 @@ public class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 				os -> false,
 				aoss -> false
 		);
+	}
+
+	@Override
+	public boolean supportsSimilarity(VectorSimilarity vectorSimilarity) {
+		switch ( vectorSimilarity ) {
+			case DOT_PRODUCT:
+			case MAX_INNER_PRODUCT:
+				return isActualVersion(
+						es -> true,
+						os -> false,
+						aoss -> false
+				);
+			default:
+				return true;
+		}
 	}
 }

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/reader/LuceneIndexReaderCodecLoadingIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/reader/LuceneIndexReaderCodecLoadingIT.java
@@ -89,7 +89,7 @@ class LuceneIndexReaderCodecLoadingIT {
 		final IndexFieldReference<byte[]> vectorField;
 
 		IndexBinding(IndexSchemaElement root) {
-			vectorField = root.field( "vector", c -> c.asByteVector().dimension( 2 ).maxConnections( 10 ) ).toReference();
+			vectorField = root.field( "vector", c -> c.asByteVector().dimension( 2 ).m( 10 ) ).toReference();
 		}
 	}
 }

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/mapping/LuceneVectorFieldIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/mapping/LuceneVectorFieldIT.java
@@ -29,23 +29,23 @@ class LuceneVectorFieldIT {
 
 	@ParameterizedTest
 	@ValueSource(ints = { -1, -1000, 3201, 10000, Integer.MAX_VALUE, Integer.MIN_VALUE })
-	void assertBeamWidth(int beamWidth) {
-		test( 2, beamWidth, 10, "beamWidth", beamWidth, 3200 );
+	void assertEfConstruction(int efConstruction) {
+		test( 2, efConstruction, 10, "efConstruction", efConstruction, 3200 );
 	}
 
 	@ParameterizedTest
 	@ValueSource(ints = { -1, -1000, 513, 10000, Integer.MAX_VALUE, Integer.MIN_VALUE })
-	void assertMaxConnections(int maxConnections) {
-		test( 2, 2, maxConnections, "maxConnections", maxConnections, 512 );
+	void assertM(int m) {
+		test( 2, 2, m, "m", m, 512 );
 	}
 
-	void test(int dimension, int beamWidth, int maxConnections, String property, int value, int maxValue) {
+	void test(int dimension, int efConstruction, int m, String property, int value, int maxValue) {
 		assertThatThrownBy( () -> setupHelper.start()
 				.withIndex( SimpleMappedIndex
 						.of( root -> root
 								.field( "vector",
-										f -> f.asByteVector().dimension( dimension ).beamWidth( beamWidth )
-												.maxConnections( maxConnections ) )
+										f -> f.asByteVector().dimension( dimension ).efConstruction( efConstruction )
+												.m( m ) )
 								.toReference() ) )
 				.setup()
 		).isInstanceOf( SearchException.class )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/KnnPredicateSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/KnnPredicateSpecificsIT.java
@@ -77,8 +77,8 @@ class KnnPredicateSpecificsIT {
 						WrongVectorConfigured.index,
 						SearchScopeConfigured.index,
 						SearchScopeConfigured.indexDifferentDimension,
-						SearchScopeConfigured.indexDifferentBeamWidth,
-						SearchScopeConfigured.indexDifferentMaxConnection,
+						SearchScopeConfigured.indexDifferentEfConstruction,
+						SearchScopeConfigured.indexDifferentM,
 						SearchScopeConfigured.indexDifferentSimilarity,
 						VectorSimilarityConfigured.indexDefault,
 						ExampleKnnSearchConfigured.index,
@@ -109,15 +109,17 @@ class KnnPredicateSpecificsIT {
 		SearchScopeConfigured.dataSetsDimension
 				.forEach( d -> d.contribute( SearchScopeConfigured.indexDifferentDimension, scopeDifferentDimensionIndexer ) );
 		bulkIndexers.add( scopeDifferentDimensionIndexer );
-		final BulkIndexer scopeDifferentBeamWidthIndexer = SearchScopeConfigured.indexDifferentBeamWidth.bulkIndexer();
+		final BulkIndexer scopeDifferentEfConstructionIndexer =
+				SearchScopeConfigured.indexDifferentEfConstruction.bulkIndexer();
 		SearchScopeConfigured.dataSets
-				.forEach( d -> d.contribute( SearchScopeConfigured.indexDifferentBeamWidth, scopeDifferentBeamWidthIndexer ) );
-		bulkIndexers.add( scopeDifferentBeamWidthIndexer );
-		final BulkIndexer scopeDifferentMaxConnectionIndexer = SearchScopeConfigured.indexDifferentMaxConnection.bulkIndexer();
+				.forEach( d -> d.contribute( SearchScopeConfigured.indexDifferentEfConstruction,
+						scopeDifferentEfConstructionIndexer ) );
+		bulkIndexers.add( scopeDifferentEfConstructionIndexer );
+		final BulkIndexer scopeDifferentMIndexer = SearchScopeConfigured.indexDifferentM.bulkIndexer();
 		SearchScopeConfigured.dataSets
-				.forEach( d -> d.contribute( SearchScopeConfigured.indexDifferentMaxConnection,
-						scopeDifferentMaxConnectionIndexer ) );
-		bulkIndexers.add( scopeDifferentMaxConnectionIndexer );
+				.forEach( d -> d.contribute( SearchScopeConfigured.indexDifferentM,
+						scopeDifferentMIndexer ) );
+		bulkIndexers.add( scopeDifferentMIndexer );
 		final BulkIndexer scopeDifferentSimilarityIndexer = SearchScopeConfigured.indexDifferentSimilarity.bulkIndexer();
 		SearchScopeConfigured.dataSets
 				.forEach(
@@ -148,8 +150,8 @@ class KnnPredicateSpecificsIT {
 		}
 
 		bulkIndexers.add( scopeDifferentDimensionIndexer );
-		bulkIndexers.add( scopeDifferentBeamWidthIndexer );
-		bulkIndexers.add( scopeDifferentMaxConnectionIndexer );
+		bulkIndexers.add( scopeDifferentEfConstructionIndexer );
+		bulkIndexers.add( scopeDifferentMIndexer );
 		bulkIndexers.add( scopeDifferentSimilarityIndexer );
 		bulkIndexers.add( exampleKnnSearchIndexer );
 		bulkIndexers.add( exampleKnnSearchNestedIndexer );
@@ -262,13 +264,13 @@ class KnnPredicateSpecificsIT {
 						VectorSimilarity.L2
 				) ).name( "scopeDifferentDimension" );
 
-		private static final SimpleMappedIndex<IndexBinding> indexDifferentBeamWidth =
+		private static final SimpleMappedIndex<IndexBinding> indexDifferentEfConstruction =
 				SimpleMappedIndex.of( root -> new IndexBinding( root, supportedFieldTypes, 4, 2, VectorSimilarity.L2 ) )
-						.name( "scopeDifferentBeamWidth" );
+						.name( "scopeDifferentEfConstruction" );
 
-		private static final SimpleMappedIndex<IndexBinding> indexDifferentMaxConnection =
+		private static final SimpleMappedIndex<IndexBinding> indexDifferentM =
 				SimpleMappedIndex.of( root -> new IndexBinding( root, supportedFieldTypes, 2, 4, VectorSimilarity.L2 ) )
-						.name( "scopeDifferentMaxConnection" );
+						.name( "scopeDifferentM" );
 
 		private static final SimpleMappedIndex<IndexBinding> indexDifferentSimilarity =
 				SimpleMappedIndex.of( root -> new IndexBinding( root, supportedFieldTypes, 2, 2, VectorSimilarity.COSINE ) )
@@ -280,8 +282,8 @@ class KnnPredicateSpecificsIT {
 		private static final List<Arguments> parameters = new ArrayList<>();
 		static {
 			for ( VectorFieldTypeDescriptor<?> fieldType : supportedFieldTypes ) {
-				parameters.add( Arguments.of( fieldType, index, indexDifferentDimension, indexDifferentBeamWidth,
-						indexDifferentMaxConnection, indexDifferentSimilarity ) );
+				parameters.add( Arguments.of( fieldType, index, indexDifferentDimension, indexDifferentEfConstruction,
+						indexDifferentM, indexDifferentSimilarity ) );
 				dataSets.add( new DataSet<>( fieldType ) );
 			}
 			for ( VectorFieldTypeDescriptor<?> fieldType : supportedFieldTypesWithDifferentDimension ) {
@@ -298,8 +300,8 @@ class KnnPredicateSpecificsIT {
 		void dimension(VectorFieldTypeDescriptor<?> fieldType,
 				SimpleMappedIndex<IndexBinding> index,
 				SimpleMappedIndex<IndexBinding> indexDifferentDimension,
-				SimpleMappedIndex<IndexBinding> indexDifferentBeamWidth,
-				SimpleMappedIndex<IndexBinding> indexDifferentMaxConnection,
+				SimpleMappedIndex<IndexBinding> indexDifferentEfConstruction,
+				SimpleMappedIndex<IndexBinding> indexDifferentM,
 				SimpleMappedIndex<IndexBinding> indexDifferentSimilarity) {
 			SearchPredicateFactory f = index.createScope( indexDifferentDimension ).predicate();
 
@@ -321,8 +323,8 @@ class KnnPredicateSpecificsIT {
 		void similarity(VectorFieldTypeDescriptor<?> fieldType,
 				SimpleMappedIndex<IndexBinding> index,
 				SimpleMappedIndex<IndexBinding> indexDifferentDimension,
-				SimpleMappedIndex<IndexBinding> indexDifferentBeamWidth,
-				SimpleMappedIndex<IndexBinding> indexDifferentMaxConnection,
+				SimpleMappedIndex<IndexBinding> indexDifferentEfConstruction,
+				SimpleMappedIndex<IndexBinding> indexDifferentM,
 				SimpleMappedIndex<IndexBinding> indexDifferentSimilarity) {
 			SearchPredicateFactory f = index.createScope( indexDifferentSimilarity ).predicate();
 
@@ -341,13 +343,13 @@ class KnnPredicateSpecificsIT {
 
 		@ParameterizedTest(name = "{0}")
 		@MethodSource("params")
-		void beamWidth(VectorFieldTypeDescriptor<?> fieldType,
+		void efConstruction(VectorFieldTypeDescriptor<?> fieldType,
 				SimpleMappedIndex<IndexBinding> index,
 				SimpleMappedIndex<IndexBinding> indexDifferentDimension,
-				SimpleMappedIndex<IndexBinding> indexDifferentBeamWidth,
-				SimpleMappedIndex<IndexBinding> indexDifferentMaxConnection,
+				SimpleMappedIndex<IndexBinding> indexDifferentEfConstruction,
+				SimpleMappedIndex<IndexBinding> indexDifferentM,
 				SimpleMappedIndex<IndexBinding> indexDifferentSimilarity) {
-			StubMappingScope scope = index.createScope( indexDifferentBeamWidth );
+			StubMappingScope scope = index.createScope( indexDifferentEfConstruction );
 			SearchPredicateFactory f = scope.predicate();
 
 			String fieldPath = index.binding().field.get( fieldType ).relativeFieldName;
@@ -358,20 +360,20 @@ class KnnPredicateSpecificsIT {
 							"'predicate:knn'", fieldPath,
 							"Inconsistent configuration for field '" + fieldPath + "'",
 							"codec", "differs",
-							"beamWidth=2",
-							"beamWidth=4"
+							"efConstruction=2",
+							"efConstruction=4"
 					);
 		}
 
 		@ParameterizedTest(name = "{0}")
 		@MethodSource("params")
-		void maxConnection(VectorFieldTypeDescriptor<?> fieldType,
+		void m(VectorFieldTypeDescriptor<?> fieldType,
 				SimpleMappedIndex<IndexBinding> index,
 				SimpleMappedIndex<IndexBinding> indexDifferentDimension,
-				SimpleMappedIndex<IndexBinding> indexDifferentBeamWidth,
-				SimpleMappedIndex<IndexBinding> indexDifferentMaxConnection,
+				SimpleMappedIndex<IndexBinding> indexDifferentEfConstruction,
+				SimpleMappedIndex<IndexBinding> indexDifferentM,
 				SimpleMappedIndex<IndexBinding> indexDifferentSimilarity) {
-			StubMappingScope scope = index.createScope( indexDifferentMaxConnection );
+			StubMappingScope scope = index.createScope( indexDifferentM );
 			SearchPredicateFactory f = scope.predicate();
 
 			String fieldPath = index.binding().field.get( fieldType ).relativeFieldName;
@@ -382,8 +384,8 @@ class KnnPredicateSpecificsIT {
 							"'predicate:knn'", fieldPath,
 							"Inconsistent configuration for field '" + fieldPath + "'",
 							"codec", "differs",
-							"maxConnection=2",
-							"maxConnection=4"
+							"m=2",
+							"m=4"
 					);
 		}
 
@@ -402,10 +404,10 @@ class KnnPredicateSpecificsIT {
 
 
 			public IndexBinding(IndexSchemaElement root, Collection<? extends VectorFieldTypeDescriptor<?>> fieldTypes,
-					int beamWidth, int maxConnections, VectorSimilarity vectorSimilarity) {
+					int efConstruction, int m, VectorSimilarity vectorSimilarity) {
 
-				field = SimpleFieldModelsByType.mapAll( fieldTypes, root, "", c -> c.beamWidth( beamWidth )
-						.maxConnections( maxConnections ).vectorSimilarity( vectorSimilarity ) );
+				field = SimpleFieldModelsByType.mapAll( fieldTypes, root, "", c -> c.efConstruction( efConstruction )
+						.m( m ).vectorSimilarity( vectorSimilarity ) );
 			}
 
 			public <F> F sampleVector(VectorFieldTypeDescriptor<F> vectorFieldTypeDescriptor) {
@@ -818,7 +820,7 @@ class KnnPredicateSpecificsIT {
 				parking = root.field( "parking", f -> f.asBoolean().projectable( Projectable.YES ) ).toReference();
 				rating = root.field( "rating", f -> f.asInteger().projectable( Projectable.YES ) ).toReference();
 				location = root.field( "location", f -> f.asFloatVector().dimension( 2 ).projectable( Projectable.YES )
-						.maxConnections( 16 ).beamWidth( 100 ).vectorSimilarity( VectorSimilarity.L2 ) ).toReference();
+						.m( 16 ).efConstruction( 100 ).vectorSimilarity( VectorSimilarity.L2 ) ).toReference();
 			}
 		}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ByteVectorFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ByteVectorFieldTypeDescriptor.java
@@ -54,14 +54,10 @@ public class ByteVectorFieldTypeDescriptor extends VectorFieldTypeDescriptor<byt
 	protected List<byte[]> createUniquelyMatchableValues() {
 		// need to make sure that we'll get only unique arrays;
 		TreeSet<byte[]> set = new TreeSet<>( Arrays::compare );
-		set.add( arrayOf( size, Byte.MIN_VALUE ) );
-		set.add( arrayOf( size, (byte) -42 ) );
-		set.add( arrayOf( size, (byte) -1 ) );
 		set.add( arrayOf( size, (byte) 0 ) );
 		set.add( arrayOf( size, (byte) 1 ) );
+		set.add( arrayOf( size, (byte) 2 ) );
 		set.add( arrayOf( size, (byte) 3 ) );
-		set.add( arrayOf( size, (byte) 42 ) );
-		set.add( arrayOf( size, Byte.MAX_VALUE ) );
 		return new ArrayList<>( set );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.testsupport.util;
 
 import org.hibernate.search.engine.backend.types.ObjectStructure;
+import org.hibernate.search.engine.backend.types.VectorSimilarity;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingBackendFeatures;
 
 public abstract class TckBackendFeatures implements StubMappingBackendFeatures {
@@ -145,6 +146,10 @@ public abstract class TckBackendFeatures implements StubMappingBackendFeatures {
 	}
 
 	public boolean supportsVectorSearchRequiredMinimumSimilarity() {
+		return true;
+	}
+
+	public boolean supportsSimilarity(VectorSimilarity vectorSimilarity) {
 		return true;
 	}
 }

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/VectorFieldIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/VectorFieldIT.java
@@ -75,34 +75,34 @@ class VectorFieldIT {
 	}
 
 	@Test
-	void beamWidth() {
+	void efConstruction() {
 		@Indexed(index = INDEX_NAME)
 		class IndexedEntity {
 			@DocumentId
 			Integer id;
-			@VectorField(dimension = 5, beamWidth = 10)
+			@VectorField(dimension = 5, efConstruction = 10)
 			byte[] vector;
 		}
 
 		backendMock.expectSchema( INDEX_NAME, b -> b
-				.field( "vector", byte[].class, f -> f.dimension( 5 ).beamWidth( 10 ) )
+				.field( "vector", byte[].class, f -> f.dimension( 5 ).efConstruction( 10 ) )
 		);
 		setupHelper.start().setup( IndexedEntity.class );
 		backendMock.verifyExpectationsMet();
 	}
 
 	@Test
-	void maxConnections() {
+	void m() {
 		@Indexed(index = INDEX_NAME)
 		class IndexedEntity {
 			@DocumentId
 			Integer id;
-			@VectorField(dimension = 5, maxConnections = 10)
+			@VectorField(dimension = 5, m = 10)
 			byte[] vector;
 		}
 
 		backendMock.expectSchema( INDEX_NAME, b -> b
-				.field( "vector", byte[].class, f -> f.dimension( 5 ).maxConnections( 10 ) )
+				.field( "vector", byte[].class, f -> f.dimension( 5 ).m( 10 ) )
 		);
 		setupHelper.start().setup( IndexedEntity.class );
 		backendMock.verifyExpectationsMet();

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/VectorFieldIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/VectorFieldIT.java
@@ -187,7 +187,7 @@ class VectorFieldIT {
 			float[] vectorSimilarityL2;
 			@VectorField(dimension = 4, vectorSimilarity = VectorSimilarity.COSINE)
 			float[] vectorSimilarityCosine;
-			@VectorField(dimension = 4, vectorSimilarity = VectorSimilarity.INNER_PRODUCT)
+			@VectorField(dimension = 4, vectorSimilarity = VectorSimilarity.DOT_PRODUCT)
 			float[] vectorSimilarityInnerProduct;
 			@VectorField(dimension = 4, vectorSimilarity = VectorSimilarity.DEFAULT)
 			float[] vectorSimilarityDefault;
@@ -200,7 +200,7 @@ class VectorFieldIT {
 				.field( "vectorSimilarityCosine", float[].class,
 						f -> f.dimension( 4 ).vectorSimilarity( VectorSimilarity.COSINE ) )
 				.field( "vectorSimilarityInnerProduct", float[].class,
-						f -> f.dimension( 4 ).vectorSimilarity( VectorSimilarity.INNER_PRODUCT ) )
+						f -> f.dimension( 4 ).vectorSimilarity( VectorSimilarity.DOT_PRODUCT ) )
 				.field( "vectorSimilarityDefault", float[].class, f -> f.dimension( 4 ) )
 				.field( "implicit", float[].class, f -> f.dimension( 4 ) )
 		);

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/AnnotationDefaultValues.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/AnnotationDefaultValues.java
@@ -24,13 +24,13 @@ public final class AnnotationDefaultValues {
 	 * This extreme value is both invalid and very unlikely to be used.
 	 * So we use it to mark that the user has not set the value.
 	 */
-	public static final int DEFAULT_BEAM_WIDTH = Integer.MIN_VALUE;
+	public static final int DEFAULT_EF_CONSTRUCTION = Integer.MIN_VALUE;
 
 	/**
 	 * This extreme value is both invalid and very unlikely to be used.
 	 * So we use it to mark that the user has not set the value.
 	 */
-	public static final int DEFAULT_MAX_CONNECTIONS = Integer.MIN_VALUE;
+	public static final int DEFAULT_M = Integer.MIN_VALUE;
 
 	/**
 	 * This extreme value is both invalid and very unlikely to be used.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/VectorField.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/VectorField.java
@@ -83,7 +83,7 @@ public @interface VectorField {
 	 * Higher values lead to a more accurate graph but slower indexing speed.
 	 * Default value is backend-specific.
 	 */
-	int beamWidth() default AnnotationDefaultValues.DEFAULT_BEAM_WIDTH;
+	int efConstruction() default AnnotationDefaultValues.DEFAULT_EF_CONSTRUCTION;
 
 	/**
 	 * @return The number of neighbors each node will be connected to in the HNSW graph.
@@ -91,7 +91,7 @@ public @interface VectorField {
 	 * It is recommended to keep this value between 2 and 100.
 	 * Default value is backend-specific.
 	 */
-	int maxConnections() default AnnotationDefaultValues.DEFAULT_MAX_CONNECTIONS;
+	int m() default AnnotationDefaultValues.DEFAULT_M;
 
 	/**
 	 * @return A reference to the value bridge to use for this field.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/VectorFieldAnnotationProcessor.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/VectorFieldAnnotationProcessor.java
@@ -30,14 +30,14 @@ public class VectorFieldAnnotationProcessor extends AbstractFieldAnnotationProce
 				? mappingContext.vectorField( fieldName )
 				: mappingContext.vectorField( dimension, fieldName );
 
-		int maxConnections = annotation.maxConnections();
-		if ( maxConnections != AnnotationDefaultValues.DEFAULT_MAX_CONNECTIONS ) {
-			fieldContext.maxConnections( maxConnections );
+		int m = annotation.m();
+		if ( m != AnnotationDefaultValues.DEFAULT_M ) {
+			fieldContext.m( m );
 		}
 
-		int beamWidth = annotation.beamWidth();
-		if ( beamWidth != AnnotationDefaultValues.DEFAULT_BEAM_WIDTH ) {
-			fieldContext.beamWidth( beamWidth );
+		int efConstruction = annotation.efConstruction();
+		if ( efConstruction != AnnotationDefaultValues.DEFAULT_EF_CONSTRUCTION ) {
+			fieldContext.efConstruction( efConstruction );
 		}
 
 		VectorSimilarity vectorSimilarity = annotation.vectorSimilarity();

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/PropertyMappingVectorFieldOptionsStep.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/PropertyMappingVectorFieldOptionsStep.java
@@ -47,18 +47,18 @@ public interface PropertyMappingVectorFieldOptionsStep
 	PropertyMappingVectorFieldOptionsStep vectorSimilarity(VectorSimilarity vectorSimilarity);
 
 	/**
-	 * @param beamWidth The size of the dynamic list used during k-NN graph creation.
+	 * @param efConstruction The size of the dynamic list used during k-NN graph creation.
 	 * @return {@code this}, for method chaining.
-	 * @see VectorField#beamWidth()
+	 * @see VectorField#efConstruction()
 	 */
-	PropertyMappingVectorFieldOptionsStep beamWidth(int beamWidth);
+	PropertyMappingVectorFieldOptionsStep efConstruction(int efConstruction);
 
 	/**
-	 * @param maxConnections The number of neighbors each node will be connected to in the HNSW graph.
+	 * @param m The number of neighbors each node will be connected to in the HNSW graph.
 	 * @return {@code this}, for method chaining.
-	 * @see VectorField#maxConnections()
+	 * @see VectorField#m()
 	 */
-	PropertyMappingVectorFieldOptionsStep maxConnections(int maxConnections);
+	PropertyMappingVectorFieldOptionsStep m(int m);
 
 	/**
 	 * @param indexNullAs A value used instead of null values when indexing.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyMappingVectorFieldOptionsStepImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyMappingVectorFieldOptionsStepImpl.java
@@ -55,14 +55,14 @@ class PropertyMappingVectorFieldOptionsStepImpl
 	}
 
 	@Override
-	public PropertyMappingVectorFieldOptionsStep beamWidth(int beamWidth) {
-		fieldModelContributor.add( c -> c.vectorTypeOptionsStep().beamWidth( beamWidth ) );
+	public PropertyMappingVectorFieldOptionsStep efConstruction(int efConstruction) {
+		fieldModelContributor.add( c -> c.vectorTypeOptionsStep().efConstruction( efConstruction ) );
 		return thisAsS();
 	}
 
 	@Override
-	public PropertyMappingVectorFieldOptionsStep maxConnections(int maxConnections) {
-		fieldModelContributor.add( c -> c.vectorTypeOptionsStep().maxConnections( maxConnections ) );
+	public PropertyMappingVectorFieldOptionsStep m(int m) {
+		fieldModelContributor.add( c -> c.vectorTypeOptionsStep().m( m ) );
 		return thisAsS();
 	}
 

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/ElasticsearchTestDialect.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/ElasticsearchTestDialect.java
@@ -162,7 +162,7 @@ public class ElasticsearchTestDialect {
 				switch ( similarity ) {
 					case L2:
 						return "l2_norm";
-					case INNER_PRODUCT:
+					case DOT_PRODUCT:
 						return "dot_product";
 					case COSINE:
 						return "cosine";
@@ -174,7 +174,7 @@ public class ElasticsearchTestDialect {
 				switch ( similarity ) {
 					case L2:
 						return "l2";
-					case INNER_PRODUCT:
+					case DOT_PRODUCT:
 						return "l2";
 					case COSINE:
 						return "cosinesimil";

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/StubIndexSchemaDataNode.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/StubIndexSchemaDataNode.java
@@ -248,13 +248,13 @@ public final class StubIndexSchemaDataNode extends StubTreeNode<StubIndexSchemaD
 			return this;
 		}
 
-		public Builder maxConnections(int maxConnections) {
-			attribute( "maxConnections", maxConnections );
+		public Builder m(int m) {
+			attribute( "m", m );
 			return this;
 		}
 
-		public Builder beamWidth(int beamWidth) {
-			attribute( "beamWidth", beamWidth );
+		public Builder efConstruction(int efConstruction) {
+			attribute( "efConstruction", efConstruction );
 			return this;
 		}
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/dsl/impl/StubVectorFieldTypeOptionsStep.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/dsl/impl/StubVectorFieldTypeOptionsStep.java
@@ -24,14 +24,14 @@ class StubVectorFieldTypeOptionsStep<F>
 	}
 
 	@Override
-	public StubVectorFieldTypeOptionsStep<F> beamWidth(int beamWidth) {
-		builder.modifier( b -> b.beamWidth( beamWidth ) );
+	public StubVectorFieldTypeOptionsStep<F> efConstruction(int efConstruction) {
+		builder.modifier( b -> b.efConstruction( efConstruction ) );
 		return this;
 	}
 
 	@Override
-	public StubVectorFieldTypeOptionsStep<F> maxConnections(int maxConnections) {
-		builder.modifier( b -> b.maxConnections( maxConnections ) );
+	public StubVectorFieldTypeOptionsStep<F> m(int m) {
+		builder.modifier( b -> b.m( m ) );
 		return this;
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5038
https://hibernate.atlassian.net/browse/HSEARCH-5056


@fax4ever this particular change (the last commit) may be interesting for you since it'll rename one constant (`INNER_PRODUCT` -> `DOT_PRODUCT`) and add one more (`MAX_INNER_PRODUCT`) in the `VectorSimilarity` enum.