### PR TITLE
Follow up on HSEARCH-5006 Use single-sharded indexes in tests with knn predicates

### DIFF
--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendHelper.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendHelper.java
@@ -40,6 +40,12 @@ public class ElasticsearchTckBackendHelper implements TckBackendHelper {
 	}
 
 	@Override
+	public TckBackendSetupStrategy<?> createNoShardingMultiTenancyBackendSetupStrategy() {
+		return createNoShardingBackendSetupStrategy()
+				.setProperty( "multi_tenancy.strategy", "discriminator" );
+	}
+
+	@Override
 	public TckBackendSetupStrategy<?> createAnalysisNotConfiguredBackendSetupStrategy() {
 		return new ElasticsearchTckBackendSetupStrategy()
 				.setProperty( "analysis.configurer", null );

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/LuceneTckBackendHelper.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/LuceneTckBackendHelper.java
@@ -39,6 +39,12 @@ public class LuceneTckBackendHelper implements TckBackendHelper {
 	}
 
 	@Override
+	public TckBackendSetupStrategy<?> createNoShardingMultiTenancyBackendSetupStrategy() {
+		return createNoShardingBackendSetupStrategy()
+				.setProperty( "multi_tenancy.strategy", "discriminator" );
+	}
+
+	@Override
 	public TckBackendSetupStrategy<?> createAnalysisCustomBackendSetupStrategy() {
 		return new LuceneTckBackendSetupStrategy()
 				.expectCustomBeans()

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendHelper.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendHelper.java
@@ -19,6 +19,8 @@ public interface TckBackendHelper {
 
 	TckBackendSetupStrategy<?> createMultiTenancyBackendSetupStrategy();
 
+	TckBackendSetupStrategy<?> createNoShardingMultiTenancyBackendSetupStrategy();
+
 	/**
 	 * @return A setup strategy for {@link org.hibernate.search.integrationtest.backend.tck.analysis.AnalysisBuiltinIT}.
 	 */


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5006

noticed test failures on aws OpenSearch: https://ci.hibernate.org/blue/organizations/jenkins/hibernate-search/detail/main/1034/pipeline/136/

and while at it -- updated the test to create an index once for the entire class rather than creating/removing it for each test 