### PR TITLE
Reduce disk space taken by JUnit test reports on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -878,6 +878,12 @@ void withMavenWorkspace(Closure body) {
 }
 
 void withMavenWorkspace(Map args, Closure body) {
+	args.put("options", [
+			// Artifacts are not needed and take up disk space
+			artifactsPublisher(disabled: true),
+			// stdout/stderr for successful tests is not needed and takes up disk space
+			junitPublisher(stdioRetention: 'failed')
+	])
 	helper.withMavenWorkspace(args, {
 		// The script is in the code repository, so we need the scm checkout
 		// to be performed by helper.withMavenWorkspace before we can call the script.

--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -75,7 +75,12 @@ def pullContainerImages() {
 def withMavenWorkspace(Closure body) {
 	withMaven(jdk: 'OpenJDK 17 Latest', maven: 'Apache Maven 3.9',
 			mavenLocalRepo: env.WORKSPACE_TMP + '/.m2repository',
-			options: [artifactsPublisher(disabled: true)]) {
+			options: [
+					// Artifacts are not needed and take up disk space
+					artifactsPublisher(disabled: true),
+					// stdout/stderr for successful tests is not needed and takes up disk space
+					junitPublisher(stdioRetention: 'failed')
+			]) {
 		body()
 	}
 }


### PR DESCRIPTION
This attempts to take advantage of https://github.com/jenkinsci/junit-plugin/pull/601

I'm not sure `stdioRetention` is available in the pipeline syntax though, so... let's see how this PR goes on CI.

I wish there was a way to set defaults for this globally :/