### PR TITLE
Test against OpenSearch 2.11 on AWS [6.2]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -299,10 +299,9 @@ stage('Configure') {
 					// --------------------------------------------
 					// AWS OpenSearch service
 					new OpenSearchAwsBuildEnvironment(version: '1.3', condition: TestCondition.AFTER_MERGE),
-					new OpenSearchAwsBuildEnvironment(version: '2.3', condition: TestCondition.ON_DEMAND),
-					new OpenSearchAwsBuildEnvironment(version: '2.5', condition: TestCondition.AFTER_MERGE),
+					new OpenSearchAwsBuildEnvironment(version: '2.11', condition: TestCondition.AFTER_MERGE),
 					// Also test static credentials, but only for the latest version
-					new OpenSearchAwsBuildEnvironment(version: '2.5', condition: TestCondition.AFTER_MERGE, staticCredentials: true)
+					new OpenSearchAwsBuildEnvironment(version: '2.11', condition: TestCondition.AFTER_MERGE, staticCredentials: true)
 			]
 	])
 


### PR DESCRIPTION
Luckily for 6.2 we have:
```
new OpenSearchLocalBuildEnvironment(version: '2.11.0', condition: TestCondition.AFTER_MERGE)
```

And 6.1 is only testing against 1.x (though it's 1.2 1.0 for them and not 1.3 that we are using for later versions ... )
any earlier versions do not run tests against OpenSearch