### PR TITLE
Stop testing against JDK 20

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -177,9 +177,6 @@ stage('Configure') {
 					// We want to enable preview features when testing newer builds of OpenJDK:
 					// even if we don't use these features, just enabling them can cause side effects
 					// and it's useful to test that.
-					new JdkBuildEnvironment(version: '20', testCompilerTool: 'OpenJDK 20 Latest',
-							testLauncherArgs: '--enable-preview',
-							condition: TestCondition.AFTER_MERGE),
 					new JdkBuildEnvironment(version: '21', testCompilerTool: 'OpenJDK 21 Latest',
 							testLauncherArgs: '--enable-preview',
 							condition: TestCondition.AFTER_MERGE),

--- a/pom.xml
+++ b/pom.xml
@@ -1436,20 +1436,6 @@
         </profile>
 
         <profile>
-            <id>testWithJdk20</id>
-            <activation>
-                <property>
-                    <name>java-version.test.release</name>
-                    <value>20</value>
-                </property>
-            </activation>
-            <properties>
-                <!-- impsort-maven-plugin doesn't work with JDK20 yet? -->
-                <format.skip>true</format.skip>
-            </properties>
-        </profile>
-
-        <profile>
             <id>testWithJdk21</id>
             <activation>
                 <property>


### PR DESCRIPTION
It EOL'd on Sept 19th, 2023.
See https://endoflife.date/oracle-jdk

Also, we already test against the next version (21).