### PR TITLE
Enable dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ registries:
     password: ${{secrets.DOCKERHUB_TOKEN}}
     replaces-base: true
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
   - package-ecosystem: "maven"
     directory: "/"
     schedule:


### PR DESCRIPTION
Apparently we have a few outdated actions:

![Screenshot from 2024-03-06 13-51-39](https://github.com/hibernate/hibernate-search/assets/412878/bfa531ed-4744-49f8-a762-4d9943d0c6d5)
