### PR TITLE
Backport HSEARCH-5067 to branch 7.0 - Allow targeting entities by name in the Standalone POJO Mapper

### DIFF
--- a/documentation/src/main/asciidoc/public/reference/_entrypoints.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_entrypoints.adoc
@@ -198,9 +198,12 @@ The scope's generic type parameter can be any common supertype of those entity t
 <4> A scope will always target all subtypes of the given classes, and the given classes do not need to be indexed entity types themselves.
 This creates a `SearchScope` targeting all (indexed entity) subtypes of the `Person` interface;
 in our case this will target both the `Associate` entity type and the `Manager` entity type.
-<5> For advanced use cases and with the <<mapper-orm,Hibernate ORM integration>> only,
-it is possible to target (indexed entity) types by their name,
-e.g. the JPA entity name.
+<5> For advanced use cases,
+it is possible to target entity types by their name.
+For <<mapper-orm,Hibernate ORM>> this would be the JPA entity name,
+and for the <<mapper-pojo-standalone,Standalone POJO Mapper>>
+this would be the name assigned to the entity type upon declaration in the <<mapper-pojo-standalone-startup,configurer>>.
+In both cases, the entity name is the simple name of the Java class by default.
 <6> Passing `Object.class` will create a scope targeting every single indexed entity types.
 ====
 
@@ -217,8 +220,11 @@ The scope's generic type parameter can be any common supertype of those entity t
 <4> A scope will always target all subtypes of the given classes, and the given classes do not need to be indexed entity types themselves.
 This creates a `SearchScope` targeting all (indexed entity) subtypes of the `Person` interface;
 in our case this will target both the `Associate` entity type and the `Manager` entity type.
-<5> For advanced use cases and with the <<mapper-orm,Hibernate ORM integration>> only,
-it is possible to target (indexed entity) types by their name,
-e.g. the JPA entity name.
+<5> For advanced use cases,
+it is possible to target entity types by their name.
+For <<mapper-orm,Hibernate ORM>> this would be the JPA entity name,
+and for the <<mapper-pojo-standalone,Standalone POJO Mapper>>
+this would be the name assigned to the entity type upon declaration in the <<mapper-pojo-standalone-startup,configurer>>.
+In both cases, the entity name is the simple name of the Java class by default.
 <6> Passing `Object.class` will create a scope targeting every single indexed entity types.
 ====

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/pojo/standalone/entrypoints/StandalonePojoEntryPointsIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/pojo/standalone/entrypoints/StandalonePojoEntryPointsIT.java
@@ -115,12 +115,12 @@ class StandalonePojoEntryPointsIT {
 	@Test
 	void searchScope_fromSearchMapping() {
 		SearchMapping searchMapping = theSearchMapping;
-		// tag::searchScope-fromSearchMapping[]
 		SearchScope<Book> bookScope = searchMapping.scope( Book.class );
 		SearchScope<Person> associateAndManagerScope = searchMapping.scope( Arrays.asList( Associate.class, Manager.class ) );
 		SearchScope<Person> personScope = searchMapping.scope( Person.class );
+		SearchScope<Person> personSubTypesScope = searchMapping.scope( Person.class,
+				Arrays.asList( "Manager", "Associate" ) );
 		SearchScope<Object> allScope = searchMapping.scope( Object.class );
-		// end::searchScope-fromSearchMapping[]
 		assertThat( bookScope.includedTypes() )
 				.extracting( SearchIndexedEntity::name )
 				.containsExactlyInAnyOrder( "Book" );
@@ -128,6 +128,9 @@ class StandalonePojoEntryPointsIT {
 				.extracting( SearchIndexedEntity::name )
 				.containsExactlyInAnyOrder( "Manager", "Associate" );
 		assertThat( personScope.includedTypes() )
+				.extracting( SearchIndexedEntity::name )
+				.containsExactlyInAnyOrder( "Manager", "Associate" );
+		assertThat( personSubTypesScope.includedTypes() )
 				.extracting( SearchIndexedEntity::name )
 				.containsExactlyInAnyOrder( "Manager", "Associate" );
 		assertThat( allScope.includedTypes() )
@@ -143,8 +146,9 @@ class StandalonePojoEntryPointsIT {
 			SearchScope<Person> associateAndManagerScope =
 					searchSession.scope( Arrays.asList( Associate.class, Manager.class ) );
 			SearchScope<Person> personScope = searchSession.scope( Person.class );
+			SearchScope<Person> personSubTypesScope = searchSession.scope( Person.class,
+					Arrays.asList( "Manager", "Associate" ) );
 			SearchScope<Object> allScope = searchSession.scope( Object.class );
-			// end::searchScope-fromSearchSession[]
 			assertThat( bookScope.includedTypes() )
 					.extracting( SearchIndexedEntity::name )
 					.containsExactlyInAnyOrder( "Book" );
@@ -152,6 +156,9 @@ class StandalonePojoEntryPointsIT {
 					.extracting( SearchIndexedEntity::name )
 					.containsExactlyInAnyOrder( "Manager", "Associate" );
 			assertThat( personScope.includedTypes() )
+					.extracting( SearchIndexedEntity::name )
+					.containsExactlyInAnyOrder( "Manager", "Associate" );
+			assertThat( personSubTypesScope.includedTypes() )
 					.extracting( SearchIndexedEntity::name )
 					.containsExactlyInAnyOrder( "Manager", "Associate" );
 			assertThat( allScope.includedTypes() )

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/logging/impl/Log.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/logging/impl/Log.java
@@ -92,4 +92,21 @@ public interface Log extends BasicLogger {
 			+ " Valid classes for mapped entity types are: %2$s")
 	SearchException unknownClassForMappedEntityType(@FormatWith(ClassFormatter.class) Class<?> invalidClass,
 			@FormatWith(CommaSeparatedClassesFormatter.class) Collection<Class<?>> validClasses);
+
+	@Message(id = ID_OFFSET + 19, value = "No matching entity type for class '%1$s'."
+			+ " Valid classes are: %2$s")
+	SearchException unknownClassForEntityType(@FormatWith(ClassFormatter.class) Class<?> invalidClass,
+			@FormatWith(CommaSeparatedClassesFormatter.class) Collection<Class<?>> validClasses);
+
+	@Message(id = ID_OFFSET + 20, value = "No matching entity type for name '%1$s'."
+			+ " Valid names for entity types are: %2$s")
+	SearchException unknownEntityNameForEntityType(String invalidName, Collection<String> validNames);
+
+	@Message(id = ID_OFFSET + 21,
+			value = "Invalid type for '%1$s': the entity type must extend '%2$s'," +
+					" but entity type '%3$s' does not."
+	)
+	SearchException invalidEntitySuperType(String entityName,
+			@FormatWith(ClassFormatter.class) Class<?> expectedSuperType,
+			@FormatWith(ClassFormatter.class) Class<?> actualJavaType);
 }

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/SearchMapping.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/SearchMapping.java
@@ -51,6 +51,30 @@ public interface SearchMapping {
 	<T> SearchScope<T> scope(Collection<? extends Class<? extends T>> types);
 
 	/**
+	 * Create a {@link SearchScope} limited to entity types referenced by their name.
+	 *
+	 * @param expectedSuperType A supertype of all entity types to include in the scope.
+	 * @param entityName An entity name. See {@link StandalonePojoMappingConfigurationContext#addEntityType(Class, String)}.
+	 * @param <T> A supertype of all entity types to include in the scope.
+	 * @return The created scope.
+	 * @see SearchScope
+	 */
+	default <T> SearchScope<T> scope(Class<T> expectedSuperType, String entityName) {
+		return scope( expectedSuperType, Collections.singleton( entityName ) );
+	}
+
+	/**
+	 * Create a {@link SearchScope} limited to entity types referenced by their name.
+	 *
+	 * @param expectedSuperType A supertype of all entity types to include in the scope.
+	 * @param entityNames A collection of entity names. See {@link StandalonePojoMappingConfigurationContext#addEntityType(Class, String)}.
+	 * @param <T> A supertype of all entity types to include in the scope.
+	 * @return The created scope.
+	 * @see SearchScope
+	 */
+	<T> SearchScope<T> scope(Class<T> expectedSuperType, Collection<String> entityNames);
+
+	/**
 	 * @return A new session allowing to {@link SearchSession#indexingPlan() index} or
 	 * {@link SearchSession#search(Class) search for} entities.
 	 * @see #createSessionWithOptions()

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoMapperDelegate.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoMapperDelegate.java
@@ -20,13 +20,13 @@ public final class StandalonePojoMapperDelegate
 		implements PojoMapperDelegate<StandalonePojoMappingPartialBuildState> {
 
 	private final StandalonePojoEntityTypeMetadataProvider metadataProvider;
-	private final StandalonePojoTypeContextContainer.Builder typeContextContainerBuilder =
-			new StandalonePojoTypeContextContainer.Builder();
+	private final StandalonePojoTypeContextContainer.Builder typeContextContainerBuilder;
 	private final SchemaManagementListener schemaManagementListener;
 
 	public StandalonePojoMapperDelegate(StandalonePojoEntityTypeMetadataProvider metadataProvider,
 			SchemaManagementListener schemaManagementListener) {
 		this.metadataProvider = metadataProvider;
+		this.typeContextContainerBuilder = new StandalonePojoTypeContextContainer.Builder( metadataProvider );
 		this.schemaManagementListener = schemaManagementListener;
 	}
 

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/session/SearchSession.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/session/SearchSession.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 
 import org.hibernate.search.engine.common.EntityReference;
 import org.hibernate.search.engine.search.query.dsl.SearchQuerySelectStep;
+import org.hibernate.search.mapper.pojo.standalone.mapping.StandalonePojoMappingConfigurationContext;
 import org.hibernate.search.mapper.pojo.standalone.massindexing.MassIndexer;
 import org.hibernate.search.mapper.pojo.standalone.schema.management.SearchSchemaManager;
 import org.hibernate.search.mapper.pojo.standalone.scope.SearchScope;
@@ -187,6 +188,30 @@ public interface SearchSession extends AutoCloseable {
 	 * @see SearchScope
 	 */
 	<T> SearchScope<T> scope(Collection<? extends Class<? extends T>> types);
+
+	/**
+	 * Create a {@link SearchScope} limited to entity types referenced by their name.
+	 *
+	 * @param expectedSuperType A supertype of all entity types to include in the scope.
+	 * @param entityName An entity name. See {@link StandalonePojoMappingConfigurationContext#addEntityType(Class, String)}.
+	 * @param <T> A supertype of all entity types to include in the scope.
+	 * @return The created scope.
+	 * @see SearchScope
+	 */
+	default <T> SearchScope<T> scope(Class<T> expectedSuperType, String entityName) {
+		return scope( expectedSuperType, Collections.singleton( entityName ) );
+	}
+
+	/**
+	 * Create a {@link SearchScope} limited to entity types referenced by their name.
+	 *
+	 * @param expectedSuperType A supertype of all entity types to include in the scope.
+	 * @param entityNames A collection of entity names. See {@link StandalonePojoMappingConfigurationContext#addEntityType(Class, String)}.
+	 * @param <T> A supertype of all entity types to include in the scope.
+	 * @return The created scope.
+	 * @see SearchScope
+	 */
+	<T> SearchScope<T> scope(Class<T> expectedSuperType, Collection<String> entityNames);
 
 	/**
 	 * @return The indexing plan for this session. It will be executed upon closing this session.

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/session/impl/StandalonePojoSearchSession.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/session/impl/StandalonePojoSearchSession.java
@@ -150,6 +150,11 @@ public class StandalonePojoSearchSession extends AbstractPojoSearchSession
 	}
 
 	@Override
+	public <T> SearchScopeImpl<T> scope(Class<T> expectedSuperType, Collection<String> entityNames) {
+		return mappingContext.createScope( expectedSuperType, entityNames );
+	}
+
+	@Override
 	public SearchIndexingPlan indexingPlan() {
 		if ( indexingPlan == null ) {
 			indexingPlan = new SearchIndexingPlanImpl(

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/session/impl/StandalonePojoSearchSessionMappingContext.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/session/impl/StandalonePojoSearchSessionMappingContext.java
@@ -19,4 +19,6 @@ public interface StandalonePojoSearchSessionMappingContext
 
 	<T> SearchScopeImpl<T> createScope(Collection<? extends Class<? extends T>> types);
 
+	<T> SearchScopeImpl<T> createScope(Class<T> expectedSuperType, Collection<String> entityNames);
+
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5067

Backport of #3927 to branch 7.0