### PR TITLE
Safely publish build scans even for pull requests 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,9 @@ on:
       - '!wip/**/dependency-update/**'
     tags:
       - '**'
-  pull_request:
+  # WARNING: Using pull_request_target to access secrets, but we check out the merge commit.
+  # See checkout action for details.
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       # Pattern order matters: the last matching inclusion/exclusion wins
@@ -85,8 +87,21 @@ jobs:
       - name: Support longpaths on Windows
         if: "startsWith(matrix.os.runs-on, 'windows')"
         run: git config --global core.longpaths true
-      - uses: actions/checkout@v4
+      - name: Check out commit already pushed to branch
+        if: "! github.event.pull_request.number"
+        uses: actions/checkout@v4
+      - name: Check out PR merge commit
+        uses: actions/checkout@v2
+        if: github.event.pull_request.number
         with:
+          # WARNING: This is potentially dangerous since we're checking out unreviewed code,
+          # and since we're using the pull_request_target event we can use secrets.
+          # Thus, we must be extra careful to never expose secrets to steps that execute this code,
+          # and to strictly limit our of secrets to those that only pose minor security threads.
+          # This means in particular we won't expose Develocity credentials to the main maven executions,
+          # but instead will execute maven a third time just to push build scans to Develocity;
+          # see below.
+          ref: "refs/pull/${{ github.event.pull_request.number }}/merge"
           # Fetch the whole history to make sure that gitflow incremental builder
           # can find the base commit.
           fetch-depth: 0
@@ -107,21 +122,39 @@ jobs:
         run: ./mvnw -v
       - name: Docker cleanup
         run: ./ci/docker-cleanup.sh
-      - name: Building code and running unit tests and basic checks
+
+      - name: Build code and run unit tests and basic checks
         run: |
           ./mvnw $MAVEN_ARGS ${{ matrix.os.maven.args }} clean install \
           -Pjqassistant -Pdist -Pci-build -DskipITs
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      - name: Running integration tests in the default environment
+          # WARNING: exposes secrets, so must only be passed to a step that doesn't run unapproved code.
+          GRADLE_ENTERPRISE_ACCESS_KEY: "${{ github.event.pull_request.number && '' || secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}"
+      - name: Publish Develocity build scan for previous build (pull request)
+        if: "!cancelled() && github.event.pull_request.number && secrets.GRADLE_ENTERPRISE_ACCESS_KEY_PR"
+        run: |
+          ./mvnw gradle-enterprise:build-scan-publish-previous
+        env:
+          # WARNING: exposes secrets, so must only be passed to a step that doesn't run unapproved code.
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY_PR }}
+
+      - name: Run integration tests in the default environment
         run: |
           ./mvnw $MAVEN_ARGS ${{ matrix.os.maven.args }} clean verify \
           -Pskip-checks \
           ${{ github.event.pull_request.base.ref && format('-Dincremental -Dgib.referenceBranch=refs/remotes/origin/{0}', github.event.pull_request.base.ref) || '' }}
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          # WARNING: exposes secrets, so must only be passed to a step that doesn't run unapproved code.
+          GRADLE_ENTERPRISE_ACCESS_KEY: "${{ github.event.pull_request.number && '' || secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}"
+      - name: Publish Develocity build scan for previous build (pull request)
+        if: "!cancelled() && github.event.pull_request.number && secrets.GRADLE_ENTERPRISE_ACCESS_KEY_PR"
+        run: |
+          ./mvnw gradle-enterprise:build-scan-publish-previous
+        env:
+          # WARNING: exposes secrets, so must only be passed to a step that doesn't run unapproved code.
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY_PR }}
+
       - name: Docker cleanup
-        if: always()
         run: ./ci/docker-cleanup.sh
       - name: Omit produced artifacts from build cache
         run: rm -r ~/.m2/repository/org/hibernate/search


### PR DESCRIPTION
And do it synchronously (before the build ends) so that Hibernate GitHub Bot is able to list build scans immediately.