### PR TITLE
Backport HSEARCH-5089 to branch 7.1 - Retrieve the schema management strategy on start for the Standalone Pojo Mapper

### DIFF
--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/bootstrap/impl/StandalonePojoIntegrationPartialBuildState.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/bootstrap/impl/StandalonePojoIntegrationPartialBuildState.java
@@ -68,7 +68,7 @@ final class StandalonePojoIntegrationPartialBuildState {
 
 		StandalonePojoMapping mapping = finalizer.finalizeMapping(
 				mappingKey,
-				(context, partialMapping) -> partialMapping.finalizeMapping()
+				(context, partialMapping) -> partialMapping.finalizeMapping( context )
 		);
 		finalizer.finalizeIntegration();
 

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoMapperDelegate.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoMapperDelegate.java
@@ -13,17 +13,14 @@ import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoMapperDelegate;
 import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingDelegate;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeModel;
 import org.hibernate.search.mapper.pojo.standalone.reporting.impl.StandalonePojoMappingHints;
-import org.hibernate.search.mapper.pojo.standalone.schema.management.impl.SchemaManagementListener;
 
 public final class StandalonePojoMapperDelegate
 		implements PojoMapperDelegate<StandalonePojoMappingPartialBuildState> {
 
 	private final StandalonePojoTypeContextContainer.Builder typeContextContainerBuilder;
-	private final SchemaManagementListener schemaManagementListener;
 
-	public StandalonePojoMapperDelegate(SchemaManagementListener schemaManagementListener) {
+	public StandalonePojoMapperDelegate() {
 		this.typeContextContainerBuilder = new StandalonePojoTypeContextContainer.Builder();
-		this.schemaManagementListener = schemaManagementListener;
 	}
 
 	@Override
@@ -45,8 +42,7 @@ public final class StandalonePojoMapperDelegate
 
 	@Override
 	public StandalonePojoMappingPartialBuildState prepareBuild(PojoMappingDelegate mappingDelegate) {
-		return new StandalonePojoMappingPartialBuildState( mappingDelegate, typeContextContainerBuilder.build(),
-				schemaManagementListener );
+		return new StandalonePojoMappingPartialBuildState( mappingDelegate, typeContextContainerBuilder.build() );
 	}
 
 	@Override

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoMappingInitiator.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoMappingInitiator.java
@@ -22,17 +22,9 @@ import org.hibernate.search.mapper.pojo.standalone.cfg.StandalonePojoMapperSetti
 import org.hibernate.search.mapper.pojo.standalone.mapping.StandalonePojoMappingConfigurationContext;
 import org.hibernate.search.mapper.pojo.standalone.mapping.StandalonePojoMappingConfigurer;
 import org.hibernate.search.mapper.pojo.standalone.model.impl.StandalonePojoBootstrapIntrospector;
-import org.hibernate.search.mapper.pojo.standalone.schema.management.SchemaManagementStrategyName;
-import org.hibernate.search.mapper.pojo.standalone.schema.management.impl.SchemaManagementListener;
 
 public class StandalonePojoMappingInitiator extends AbstractPojoMappingInitiator<StandalonePojoMappingPartialBuildState>
 		implements StandalonePojoMappingConfigurationContext {
-
-	private static final ConfigurationProperty<SchemaManagementStrategyName> SCHEMA_MANAGEMENT_STRATEGY =
-			ConfigurationProperty.forKey( StandalonePojoMapperSettings.Radicals.SCHEMA_MANAGEMENT_STRATEGY )
-					.as( SchemaManagementStrategyName.class, SchemaManagementStrategyName::of )
-					.withDefault( StandalonePojoMapperSettings.Defaults.SCHEMA_MANAGEMENT_STRATEGY )
-					.build();
 
 	private static final OptionalConfigurationProperty<
 			List<BeanReference<? extends StandalonePojoMappingConfigurer>>> MAPPING_CONFIGURER =
@@ -47,12 +39,8 @@ public class StandalonePojoMappingInitiator extends AbstractPojoMappingInitiator
 					.withDefault( StandalonePojoMapperSettings.Defaults.MULTI_TENANCY_ENABLED )
 					.build();
 
-	private final StandalonePojoBootstrapIntrospector introspector;
-	private SchemaManagementListener schemaManagementListener;
-
 	public StandalonePojoMappingInitiator(StandalonePojoBootstrapIntrospector introspector) {
 		super( introspector );
-		this.introspector = introspector;
 		// Enable annotated type discovery by default
 		annotationMapping()
 				.discoverAnnotatedTypesFromRootMappingAnnotations( true )
@@ -79,15 +67,11 @@ public class StandalonePojoMappingInitiator extends AbstractPojoMappingInitiator
 					}
 				} );
 
-		SchemaManagementStrategyName schemaManagementStrategyName = SCHEMA_MANAGEMENT_STRATEGY.get(
-				buildContext.configurationPropertySource() );
-		schemaManagementListener = new SchemaManagementListener( schemaManagementStrategyName );
-
 		super.configure( buildContext, configurationCollector );
 	}
 
 	@Override
 	protected PojoMapperDelegate<StandalonePojoMappingPartialBuildState> createMapperDelegate() {
-		return new StandalonePojoMapperDelegate( schemaManagementListener );
+		return new StandalonePojoMapperDelegate();
 	}
 }

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoMappingPartialBuildState.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoMappingPartialBuildState.java
@@ -6,22 +6,29 @@
  */
 package org.hibernate.search.mapper.pojo.standalone.mapping.impl;
 
+import org.hibernate.search.engine.cfg.spi.ConfigurationProperty;
+import org.hibernate.search.engine.mapper.mapping.building.spi.MappingFinalizationContext;
 import org.hibernate.search.engine.mapper.mapping.building.spi.MappingPartialBuildState;
 import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingDelegate;
+import org.hibernate.search.mapper.pojo.standalone.cfg.StandalonePojoMapperSettings;
+import org.hibernate.search.mapper.pojo.standalone.schema.management.SchemaManagementStrategyName;
 import org.hibernate.search.mapper.pojo.standalone.schema.management.impl.SchemaManagementListener;
 
 public class StandalonePojoMappingPartialBuildState implements MappingPartialBuildState {
 
+	private static final ConfigurationProperty<SchemaManagementStrategyName> SCHEMA_MANAGEMENT_STRATEGY =
+			ConfigurationProperty.forKey( StandalonePojoMapperSettings.Radicals.SCHEMA_MANAGEMENT_STRATEGY )
+					.as( SchemaManagementStrategyName.class, SchemaManagementStrategyName::of )
+					.withDefault( StandalonePojoMapperSettings.Defaults.SCHEMA_MANAGEMENT_STRATEGY )
+					.build();
+
 	private final PojoMappingDelegate mappingDelegate;
 	private final StandalonePojoTypeContextContainer typeContextContainer;
-	private final SchemaManagementListener schemaManagementListener;
 
 	StandalonePojoMappingPartialBuildState(PojoMappingDelegate mappingDelegate,
-			StandalonePojoTypeContextContainer typeContextContainer,
-			SchemaManagementListener schemaManagementListener) {
+			StandalonePojoTypeContextContainer typeContextContainer) {
 		this.mappingDelegate = mappingDelegate;
 		this.typeContextContainer = typeContextContainer;
-		this.schemaManagementListener = schemaManagementListener;
 	}
 
 	@Override
@@ -29,7 +36,10 @@ public class StandalonePojoMappingPartialBuildState implements MappingPartialBui
 		mappingDelegate.close();
 	}
 
-	public StandalonePojoMapping finalizeMapping() {
+	public StandalonePojoMapping finalizeMapping(MappingFinalizationContext context) {
+		SchemaManagementStrategyName schemaManagementStrategyName = SCHEMA_MANAGEMENT_STRATEGY.get(
+				context.configurationPropertySource() );
+		SchemaManagementListener schemaManagementListener = new SchemaManagementListener( schemaManagementStrategyName );
 		return new StandalonePojoMapping( mappingDelegate, typeContextContainer, schemaManagementListener );
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5089

Backport of #3977 to branch 7.1
