### PR TITLE
Require approval for Jenkins builds on PRs from external contributors

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ import groovy.transform.Field
 /*
  * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
  */
-@Library('hibernate-jenkins-pipeline-helpers@1.4')
+@Library('hibernate-jenkins-pipeline-helpers@1.9')
 import org.hibernate.jenkins.pipeline.helpers.job.JobHelper
 import org.hibernate.jenkins.pipeline.helpers.alternative.AlternativeMultiMap
 
@@ -181,6 +181,9 @@ stage('Configure') {
 											 Change the branch name and open a new Pull Request.
 										   """)
 	}
+
+	requireApprovalForPullRequest 'hibernate'
+
 	this.environments = AlternativeMultiMap.create([
 			jdk: [
 					// This should not include every JDK; in particular let's not care too much about EOL'd JDKs like version 9


### PR DESCRIPTION
It looks like this in practice:

![image](https://github.com/hibernate/hibernate-search/assets/412878/e08d2f60-355b-4e9f-8c1b-ff8ad5583660)

Anybody in the Hibernate organization is able to approve something like this.

Approval is not required for non-PR builds, or builds of PRs submitted by members of the organization, or builds of PRs explicitly triggered (through the UI) by members of the organization.