### PR TITLE
HSEARCH-5094 Follow-up: Enable testcontainers reuse on CI through workflow/pipeline config rather than the POM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ defaults:
 
 env:
   MAVEN_ARGS: "-e -B --settings .github/mvn-settings.xml --fail-at-end"
+  TESTCONTAINERS_REUSE_ENABLE: true
 
 jobs:
   build:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -447,7 +447,7 @@ or `docker kill <container name>`).
 There are a few ways to enable reusable testcontainers:
 
 1. Enable reusable testcontainers in `~/.testcontainers.properties`, by adding `testcontainers.reuse.enable=true`
-2. Build with `ci-build` Maven profile: `./mvnw clean install -Pci-build`
+2. Set the environment variable `TESTCONTAINERS_REUSE_ENABLE` to `true`.
 
 ### JQAssistant
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -329,6 +329,7 @@ stage('Configure') {
 							+ helper.generateUpstreamTriggers()
 			),
 			helper.generateNotificationProperty(),
+			[$class: 'EnvInjectJobProperty', info: [propertiesContent: 'TESTCONTAINERS_REUSE_ENABLE=true']],
 			parameters([
 					choice(
 							name: 'ENVIRONMENT_SET',

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -1361,25 +1361,6 @@
     </build>
 
     <profiles>
-        <profile>
-            <id>ci-build</id>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-failsafe-plugin</artifactId>
-                            <configuration>
-                                <environmentVariables>
-                                    <!-- To make Testcontainers reusable on CI, where ~/.testcontainers.properties is not necessarily defined -->
-                                    <TESTCONTAINERS_REUSE_ENABLE>true</TESTCONTAINERS_REUSE_ENABLE>
-                                </environmentVariables>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
         <!-- Profile used when testing dependency updates on CI -->
         <profile>
             <id>dependency-update</id>

--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -123,6 +123,7 @@ pipeline {
 		buildDiscarder logRotator(daysToKeepStr: '10', numToKeepStr: '3')
 		disableConcurrentBuilds(abortPrevious: true)
 		overrideIndexTriggers(false)
+		[$class: 'EnvInjectJobProperty', info: [propertiesContent: 'TESTCONTAINERS_REUSE_ENABLE=true']]
 	}
 	stages {
 		// This allows testing the original (unpatched) artifacts,


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5094

Because if we do this through the POM, the environment variable is taken
into account for build caching, which results in cache entries
contributed by CI being ignored when building locally.