### PR TITLE
Enable remote cache storing when GITHUB_BASE_REF is set to an empty string

### DIFF
--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -32,7 +32,7 @@
         </local>
         <remote>
             <enabled>#{properties['no-build-cache'] == null}</enabled>
-            <storeEnabled>#{env['CI'] != null and env['CHANGE_ID'] == null and env['GITHUB_BASE_REF'] == null and env['GRADLE_ENTERPRISE_ACCESS_KEY'] != null and env['GRADLE_ENTERPRISE_ACCESS_KEY'] != ''}</storeEnabled>
+            <storeEnabled>#{env['CI'] != null and (env['CHANGE_ID']?:'').isBlank() and (env['GITHUB_BASE_REF']?:'').isBlank() and !(env['GRADLE_ENTERPRISE_ACCESS_KEY']?:'').isBlank()}</storeEnabled>
             <server>
                 <url>https://ge.hibernate.org/cache/hsearchtest01/</url>
             </server>


### PR DESCRIPTION
Because it seems to be the case when building directly from branches: instead of not setting the env variable, GitHub sets it to an empty string. That threw off our previous condition, but not the new one.

cc @marko-bekhta FYI, merging now.