### PR TITLE
HSEARCH-5039 Tenant filter should be a pre-filter for knn predicates

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -880,4 +880,9 @@ public interface Log extends BasicLogger {
 					+ " Try using a different similarity type and refer to the OpenSearch documentation for more details.")
 	SearchException vectorSimilarityNotSupportedByOpenSearchBackend(VectorSimilarity vectorSimilarity);
 
+	@LogMessage(level = Level.WARN)
+	@Message(id = ID_OFFSET + 189,
+			value = "Using a knn predicate in the nested context when tenant or routing filters are required "
+					+ "will lead to unpredictable results and may return fewer documents then expected.")
+	void knnUsedInNestedContextRequiresFilters();
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/lowlevel/query/impl/Queries.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/lowlevel/query/impl/Queries.java
@@ -49,7 +49,7 @@ public final class Queries {
 	}
 
 	public static JsonObject boolFilter(JsonObject must, JsonArray filters) {
-		if ( filters == null || filters.size() == 0 ) {
+		if ( filters == null || filters.isEmpty() ) {
 			return must;
 		}
 
@@ -61,6 +61,27 @@ public final class Queries {
 			innerObject.add( "must", must );
 		}
 		innerObject.add( "filter", filters );
+
+		return predicate;
+	}
+
+	public static JsonObject boolCombineMust(JsonObject must, JsonArray otherMustClauses) {
+		if ( otherMustClauses == null || otherMustClauses.isEmpty() ) {
+			return must;
+		}
+		if ( must == null && otherMustClauses.size() == 1 ) {
+			return otherMustClauses.get( 0 ).getAsJsonObject();
+		}
+
+		JsonObject predicate = new JsonObject();
+		JsonObject innerObject = new JsonObject();
+		predicate.add( "bool", innerObject );
+		JsonArray mustClauses = new JsonArray();
+		if ( must != null ) {
+			mustClauses.add( must );
+		}
+		mustClauses.addAll( otherMustClauses );
+		innerObject.add( "must", mustClauses );
 
 		return predicate;
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchKnnPredicate.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchKnnPredicate.java
@@ -49,7 +49,13 @@ public abstract class ElasticsearchKnnPredicate extends AbstractElasticsearchSin
 	protected JsonObject prepareFilter(PredicateRequestContext context) {
 		JsonObject mainFilter = filter == null ? null : filter.toJsonQuery( context );
 		JsonArray filters = context.tenantAndRoutingFilters();
-		return Queries.boolCombineMust( mainFilter, filters );
+		if ( context.getNestedPath() == null ) {
+			return Queries.boolCombineMust( mainFilter, filters );
+		}
+		else if ( !filters.isEmpty() ) {
+			log.knnUsedInNestedContextRequiresFilters();
+		}
+		return mainFilter;
 	}
 
 	public static class Elasticsearch812Factory<F>

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchKnnPredicate.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchKnnPredicate.java
@@ -47,16 +47,9 @@ public abstract class ElasticsearchKnnPredicate extends AbstractElasticsearchSin
 	}
 
 	protected JsonObject prepareFilter(PredicateRequestContext context) {
-		String tenantIdentifier = context.getTenantId();
-		if ( tenantIdentifier != null ) {
-			JsonObject tenantFilter = context.getSearchIndexScope().filterOrNull( tenantIdentifier );
-			if ( tenantFilter != null ) {
-				JsonArray filters = new JsonArray();
-				filters.add( tenantFilter );
-				return filter == null ? tenantFilter : Queries.boolFilter( filter.toJsonQuery( context ), filters );
-			}
-		}
-		return filter == null ? null : filter.toJsonQuery( context );
+		JsonObject mainFilter = filter == null ? null : filter.toJsonQuery( context );
+		JsonArray filters = context.tenantAndRoutingFilters();
+		return Queries.boolCombineMust( mainFilter, filters );
 	}
 
 	public static class Elasticsearch812Factory<F>

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/PredicateRequestContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/PredicateRequestContext.java
@@ -6,23 +6,34 @@
  */
 package org.hibernate.search.backend.elasticsearch.search.predicate.impl;
 
+import java.util.Set;
+
+import org.hibernate.search.backend.elasticsearch.lowlevel.query.impl.Queries;
 import org.hibernate.search.backend.elasticsearch.search.common.impl.ElasticsearchSearchIndexScope;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 
 public class PredicateRequestContext {
 
 	private final BackendSessionContext sessionContext;
 	private final ElasticsearchSearchIndexScope<?> searchIndexScope;
+	private final Set<String> routingKeys;
 	private final String nestedPath;
 
-	public PredicateRequestContext(BackendSessionContext sessionContext, ElasticsearchSearchIndexScope<?> searchIndexScope) {
-		this( sessionContext, searchIndexScope, null );
+
+	public PredicateRequestContext(BackendSessionContext sessionContext, ElasticsearchSearchIndexScope<?> searchIndexScope,
+			Set<String> routingKeys) {
+		this( sessionContext, searchIndexScope, routingKeys, null );
 	}
 
-	private PredicateRequestContext(BackendSessionContext sessionContext, ElasticsearchSearchIndexScope<?> searchIndexScope,
-			String nestedPath) {
+	private PredicateRequestContext(BackendSessionContext sessionContext,
+			ElasticsearchSearchIndexScope<?> searchIndexScope,
+			Set<String> routingKeys, String nestedPath) {
 		this.sessionContext = sessionContext;
 		this.searchIndexScope = searchIndexScope;
+		this.routingKeys = routingKeys;
 		this.nestedPath = nestedPath;
 	}
 
@@ -34,11 +45,19 @@ public class PredicateRequestContext {
 		return sessionContext.tenantIdentifier();
 	}
 
-	public ElasticsearchSearchIndexScope<?> getSearchIndexScope() {
-		return searchIndexScope;
+	public JsonArray tenantAndRoutingFilters() {
+		JsonArray filters = new JsonArray();
+		JsonObject filter = searchIndexScope.filterOrNull( sessionContext.tenantIdentifier() );
+		if ( filter != null ) {
+			filters.add( filter );
+		}
+		if ( !routingKeys.isEmpty() ) {
+			filters.add( Queries.anyTerm( "_routing", routingKeys ) );
+		}
+		return filters;
 	}
 
 	public PredicateRequestContext withNestedPath(String path) {
-		return new PredicateRequestContext( sessionContext, searchIndexScope, path );
+		return new PredicateRequestContext( sessionContext, searchIndexScope, routingKeys, path );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/PredicateRequestContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/PredicateRequestContext.java
@@ -6,20 +6,23 @@
  */
 package org.hibernate.search.backend.elasticsearch.search.predicate.impl;
 
+import org.hibernate.search.backend.elasticsearch.search.common.impl.ElasticsearchSearchIndexScope;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
 
 public class PredicateRequestContext {
 
 	private final BackendSessionContext sessionContext;
+	private final ElasticsearchSearchIndexScope<?> searchIndexScope;
 	private final String nestedPath;
 
-	public PredicateRequestContext(BackendSessionContext sessionContext) {
-		this.sessionContext = sessionContext;
-		this.nestedPath = null;
+	public PredicateRequestContext(BackendSessionContext sessionContext, ElasticsearchSearchIndexScope<?> searchIndexScope) {
+		this( sessionContext, searchIndexScope, null );
 	}
 
-	private PredicateRequestContext(BackendSessionContext sessionContext, String nestedPath) {
+	private PredicateRequestContext(BackendSessionContext sessionContext, ElasticsearchSearchIndexScope<?> searchIndexScope,
+			String nestedPath) {
 		this.sessionContext = sessionContext;
+		this.searchIndexScope = searchIndexScope;
 		this.nestedPath = nestedPath;
 	}
 
@@ -31,7 +34,11 @@ public class PredicateRequestContext {
 		return sessionContext.tenantIdentifier();
 	}
 
+	public ElasticsearchSearchIndexScope<?> getSearchIndexScope() {
+		return searchIndexScope;
+	}
+
 	public PredicateRequestContext withNestedPath(String path) {
-		return new PredicateRequestContext( sessionContext, path );
+		return new PredicateRequestContext( sessionContext, searchIndexScope, path );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryBuilder.java
@@ -72,7 +72,7 @@ public class ElasticsearchSearchQueryBuilder<H>
 	private final Integer scrollTimeout;
 
 	private final Set<String> routingKeys;
-	private JsonObject jsonPredicate;
+	private ElasticsearchSearchPredicate elasticsearchPredicate;
 	private JsonArray jsonSort;
 	private Map<DistanceSortKey, Integer> distanceSorts;
 	private Map<AggregationKey<?>, ElasticsearchSearchAggregation<?>> aggregations;
@@ -101,7 +101,7 @@ public class ElasticsearchSearchQueryBuilder<H>
 		this.sessionContext = sessionContext;
 		this.routingKeys = new HashSet<>();
 
-		this.rootPredicateContext = new PredicateRequestContext( sessionContext );
+		this.rootPredicateContext = new PredicateRequestContext( sessionContext, scope );
 		this.loadingContextBuilder = loadingContextBuilder;
 		this.rootProjection = rootProjection;
 		this.scrollTimeout = scrollTimeout;
@@ -110,7 +110,7 @@ public class ElasticsearchSearchQueryBuilder<H>
 	@Override
 	public void predicate(SearchPredicate predicate) {
 		ElasticsearchSearchPredicate elasticsearchPredicate = ElasticsearchSearchPredicate.from( scope, predicate );
-		this.jsonPredicate = elasticsearchPredicate.toJsonQuery( rootPredicateContext );
+		this.elasticsearchPredicate = elasticsearchPredicate;
 	}
 
 	@Override
@@ -231,6 +231,8 @@ public class ElasticsearchSearchQueryBuilder<H>
 		if ( !routingKeys.isEmpty() ) {
 			filters.add( Queries.anyTerm( "_routing", routingKeys ) );
 		}
+
+		JsonObject jsonPredicate = elasticsearchPredicate.toJsonQuery( rootPredicateContext );
 
 		JsonObject jsonQuery = Queries.boolFilter( jsonPredicate, filters );
 		if ( jsonQuery != null ) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/aggregation/impl/AggregationExtractContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/aggregation/impl/AggregationExtractContext.java
@@ -9,6 +9,9 @@ package org.hibernate.search.backend.lucene.search.aggregation.impl;
 import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorKey;
 import org.hibernate.search.backend.lucene.lowlevel.join.impl.NestedDocsProvider;
 import org.hibernate.search.backend.lucene.search.extraction.impl.HibernateSearchMultiCollectorManager;
+import org.hibernate.search.backend.lucene.search.predicate.impl.PredicateRequestContext;
+import org.hibernate.search.backend.lucene.search.query.impl.LuceneSearchQueryIndexScope;
+import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
 import org.hibernate.search.engine.backend.types.converter.runtime.FromDocumentValueConvertContext;
 
 import org.apache.lucene.index.IndexReader;
@@ -17,16 +20,25 @@ import org.apache.lucene.search.Query;
 
 public class AggregationExtractContext {
 
+	private final LuceneSearchQueryIndexScope<?> queryIndexScope;
+	private final BackendSessionContext sessionContext;
 	private final IndexReader indexReader;
 	private final FromDocumentValueConvertContext fromDocumentValueConvertContext;
 	private final HibernateSearchMultiCollectorManager.MultiCollectedResults multiCollectedResults;
 
-	public AggregationExtractContext(IndexReader indexReader,
+	public AggregationExtractContext(LuceneSearchQueryIndexScope<?> queryIndexScope, BackendSessionContext sessionContext,
+			IndexReader indexReader,
 			FromDocumentValueConvertContext fromDocumentValueConvertContext,
 			HibernateSearchMultiCollectorManager.MultiCollectedResults multiCollectedResults) {
+		this.queryIndexScope = queryIndexScope;
+		this.sessionContext = sessionContext;
 		this.indexReader = indexReader;
 		this.fromDocumentValueConvertContext = fromDocumentValueConvertContext;
 		this.multiCollectedResults = multiCollectedResults;
+	}
+
+	public PredicateRequestContext toPredicateRequestContext(String absolutePath) {
+		return PredicateRequestContext.withSession( queryIndexScope, sessionContext ).withNestedPath( absolutePath );
 	}
 
 	public IndexReader getIndexReader() {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/aggregation/impl/AggregationExtractContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/aggregation/impl/AggregationExtractContext.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.backend.lucene.search.aggregation.impl;
 
+import java.util.Set;
+
 import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorKey;
 import org.hibernate.search.backend.lucene.lowlevel.join.impl.NestedDocsProvider;
 import org.hibernate.search.backend.lucene.search.extraction.impl.HibernateSearchMultiCollectorManager;
@@ -25,20 +27,23 @@ public class AggregationExtractContext {
 	private final IndexReader indexReader;
 	private final FromDocumentValueConvertContext fromDocumentValueConvertContext;
 	private final HibernateSearchMultiCollectorManager.MultiCollectedResults multiCollectedResults;
+	private final Set<String> routingKeys;
 
 	public AggregationExtractContext(LuceneSearchQueryIndexScope<?> queryIndexScope, BackendSessionContext sessionContext,
 			IndexReader indexReader,
 			FromDocumentValueConvertContext fromDocumentValueConvertContext,
-			HibernateSearchMultiCollectorManager.MultiCollectedResults multiCollectedResults) {
+			HibernateSearchMultiCollectorManager.MultiCollectedResults multiCollectedResults, Set<String> routingKeys) {
 		this.queryIndexScope = queryIndexScope;
 		this.sessionContext = sessionContext;
 		this.indexReader = indexReader;
 		this.fromDocumentValueConvertContext = fromDocumentValueConvertContext;
 		this.multiCollectedResults = multiCollectedResults;
+		this.routingKeys = routingKeys;
 	}
 
 	public PredicateRequestContext toPredicateRequestContext(String absolutePath) {
-		return PredicateRequestContext.withSession( queryIndexScope, sessionContext ).withNestedPath( absolutePath );
+		return PredicateRequestContext.withSession( queryIndexScope, sessionContext, routingKeys )
+				.withNestedPath( absolutePath );
 	}
 
 	public IndexReader getIndexReader() {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/AbstractLuceneNestablePredicate.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/AbstractLuceneNestablePredicate.java
@@ -51,7 +51,7 @@ abstract class AbstractLuceneNestablePredicate extends AbstractLuceneSearchPredi
 		// We'll make sure to wrap it in nested predicates as appropriate in the next few lines,
 		// so that the Query is actually executed in this context.
 		PredicateRequestContext contextAfterImplicitNesting =
-				new PredicateRequestContext( expectedNestedPath );
+				context.withNestedPath( expectedNestedPath );
 
 		Query result = super.toQuery( contextAfterImplicitNesting );
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneKnnPredicate.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneKnnPredicate.java
@@ -10,7 +10,6 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Array;
 
 import org.hibernate.search.backend.lucene.logging.impl.Log;
-import org.hibernate.search.backend.lucene.lowlevel.query.impl.Queries;
 import org.hibernate.search.backend.lucene.lowlevel.query.impl.VectorSimilarityFilterQuery;
 import org.hibernate.search.backend.lucene.search.common.impl.AbstractLuceneValueFieldSearchQueryElementFactory;
 import org.hibernate.search.backend.lucene.search.common.impl.LuceneSearchIndexScope;
@@ -67,13 +66,7 @@ public class LuceneKnnPredicate extends AbstractLuceneSingleFieldPredicate imple
 	}
 
 	private Query prepareFilter(PredicateRequestContext context) {
-		Query tenantFilter = context.tenantFilterOrNull();
-		if ( tenantFilter != null ) {
-			return filter == null ? tenantFilter : Queries.boolFilter( filter.toQuery( context ), tenantFilter );
-		}
-		else {
-			return filter == null ? null : filter.toQuery( context );
-		}
+		return context.appendTenantAndRoutingFilters( filter == null ? null : filter.toQuery( context ) );
 	}
 
 	public static class DefaultFactory<F>

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneNestedPredicate.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneNestedPredicate.java
@@ -32,7 +32,7 @@ public class LuceneNestedPredicate extends AbstractLuceneSingleFieldPredicate {
 
 	@Override
 	protected Query doToQuery(PredicateRequestContext context) {
-		PredicateRequestContext childContext = new PredicateRequestContext( absoluteFieldPath );
+		PredicateRequestContext childContext = context.withNestedPath( absoluteFieldPath );
 		return createNestedQuery( context.getNestedPath(), absoluteFieldPath, nestedPredicate.toQuery( childContext ) );
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/PredicateRequestContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/PredicateRequestContext.java
@@ -6,13 +6,22 @@
  */
 package org.hibernate.search.backend.lucene.search.predicate.impl;
 
-public class PredicateRequestContext {
+import java.lang.invoke.MethodHandles;
 
-	private static final PredicateRequestContext ROOT = new PredicateRequestContext( null );
+import org.hibernate.search.backend.lucene.logging.impl.Log;
+import org.hibernate.search.backend.lucene.search.query.impl.LuceneSearchQueryIndexScope;
+import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
+import org.hibernate.search.util.common.AssertionFailure;
+import org.hibernate.search.util.common.impl.Contracts;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
+import org.apache.lucene.search.Query;
+
+public abstract class PredicateRequestContext {
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 	private final String nestedPath;
 
-	public PredicateRequestContext(String nestedPath) {
+	private PredicateRequestContext(String nestedPath) {
 		this.nestedPath = nestedPath;
 	}
 
@@ -20,7 +29,62 @@ public class PredicateRequestContext {
 		return nestedPath;
 	}
 
-	public static PredicateRequestContext root() {
-		return ROOT;
+	public abstract Query tenantFilterOrNull();
+
+	public abstract PredicateRequestContext withNestedPath(String nestedPath);
+
+	public static PredicateRequestContext withSession(LuceneSearchQueryIndexScope<?> scope,
+			BackendSessionContext sessionContext) {
+		Contracts.assertNotNull( scope, "scope" );
+		Contracts.assertNotNull( scope, "sessionContext" );
+		return new FullPredicateRequestContext( null, scope, sessionContext );
+	}
+
+	public static PredicateRequestContext withoutSession() {
+		return new LimitedPredicateRequestContext( null );
+	}
+
+	private static class LimitedPredicateRequestContext extends PredicateRequestContext {
+
+		public LimitedPredicateRequestContext(String nestedPath) {
+			super( nestedPath );
+		}
+
+		@Override
+		public Query tenantFilterOrNull() {
+			// this context is created via migration utils, where the predicates are created as queries,
+			//  hence we should not expect that a knn predicate is passed in.
+			//  Alternatively it can be created in a place which we have total control over, and we only need to create an exists predicate,
+			//  which does not need the session context anyway.
+			throw new AssertionFailure( "A tenant/routing filter requires session context." );
+		}
+
+		@Override
+		public PredicateRequestContext withNestedPath(String nestedPath) {
+			return new LimitedPredicateRequestContext( nestedPath );
+		}
+	}
+
+	private static class FullPredicateRequestContext extends PredicateRequestContext {
+		private final LuceneSearchQueryIndexScope<?> scope;
+
+		private final BackendSessionContext sessionContext;
+
+		private FullPredicateRequestContext(String nestedPath, LuceneSearchQueryIndexScope<?> scope,
+				BackendSessionContext sessionContext) {
+			super( nestedPath );
+			this.scope = scope;
+			this.sessionContext = sessionContext;
+		}
+
+		public Query tenantFilterOrNull() {
+			String tenantIdentifier = sessionContext.tenantIdentifier();
+
+			return tenantIdentifier == null ? null : scope.filterOrNull( tenantIdentifier );
+		}
+
+		public PredicateRequestContext withNestedPath(String nestedPath) {
+			return new FullPredicateRequestContext( nestedPath, scope, sessionContext );
+		}
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/PredicateRequestContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/PredicateRequestContext.java
@@ -7,14 +7,19 @@
 package org.hibernate.search.backend.lucene.search.predicate.impl;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Set;
 
 import org.hibernate.search.backend.lucene.logging.impl.Log;
+import org.hibernate.search.backend.lucene.lowlevel.common.impl.MetadataFields;
+import org.hibernate.search.backend.lucene.lowlevel.query.impl.Queries;
 import org.hibernate.search.backend.lucene.search.query.impl.LuceneSearchQueryIndexScope;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
 import org.hibernate.search.util.common.AssertionFailure;
 import org.hibernate.search.util.common.impl.Contracts;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 
 public abstract class PredicateRequestContext {
@@ -29,15 +34,15 @@ public abstract class PredicateRequestContext {
 		return nestedPath;
 	}
 
-	public abstract Query tenantFilterOrNull();
+	public abstract Query appendTenantAndRoutingFilters(Query originalFilterQuery);
 
 	public abstract PredicateRequestContext withNestedPath(String nestedPath);
 
 	public static PredicateRequestContext withSession(LuceneSearchQueryIndexScope<?> scope,
-			BackendSessionContext sessionContext) {
+			BackendSessionContext sessionContext, Set<String> routingKeys) {
 		Contracts.assertNotNull( scope, "scope" );
 		Contracts.assertNotNull( scope, "sessionContext" );
-		return new FullPredicateRequestContext( null, scope, sessionContext );
+		return new FullPredicateRequestContext( null, scope, sessionContext, routingKeys );
 	}
 
 	public static PredicateRequestContext withoutSession() {
@@ -51,7 +56,7 @@ public abstract class PredicateRequestContext {
 		}
 
 		@Override
-		public Query tenantFilterOrNull() {
+		public Query appendTenantAndRoutingFilters(Query originalFilterQuery) {
 			// this context is created via migration utils, where the predicates are created as queries,
 			//  hence we should not expect that a knn predicate is passed in.
 			//  Alternatively it can be created in a place which we have total control over, and we only need to create an exists predicate,
@@ -69,22 +74,38 @@ public abstract class PredicateRequestContext {
 		private final LuceneSearchQueryIndexScope<?> scope;
 
 		private final BackendSessionContext sessionContext;
+		private final Set<String> routingKeys;
 
 		private FullPredicateRequestContext(String nestedPath, LuceneSearchQueryIndexScope<?> scope,
-				BackendSessionContext sessionContext) {
+				BackendSessionContext sessionContext, Set<String> routingKeys) {
 			super( nestedPath );
 			this.scope = scope;
 			this.sessionContext = sessionContext;
+			this.routingKeys = routingKeys;
 		}
 
-		public Query tenantFilterOrNull() {
-			String tenantIdentifier = sessionContext.tenantIdentifier();
+		public Query appendTenantAndRoutingFilters(Query originalFilterQuery) {
+			// We append all these "filters" as must clauses since the constructed query will be passed in as a filter itself:
+			BooleanQuery.Builder filterBuilder = new BooleanQuery.Builder();
+			if ( originalFilterQuery != null ) {
+				filterBuilder.add( originalFilterQuery, BooleanClause.Occur.MUST );
+			}
 
-			return tenantIdentifier == null ? null : scope.filterOrNull( tenantIdentifier );
+			Query tenantFilter = scope.filterOrNull( sessionContext.tenantIdentifier() );
+			if ( tenantFilter != null ) {
+				filterBuilder.add( tenantFilter, BooleanClause.Occur.MUST );
+			}
+
+			if ( !routingKeys.isEmpty() ) {
+				Query routingKeysQuery = Queries.anyTerm( MetadataFields.routingKeyFieldName(), routingKeys );
+				filterBuilder.add( routingKeysQuery, BooleanClause.Occur.MUST );
+			}
+			BooleanQuery filter = filterBuilder.build();
+			return filter.clauses().isEmpty() ? null : filter;
 		}
 
 		public PredicateRequestContext withNestedPath(String nestedPath) {
-			return new FullPredicateRequestContext( nestedPath, scope, sessionContext );
+			return new FullPredicateRequestContext( nestedPath, scope, sessionContext, routingKeys );
 		}
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneObjectProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneObjectProjection.java
@@ -194,7 +194,9 @@ public class LuceneObjectProjection<E, V, P>
 				}
 				try {
 					filter = LuceneSearchPredicate.from( scope, node.queryElement( PredicateTypeKeys.EXISTS, scope ).build() )
-							.toQuery( PredicateRequestContext.root() );
+							// We are creating an exists predicate that does not need any session info,
+							//  hence it should be safe here to use the context without session:
+							.toQuery( PredicateRequestContext.withoutSession() );
 				}
 				catch (SearchException e) {
 					throw node.cannotUseQueryElement( ProjectionTypeKeys.OBJECT, e.getMessage(), e );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneExtractableSearchResult.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneExtractableSearchResult.java
@@ -115,6 +115,8 @@ public class LuceneExtractableSearchResult<H> {
 
 	private Map<AggregationKey<?>, ?> extractAggregations() throws IOException {
 		AggregationExtractContext aggregationExtractContext = new AggregationExtractContext(
+				requestContext.getQueryIndexScope(),
+				requestContext.getSessionContext(),
 				indexSearcher.getIndexReader(),
 				fromDocumentValueConvertContext,
 				luceneCollectors.collectedMultiResults()

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneExtractableSearchResult.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneExtractableSearchResult.java
@@ -45,7 +45,7 @@ public class LuceneExtractableSearchResult<H> {
 	private final Map<AggregationKey<?>, LuceneSearchAggregation<?>> aggregations;
 	private final TimeoutManager timeoutManager;
 
-	public LuceneExtractableSearchResult(LuceneSearchQueryRequestContext requestContext,
+	LuceneExtractableSearchResult(LuceneSearchQueryRequestContext requestContext,
 			IndexSearcher indexSearcher,
 			LuceneCollectors luceneCollectors,
 			LuceneSearchProjection.Extractor<?, H> rootExtractor,
@@ -119,7 +119,8 @@ public class LuceneExtractableSearchResult<H> {
 				requestContext.getSessionContext(),
 				indexSearcher.getIndexReader(),
 				fromDocumentValueConvertContext,
-				luceneCollectors.collectedMultiResults()
+				luceneCollectors.collectedMultiResults(),
+				requestContext.getRoutingKeys()
 		);
 
 		Map<AggregationKey<?>, Object> extractedMap = new LinkedHashMap<>();

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilder.java
@@ -97,7 +97,7 @@ public class LuceneSearchQueryBuilder<H> implements SearchQueryBuilder<H>, Lucen
 	@Override
 	public void predicate(SearchPredicate predicate) {
 		LuceneSearchPredicate lucenePredicate = LuceneSearchPredicate.from( scope, predicate );
-		this.luceneQuery = lucenePredicate.toQuery( PredicateRequestContext.root() );
+		this.luceneQuery = lucenePredicate.toQuery( PredicateRequestContext.withSession( scope, sessionContext ) );
 	}
 
 	@Override
@@ -195,6 +195,11 @@ public class LuceneSearchQueryBuilder<H> implements SearchQueryBuilder<H>, Lucen
 	}
 
 	@Override
+	public PredicateRequestContext toPredicateRequestContext(String absoluteNestedPath) {
+		return PredicateRequestContext.withSession( scope, sessionContext ).withNestedPath( absoluteNestedPath );
+	}
+
+	@Override
 	public LuceneSearchQuery<H> build() {
 		SearchLoadingContext<?> loadingContext = loadingContextBuilder.build();
 
@@ -222,7 +227,7 @@ public class LuceneSearchQueryBuilder<H> implements SearchQueryBuilder<H>, Lucen
 		}
 
 		LuceneSearchQueryRequestContext requestContext = new LuceneSearchQueryRequestContext(
-				sessionContext, loadingContext, definitiveLuceneQuery, luceneSort
+				scope, sessionContext, loadingContext, definitiveLuceneQuery, luceneSort
 		);
 
 		LuceneAbstractSearchHighlighter resolvedGlobalHighlighter =

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilder.java
@@ -32,7 +32,6 @@ import org.hibernate.search.backend.lucene.search.projection.impl.ProjectionRequ
 import org.hibernate.search.backend.lucene.search.query.LuceneSearchQuery;
 import org.hibernate.search.backend.lucene.search.sort.impl.LuceneSearchSort;
 import org.hibernate.search.backend.lucene.search.sort.impl.LuceneSearchSortCollector;
-import org.hibernate.search.backend.lucene.types.sort.comparatorsource.impl.LuceneFieldComparatorSource;
 import org.hibernate.search.backend.lucene.work.impl.LuceneWorkFactory;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
 import org.hibernate.search.engine.search.aggregation.AggregationKey;
@@ -181,11 +180,6 @@ public class LuceneSearchQueryBuilder<H> implements SearchQueryBuilder<H>, Lucen
 			sortFields = new ArrayList<>( 5 );
 		}
 		sortFields.add( sortField );
-	}
-
-	@Override
-	public void collectSortField(SortField sortField, LuceneFieldComparatorSource nestedFieldSort) {
-		collectSortField( sortField );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryRequestContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryRequestContext.java
@@ -18,20 +18,26 @@ import org.apache.lucene.search.Sort;
  */
 class LuceneSearchQueryRequestContext {
 
+	private final LuceneSearchQueryIndexScope<?> queryIndexScope;
 	private final BackendSessionContext sessionContext;
 	private final SearchLoadingContext<?> loadingContext;
 	private final Query luceneQuery;
 	private final Sort luceneSort;
 
 	LuceneSearchQueryRequestContext(
-			BackendSessionContext sessionContext,
+			LuceneSearchQueryIndexScope<?> queryIndexScope, BackendSessionContext sessionContext,
 			SearchLoadingContext<?> loadingContext,
 			Query luceneQuery,
 			Sort luceneSort) {
+		this.queryIndexScope = queryIndexScope;
 		this.sessionContext = sessionContext;
 		this.loadingContext = loadingContext;
 		this.luceneQuery = luceneQuery;
 		this.luceneSort = luceneSort;
+	}
+
+	public LuceneSearchQueryIndexScope<?> getQueryIndexScope() {
+		return queryIndexScope;
 	}
 
 	BackendSessionContext getSessionContext() {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryRequestContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryRequestContext.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.backend.lucene.search.query.impl;
 
+import java.util.Set;
+
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
 import org.hibernate.search.engine.search.loading.spi.SearchLoadingContext;
 
@@ -23,17 +25,20 @@ class LuceneSearchQueryRequestContext {
 	private final SearchLoadingContext<?> loadingContext;
 	private final Query luceneQuery;
 	private final Sort luceneSort;
+	private final Set<String> routingKeys;
 
 	LuceneSearchQueryRequestContext(
 			LuceneSearchQueryIndexScope<?> queryIndexScope, BackendSessionContext sessionContext,
 			SearchLoadingContext<?> loadingContext,
 			Query luceneQuery,
-			Sort luceneSort) {
+			Sort luceneSort,
+			Set<String> routingKeys) {
 		this.queryIndexScope = queryIndexScope;
 		this.sessionContext = sessionContext;
 		this.loadingContext = loadingContext;
 		this.luceneQuery = luceneQuery;
 		this.luceneSort = luceneSort;
+		this.routingKeys = routingKeys;
 	}
 
 	public LuceneSearchQueryIndexScope<?> getQueryIndexScope() {
@@ -56,4 +61,7 @@ class LuceneSearchQueryRequestContext {
 		return luceneSort;
 	}
 
+	public Set<String> getRoutingKeys() {
+		return routingKeys;
+	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/sort/impl/LuceneSearchSortCollector.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/sort/impl/LuceneSearchSortCollector.java
@@ -15,7 +15,7 @@ import org.apache.lucene.search.SortField;
  *
  * @see LuceneSearchSort#toSortFields(org.hibernate.search.backend.lucene.search.sort.impl.LuceneSearchSortCollector)
  */
-public interface LuceneSearchSortCollector {
+public interface LuceneSearchSortCollector extends SortRequestContext {
 
 	void collectSortField(SortField sortField);
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/sort/impl/LuceneSearchSortCollector.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/sort/impl/LuceneSearchSortCollector.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.search.backend.lucene.search.sort.impl;
 
-import org.hibernate.search.backend.lucene.types.sort.comparatorsource.impl.LuceneFieldComparatorSource;
-
 import org.apache.lucene.search.SortField;
 
 /**
@@ -20,8 +18,6 @@ import org.apache.lucene.search.SortField;
 public interface LuceneSearchSortCollector {
 
 	void collectSortField(SortField sortField);
-
-	void collectSortField(SortField sortField, LuceneFieldComparatorSource nestedFieldSort);
 
 	void collectSortFields(SortField[] sortFields);
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/sort/impl/SortRequestContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/sort/impl/SortRequestContext.java
@@ -1,0 +1,15 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.search.sort.impl;
+
+import org.hibernate.search.backend.lucene.search.predicate.impl.PredicateRequestContext;
+
+public interface SortRequestContext {
+
+	PredicateRequestContext toPredicateRequestContext(String absoluteNestedPath);
+
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/spi/LuceneMigrationUtils.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/spi/LuceneMigrationUtils.java
@@ -27,7 +27,9 @@ public final class LuceneMigrationUtils {
 	}
 
 	public static Query toLuceneQuery(SearchPredicate predicate) {
-		return ( (LuceneSearchPredicate) predicate ).toQuery( PredicateRequestContext.root() );
+		// TODO: this util is for v5 predicates so we won't get a knn predicate here ...
+		//  and if we do, there will be an exception that user would need to report back so we can see what's their use case is...
+		return ( (LuceneSearchPredicate) predicate ).toQuery( PredicateRequestContext.withoutSession() );
 	}
 
 	public static Sort toLuceneSort(SearchSort sort) {
@@ -41,6 +43,12 @@ public final class LuceneMigrationUtils {
 			@Override
 			public void collectSortFields(SortField[] sortFields) {
 				Collections.addAll( result, sortFields );
+			}
+
+			@Override
+			public PredicateRequestContext toPredicateRequestContext(String absoluteNestedPath) {
+				// and if someone tries to access filter methods the sessionless context will take care of throwing an exception.
+				return PredicateRequestContext.withoutSession().withNestedPath( absoluteNestedPath );
 			}
 		};
 		( (LuceneSearchSort) sort ).toSortFields( collector );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/spi/LuceneMigrationUtils.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/spi/LuceneMigrationUtils.java
@@ -14,7 +14,6 @@ import org.hibernate.search.backend.lucene.search.predicate.impl.LuceneSearchPre
 import org.hibernate.search.backend.lucene.search.predicate.impl.PredicateRequestContext;
 import org.hibernate.search.backend.lucene.search.sort.impl.LuceneSearchSort;
 import org.hibernate.search.backend.lucene.search.sort.impl.LuceneSearchSortCollector;
-import org.hibernate.search.backend.lucene.types.sort.comparatorsource.impl.LuceneFieldComparatorSource;
 import org.hibernate.search.engine.search.predicate.SearchPredicate;
 import org.hibernate.search.engine.search.sort.SearchSort;
 
@@ -36,11 +35,6 @@ public final class LuceneMigrationUtils {
 		LuceneSearchSortCollector collector = new LuceneSearchSortCollector() {
 			@Override
 			public void collectSortField(SortField sortField) {
-				result.add( sortField );
-			}
-
-			@Override
-			public void collectSortField(SortField sortField, LuceneFieldComparatorSource nestedFieldSort) {
 				result.add( sortField );
 			}
 

--- a/documentation/src/main/asciidoc/public/reference/_search-dsl-predicate.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_search-dsl-predicate.adoc
@@ -1568,7 +1568,7 @@ an <<backend-elasticsearch,Elasticsearch backend>>.
 and trying to use it will lead to an exception being thrown.
 
 [[search-dsl-predicate-knn-limitations]]
-=== Backend specifics
+=== Backend specifics and limitations
 
 The parameter `k` has different behavior between backends, and their distributions.
 
@@ -1581,6 +1581,11 @@ While when an <<backend-elasticsearch-compatibility-opensearch,OpenSearch>> dist
 `k` will be mapped to `k` attribute of `knn` query. Note that in this case you may get more than `k` results,
 when the index is configured to have more than one shard.
 See this section of the OpenSearch link:{openSearchDocUrl}/search-plugins/knn/approximate-knn/#get-started-with-approximate-k-nn[documentation] for more details.
+
+Using the `knn` predicate inside a nested predicate with the Elasticsearch backend has some limitations.
+In particular, when a <<backend-elasticsearch-multi-tenancy,tenant>> or <<concepts-sharding-routing,routing>> filters
+are implicitly applied, the produced results may contain fewer documents than expected. To address this limitation,
+a schema change is required and should be addressed in one of the future major releases (link:{hibernateSearchJiraUrl}/HSEARCH-5085[HSEARCH-5085]).
 
 [[search-dsl-predicate-knn-other]]
 === Other options

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -297,4 +297,9 @@ public class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 				aoss -> false
 		);
 	}
+
+	@Override
+	public boolean knnWorksInsideNestedPredicateWithImplicitFilters() {
+		return false;
+	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/multitenancy/MultiTenancyBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/multitenancy/MultiTenancyBaseIT.java
@@ -9,6 +9,7 @@ package org.hibernate.search.integrationtest.backend.tck.multitenancy;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
 import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.util.List;
 
@@ -25,6 +26,7 @@ import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendHelper;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.extension.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
@@ -427,6 +429,9 @@ class MultiTenancyBaseIT {
 
 	@Test
 	void searchingForVectors_nested_vectorCloseToTheOneForOtherTenant() {
+		assumeTrue(
+				TckConfiguration.get().getBackendFeatures().knnWorksInsideNestedPredicateWithImplicitFilters()
+		);
 		StubMappingScope scope = index.createScope();
 
 		SearchQuery<List<?>> query = scope.query( tenant1SessionContext )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/RoutingVectorSearchIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/RoutingVectorSearchIT.java
@@ -1,0 +1,183 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.sharding;
+
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.IndexObjectFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
+import org.hibernate.search.engine.backend.types.ObjectStructure;
+import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.engine.backend.types.VectorSimilarity;
+import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
+import org.hibernate.search.engine.search.query.SearchQuery;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.extension.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapping;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class RoutingVectorSearchIT {
+
+	private static final String ROUTING_KEY_1 = "routingKey1";
+	private static final String ROUTING_KEY_2 = "routingKey2";
+	private static final String DOCUMENT_ID_1 = "1";
+	private static final String DOCUMENT_ID_2 = "2";
+	private static final String DOCUMENT_ID_3 = "3";
+	private static final String DOCUMENT_ID_4 = "4";
+
+	private static final Integer INTEGER_VALUE_1 = 1;
+	private static final Integer INTEGER_VALUE_2 = 2;
+	private static final Integer INTEGER_VALUE_3 = 3;
+	private static final Integer INTEGER_VALUE_4 = 4;
+
+	private static final float[] FLOATS_VALUE_1 = new float[] { 1.0f, 1.0f };
+	private static final float[] FLOATS_VALUE_2 = new float[] { -50.0f, -50.0f };
+	private static final float[] FLOATS_VALUE_3 = new float[] { 1000.0f, 1000.0f };
+	private static final float[] FLOATS_VALUE_4 = new float[] { 687.0f, 359.0f };
+
+	@RegisterExtension
+	public final SearchSetupHelper setupHelper = SearchSetupHelper.create();
+
+	private final SimpleMappedIndex<IndexBinding> index = SimpleMappedIndex.of( IndexBinding::new );
+
+	@BeforeEach
+	void setup() {
+		StubMapping mapping = setupHelper.start()
+				.withIndex( index )
+				.setup();
+
+		IndexIndexingPlan plan = index.createIndexingPlan( mapping.session() );
+		plan.add( referenceProvider( DOCUMENT_ID_1, ROUTING_KEY_1 ), document -> {
+			document.addValue( index.binding().integer, INTEGER_VALUE_1 );
+			document.addValue( index.binding().floats, FLOATS_VALUE_1 );
+
+			DocumentElement nestedObject = document.addObject( index.binding().nestedObject.self );
+			nestedObject.addValue( index.binding().nestedObject.floats, FLOATS_VALUE_1 );
+		} );
+
+		plan.add( referenceProvider( DOCUMENT_ID_2, ROUTING_KEY_1 ), document -> {
+			document.addValue( index.binding().integer, INTEGER_VALUE_2 );
+			document.addValue( index.binding().floats, FLOATS_VALUE_2 );
+
+			DocumentElement nestedObject = document.addObject( index.binding().nestedObject.self );
+			nestedObject.addValue( index.binding().nestedObject.floats, FLOATS_VALUE_2 );
+		} );
+
+		plan.add( referenceProvider( DOCUMENT_ID_3, ROUTING_KEY_2 ), document -> {
+			document.addValue( index.binding().integer, INTEGER_VALUE_3 );
+			document.addValue( index.binding().floats, FLOATS_VALUE_3 );
+
+			DocumentElement nestedObject = document.addObject( index.binding().nestedObject.self );
+			nestedObject.addValue( index.binding().nestedObject.floats, FLOATS_VALUE_3 );
+		} );
+
+		plan.add( referenceProvider( DOCUMENT_ID_4, ROUTING_KEY_2 ), document -> {
+			document.addValue( index.binding().integer, INTEGER_VALUE_4 );
+			document.addValue( index.binding().floats, FLOATS_VALUE_4 );
+
+			DocumentElement nestedObject = document.addObject( index.binding().nestedObject.self );
+			nestedObject.addValue( index.binding().nestedObject.floats, FLOATS_VALUE_4 );
+		} );
+
+		plan.execute( OperationSubmitter.blocking() ).join();
+	}
+
+	@Test
+	void searchingForVectors_moreElements() {
+		StubMappingScope scope = index.createScope();
+
+		SearchQuery<?> query = scope.query()
+				.where( f -> f.knn( 5 ).field( "floats" ).matching( FLOATS_VALUE_1 ) )
+				.routing( ROUTING_KEY_1 )
+				.toQuery();
+
+		assertThatQuery( query )
+				.hits().hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_ID_1, DOCUMENT_ID_2 );
+
+		query = scope.query()
+				.where( f -> f.knn( 5 ).field( "floats" ).matching( FLOATS_VALUE_1 ) )
+				.routing( ROUTING_KEY_1 )
+				.routing( ROUTING_KEY_2 )
+				.toQuery();
+
+		assertThatQuery( query )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_ID_1, DOCUMENT_ID_2, DOCUMENT_ID_3, DOCUMENT_ID_4 );
+	}
+
+	@Test
+	void searchingForVectors_vectorCloseToTheOneForOtherRoute() {
+		StubMappingScope scope = index.createScope();
+
+		SearchQuery<?> query = scope.query()
+				.where( f -> f.knn( 1 ).field( "floats" ).matching( FLOATS_VALUE_3 ) )
+				.routing( ROUTING_KEY_1 )
+				.toQuery();
+
+
+		assertThatQuery( query )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_ID_1 );
+	}
+
+	@Test
+	void searchingForVectors_nested_vectorCloseToTheOneForOtherRoute() {
+		StubMappingScope scope = index.createScope();
+
+		SearchQuery<?> query = scope.query()
+				.where( f -> f.knn( 1 ).field( "nestedObject.floats" ).matching( FLOATS_VALUE_3 ) )
+				.routing( ROUTING_KEY_1 )
+				.toQuery();
+
+		assertThatQuery( query )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_ID_1 );
+
+		query = scope.query()
+				.where( f -> f.nested( "nestedObject" ).add(
+						f.knn( 1 ).field( "nestedObject.floats" ).matching( FLOATS_VALUE_3 )
+				) )
+				.routing( ROUTING_KEY_1 )
+				.toQuery();
+
+		assertThatQuery( query )
+				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_ID_1 );
+	}
+
+	private static class IndexBinding {
+		final IndexFieldReference<Integer> integer;
+		final IndexFieldReference<float[]> floats;
+		final ObjectMapping nestedObject;
+
+		IndexBinding(IndexSchemaElement root) {
+			integer = root.field( "integer", f -> f.asInteger().projectable( Projectable.YES ) )
+					.toReference();
+			floats = root.field( "floats", f -> f.asFloatVector().dimension( 2 ).vectorSimilarity( VectorSimilarity.L2 )
+					.projectable( Projectable.YES ) ).toReference();
+			IndexSchemaObjectField nestedObjectField =
+					root.objectField( "nestedObject", ObjectStructure.NESTED ).multiValued();
+			nestedObject = new ObjectMapping( nestedObjectField );
+		}
+	}
+
+	private static class ObjectMapping {
+		final IndexObjectFieldReference self;
+		final IndexFieldReference<float[]> floats;
+
+		ObjectMapping(IndexSchemaObjectField objectField) {
+			self = objectField.toReference();
+			floats = objectField.field( "floats", f -> f.asFloatVector().dimension( 2 ).vectorSimilarity( VectorSimilarity.L2 )
+					.projectable( Projectable.YES ) ).toReference();
+		}
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/RoutingVectorSearchIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/RoutingVectorSearchIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.integrationtest.backend.tck.sharding;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
 import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
@@ -20,6 +21,7 @@ import org.hibernate.search.engine.backend.types.VectorSimilarity;
 import org.hibernate.search.engine.backend.work.execution.OperationSubmitter;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.search.query.SearchQuery;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.extension.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapping;
@@ -133,6 +135,9 @@ class RoutingVectorSearchIT {
 
 	@Test
 	void searchingForVectors_nested_vectorCloseToTheOneForOtherRoute() {
+		assumeTrue(
+				TckConfiguration.get().getBackendFeatures().knnWorksInsideNestedPredicateWithImplicitFilters()
+		);
 		StubMappingScope scope = index.createScope();
 
 		SearchQuery<?> query = scope.query()

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
@@ -153,4 +153,8 @@ public abstract class TckBackendFeatures implements StubMappingBackendFeatures {
 	public boolean canPerformTermsQuery(FieldTypeDescriptor<?, ?> fieldType) {
 		return true;
 	}
+
+	public boolean knnWorksInsideNestedPredicateWithImplicitFilters() {
+		return true;
+	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5039

I thought I'd add a couple of tests and ... well. ... . .  😃 
The outer tenant filter is applied "too late". It finds similar vectors among all tenants, and only then it applies the tenant filter, returning fewer results than the user expected.

With the Elasticsearch backend, the change was much cleaner, while with the Lucene one... needed to delay converting some things to Lucene queries 😞 

I also noticed an unused method on the collector interface, so I've dropped it since it is in the impl package.