### PR TITLE
HSEARCH-4965 Enable outbox-polling integration tests on Windows

### DIFF
--- a/integrationtest/mapper/orm-outbox-polling/pom.xml
+++ b/integrationtest/mapper/orm-outbox-polling/pom.xml
@@ -100,19 +100,4 @@
         </plugins>
     </build>
 
-    <profiles>
-        <profile>
-            <id>windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <properties>
-                <!-- For some reason these outbox-polling tests don't seem to work on Windows -->
-                <skipITs>true</skipITs>
-            </properties>
-        </profile>
-    </profiles>
-
 </project>

--- a/integrationtest/mapper/orm-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingDynamicShardingRebalancingIT.java
+++ b/integrationtest/mapper/orm-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingDynamicShardingRebalancingIT.java
@@ -130,6 +130,9 @@ class OutboxPollingAutomaticIndexingDynamicShardingRebalancingIT {
 			backendMock.expectWorks( IndexedEntity.NAME )
 					.add( String.valueOf( i ), b -> b.field( "text", "initial" ) );
 		}
+
+		// The filter is there to make sure we don't consume all events while we're creating them,
+		// which apparently can happen on Windows.
 		eventFilter.showAllEvents();
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4965

From what it seems, the recent changes to address various flaky tests addressed the issues on Windows as well. 
I've tried running these tests on my Win-env and also on my fork here: https://github.com/marko-bekhta/hibernate-search/actions/runs/8449830574/job/23144761949?pr=248 (forcing some changes to the module so that the tests will actually get executed and not skipped because of the cache). And there are no failures anymore 🤞🏻 