### PR TITLE
Backport HSEARCH-5065 to branch 7.0 - Two-phase boot for the standalone POJO mapper

### DIFF
--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/bootstrap/StandalonePojoIntegrationBooterIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/bootstrap/StandalonePojoIntegrationBooterIT.java
@@ -1,0 +1,175 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.bootstrap;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.hibernate.search.engine.backend.analysis.AnalyzerNames;
+import org.hibernate.search.engine.cfg.BackendSettings;
+import org.hibernate.search.engine.cfg.EngineSettings;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.standalone.bootstrap.spi.StandalonePojoIntegrationBooter;
+import org.hibernate.search.mapper.pojo.standalone.cfg.StandalonePojoMapperSettings;
+import org.hibernate.search.mapper.pojo.standalone.mapping.CloseableSearchMapping;
+import org.hibernate.search.mapper.pojo.standalone.mapping.StandalonePojoMappingConfigurationContext;
+import org.hibernate.search.mapper.pojo.standalone.mapping.StandalonePojoMappingConfigurer;
+import org.hibernate.search.mapper.pojo.standalone.session.SearchSession;
+import org.hibernate.search.util.common.impl.Closer;
+import org.hibernate.search.util.common.reflect.spi.ValueHandleFactory;
+import org.hibernate.search.util.common.reflect.spi.ValueReadHandle;
+import org.hibernate.search.util.impl.integrationtest.common.extension.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.common.stub.backend.BackendMappingHandle;
+import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.StubSchemaManagementWork;
+import org.hibernate.search.util.impl.integrationtest.mapper.pojo.standalone.StandalonePojoMappingHandle;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.assertj.core.api.Fail;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+class StandalonePojoIntegrationBooterIT {
+
+	private static final String INDEX_NAME = "IndexName";
+
+	private final List<AutoCloseable> toClose = new ArrayList<>();
+
+	@RegisterExtension
+	public BackendMock backendMock = BackendMock.create();
+
+	@Mock
+	private ValueReadHandle<Integer> idValueReadHandleMock;
+
+	@Mock
+	private ValueReadHandle<String> textValueReadHandleMock;
+
+	@Mock
+	private ValueHandleFactory valueHandleFactoryMock;
+
+	@AfterEach
+	void cleanup() throws Exception {
+		try ( Closer<Exception> closer = new Closer<>() ) {
+			closer.pushAll( AutoCloseable::close, toClose );
+		}
+	}
+
+	@Test
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	void twoPhaseBoot() throws Exception {
+		CompletableFuture<BackendMappingHandle> mappingHandlePromise = new CompletableFuture<>();
+		StandalonePojoIntegrationBooter preBooter = StandalonePojoIntegrationBooter.builder()
+				.valueReadHandleFactory( valueHandleFactoryMock )
+				.property(
+						EngineSettings.BACKEND + "." + BackendSettings.TYPE,
+						backendMock.factory( mappingHandlePromise )
+				)
+				.property( StandalonePojoMapperSettings.MAPPING_CONFIGURER, new StandalonePojoMappingConfigurer() {
+					@Override
+					public void configure(StandalonePojoMappingConfigurationContext context) {
+						context.addEntityType( IndexedEntity.class );
+					}
+				} )
+				.build();
+
+		Map<String, Object> preBooterGeneratedProperties = new LinkedHashMap<>();
+
+		// Pre-booting should lead to a schema definition in the backend.
+		backendMock.expectSchema( INDEX_NAME, b -> b.field( "text", String.class,
+				b2 -> b2.analyzerName( AnalyzerNames.DEFAULT ) ) );
+		// Pre-booting should retrieve value-read handles
+		// Simulate a custom handle from a framework, e.g. Quarkus
+		when( valueHandleFactoryMock.createForField( IndexedEntity.ID_FIELD ) )
+				.thenReturn( (ValueReadHandle) idValueReadHandleMock );
+		when( valueHandleFactoryMock.createForField( IndexedEntity.TEXT_FIELD ) )
+				.thenReturn( (ValueReadHandle) textValueReadHandleMock );
+		preBooter.preBoot( preBooterGeneratedProperties::put );
+		backendMock.verifyExpectationsMet();
+		verify( valueHandleFactoryMock ).createForField( IndexedEntity.ID_FIELD );
+		verify( valueHandleFactoryMock ).createForField( IndexedEntity.TEXT_FIELD );
+
+		StandalonePojoIntegrationBooter actualBooter = StandalonePojoIntegrationBooter.builder()
+				.properties( preBooterGeneratedProperties )
+				/*
+				 * We use a "trapped" mapping configurer to check that Hibernate Search does not generate the mapping,
+				 * but re-uses the one generated by the "pre-boot" above.
+				 */
+				.property( StandalonePojoMapperSettings.MAPPING_CONFIGURER, new StandalonePojoMappingConfigurer() {
+					@Override
+					public void configure(StandalonePojoMappingConfigurationContext context) {
+						Fail.fail( "Hibernate Search did not re-use the mapping generated when pre-booting" );
+					}
+				} )
+				.build();
+
+		// Actually booting the mapping should lead to a schema creation in the backend.
+		backendMock.expectSchemaManagementWorks( INDEX_NAME )
+				.work( StubSchemaManagementWork.Type.CREATE_OR_VALIDATE );
+		try ( CloseableSearchMapping mapping = actualBooter.boot() ) {
+			mappingHandlePromise.complete( new StandalonePojoMappingHandle() );
+
+			/*
+			 * Building the session should NOT lead to a second schema creation in the backend:
+			 * that would mean the pre-boot was ignored...
+			 */
+			backendMock.verifyExpectationsMet();
+
+			try ( SearchSession session = mapping.createSession() ) {
+				IndexedEntity entity = new IndexedEntity();
+				entity.id = 1;
+				entity.text = "someText";
+				when( idValueReadHandleMock.get( entity ) ).thenReturn( entity.id );
+				session.indexingPlan().add( entity );
+
+				when( textValueReadHandleMock.get( entity ) ).thenReturn( entity.text );
+
+				backendMock.expectWorks( INDEX_NAME )
+						.add( "1", b -> b.field( "text", "someText" ) );
+			}
+			// If the entity was indexed, it means Hibernate Search booted correctly
+			backendMock.verifyExpectationsMet();
+
+			// Also check that the value handle has been called
+			verify( textValueReadHandleMock ).get( any() );
+		}
+	}
+
+	@Indexed(index = INDEX_NAME)
+	private static class IndexedEntity {
+		private static final Field ID_FIELD;
+		private static final Field TEXT_FIELD;
+
+		static {
+			try {
+				ID_FIELD = IndexedEntity.class.getDeclaredField( "id" );
+				TEXT_FIELD = IndexedEntity.class.getDeclaredField( "text" );
+			}
+			catch (NoSuchFieldException e) {
+				throw new IllegalStateException( e );
+			}
+		}
+
+		@DocumentId
+		private Integer id;
+		@FullTextField
+		private String text;
+	}
+}

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/bootstrap/UnusedPropertiesIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/bootstrap/UnusedPropertiesIT.java
@@ -1,0 +1,135 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.bootstrap;
+
+import java.lang.invoke.MethodHandles;
+import java.util.function.UnaryOperator;
+
+import org.hibernate.search.engine.cfg.EngineSettings;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.standalone.cfg.StandalonePojoMapperSettings;
+import org.hibernate.search.util.impl.integrationtest.common.extension.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.pojo.standalone.StandalonePojoMappingSetupHelper;
+import org.hibernate.search.util.impl.test.extension.ExpectedLog4jLog;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.apache.logging.log4j.Level;
+
+class UnusedPropertiesIT {
+	private static final String KEY_UNUSED = "hibernate.search.indexes.myIndex.foo";
+	private static final String KEY_UNUSED_BUT_EMPTY_VALUE = "hibernate.search.indexes.myIndex.emptyValue";
+	private static final String KEY_UNUSED_BUT_BLANK_VALUE = "hibernate.search.indexes.myIndex.blankValue";
+	private static final String KEY_UNUSED_BUT_NULL_VALUE = "hibernate.search.indexes.myIndex.nullValue";
+
+	@RegisterExtension
+	public BackendMock backendMock = BackendMock.create();
+
+	@RegisterExtension
+	public StandalonePojoMappingSetupHelper setupHelper =
+			StandalonePojoMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );
+
+	@RegisterExtension
+	public ExpectedLog4jLog logged = ExpectedLog4jLog.create();
+
+	@Test
+	void checkDisabled_unusedProperty() {
+		logged.expectMessage( "some properties in the given configuration are not used" )
+				.never();
+		logged.expectEvent( Level.INFO, "Configuration property tracking is disabled" )
+				.once();
+		setup( builder -> builder.withProperty( EngineSettings.CONFIGURATION_PROPERTY_CHECKING_STRATEGY, "ignore" )
+				.withProperty( KEY_UNUSED, "bar" )
+				// These properties should be ignored
+				.withProperty( KEY_UNUSED_BUT_EMPTY_VALUE, "" )
+				.withProperty( KEY_UNUSED_BUT_BLANK_VALUE, "   " )
+				.withProperty( KEY_UNUSED_BUT_NULL_VALUE, null ) );
+	}
+
+	@Test
+	void checkEnabledByDefault_unusedProperty() {
+		logged.expectEvent( Level.WARN,
+				"Invalid configuration passed to Hibernate Search",
+				"some properties in the given configuration are not used",
+				"[" + KEY_UNUSED + "]",
+				"To disable this warning, set the property '"
+						+ EngineSettings.CONFIGURATION_PROPERTY_CHECKING_STRATEGY + "' to 'ignore'" )
+				.once();
+		logged.expectMessage( "Configuration property tracking is disabled" )
+				.never();
+		// Also check that used properties are not reported as unused
+		logged.expectMessage( "not used", StandalonePojoMapperSettings.INDEXING_PLAN_SYNCHRONIZATION_STRATEGY )
+				.never();
+
+		setup( builder -> builder.withProperty( KEY_UNUSED, "bar" )
+				.withProperty( StandalonePojoMapperSettings.INDEXING_PLAN_SYNCHRONIZATION_STRATEGY, "sync" )
+				// These properties should be ignored
+				.withProperty( KEY_UNUSED_BUT_EMPTY_VALUE, "" )
+				.withProperty( KEY_UNUSED_BUT_BLANK_VALUE, "   " )
+				.withProperty( KEY_UNUSED_BUT_NULL_VALUE, null ) );
+	}
+
+	@Test
+	void checkEnabledExplicitly_noUnusedProperty() {
+		/*
+		 * Check that the "configuration property tracking strategy" property is considered used.
+		 * This is a corner case worth testing, since the property may legitimately be accessed before
+		 * we start tracking property usage.
+		 */
+		logged.expectMessage( "some properties in the given configuration are not used" )
+				.never();
+		logged.expectMessage( "Configuration property tracking is disabled" )
+				.never();
+		setup( builder -> builder.withProperty( EngineSettings.CONFIGURATION_PROPERTY_CHECKING_STRATEGY, "warn" )
+				// These properties should be ignored
+				.withProperty( KEY_UNUSED_BUT_EMPTY_VALUE, "" )
+				.withProperty( KEY_UNUSED_BUT_BLANK_VALUE, "   " )
+				.withProperty( KEY_UNUSED_BUT_NULL_VALUE, null ) );
+	}
+
+	private void setup(UnaryOperator<StandalonePojoMappingSetupHelper.SetupContext> configurationContributor) {
+		backendMock.expectSchema( IndexedEntity.INDEX, b -> b
+				.field( "myTextField", String.class ) );
+
+		setupHelper.start()
+				.with( configurationContributor )
+				.setup( IndexedEntity.class );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Indexed(index = IndexedEntity.INDEX)
+	public static class IndexedEntity {
+
+		public static final String INDEX = "IndexedEntity";
+
+		@DocumentId
+		private Integer id;
+
+		@GenericField(name = "myTextField")
+		private String text;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getText() {
+			return text;
+		}
+
+		public void setText(String text) {
+			this.text = text;
+		}
+	}
+
+}

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/bootstrap/impl/StandalonePojoIntegrationBooterImpl.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/bootstrap/impl/StandalonePojoIntegrationBooterImpl.java
@@ -1,0 +1,160 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.standalone.bootstrap.impl;
+
+import java.lang.invoke.MethodHandles;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
+import org.hibernate.search.engine.cfg.spi.AllAwareConfigurationPropertySource;
+import org.hibernate.search.engine.cfg.spi.ConfigurationProperty;
+import org.hibernate.search.engine.cfg.spi.ConfigurationPropertyChecker;
+import org.hibernate.search.engine.cfg.spi.OptionalConfigurationProperty;
+import org.hibernate.search.engine.common.spi.SearchIntegration;
+import org.hibernate.search.engine.common.spi.SearchIntegrationEnvironment;
+import org.hibernate.search.engine.common.spi.SearchIntegrationPartialBuildState;
+import org.hibernate.search.engine.environment.bean.spi.BeanProvider;
+import org.hibernate.search.mapper.pojo.standalone.bootstrap.spi.StandalonePojoIntegrationBooter;
+import org.hibernate.search.mapper.pojo.standalone.bootstrap.spi.StandalonePojoIntegrationBooterBehavior;
+import org.hibernate.search.mapper.pojo.standalone.cfg.spi.StandalonePojoMapperSpiSettings;
+import org.hibernate.search.mapper.pojo.standalone.logging.impl.Log;
+import org.hibernate.search.mapper.pojo.standalone.mapping.impl.StandalonePojoMapping;
+import org.hibernate.search.mapper.pojo.standalone.mapping.impl.StandalonePojoMappingInitiator;
+import org.hibernate.search.mapper.pojo.standalone.mapping.impl.StandalonePojoMappingKey;
+import org.hibernate.search.mapper.pojo.standalone.model.impl.StandalonePojoBootstrapIntrospector;
+import org.hibernate.search.util.common.impl.SuppressingCloser;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
+import org.hibernate.search.util.common.reflect.spi.ValueHandleFactory;
+
+public class StandalonePojoIntegrationBooterImpl implements StandalonePojoIntegrationBooter {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
+	private static final OptionalConfigurationProperty<BeanProvider> BEAN_PROVIDER =
+			ConfigurationProperty.forKey( StandalonePojoMapperSpiSettings.BEAN_PROVIDER )
+					.as( BeanProvider.class, value -> {
+						throw log.invalidStringForBeanProvider( value, BeanProvider.class );
+					} )
+					.build();
+
+	private final ConfigurationPropertyChecker propertyChecker;
+	private final ValueHandleFactory valueHandleFactory;
+	private final ConfigurationPropertySource propertySource;
+
+	private StandalonePojoIntegrationBooterImpl(BuilderImpl builder) {
+		propertyChecker = ConfigurationPropertyChecker.create();
+		valueHandleFactory = builder.valueHandleFactory;
+
+		propertySource = propertyChecker.wrap(
+				AllAwareConfigurationPropertySource.fromMap( builder.properties )
+		);
+	}
+
+	@Override
+	public void preBoot(BiConsumer<String, Object> propertyCollector) {
+		doBootFirstPhase()
+				.set( propertyCollector );
+	}
+
+	private StandalonePojoIntegrationPartialBuildState getPartialBuildStateOrDoBootFirstPhase() {
+		Optional<StandalonePojoIntegrationPartialBuildState> partialBuildState =
+				StandalonePojoIntegrationPartialBuildState.get( propertySource );
+		if ( partialBuildState.isPresent() ) {
+			return partialBuildState.get();
+		}
+		else {
+			// Most common path (except for Quarkus): Hibernate Search wasn't pre-booted ahead of time,
+			// so we will need to perform the first phase of boot now.
+			//
+			// Do not remove the use of StandalonePojoIntegrationBooterBehavior as an intermediary:
+			// its implementation is overridden by Quarkus to make it clear to SubstrateVM
+			// that the first phase of boot is never executed in the native binary.
+			return StandalonePojoIntegrationBooterBehavior.bootFirstPhase( this::doBootFirstPhase );
+		}
+	}
+
+	private StandalonePojoIntegrationPartialBuildState doBootFirstPhase() {
+		StandalonePojoBootstrapIntrospector introspector =
+				StandalonePojoBootstrapIntrospector.create( valueHandleFactory != null
+						? valueHandleFactory
+						: ValueHandleFactory.usingMethodHandle( MethodHandles.publicLookup() ) );
+		StandalonePojoMappingKey mappingKey = new StandalonePojoMappingKey();
+		StandalonePojoMappingInitiator mappingInitiator = new StandalonePojoMappingInitiator( introspector );
+
+		SearchIntegrationEnvironment environment = null;
+		SearchIntegrationPartialBuildState integrationPartialBuildState = null;
+		try {
+			environment = createEnvironment();
+
+			SearchIntegration.Builder integrationBuilder = SearchIntegration.builder( environment );
+			integrationBuilder.addMappingInitiator( mappingKey, mappingInitiator );
+
+			integrationPartialBuildState = integrationBuilder.prepareBuild();
+
+			return new StandalonePojoIntegrationPartialBuildState( integrationPartialBuildState, mappingKey );
+		}
+		catch (RuntimeException e) {
+			new SuppressingCloser( e )
+					.push( environment )
+					.push( SearchIntegrationPartialBuildState::closeOnFailure, integrationPartialBuildState );
+			throw e;
+		}
+	}
+
+	private SearchIntegrationEnvironment createEnvironment() {
+		SearchIntegrationEnvironment.Builder environmentBuilder =
+				SearchIntegrationEnvironment.builder( propertySource, propertyChecker );
+		BEAN_PROVIDER.get( propertySource ).ifPresent( environmentBuilder::beanProvider );
+		return environmentBuilder.build();
+	}
+
+	@Override
+	public StandalonePojoMapping boot() {
+		StandalonePojoIntegrationPartialBuildState partialBuildState = getPartialBuildStateOrDoBootFirstPhase();
+
+		try {
+			return partialBuildState.doBootSecondPhase( propertySource, propertyChecker );
+		}
+		catch (RuntimeException e) {
+			new SuppressingCloser( e )
+					.push( StandalonePojoIntegrationPartialBuildState::closeOnFailure, partialBuildState );
+			throw e;
+		}
+	}
+
+	public static class BuilderImpl implements Builder {
+		private ValueHandleFactory valueHandleFactory;
+		private final Map<String, Object> properties = new HashMap<>();
+
+		public BuilderImpl() {
+		}
+
+		@Override
+		public BuilderImpl valueReadHandleFactory(ValueHandleFactory valueHandleFactory) {
+			this.valueHandleFactory = valueHandleFactory;
+			return this;
+		}
+
+		public BuilderImpl property(String name, Object value) {
+			properties.put( name, value );
+			return this;
+		}
+
+		public BuilderImpl properties(Map<String, ?> map) {
+			properties.putAll( map );
+			return this;
+		}
+
+		@Override
+		public StandalonePojoIntegrationBooterImpl build() {
+			return new StandalonePojoIntegrationBooterImpl( this );
+		}
+	}
+}

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/bootstrap/impl/StandalonePojoIntegrationPartialBuildState.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/bootstrap/impl/StandalonePojoIntegrationPartialBuildState.java
@@ -1,0 +1,77 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.standalone.bootstrap.impl;
+
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
+import org.hibernate.search.engine.cfg.spi.ConfigurationProperty;
+import org.hibernate.search.engine.cfg.spi.ConfigurationPropertyChecker;
+import org.hibernate.search.engine.cfg.spi.OptionalConfigurationProperty;
+import org.hibernate.search.engine.common.spi.SearchIntegrationFinalizer;
+import org.hibernate.search.engine.common.spi.SearchIntegrationPartialBuildState;
+import org.hibernate.search.engine.environment.bean.BeanResolver;
+import org.hibernate.search.mapper.pojo.standalone.cfg.spi.StandalonePojoMapperSpiSettings;
+import org.hibernate.search.mapper.pojo.standalone.mapping.impl.StandalonePojoMapping;
+import org.hibernate.search.mapper.pojo.standalone.mapping.impl.StandalonePojoMappingKey;
+import org.hibernate.search.util.common.AssertionFailure;
+
+final class StandalonePojoIntegrationPartialBuildState {
+
+	private static final OptionalConfigurationProperty<
+			StandalonePojoIntegrationPartialBuildState> INTEGRATION_PARTIAL_BUILD_STATE =
+					ConfigurationProperty.forKey( StandalonePojoMapperSpiSettings.INTEGRATION_PARTIAL_BUILD_STATE )
+							.as( StandalonePojoIntegrationPartialBuildState.class,
+									StandalonePojoIntegrationPartialBuildState::parse )
+							.build();
+
+	public static Optional<StandalonePojoIntegrationPartialBuildState> get(ConfigurationPropertySource propertySource) {
+		return INTEGRATION_PARTIAL_BUILD_STATE.get( propertySource );
+	}
+
+	private static StandalonePojoIntegrationPartialBuildState parse(String stringToParse) {
+		throw new AssertionFailure(
+				"The partial build state cannot be parsed from a String;"
+						+ " it must be null or an instance of " + StandalonePojoIntegrationPartialBuildState.class
+		);
+	}
+
+	private final SearchIntegrationPartialBuildState integrationBuildState;
+	private final StandalonePojoMappingKey mappingKey;
+
+	StandalonePojoIntegrationPartialBuildState(SearchIntegrationPartialBuildState integrationBuildState,
+			StandalonePojoMappingKey mappingKey) {
+		this.integrationBuildState = integrationBuildState;
+		this.mappingKey = mappingKey;
+	}
+
+	public void closeOnFailure() {
+		this.integrationBuildState.closeOnFailure();
+	}
+
+	void set(BiConsumer<String, Object> propertyCollector) {
+		propertyCollector.accept( StandalonePojoMapperSpiSettings.INTEGRATION_PARTIAL_BUILD_STATE, this );
+	}
+
+	BeanResolver beanResolver() {
+		return integrationBuildState.beanResolver();
+	}
+
+	StandalonePojoMapping doBootSecondPhase(ConfigurationPropertySource propertySource,
+			ConfigurationPropertyChecker propertyChecker) {
+		SearchIntegrationFinalizer finalizer = integrationBuildState.finalizer( propertySource, propertyChecker );
+
+		StandalonePojoMapping mapping = finalizer.finalizeMapping(
+				mappingKey,
+				(context, partialMapping) -> partialMapping.finalizeMapping()
+		);
+		finalizer.finalizeIntegration();
+
+		return mapping;
+	}
+}

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/bootstrap/spi/StandalonePojoIntegrationBooter.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/bootstrap/spi/StandalonePojoIntegrationBooter.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.standalone.bootstrap.spi;
+
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import org.hibernate.search.mapper.pojo.standalone.bootstrap.impl.StandalonePojoIntegrationBooterImpl;
+import org.hibernate.search.mapper.pojo.standalone.mapping.CloseableSearchMapping;
+import org.hibernate.search.util.common.annotation.Incubating;
+import org.hibernate.search.util.common.reflect.spi.ValueHandleFactory;
+
+@Incubating
+public interface StandalonePojoIntegrationBooter {
+
+	static Builder builder() {
+		return new StandalonePojoIntegrationBooterImpl.BuilderImpl();
+	}
+
+	interface Builder {
+		Builder valueReadHandleFactory(ValueHandleFactory valueHandleFactory);
+
+		Builder property(String name, Object value);
+
+		Builder properties(Map<String, ?> map);
+
+		StandalonePojoIntegrationBooter build();
+	}
+
+	void preBoot(BiConsumer<String, Object> propertyCollector);
+
+	CloseableSearchMapping boot();
+
+}

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/bootstrap/spi/StandalonePojoIntegrationBooterBehavior.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/bootstrap/spi/StandalonePojoIntegrationBooterBehavior.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.standalone.bootstrap.spi;
+
+import org.hibernate.search.util.common.annotation.Incubating;
+
+@Incubating
+public final class StandalonePojoIntegrationBooterBehavior {
+
+	private StandalonePojoIntegrationBooterBehavior() {
+	}
+
+	// Exposed for override in native images, to make it extra-clear to SubstrateVM
+	// that the native executable will never perform the first phase of the boot.
+	public static <T> T bootFirstPhase(BootPhase<T> phase) {
+		return phase.execute();
+	}
+
+	public interface BootPhase<T> {
+		T execute();
+	}
+}

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/cfg/spi/StandalonePojoMapperSpiSettings.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/cfg/spi/StandalonePojoMapperSpiSettings.java
@@ -18,12 +18,17 @@ public final class StandalonePojoMapperSpiSettings {
 
 	public static final String BEAN_PROVIDER = PREFIX + Radicals.BEAN_PROVIDER;
 
+	public static final String INTEGRATION_PARTIAL_BUILD_STATE =
+			PREFIX + Radicals.INTEGRATION_PARTIAL_BUILD_STATE;
+
 	public static class Radicals {
 
 		private Radicals() {
 		}
 
 		public static final String BEAN_PROVIDER = "bean_provider";
+
+		public static final String INTEGRATION_PARTIAL_BUILD_STATE = "integration_partial_build_state";
 	}
 
 	/**

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/SearchMapping.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/SearchMapping.java
@@ -18,6 +18,7 @@ import org.hibernate.search.mapper.pojo.standalone.scope.SearchScope;
 import org.hibernate.search.mapper.pojo.standalone.session.SearchSession;
 import org.hibernate.search.mapper.pojo.standalone.session.SearchSessionBuilder;
 import org.hibernate.search.util.common.annotation.Incubating;
+import org.hibernate.search.util.common.reflect.spi.ValueHandleFactory;
 
 /**
  * The Hibernate Search mapping between the POJO model and the backend(s).
@@ -104,7 +105,7 @@ public interface SearchMapping {
 	 * @return A {@link SearchMapping} builder.
 	 */
 	static SearchMappingBuilder builder() {
-		return builder( MethodHandles.publicLookup() );
+		return new SearchMappingBuilder();
 	}
 
 	/**
@@ -112,7 +113,8 @@ public interface SearchMapping {
 	 * @return A {@link SearchMapping} builder.
 	 */
 	static SearchMappingBuilder builder(MethodHandles.Lookup lookup) {
-		return new SearchMappingBuilder( lookup );
+		return builder()
+				.valueReadHandleFactory( ValueHandleFactory.usingMethodHandle( lookup ) );
 	}
 
 }

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoEntityTypeContributor.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoEntityTypeContributor.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.mapper.pojo.standalone.impl;
+package org.hibernate.search.mapper.pojo.standalone.mapping.impl;
 
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoTypeMetadataContributor;
 import org.hibernate.search.mapper.pojo.model.additionalmetadata.building.spi.PojoAdditionalMetadataCollectorTypeNode;

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoMappingInitiator.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoMappingInitiator.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.mapper.pojo.standalone.impl;
+package org.hibernate.search.mapper.pojo.standalone.mapping.impl;
 
 import java.util.List;
 
@@ -21,8 +21,6 @@ import org.hibernate.search.mapper.pojo.mapping.spi.AbstractPojoMappingInitiator
 import org.hibernate.search.mapper.pojo.standalone.cfg.StandalonePojoMapperSettings;
 import org.hibernate.search.mapper.pojo.standalone.mapping.StandalonePojoMappingConfigurationContext;
 import org.hibernate.search.mapper.pojo.standalone.mapping.StandalonePojoMappingConfigurer;
-import org.hibernate.search.mapper.pojo.standalone.mapping.impl.StandalonePojoMapperDelegate;
-import org.hibernate.search.mapper.pojo.standalone.mapping.impl.StandalonePojoMappingPartialBuildState;
 import org.hibernate.search.mapper.pojo.standalone.mapping.metadata.EntityConfigurer;
 import org.hibernate.search.mapper.pojo.standalone.mapping.metadata.impl.StandalonePojoEntityTypeMetadataProvider;
 import org.hibernate.search.mapper.pojo.standalone.model.impl.StandalonePojoBootstrapIntrospector;
@@ -59,6 +57,12 @@ public class StandalonePojoMappingInitiator extends AbstractPojoMappingInitiator
 	public StandalonePojoMappingInitiator(StandalonePojoBootstrapIntrospector introspector) {
 		super( introspector );
 		entityTypeMetadataProviderBuilder = new StandalonePojoEntityTypeMetadataProvider.Builder( introspector );
+
+		// Enable annotated type discovery by default
+		annotationMapping()
+				.discoverAnnotatedTypesFromRootMappingAnnotations( true )
+				.discoverJandexIndexesFromAddedTypes( true )
+				.discoverAnnotationsFromReferencedTypes( true );
 	}
 
 	public <E> StandalonePojoMappingInitiator addEntityType(Class<E> clazz, String entityName,

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoTypeConfigurationContributor.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoTypeConfigurationContributor.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.mapper.pojo.standalone.impl;
+package org.hibernate.search.mapper.pojo.standalone.mapping.impl;
 
 import org.hibernate.search.engine.mapper.mapping.building.spi.MappingBuildContext;
 import org.hibernate.search.engine.mapper.mapping.building.spi.MappingConfigurationCollector;

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoTypeContextContainer.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoTypeContextContainer.java
@@ -22,7 +22,7 @@ import org.hibernate.search.mapper.pojo.standalone.session.impl.StandalonePojoSe
 import org.hibernate.search.util.common.data.spi.KeyValueProvider;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
-class StandalonePojoTypeContextContainer
+public class StandalonePojoTypeContextContainer
 		implements StandalonePojoSearchSessionTypeContextProvider, LoadingTypeContextProvider {
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/model/impl/StandalonePojoBootstrapIntrospector.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/model/impl/StandalonePojoBootstrapIntrospector.java
@@ -37,8 +37,7 @@ public class StandalonePojoBootstrapIntrospector extends AbstractPojoHCAnnBootst
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	public static StandalonePojoBootstrapIntrospector create(MethodHandles.Lookup lookup) {
-		ValueHandleFactory valueHandleFactory = ValueHandleFactory.usingMethodHandle( lookup );
+	public static StandalonePojoBootstrapIntrospector create(ValueHandleFactory valueHandleFactory) {
 		return new StandalonePojoBootstrapIntrospector( valueHandleFactory );
 	}
 

--- a/util/internal/integrationtest/mapper/pojo-standalone/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/pojo/standalone/StandalonePojoMappingHandle.java
+++ b/util/internal/integrationtest/mapper/pojo-standalone/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/pojo/standalone/StandalonePojoMappingHandle.java
@@ -10,7 +10,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.BackendMappingHandle;
 
-final class StandalonePojoMappingHandle implements BackendMappingHandle {
+public final class StandalonePojoMappingHandle implements BackendMappingHandle {
 	@Override
 	public CompletableFuture<?> backgroundIndexingCompletion() {
 		throw new IllegalStateException( "We never test asynchronous indexing with the Standalone POJO mapper,"


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5065

Backport of #3924 to branch 7.0
