### PR TITLE
HSEARCH-5118 Generate module-info for `hibernate-search-backend-lucene`

### DIFF
--- a/backend/lucene/pom.xml
+++ b/backend/lucene/pom.xml
@@ -71,21 +71,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.moditect</groupId>
-                <artifactId>moditect-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>add-module-infos</id>
-                        <!-- Do not generate module-info with moditect-maven-plugin:
-                            Lucene has split packages module issue and thus cannot be consumed as a module. -->
-                        <phase>none</phase>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/build/config/src/main/resources/forbidden-internal.txt
+++ b/build/config/src/main/resources/forbidden-internal.txt
@@ -84,3 +84,7 @@ junit.framework.Assert @ Use AssertJ or non-deprecated JUnit assertions instead
 ################################################################################################################
 # Nobody should be using the StringHelper from commons-annotations: use org.hibernate.search.util.StringHelper.
 org.hibernate.annotations.common.util.StringHelper @ Use org.hibernate.search.util.StringHelper instead.
+
+################################################################################################################
+# Nobody should be using the unstable, experimental code from org.apache.lucene.sandbox that cannot reasonably be relied on.
+org.apache.lucene.sandbox.*

--- a/build/config/src/main/resources/forbidden-public.txt
+++ b/build/config/src/main/resources/forbidden-public.txt
@@ -124,3 +124,7 @@ junit.framework.Assert @ Use AssertJ or non-deprecated JUnit assertions instead
 ################################################################################################################
 # Nobody should be using the StringHelper from commons-annotations: use org.hibernate.search.util.StringHelper.
 org.hibernate.annotations.common.util.StringHelper @ Use org.hibernate.search.util.StringHelper instead.
+
+################################################################################################################
+# Nobody should be using the unstable, experimental code from org.apache.lucene.sandbox that cannot reasonably be relied on.
+org.apache.lucene.sandbox.*

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -430,13 +430,6 @@
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-queryparser</artifactId>
                 <version>${version.org.apache.lucene}</version>
-                <exclusions>
-                    <!-- This artifact contains unstable, experimental code that we cannot reasonably rely on. -->
-                    <exclusion>
-                        <groupId>org.apache.lucene</groupId>
-                        <artifactId>lucene-sandbox</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.lucene</groupId>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5118

There's no split package problem in Lucene anymore. 
To make moditec generate the module info the `lucene-sandbox` cannot be excluded, but I've added a couple of rules to the forbidden API config instead.