### PR TITLE
HSEARCH-4961 API to list all analyzer names

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/analysis/impl/ElasticsearchAnalysisDescriptor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/analysis/impl/ElasticsearchAnalysisDescriptor.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.analysis.impl;
+
+import java.util.Objects;
+
+import org.hibernate.search.engine.backend.analysis.AnalyzerDescriptor;
+import org.hibernate.search.engine.backend.analysis.NormalizerDescriptor;
+
+public class ElasticsearchAnalysisDescriptor
+		implements AnalyzerDescriptor,
+		NormalizerDescriptor {
+
+
+	private final String name;
+
+	public ElasticsearchAnalysisDescriptor(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public String name() {
+		return name;
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if ( this == object ) {
+			return true;
+		}
+		if ( object == null || getClass() != object.getClass() ) {
+			return false;
+		}
+		ElasticsearchAnalysisDescriptor that = (ElasticsearchAnalysisDescriptor) object;
+		return Objects.equals( name, that.name );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( name );
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/analysis/model/impl/ElasticsearchAnalysisDefinitionRegistry.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/analysis/model/impl/ElasticsearchAnalysisDefinitionRegistry.java
@@ -7,16 +7,25 @@
 package org.hibernate.search.backend.elasticsearch.analysis.model.impl;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
+import org.hibernate.search.backend.elasticsearch.analysis.impl.ElasticsearchAnalysisDescriptor;
 import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.AnalyzerDefinition;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.CharFilterDefinition;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.NormalizerDefinition;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.TokenFilterDefinition;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.analysis.impl.TokenizerDefinition;
+import org.hibernate.search.engine.backend.analysis.AnalyzerDescriptor;
+import org.hibernate.search.engine.backend.analysis.NormalizerDescriptor;
+import org.hibernate.search.engine.backend.analysis.spi.AnalysisDescriptorRegistry;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 /**
@@ -26,7 +35,7 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
  * (see {@link #getAnalyzerDefinitions} for instance).
  *
  */
-public final class ElasticsearchAnalysisDefinitionRegistry {
+public final class ElasticsearchAnalysisDefinitionRegistry implements AnalysisDescriptorRegistry {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
@@ -110,4 +119,39 @@ public final class ElasticsearchAnalysisDefinitionRegistry {
 		return Collections.unmodifiableMap( charFilterDefinitions );
 	}
 
+	@Override
+	public Optional<? extends AnalyzerDescriptor> analyzerDescriptor(String name) {
+		if ( analyzerDefinitions.containsKey( name ) ) {
+			return Optional.of( new ElasticsearchAnalysisDescriptor( name ) );
+		}
+		else {
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	public Collection<? extends AnalyzerDescriptor> analyzerDescriptors() {
+		Set<AnalyzerDescriptor> descriptors = new HashSet<>();
+		for ( String name : analyzerDefinitions.keySet() ) {
+			descriptors.add( new ElasticsearchAnalysisDescriptor( name ) );
+		}
+		return Collections.unmodifiableSet( descriptors );
+	}
+
+	@Override
+	public Optional<? extends NormalizerDescriptor> normalizerDescriptor(String name) {
+		if ( normalizerDefinitions.containsKey( name ) ) {
+			return Optional.of( new ElasticsearchAnalysisDescriptor( name ) );
+		}
+		else {
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	public Collection<? extends NormalizerDescriptor> normalizerDescriptors() {
+		return normalizerDefinitions.keySet().stream()
+				.map( ElasticsearchAnalysisDescriptor::new )
+				.collect( Collectors.toUnmodifiableSet() );
+	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/ElasticsearchIndexModel.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/ElasticsearchIndexModel.java
@@ -40,7 +40,8 @@ public class ElasticsearchIndexModel
 			PropertyMappingIndexSettingsContributor propertyMappingIndexSettingsContributor,
 			IndexSettings customIndexSettings,
 			RootTypeMapping mapping, RootTypeMapping customMapping) {
-		super( names.hibernateSearchIndex(), mappedTypeName, identifier, rootNode, staticFields, fieldTemplates );
+		super( analysisDefinitionRegistry, names.hibernateSearchIndex(), mappedTypeName, identifier, rootNode, staticFields,
+				fieldTemplates );
 		this.names = names;
 		this.analysisDefinitionRegistry = analysisDefinitionRegistry;
 		this.propertyMappingIndexSettingsContributor = propertyMappingIndexSettingsContributor;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/analysis/impl/LuceneAnalysisDescriptor.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/analysis/impl/LuceneAnalysisDescriptor.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.analysis.impl;
+
+import java.util.Objects;
+
+import org.hibernate.search.engine.backend.analysis.AnalyzerDescriptor;
+import org.hibernate.search.engine.backend.analysis.NormalizerDescriptor;
+
+import org.apache.lucene.analysis.Analyzer;
+
+public class LuceneAnalysisDescriptor implements AnalyzerDescriptor, NormalizerDescriptor {
+
+	protected final String name;
+	protected final Analyzer analyzer;
+
+	public LuceneAnalysisDescriptor(String name, Analyzer analyzer) {
+		this.name = name;
+		this.analyzer = analyzer;
+	}
+
+	@Override
+	public String name() {
+		return name;
+	}
+
+	public Analyzer analyzer() {
+		return analyzer;
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if ( this == object ) {
+			return true;
+		}
+		if ( object == null || getClass() != object.getClass() ) {
+			return false;
+		}
+		LuceneAnalysisDescriptor that = (LuceneAnalysisDescriptor) object;
+		return Objects.equals( name, that.name ) && Objects.equals( analyzer, that.analyzer );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( name, analyzer );
+	}
+
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexRootBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexRootBuilder.java
@@ -130,7 +130,7 @@ public class LuceneIndexRootBuilder extends AbstractLuceneIndexCompositeNodeBuil
 		LuceneIndexRoot rootNode = new LuceneIndexRoot( typeBuilder.build(), staticChildrenByName );
 		contributeChildren( rootNode, collector, staticChildrenByName );
 
-		return new LuceneIndexModel( indexName, mappedTypeName, identifier,
+		return new LuceneIndexModel( analysisDefinitionRegistry, indexName, mappedTypeName, identifier,
 				rootNode, staticFields, fieldTemplates, hasNestedDocument[0] );
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexModel.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexModel.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import org.hibernate.search.backend.lucene.lowlevel.codec.impl.HibernateSearchLuceneCodec;
 import org.hibernate.search.backend.lucene.lowlevel.common.impl.AnalyzerConstants;
+import org.hibernate.search.engine.backend.analysis.spi.AnalysisDescriptorRegistry;
 import org.hibernate.search.engine.backend.document.model.spi.AbstractIndexModel;
 import org.hibernate.search.engine.backend.document.model.spi.IndexFieldFilter;
 import org.hibernate.search.engine.backend.document.model.spi.IndexIdentifier;
@@ -29,12 +30,14 @@ public class LuceneIndexModel extends AbstractIndexModel<LuceneIndexModel, Lucen
 	private final SearchScopedAnalyzer searchAnalyzer;
 	private final Codec codec;
 
-	public LuceneIndexModel(String hibernateSearchName, String mappedTypeName,
+	public LuceneIndexModel(AnalysisDescriptorRegistry analysisDescriptorRegistry, String hibernateSearchName,
+			String mappedTypeName,
 			IndexIdentifier identifier,
 			LuceneIndexRoot rootNode, Map<String, LuceneIndexField> staticFields,
 			List<? extends AbstractLuceneIndexFieldTemplate<?>> fieldTemplates,
 			boolean hasNestedDocuments) {
-		super( hibernateSearchName, mappedTypeName, identifier, rootNode, staticFields, fieldTemplates );
+		super( analysisDescriptorRegistry, hibernateSearchName, mappedTypeName, identifier, rootNode, staticFields,
+				fieldTemplates );
 		this.indexingAnalyzer = new IndexingScopedAnalyzer();
 		this.searchAnalyzer = new SearchScopedAnalyzer();
 		this.hasNestedDocuments = hasNestedDocuments;

--- a/documentation/src/main/asciidoc/public/reference/_mapping-inspect.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_mapping-inspect.adoc
@@ -52,6 +52,14 @@ what are the analyzers/normalizer set on this field,
 each trait represents a predicate/sort/projection/aggregation
 that can be used on fields of that type.
 <10> Object fields can also be inspected.
+<11> A collection of all configured analyzers
+available for the index represented by the descriptor can also be inspected.
+<12> Alternatively, analyzer descriptors can be retrieved by name
+to see if a particular analyzer is available within the index context.
+<13> A collection of all configured normalizers
+available for the index represented by the descriptor can also be inspected.
+<14> Alternatively, normalizer descriptors can be retrieved by name
+to see if a particular normalizer is available within the index context.
 ====
 
 [TIP]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedentities/SearchMappingIndexedEntitiesIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexedentities/SearchMappingIndexedEntitiesIT.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 
@@ -18,6 +19,8 @@ import jakarta.persistence.EntityManagerFactory;
 import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.engine.backend.Backend;
+import org.hibernate.search.engine.backend.analysis.AnalyzerDescriptor;
+import org.hibernate.search.engine.backend.analysis.NormalizerDescriptor;
 import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.backend.metamodel.IndexDescriptor;
 import org.hibernate.search.engine.backend.metamodel.IndexObjectFieldDescriptor;
@@ -139,6 +142,24 @@ class SearchMappingIndexedEntitiesIT {
 				// Etc.
 			}
 		} );
+
+		Collection<? extends AnalyzerDescriptor> analyzerDescriptors = indexDescriptor.analyzers(); // <11>
+		for ( AnalyzerDescriptor analyzerDescriptor : analyzerDescriptors ) {
+			String analyzerName = analyzerDescriptor.name();
+			// ...
+		}
+
+		Optional<? extends AnalyzerDescriptor> analyzerDescriptor = indexDescriptor.analyzer( "some-analyzer-name" ); // <12>
+		// ...
+
+		Collection<? extends NormalizerDescriptor> normalizerDescriptors = indexDescriptor.normalizers(); // <13>
+		for ( NormalizerDescriptor normalizerDescriptor : normalizerDescriptors ) {
+			String normalizerName = normalizerDescriptor.name();
+			// ...
+		}
+
+		Optional<? extends NormalizerDescriptor> normalizerDescriptor = indexDescriptor.normalizer( "some-normalizer-name" ); // <14>
+		// ...
 		//end::indexMetamodel[]
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/backend/analysis/AnalysisDescriptor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/analysis/AnalysisDescriptor.java
@@ -1,0 +1,24 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.backend.analysis;
+
+import org.hibernate.search.util.common.annotation.Incubating;
+
+/**
+ * A descriptor of an abstract analysis concept.
+ *
+ * @see AnalyzerDescriptor
+ * @see NormalizerDescriptor
+ */
+@Incubating
+public interface AnalysisDescriptor {
+
+	/**
+	 * @return The name that identifies the concept behind this descriptor.
+	 */
+	String name();
+}

--- a/engine/src/main/java/org/hibernate/search/engine/backend/analysis/AnalyzerDescriptor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/analysis/AnalyzerDescriptor.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.backend.analysis;
+
+import org.hibernate.search.util.common.annotation.Incubating;
+
+/**
+ * A descriptor of an analyzer, exposing in particular the name of the analyzer.
+ */
+@Incubating
+public interface AnalyzerDescriptor extends AnalysisDescriptor {
+}

--- a/engine/src/main/java/org/hibernate/search/engine/backend/analysis/NormalizerDescriptor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/analysis/NormalizerDescriptor.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.backend.analysis;
+
+import org.hibernate.search.util.common.annotation.Incubating;
+
+/**
+ * A descriptor of a normalizer, exposing in particular the name of the normalizer.
+ */
+@Incubating
+public interface NormalizerDescriptor extends AnalysisDescriptor {
+}

--- a/engine/src/main/java/org/hibernate/search/engine/backend/analysis/spi/AnalysisDescriptorRegistry.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/analysis/spi/AnalysisDescriptorRegistry.java
@@ -1,0 +1,44 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.backend.analysis.spi;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import org.hibernate.search.engine.backend.analysis.AnalyzerDescriptor;
+import org.hibernate.search.engine.backend.analysis.NormalizerDescriptor;
+import org.hibernate.search.util.common.annotation.Incubating;
+
+@Incubating
+public interface AnalysisDescriptorRegistry {
+
+	/**
+	 * Looks up the configured analyzers.
+	 *
+	 * @param name The name of the analyzer.
+	 * @return An {@link Optional#empty() empty optional} if there is no analyzer configured with the given name.
+	 */
+	Optional<? extends AnalyzerDescriptor> analyzerDescriptor(String name);
+
+	/**
+	 * @return A collection of configured analyzer descriptors.
+	 */
+	Collection<? extends AnalyzerDescriptor> analyzerDescriptors();
+
+	/**
+	 * Looks up the configured normalizers.
+	 *
+	 * @param name The name of the normalizer.
+	 * @return An {@link Optional#empty() empty optional} if there is no normalizer configured with the given name.
+	 */
+	Optional<? extends NormalizerDescriptor> normalizerDescriptor(String name);
+
+	/**
+	 * @return A collection of configured normalizer descriptors.
+	 */
+	Collection<? extends NormalizerDescriptor> normalizerDescriptors();
+}

--- a/engine/src/main/java/org/hibernate/search/engine/backend/metamodel/IndexDescriptor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/metamodel/IndexDescriptor.java
@@ -10,7 +10,10 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Function;
 
+import org.hibernate.search.engine.backend.analysis.AnalyzerDescriptor;
+import org.hibernate.search.engine.backend.analysis.NormalizerDescriptor;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.util.common.annotation.Incubating;
 
 /**
  * A descriptor of an index, exposing in particular the available fields and their characteristics.
@@ -51,5 +54,35 @@ public interface IndexDescriptor {
 	 * @return A collection containing all fields.
 	 */
 	Collection<IndexFieldDescriptor> staticFields();
+
+	/**
+	 * Looks up the configured analyzers available to the index represented by this descriptor.
+	 *
+	 * @param name The name of the analyzer.
+	 * @return An {@link Optional#empty() empty optional} if there is no analyzer configured with the given name.
+	 */
+	@Incubating
+	Optional<? extends AnalyzerDescriptor> analyzer(String name);
+
+	/**
+	 * @return A collection of configured analyzer descriptors available to the index represented by this descriptor.
+	 */
+	@Incubating
+	Collection<? extends AnalyzerDescriptor> analyzers();
+
+	/**
+	 * Looks up the configured normalizers available to the index represented by this descriptor.
+	 *
+	 * @param name The name of the normalizer.
+	 * @return An {@link Optional#empty() empty optional} if there is no normalizer configured with the given name.
+	 */
+	@Incubating
+	Optional<? extends NormalizerDescriptor> normalizer(String name);
+
+	/**
+	 * @return A collection of configured normalizer descriptors available to the index represented by this descriptor.
+	 */
+	@Incubating
+	Collection<? extends NormalizerDescriptor> normalizers();
 
 }

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -279,4 +279,9 @@ public class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 				return true;
 		}
 	}
+
+	@Override
+	public boolean hasBuiltInAnalyzerDescriptorsAvailable() {
+		return false;
+	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/analysis/AnalysisBuiltinOverrideIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/analysis/AnalysisBuiltinOverrideIT.java
@@ -6,10 +6,13 @@
  */
 package org.hibernate.search.integrationtest.backend.tck.analysis;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
 
+import java.util.Collection;
 import java.util.function.Consumer;
 
+import org.hibernate.search.engine.backend.analysis.AnalyzerDescriptor;
 import org.hibernate.search.engine.backend.analysis.AnalyzerNames;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
@@ -74,6 +77,29 @@ class AnalysisBuiltinOverrideIT {
 	@Test
 	void analyzer_keyword() {
 		verifyOverride( index.binding().keywordAnalyzer );
+	}
+
+	@Test
+	void indexAnalyzerDescriptor() {
+		Collection<? extends AnalyzerDescriptor> analyzerDescriptors = index.toApi().descriptor().analyzers();
+		assertThat( analyzerDescriptors )
+				.isNotEmpty()
+				.extracting( AnalyzerDescriptor::name )
+				.containsExactlyInAnyOrder(
+						AnalyzerNames.DEFAULT,
+						AnalyzerNames.STOP,
+						AnalyzerNames.KEYWORD,
+						AnalyzerNames.WHITESPACE,
+						AnalyzerNames.SIMPLE,
+						AnalyzerNames.STANDARD
+				);
+
+		for ( AnalyzerDescriptor descriptor : analyzerDescriptors ) {
+			assertThat( index.toApi().descriptor().analyzer( descriptor.name() ) )
+					.isPresent()
+					.get()
+					.isEqualTo( descriptor );
+		}
 	}
 
 	private void verifyOverride(SimpleFieldModel<String> field) {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
@@ -145,4 +145,7 @@ public abstract class TckBackendFeatures implements StubMappingBackendFeatures {
 		return true;
 	}
 
+	public boolean hasBuiltInAnalyzerDescriptorsAvailable() {
+		return true;
+	}
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/dsl/impl/StubIndexRootBuilder.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/dsl/impl/StubIndexRootBuilder.java
@@ -6,9 +6,15 @@
  */
 package org.hibernate.search.util.impl.integrationtest.common.stub.backend.document.model.dsl.impl;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 
+import org.hibernate.search.engine.backend.analysis.AnalyzerDescriptor;
+import org.hibernate.search.engine.backend.analysis.NormalizerDescriptor;
+import org.hibernate.search.engine.backend.analysis.spi.AnalysisDescriptorRegistry;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexRootBuilder;
 import org.hibernate.search.engine.backend.document.model.spi.IndexIdentifier;
 import org.hibernate.search.engine.backend.types.ObjectStructure;
@@ -83,7 +89,8 @@ public class StubIndexRootBuilder extends AbstractStubIndexCompositeNodeBuilder
 		type.apply( schemaDataNodeBuilder );
 		StubIndexRoot root = new StubIndexRoot( type, staticChildren, schemaDataNodeBuilder.build() );
 		contributeChildren( root, staticChildren, allFields::put );
-		return new StubIndexModel( indexName, mappedTypeName, identifier, root, allFields );
+		return new StubIndexModel( StubAnalysisDescriptorRegistry.REGISTRY, indexName, mappedTypeName, identifier, root,
+				allFields );
 	}
 
 	@Override
@@ -101,5 +108,29 @@ public class StubIndexRootBuilder extends AbstractStubIndexCompositeNodeBuilder
 
 	String getIndexName() {
 		return indexName;
+	}
+
+	private static class StubAnalysisDescriptorRegistry implements AnalysisDescriptorRegistry {
+		private static final StubAnalysisDescriptorRegistry REGISTRY = new StubAnalysisDescriptorRegistry();
+
+		@Override
+		public Optional<? extends AnalyzerDescriptor> analyzerDescriptor(String name) {
+			return Optional.empty();
+		}
+
+		@Override
+		public Collection<? extends AnalyzerDescriptor> analyzerDescriptors() {
+			return Collections.emptySet();
+		}
+
+		@Override
+		public Optional<? extends NormalizerDescriptor> normalizerDescriptor(String name) {
+			return Optional.empty();
+		}
+
+		@Override
+		public Collection<? extends NormalizerDescriptor> normalizerDescriptors() {
+			return Collections.emptySet();
+		}
 	}
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/impl/StubIndexModel.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/impl/StubIndexModel.java
@@ -9,14 +9,17 @@ package org.hibernate.search.util.impl.integrationtest.common.stub.backend.docum
 import java.util.Collections;
 import java.util.Map;
 
+import org.hibernate.search.engine.backend.analysis.spi.AnalysisDescriptorRegistry;
 import org.hibernate.search.engine.backend.document.model.spi.AbstractIndexModel;
 import org.hibernate.search.engine.backend.document.model.spi.IndexIdentifier;
 
 public class StubIndexModel extends AbstractIndexModel<StubIndexModel, StubIndexRoot, StubIndexField> {
 
-	public StubIndexModel(String hibernateSearchIndexName, String mappedTypeName,
+	public StubIndexModel(AnalysisDescriptorRegistry analysisDescriptorRegistry, String hibernateSearchIndexName,
+			String mappedTypeName,
 			IndexIdentifier identifier, StubIndexRoot root, Map<String, StubIndexField> fields) {
-		super( hibernateSearchIndexName, mappedTypeName, identifier, root, fields, Collections.emptyList() );
+		super( analysisDescriptorRegistry, hibernateSearchIndexName, mappedTypeName, identifier, root, fields,
+				Collections.emptyList() );
 	}
 
 	@Override


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4961

WDYT?  😃 I've ended up adding backend-specific methods to backends since, in the case of the ES backend, we'd need to pass an index name + the name of the analyzer... so it won't match the Lucene case.. and forcing to pass index name for Lucene... I wasn't sure it would be ok 😃 