### PR TITLE
HSEARCH-5110 Error message when the version of Elasticsearch/Opensearch is too old for vector search states wrong requirements

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -867,8 +867,9 @@ public interface Log extends BasicLogger {
 	SearchException vectorKnnMatchVectorDimensionDiffersFromField(String absoluteFieldPath, int expected, int actual);
 
 	@Message(id = ID_OFFSET + 185,
-			value = "An %1$s distribution version in use is not compatible with the Hibernate Search integration of vector search. "
-					+ "Update your %1$s cluster to a %2$s series to get vector search integration enabled.")
+			value = "The targeted %1$s version is not compatible with the Hibernate Search integration of vector search. "
+					+ "To get vector search integration, upgrade your %1$s cluster to version %2$s or later,"
+					+ " and if you configured the %1$s version in Hibernate Search, update it accordingly.")
 	SearchException searchBackendVersionIncompatibleWithVectorIntegration(String distribution, String version);
 
 	@Message(id = ID_OFFSET + 187,

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/provider/impl/Elasticsearch7IndexFieldTypeFactoryProvider.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/provider/impl/Elasticsearch7IndexFieldTypeFactoryProvider.java
@@ -28,12 +28,12 @@ public class Elasticsearch7IndexFieldTypeFactoryProvider extends AbstractIndexFi
 
 				@Override
 				public void contribute(PropertyMapping mapping, Context context) {
-					throw log.searchBackendVersionIncompatibleWithVectorIntegration( "Elasticsearch", "8.x" );
+					throw log.searchBackendVersionIncompatibleWithVectorIntegration( "Elasticsearch", "8.12" );
 				}
 
 				@Override
 				public <F> void contribute(ElasticsearchIndexValueFieldType.Builder<F> builder, Context context) {
-					throw log.searchBackendVersionIncompatibleWithVectorIntegration( "Elasticsearch", "8.x" );
+					throw log.searchBackendVersionIncompatibleWithVectorIntegration( "Elasticsearch", "8.12" );
 				}
 			};
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5110
