### PR TITLE
Bump the build-dependencies group with 2 updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@
         <!-- Check dependencies for security vulnerabilities -->
         <version.dependency-check.plugin>9.0.10</version.dependency-check.plugin>
         <version.exec.plugin>3.2.0</version.exec.plugin>
-        <version.forbiddenapis.plugin>3.6</version.forbiddenapis.plugin>
+        <version.forbiddenapis.plugin>3.7</version.forbiddenapis.plugin>
         <version.jandex.plugin>3.1.7</version.jandex.plugin>
         <version.maven.injection.plugin>1.0.2</version.maven.injection.plugin>
         <version.jar.plugin>3.3.0</version.jar.plugin>
@@ -291,7 +291,7 @@
         <version.source.plugin>3.3.0</version.source.plugin>
         <!-- Surefire versions are a minefield of bugs: be careful with upgrades -->
         <version.surefire.plugin>3.2.5</version.surefire.plugin>
-        <version.surefire.plugin.java-version.asm>9.6</version.surefire.plugin.java-version.asm>
+        <version.surefire.plugin.java-version.asm>9.7</version.surefire.plugin.java-version.asm>
         <version.jacoco.plugin>0.8.11</version.jacoco.plugin>
         <version.com.buschmais.jqassistant.plugin>2.1.0</version.com.buschmais.jqassistant.plugin>
         <version.moditect.plugin>1.2.0.Final</version.moditect.plugin>


### PR DESCRIPTION
Bumps the build-dependencies group with 2 updates: org.ow2.asm:asm, [de.thetaphi:forbiddenapis](https://github.com/policeman-tools/forbidden-apis).

Updates `org.ow2.asm:asm` from 9.6 to 9.7

Updates `de.thetaphi:forbiddenapis` from 3.6 to 3.7
- [Commits](https://github.com/policeman-tools/forbidden-apis/compare/3.6...3.7)

---
updated-dependencies:
- dependency-name: org.ow2.asm:asm dependency-type: direct:production update-type: version-update:semver-minor dependency-group: build-dependencies
- dependency-name: de.thetaphi:forbiddenapis dependency-type: direct:production update-type: version-update:semver-minor dependency-group: build-dependencies ...

<!--
Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HSEARCH.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HSEARCH-<digits>`).
-->