### PR TITLE
HSEARCH-5100 Bump com.google.code.gson:gson from 2.9.1 to 2.10.1

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -83,7 +83,7 @@
         <version.org.opensearch.compatible.main>${version.org.opensearch.latest}</version.org.opensearch.compatible.main>
         <documentation.org.opensearch.url>https://opensearch.org/docs/${parsed-version.org.opensearch.compatible.main.majorVersion}.${parsed-version.org.opensearch.compatible.main.minorVersion}</documentation.org.opensearch.url>
 
-        <version.com.google.code.gson>2.9.1</version.com.google.code.gson>
+        <version.com.google.code.gson>2.10.1</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.25.2</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, by Avro, by the AWS SDK and in tests (wiremock, ...) -->
         <version.com.fasterxml.jackson>2.15.2</version.com.fasterxml.jackson>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5100

Bumps [com.google.code.gson:gson](https://github.com/google/gson) from 2.9.1 to 2.10.1.
- [Release notes](https://github.com/google/gson/releases)
- [Changelog](https://github.com/google/gson/blob/main/CHANGELOG.md)
- [Commits](https://github.com/google/gson/compare/gson-parent-2.9.1...gson-parent-2.10.1)

---
updated-dependencies:
- dependency-name: com.google.code.gson:gson dependency-type: direct:production update-type: version-update:semver-minor ...

<!--
Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HSEARCH.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HSEARCH-<digits>`).
-->