### PR TITLE
Fix incorrect configuration of snapshots repositories

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -1415,14 +1415,11 @@
                  -->
                 <repository>
                     <id>sonatype-oss</id>
-                    <name>JBoss Public Maven Repository Group</name>
+                    <name>Maven Central Snapshots</name>
                     <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
                     <layout>default</layout>
                     <releases>
-                        <!-- versions-maven-plugin will ignore this repo, even for snapshots,
-                             unless we enable releases.
-                             This is most likely a bug. -->
-                        <enabled>true</enabled>
+                        <enabled>false</enabled>
                         <updatePolicy>never</updatePolicy>
                     </releases>
                     <snapshots>
@@ -1435,14 +1432,11 @@
                  -->
                 <repository>
                     <id>jboss-public-repository-group</id>
-                    <name>JBoss Public Maven Repository Group</name>
-                    <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+                    <name>JBoss Public Maven Repository Snapshots</name>
+                    <url>https://repository.jboss.org/nexus/content/repositories/snapshots/</url>
                     <layout>default</layout>
                     <releases>
-                        <!-- versions-maven-plugin will ignore this repo, even for snapshots,
-                             unless we enable releases.
-                             This is most likely a bug. -->
-                        <enabled>true</enabled>
+                        <enabled>false</enabled>
                         <updatePolicy>never</updatePolicy>
                     </releases>
                     <snapshots>
@@ -1455,10 +1449,7 @@
                     <url>https://repository.apache.org/content/groups/snapshots</url>
                     <layout>default</layout>
                     <releases>
-                        <!-- versions-maven-plugin will ignore this repo, even for snapshots,
-                             unless we enable releases.
-                             This is most likely a bug. -->
-                        <enabled>true</enabled>
+                        <enabled>false</enabled>
                         <updatePolicy>never</updatePolicy>
                     </releases>
                     <snapshots>

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -1427,23 +1427,6 @@
                         <updatePolicy>always</updatePolicy>
                     </snapshots>
                 </repository>
-                <!--
-                    Enable the JBoss Snapshots repository, for Hibernate ORM 5.6 in particular.
-                 -->
-                <repository>
-                    <id>jboss-public-repository-group</id>
-                    <name>JBoss Public Maven Repository Snapshots</name>
-                    <url>https://repository.jboss.org/nexus/content/repositories/snapshots/</url>
-                    <layout>default</layout>
-                    <releases>
-                        <enabled>false</enabled>
-                        <updatePolicy>never</updatePolicy>
-                    </releases>
-                    <snapshots>
-                        <enabled>true</enabled>
-                        <updatePolicy>always</updatePolicy>
-                    </snapshots>
-                </repository>
                 <repository>
                     <id>apache-snapshots</id>
                     <url>https://repository.apache.org/content/groups/snapshots</url>


### PR DESCRIPTION
Testing locally, it seems we no longer need to declare these snapshot repos as "release", so whatever bug there was in versions-maven-plugin, isn't there anymore.

More importantly, dependabot has been failing to update things like jackson lately, and I'm hoping this was the cause. See the logs [here](https://github.com/hibernate/hibernate-search/network/updates/795977249):

```
updater | 2024/03/05 02:15:44 INFO <job_795977249> Checking if com.fasterxml.jackson.core:jackson-core 2.15.2 needs updating
  proxy | 2024/03/05 02:15:44 [749] GET https://oss.sonatype.org:443/content/repositories/snapshots/com/fasterxml/jackson/core/jackson-core/maven-metadata.xml
  proxy | 2024/03/05 02:15:44 [749] 200 https://oss.sonatype.org:443/content/repositories/snapshots/com/fasterxml/jackson/core/jackson-core/maven-metadata.xml
updater | 2024/03/05 02:15:44 INFO <job_795977249> Latest version is 
updater | 2024/03/05 02:15:45 INFO <job_795977249> Requirements to unlock update_not_possible
updater | 2024/03/05 02:15:45 INFO <job_795977249> Requirements update strategy 
updater | 2024/03/05 02:15:45 INFO <job_795977249> No update possible for com.fasterxml.jackson.core:jackson-core 2.15.2
```