### PR TITLE
HSEARCH-5070 Change macro to correctly display formulas in HTML docs / HSEARCH-5020 Add an assumption to a test on vector search capability of a backend

### DIFF
--- a/documentation/src/main/asciidoc/public/reference/_mapping-directfieldmapping.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_mapping-directfieldmapping.adoc
@@ -385,11 +385,19 @@ Only available on `@VectorField`.
 |===============
 |Value|Definition
 |`VectorSimilarity.L2`|An L2 (Euclidean) norm, that is a sensible default for most scenarios.
-Distance between vectors `x` and `y` is calculated as latexmath:[d(x,y) = \sqrt{\sum_{i=1}^{n} (x_i - y_i)^2 } ]
-and the score function is latexmath:[s = \frac{1}{1+d*d}]
+Distance between vectors `x` and `y` is calculated as
+ifdef::backend-html5[stem:[d(x,y) = \sqrt{\sum_{i=1}^{n} (x_i - y_i)^2 } ]]
+ifdef::backend-pdf[`d(x,y) = sqrt(sum[i=1; i<n+1]( (x(i) - y(i))*(x(i) - y(i)) )`]
+and the score function is
+ifdef::backend-html5[stem:[s = \frac{1}{1+d^2}]]
+ifdef::backend-pdf[`s = 1/(1+d*d)`]
 |`VectorSimilarity.DOT_PRODUCT`|Inner product (dot product in particular).
-Distance between vectors `x` and `y` is calculated as latexmath:[d(x,y) = \sum_{i=1}^{n} x_i \cdot y_i ]
-and the score function is latexmath:[s = \frac{1}{1+d}]
+Distance between vectors `x` and `y` is calculated as
+ifdef::backend-html5[stem:[d(x,y) = \sum_{i=1}^{n} x_i \cdot y_i ]]
+ifdef::backend-pdf[`d(x,y) = sum[i=1; i< n+1] ( x(i)*y(i) ) `]
+and the score function is
+ifdef::backend-html5[stem:[s = \frac{1}{1+d}]]
+ifdef::backend-pdf[`s = 1/(1+d)`]
 
 [WARNING]
 ====
@@ -400,14 +408,24 @@ while byte vectors should simply all have the same norm.
 ====
 
 |`VectorSimilarity.COSINE`|Cosine similarity.
-Distance between vectors `x` and `y` is calculated as latexmath:[d(x,y) = \frac{1 - \sum_{i=1} ^{n} x_i \cdot y_i }{ \sqrt{ \sum_{i=1} ^{n} x_i^2 } \sqrt{ \sum_{i=1} ^{n} y_i^2 }} ]
-and the score function is latexmath:[s = \frac{1}{1+d}]
+Distance between vectors `x` and `y` is calculated as
+ifdef::backend-html5[stem:[d(x,y) = \frac{1 - \sum_{i=1} ^{n} x_i \cdot y_i }{ \sqrt{ \sum_{i=1} ^{n} x_i^2 } \sqrt{ \sum_{i=1} ^{n} y_i^2 }} ]]
+ifdef::backend-pdf[`d(x,y) = (1 - sum[i=1; i<n+1] ( x(i)*y(i) )/( sqrt( sum[i=1; i<n+1] x(i)*x(i) ) sqrt( sum[i=1; i<n+1] y(i)*y(i) ) ) )`]
+and the score function is
+ifdef::backend-html5[stem:[s = \frac{1}{1+d}]]
+ifdef::backend-pdf[`s = 1/(1+d)`]
 |`VectorSimilarity.MAX_INNER_PRODUCT`|Similar to a dot product similarity, but does not require vector normalization.
-Distance between vectors `x` and `y` is calculated as latexmath:[d(x,y) = \sum_{i=1}^{n} x_i \cdot y_i ]
-and the score function is latexmath:[s = \begin{cases}
+Distance between vectors `x` and `y` is calculated as
+ifdef::backend-html5[stem:[d(x,y) = \sum_{i=1}^{n} x_i \cdot y_i ]]
+ifdef::backend-pdf[`d(x,y) = sum[i=1; i<n+1] ( x(i)*y(i) )`]
+and the score function is
+ifdef::backend-html5[]
+stem:[s = \begin{cases}
 \frac{1}{1-d} & \text{if d < 0}\\
 d+1 & \text{otherwise}
 \end{cases} ]
+endif::[]
+ifdef::backend-pdf[`d<0 ? 1/(1-d) : d+1`]
 |`VectorSimilarity.DEFAULT`|Use the backend-specific default. For the <<backend-lucene, Lucene backend>> an `L2` similarity is used.
 |===============
 +

--- a/documentation/src/main/asciidoc/public/reference/index.adoc
+++ b/documentation/src/main/asciidoc/public/reference/index.adoc
@@ -8,6 +8,7 @@
 :docinfodir: {docinfodir}
 :docinfo: shared,private
 :title-logo-image: image:hibernate_logo_a.png[align=left,pdfwidth=33%]
+:stem: latexmath
 
 :relfileprefix: ../../
 :relfilesuffix: /../en-US/html_single/index.html

--- a/integrationtest/mapper/pojo-standalone-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/standalone/realbackend/mapping/VectorFieldIT.java
+++ b/integrationtest/mapper/pojo-standalone-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/standalone/realbackend/mapping/VectorFieldIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.integrationtest.mapper.pojo.standalone.realbackend.
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
@@ -42,6 +43,7 @@ import org.hibernate.search.util.impl.integrationtest.common.reporting.FailureRe
 import org.hibernate.search.util.impl.integrationtest.common.reporting.FailureReportUtils;
 import org.hibernate.search.util.impl.integrationtest.mapper.pojo.standalone.StandalonePojoMappingSetupHelper;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -56,6 +58,14 @@ class VectorFieldIT {
 	@RegisterExtension
 	public StandalonePojoMappingSetupHelper setupHelper = StandalonePojoMappingSetupHelper.withSingleBackend(
 			MethodHandles.lookup(), BackendConfigurations.simple() );
+
+	@BeforeAll
+	static void beforeAll() {
+		assumeTrue(
+				isVectorSearchSupported(),
+				"This test only makes sense if the backend supports vectors and vector search."
+		);
+	}
 
 	/*
 	 * While for the test of the max-allowed dimension it would be enough to index a single document and then search for it,
@@ -250,5 +260,14 @@ class VectorFieldIT {
 			}
 			return floats;
 		}
+	}
+
+	private static boolean isVectorSearchSupported() {
+		return BackendConfiguration.isLucene()
+				|| ElasticsearchTestDialect.isActualVersion(
+						es -> !es.isLessThan( "8.12.0" ),
+						os -> !os.isLessThan( "2.0.0" ),
+						aoss -> true
+				);
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5070
https://hibernate.atlassian.net/browse/HSEARCH-5020

I've noticed that https://docs.jboss.org/hibernate/search/7.1/reference/en-US/html_single/#mapping-directfieldmapping-vectorSimilarity shows unrendered formulas ... 🙈 
this should address that.... though as for the pdf ... it won't https://docs.asciidoctor.org/pdf-converter/latest/stem/ and as far as I can see there's no `asciidoctorJ-mathematical` to add it as a dependency 🙈  so  in pdf it shows up as:
![image](https://github.com/hibernate/hibernate-search/assets/4004823/e72a8a9d-6f03-4606-868d-bb64e2837344)
