### PR TITLE
HSEARCH-5087 Add compatibility with OpenSearch 2.12.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -263,7 +263,8 @@ stage('Configure') {
 					new LocalOpenSearchBuildEnvironment(version: '2.8.0', condition: TestCondition.ON_DEMAND),
 					new LocalOpenSearchBuildEnvironment(version: '2.9.0', condition: TestCondition.ON_DEMAND),
 					new LocalOpenSearchBuildEnvironment(version: '2.10.0', condition: TestCondition.ON_DEMAND),
-					new LocalOpenSearchBuildEnvironment(version: '2.11.1', condition: TestCondition.BEFORE_MERGE),
+					new LocalOpenSearchBuildEnvironment(version: '2.11.1', condition: TestCondition.ON_DEMAND),
+					new LocalOpenSearchBuildEnvironment(version: '2.12.0', condition: TestCondition.BEFORE_MERGE),
 					// See https://opensearch.org/lines/2x.html for a list of all 2.x versions
 
 					// --------------------------------------------

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
@@ -16,6 +16,7 @@ import org.hibernate.search.backend.elasticsearch.dialect.model.impl.Elasticsear
 import org.hibernate.search.backend.elasticsearch.dialect.model.impl.Elasticsearch8ModelDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.model.impl.ElasticsearchModelDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.model.impl.OpenSearch1ModelDialect;
+import org.hibernate.search.backend.elasticsearch.dialect.model.impl.OpenSearch29ModelDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.model.impl.OpenSearch2ModelDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.protocol.impl.AmazonOpenSearchServerlessProtocolDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.protocol.impl.Elasticsearch70ProtocolDialect;
@@ -126,7 +127,10 @@ public class ElasticsearchDialectFactory {
 			return new OpenSearch1ModelDialect();
 		}
 		else {
-			return new OpenSearch2ModelDialect();
+			if ( major == 2 && ( minorOptional.isEmpty() || minorOptional.getAsInt() < 9 ) ) {
+				return new OpenSearch2ModelDialect();
+			}
+			return new OpenSearch29ModelDialect();
 		}
 	}
 
@@ -134,7 +138,7 @@ public class ElasticsearchDialectFactory {
 		if ( !AMAZON_OPENSEARCH_SERVERLESS.equals( version ) ) {
 			throw log.unexpectedAwsOpenSearchServerlessVersion( version, AMAZON_OPENSEARCH_SERVERLESS );
 		}
-		return new OpenSearch2ModelDialect();
+		return new OpenSearch29ModelDialect();
 	}
 
 	public ElasticsearchProtocolDialect createProtocolDialect(ElasticsearchVersion version) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
@@ -231,7 +231,7 @@ public class ElasticsearchDialectFactory {
 	}
 
 	private ElasticsearchProtocolDialect createProtocolDialectOpenSearchV2(ElasticsearchVersion version, int minor) {
-		if ( minor > 11 ) {
+		if ( minor > 12 ) {
 			log.unknownElasticsearchVersion( version );
 		}
 		return new Elasticsearch70ProtocolDialect();

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/model/impl/OpenSearch29ModelDialect.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/model/impl/OpenSearch29ModelDialect.java
@@ -7,24 +7,24 @@
 package org.hibernate.search.backend.elasticsearch.dialect.model.impl;
 
 import org.hibernate.search.backend.elasticsearch.types.dsl.provider.impl.ElasticsearchIndexFieldTypeFactoryProvider;
-import org.hibernate.search.backend.elasticsearch.types.dsl.provider.impl.OpenSearch1IndexFieldTypeFactoryProvider;
+import org.hibernate.search.backend.elasticsearch.types.dsl.provider.impl.OpenSearch2IndexFieldTypeFactoryProvider;
 import org.hibernate.search.backend.elasticsearch.validation.impl.ElasticsearchPropertyMappingValidatorProvider;
-import org.hibernate.search.backend.elasticsearch.validation.impl.OpenSearch1PropertyMappingValidatorProvider;
+import org.hibernate.search.backend.elasticsearch.validation.impl.OpenSearch2PropertyMappingValidatorProvider;
 
 import com.google.gson.Gson;
 
 /**
- * The model dialect for OpenSearch [2.0-2.9).
+ * The model dialect for OpenSearch 2.x.
  */
-public class OpenSearch2ModelDialect implements ElasticsearchModelDialect {
+public class OpenSearch29ModelDialect implements ElasticsearchModelDialect {
 
 	@Override
 	public ElasticsearchIndexFieldTypeFactoryProvider createIndexTypeFieldFactoryProvider(Gson userFacingGson) {
-		return new OpenSearch1IndexFieldTypeFactoryProvider( userFacingGson );
+		return new OpenSearch2IndexFieldTypeFactoryProvider( userFacingGson );
 	}
 
 	@Override
 	public ElasticsearchPropertyMappingValidatorProvider createElasticsearchPropertyMappingValidatorProvider() {
-		return new OpenSearch1PropertyMappingValidatorProvider();
+		return new OpenSearch2PropertyMappingValidatorProvider();
 	}
 }

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -19,6 +19,7 @@ import org.hibernate.search.backend.elasticsearch.dialect.model.impl.Elasticsear
 import org.hibernate.search.backend.elasticsearch.dialect.model.impl.Elasticsearch8ModelDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.model.impl.ElasticsearchModelDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.model.impl.OpenSearch1ModelDialect;
+import org.hibernate.search.backend.elasticsearch.dialect.model.impl.OpenSearch29ModelDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.model.impl.OpenSearch2ModelDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.protocol.impl.Elasticsearch70ProtocolDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.protocol.impl.Elasticsearch80ProtocolDialect;
@@ -341,55 +342,55 @@ class ElasticsearchDialectFactoryTest {
 				),
 				success(
 						ElasticsearchDistributionName.OPENSEARCH, "2.9", "2.9.0",
-						OpenSearch2ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				success(
 						ElasticsearchDistributionName.OPENSEARCH, "2.9.0", "2.9.0",
-						OpenSearch2ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				success(
 						ElasticsearchDistributionName.OPENSEARCH, "2.10", "2.10.0",
-						OpenSearch2ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				success(
 						ElasticsearchDistributionName.OPENSEARCH, "2.10.0", "2.10.0",
-						OpenSearch2ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				success(
 						ElasticsearchDistributionName.OPENSEARCH, "2.11", "2.11.0",
-						OpenSearch2ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				success(
 						ElasticsearchDistributionName.OPENSEARCH, "2.11.0", "2.11.0",
-						OpenSearch2ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				success(
 						ElasticsearchDistributionName.OPENSEARCH, "2.12", "2.12.0",
-						OpenSearch2ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				success(
 						ElasticsearchDistributionName.OPENSEARCH, "2.12.0", "2.12.0",
-						OpenSearch2ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				successWithWarning(
 						ElasticsearchDistributionName.OPENSEARCH, "2.13", "2.13.0",
-						OpenSearch2ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				successWithWarning(
 						ElasticsearchDistributionName.OPENSEARCH, "2.13.0", "2.13.0",
-						OpenSearch2ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				successWithWarning(
 						ElasticsearchDistributionName.OPENSEARCH, "3", "3.0.0",
-						OpenSearch2ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				successWithWarning(
 						ElasticsearchDistributionName.OPENSEARCH, "3.0", "3.0.0",
-						OpenSearch2ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				successWithWarning(
 						ElasticsearchDistributionName.OPENSEARCH, "3.0.0", "3.0.0",
-						OpenSearch2ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				)
 		);
 	}

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -363,12 +363,20 @@ class ElasticsearchDialectFactoryTest {
 						ElasticsearchDistributionName.OPENSEARCH, "2.11.0", "2.11.0",
 						OpenSearch2ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
-				successWithWarning(
+				success(
 						ElasticsearchDistributionName.OPENSEARCH, "2.12", "2.12.0",
 						OpenSearch2ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
-				successWithWarning(
+				success(
 						ElasticsearchDistributionName.OPENSEARCH, "2.12.0", "2.12.0",
+						OpenSearch2ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.OPENSEARCH, "2.13", "2.13.0",
+						OpenSearch2ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.OPENSEARCH, "2.13.0", "2.13.0",
 						OpenSearch2ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				successWithWarning(

--- a/build/container/search-backend/amazon-opensearch-serverless.Dockerfile
+++ b/build/container/search-backend/amazon-opensearch-serverless.Dockerfile
@@ -4,4 +4,4 @@
 # IMPORTANT! When updating the version of OpenSearch in this Dockerfile,
 # make sure to update `version.org.opensearch.latest` property in a POM file,
 # and to update the version in opensearch.Dockerfile as well.
-FROM docker.io/opensearchproject/opensearch:2.11.1
+FROM docker.io/opensearchproject/opensearch:2.12.0

--- a/build/container/search-backend/opensearch.Dockerfile
+++ b/build/container/search-backend/opensearch.Dockerfile
@@ -4,4 +4,4 @@
 # IMPORTANT! When updating the version of OpenSearch in this Dockerfile,
 # make sure to update `version.org.opensearch.latest` property in a POM file,
 # and to update the version in amazon-opensearch-serverless.Dockerfile as well.
-FROM docker.io/opensearchproject/opensearch:2.11.1
+FROM docker.io/opensearchproject/opensearch:2.12.0

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -72,13 +72,13 @@
         -->
         <!-- The versions of OpenSearch advertised as compatible with Hibernate Search -->
         <!-- Make sure to only mention tested versions here -->
-        <version.org.opensearch.compatible.regularly-tested.text>1.3 or 2.11</version.org.opensearch.compatible.regularly-tested.text>
+        <version.org.opensearch.compatible.regularly-tested.text>1.3 or 2.12</version.org.opensearch.compatible.regularly-tested.text>
         <!-- These are the versions same as above, but pointing only to the major part (used in compatibility section of ES backend documentation
           as versions that Hibernate Search is compatible with. -->
         <!-- NOTE: Adding new major versions would require to update the compatibility table in `backend-elasticsearch-compatibility` section of `backend-elasticsearch.asciidoc`. -->
         <version.org.opensearch.compatible.expected.text>1.3 or 2.x</version.org.opensearch.compatible.expected.text>
         <!-- The latest version of OpenSearch tested against by default -->
-        <version.org.opensearch.latest>2.11.0</version.org.opensearch.latest>
+        <version.org.opensearch.latest>2.12.0</version.org.opensearch.latest>
         <!-- The main compatible version of OpenSearch, advertised by default. Used in documentation links. -->
         <version.org.opensearch.compatible.main>${version.org.opensearch.latest}</version.org.opensearch.compatible.main>
         <documentation.org.opensearch.url>https://opensearch.org/docs/${parsed-version.org.opensearch.compatible.main.majorVersion}.${parsed-version.org.opensearch.compatible.main.minorVersion}</documentation.org.opensearch.url>

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
@@ -62,7 +62,7 @@ class PredicateDslIT {
 		return BackendConfiguration.isLucene()
 				|| ElasticsearchTestDialect.isActualVersion(
 						es -> !es.isLessThan( "8.12.0" ),
-						os -> !os.isLessThan( "2.0.0" ),
+						os -> !os.isLessThan( "2.9.0" ),
 						aoss -> true
 				);
 	}
@@ -1309,7 +1309,7 @@ class PredicateDslIT {
 		if ( !BackendConfiguration.isElasticsearch()
 				|| ElasticsearchTestDialect.isActualVersion(
 						es -> !es.isLessThan( "8.12.0" ),
-						os -> !os.isLessThan( "2.0.0" ),
+						os -> !os.isLessThan( "2.9.0" ),
 						aoss -> true
 				) ) {
 			withinSearchSession( searchSession -> {

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -251,7 +251,7 @@ public class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 	public boolean supportsVectorSearch() {
 		return isActualVersion(
 				es -> !es.isLessThan( "8.12.0" ),
-				os -> !os.isLessThan( "2.0.0" ),
+				os -> !os.isLessThan( "2.9.0" ),
 				aoss -> true
 		);
 	}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -13,6 +13,8 @@ import java.math.BigInteger;
 
 import org.hibernate.search.engine.backend.types.VectorSimilarity;
 import org.hibernate.search.engine.spatial.GeoPoint;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FloatFieldTypeDescriptor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendFeatures;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.ElasticsearchTestDialect;
 
@@ -143,7 +145,8 @@ public class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 		// Hopefully this will get fixed in a future version.
 		return isActualVersion(
 				esVersion -> !esVersion.isBetween( "7.17.7", "7.17" ) && esVersion.isLessThan( "8.5.0" ),
-				osVersion -> true
+				// https://github.com/opensearch-project/OpenSearch/issues/12433
+				osVersion -> osVersion.isLessThan( "2.12.0" )
 		);
 	}
 
@@ -283,5 +286,15 @@ public class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 	@Override
 	public boolean hasBuiltInAnalyzerDescriptorsAvailable() {
 		return false;
+	}
+
+	@Override
+	public boolean canPerformTermsQuery(FieldTypeDescriptor<?, ?> fieldType) {
+		return isActualVersion(
+				es -> true,
+				// https://github.com/opensearch-project/OpenSearch/issues/12432
+				os -> os.isLessThan( "2.12.0" ) || !FloatFieldTypeDescriptor.INSTANCE.equals( fieldType ),
+				aoss -> false
+		);
 	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/TermsPredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/TermsPredicateBaseIT.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.integrationtest.backend.tck.search.predicate;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -16,6 +18,7 @@ import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.GeoPointFieldTypeDescriptor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.InvalidType;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ValueWrapper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.extension.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
@@ -181,6 +184,10 @@ class TermsPredicateBaseIT {
 		@Override
 		protected PredicateFinalStep predicate(SearchPredicateFactory f, String fieldPath, int matchingDocOrdinal,
 				DataSet<?, TermsPredicateTestValues<F>> dataSet) {
+			assumeTrue(
+					TckConfiguration.get().getBackendFeatures().canPerformTermsQuery( dataSet.fieldType )
+			);
+
 			if ( dataSet.values.providesNonMatchingArgs() ) {
 				return f.terms().field( fieldPath ).matchingAny( dataSet.values.nonMatchingArg( 0 ),
 						dataSet.values.matchingArg( matchingDocOrdinal ), dataSet.values.nonMatchingArg( 1 ),

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
@@ -8,6 +8,7 @@ package org.hibernate.search.integrationtest.backend.tck.testsupport.util;
 
 import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.engine.backend.types.VectorSimilarity;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingBackendFeatures;
 
 public abstract class TckBackendFeatures implements StubMappingBackendFeatures {
@@ -146,6 +147,10 @@ public abstract class TckBackendFeatures implements StubMappingBackendFeatures {
 	}
 
 	public boolean hasBuiltInAnalyzerDescriptorsAvailable() {
+		return true;
+	}
+
+	public boolean canPerformTermsQuery(FieldTypeDescriptor<?, ?> fieldType) {
 		return true;
 	}
 }

--- a/integrationtest/mapper/pojo-standalone-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/standalone/realbackend/mapping/VectorFieldIT.java
+++ b/integrationtest/mapper/pojo-standalone-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/standalone/realbackend/mapping/VectorFieldIT.java
@@ -266,7 +266,7 @@ class VectorFieldIT {
 		return BackendConfiguration.isLucene()
 				|| ElasticsearchTestDialect.isActualVersion(
 						es -> !es.isLessThan( "8.12.0" ),
-						os -> !os.isLessThan( "2.0.0" ),
+						os -> !os.isLessThan( "2.9.0" ),
 						aoss -> true
 				);
 	}

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/SearchBackendContainer.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/SearchBackendContainer.java
@@ -136,7 +136,7 @@ public final class SearchBackendContainer {
 	}
 
 	private static GenericContainer<?> opensearch(DockerImageName dockerImageName) {
-		return common( dockerImageName )
+		GenericContainer<?> container = common( dockerImageName )
 				.withEnv( "logger.level", "WARN" )
 				.withEnv( "discovery.type", "single-node" )
 				// Prevent swapping
@@ -153,6 +153,16 @@ public final class SearchBackendContainer {
 				// See https://www.elastic.co/guide/en/elasticsearch/reference/7.17/modules-cluster.html#disk-based-shard-allocation
 				// See https://opensearch.org/docs/latest/opensearch/popular-api/#change-disk-watermarks-or-other-cluster-settings
 				.withEnv( "cluster.routing.allocation.disk.threshold_enabled", "false" );
+
+		ElasticsearchVersion version =
+				ElasticsearchVersion.of( ElasticsearchDistributionName.OPENSEARCH, dockerImageName.getVersionPart() );
+
+		if ( version.majorOptional().orElse( Integer.MIN_VALUE ) == 2
+				&& version.minor().orElse( Integer.MAX_VALUE ) > 11 ) {
+			// Note: For OpenSearch 2.12 and later, a custom password for the admin user is required to be passed to set-up and utilize demo configuration.
+			container.withEnv( "OPENSEARCH_INITIAL_ADMIN_PASSWORD", "NotActua11y$trongPa$$word" );
+		}
+		return container;
 	}
 
 	/*


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5087
https://hibernate.atlassian.net/browse/HSEARCH-5088


Let's see if this won't be the same as with the Lucene update PR 😏 😄 