### PR TITLE
Move setting of net.bytebuddy.experimental to the Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -180,11 +180,15 @@ stage('Configure') {
 					new JdkBuildEnvironment(version: '21', testCompilerTool: 'OpenJDK 21 Latest',
 							testLauncherArgs: '--enable-preview',
 							condition: TestCondition.AFTER_MERGE),
+					// The following JDKs aren't supported by Hibernate ORM out-of-the box yet:
+					// they require the use of -Dnet.bytebuddy.experimental=true.
+					// Make sure to remove that argument as soon as possible
+					// -- generally that requires upgrading bytebuddy in Hibernate ORM after the JDK goes GA.
 					new JdkBuildEnvironment(version: '22', testCompilerTool: 'OpenJDK 22 Latest',
-							testLauncherArgs: '--enable-preview',
+							testLauncherArgs: '--enable-preview -Dnet.bytebuddy.experimental=true',
 							condition: TestCondition.AFTER_MERGE),
 					new JdkBuildEnvironment(version: '23', testCompilerTool: 'OpenJDK 23 Latest',
-							testLauncherArgs: '--enable-preview',
+							testLauncherArgs: '--enable-preview -Dnet.bytebuddy.experimental=true',
 							condition: TestCondition.AFTER_MERGE)
 			],
 			compiler: [

--- a/pom.xml
+++ b/pom.xml
@@ -1458,11 +1458,6 @@
                 </property>
             </activation>
             <properties>
-                <!-- We need net.bytebuddy.experimental=true to make BytecodeEnhancementIT and mockito-based tests pass -->
-                <surefire.jvm.args.java-version>
-                    -Djdk.attach.allowAttachSelf=true
-                    -Dnet.bytebuddy.experimental=true
-                </surefire.jvm.args.java-version>
                 <!-- impsort-maven-plugin doesn't work with JDK22 yet -->
                 <format.skip>true</format.skip>
             </properties>
@@ -1476,11 +1471,6 @@
                 </property>
             </activation>
             <properties>
-                <!-- We need net.bytebuddy.experimental=true to make BytecodeEnhancementIT and mockito-based tests pass -->
-                <surefire.jvm.args.java-version>
-                    -Djdk.attach.allowAttachSelf=true
-                    -Dnet.bytebuddy.experimental=true
-                </surefire.jvm.args.java-version>
                 <!-- Spring Boot 3 isn't ready for JDK23 yet -->
                 <failsafe.spring.skip>true</failsafe.spring.skip>
                 <!-- impsort-maven-plugin doesn't work with JDK23 yet -->


### PR DESCRIPTION
The hope is that whenever we add a new JDK version to test, we'll notice this setting, will try to remove it and upgrade bytebuddy if necessary. This would avoid mess-ups like the one that caused https://github.com/hibernate/hibernate-orm/pull/7790