### PR TITLE
Revert maven-compiler-plugin to 3.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,8 +274,6 @@
         <version.buildhelper.plugin>3.5.0</version.buildhelper.plugin>
         <version.checkstyle.plugin>3.3.1</version.checkstyle.plugin>
         <version.bundle.plugin>5.1.9</version.bundle.plugin>
-        <!-- Needing 3.6.2 at least because of MCOMPILER-294 -->
-        <!-- Cannot update to 3.12 because of https://issues.apache.org/jira/browse/MCOMPILER-567 -->
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <version.dependency.plugin>3.6.1</version.dependency.plugin>
         <!-- Check dependencies for security vulnerabilities -->

--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
         <version.buildhelper.plugin>3.5.0</version.buildhelper.plugin>
         <version.checkstyle.plugin>3.3.1</version.checkstyle.plugin>
         <version.bundle.plugin>5.1.9</version.bundle.plugin>
-        <version.compiler.plugin>3.13.0</version.compiler.plugin>
+        <version.compiler.plugin>3.12.1</version.compiler.plugin>
         <version.dependency.plugin>3.6.1</version.dependency.plugin>
         <!-- Check dependencies for security vulnerabilities -->
         <version.dependency-check.plugin>9.0.10</version.dependency-check.plugin>


### PR DESCRIPTION
Because:

> a new field forceLegacyJavacApi will make the compiler goal not cacheable until bumping up the Gradle Enterprise extension to 1.21 (should be available before end of month).

I hope dependabot will open another PR to upgrade again; if so let's leave that PR open until we do the Gradle Enterprise upgrade.