### PR TITLE
Backport of follow up on HSEARCH-5113 to 7.1 - Update asserts and vectors matched in knn predicates

### DIFF
--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/KnnPredicateSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/KnnPredicateSpecificsIT.java
@@ -788,16 +788,18 @@ class KnnPredicateSpecificsIT {
 							SearchProjectionFactory::id
 					)
 					.where( f -> f.bool()
-							.should( f.knn( 3 ).field( "location" ).matching( 5.2f, 4.4f ) )
-							.should( f.knn( 3 ).field( "location" ).matching( 7.0f, 9.9f ) )
+							.should( f.knn( 3 ).field( "location" ).matching( 5.2f, 4.4f ) ) // => "ID:1", "ID:2", "ID:4"
+							.should( f.knn( 3 ).field( "location" ).matching( 7.0f, 9.9f ) ) // => "ID:1", "ID:7", "ID:10"
 							// so that we can get to a step where we add another knn clause to already an array of knn clauses:
-							.should( f.knn( 3 ).field( "location" ).matching( 1.4f, 3.2f ) )
+							.should( f.knn( 3 ).field( "location" ).matching( 1.4f, 3.2f ) ) // => "ID:8", "ID:9", "ID:11"
 					).toQuery();
 
 			List<Object> result = query.fetchAll().hits();
 
-			assertThat( result ).hasSizeGreaterThanOrEqualTo( 8 )
-					.contains( "ID:1", "ID:10", "ID:9", "ID:2", "ID:4", "ID:8", "ID:11", "ID:7" );
+			// This test can sometimes result in 8 sometimes in 6 documents returned.
+			//  But the main goal of this test is to make sure that multiple should knn clauses are combining the results
+			//  hence it should be enough to make sure that there are more than 3 docs returned.
+			assertThat( result ).hasSizeGreaterThan( 3 );
 		}
 
 		private static class PredicateIndexBinding {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5113

backport of https://github.com/hibernate/hibernate-search/pull/4080