### PR TITLE
Bump the build-dependencies group with 4 updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
         <version.japicmp.plugin>0.20.0</version.japicmp.plugin>
         <version.nexus-staging.plugin>1.6.13</version.nexus-staging.plugin>
         <version.deploy.plugin>3.1.1</version.deploy.plugin>
-        <version.gpg.plugin>3.2.1</version.gpg.plugin>
+        <version.gpg.plugin>3.2.2</version.gpg.plugin>
         <version.flatten-maven-plugin>1.6.0</version.flatten-maven-plugin>
         <version.assembly.plugin>3.7.1</version.assembly.plugin>
         <version.buildhelper.plugin>3.5.0</version.buildhelper.plugin>
@@ -277,7 +277,7 @@
         <version.compiler.plugin>3.12.1</version.compiler.plugin>
         <version.dependency.plugin>3.6.1</version.dependency.plugin>
         <!-- Check dependencies for security vulnerabilities -->
-        <version.dependency-check.plugin>9.0.10</version.dependency-check.plugin>
+        <version.dependency-check.plugin>9.1.0</version.dependency-check.plugin>
         <version.exec.plugin>3.2.0</version.exec.plugin>
         <version.forbiddenapis.plugin>3.7</version.forbiddenapis.plugin>
         <version.jandex.plugin>3.1.7</version.jandex.plugin>
@@ -294,11 +294,11 @@
         <version.surefire.plugin.java-version.asm>9.7</version.surefire.plugin.java-version.asm>
         <version.jacoco.plugin>0.8.11</version.jacoco.plugin>
         <version.com.buschmais.jqassistant.plugin>2.1.0</version.com.buschmais.jqassistant.plugin>
-        <version.moditect.plugin>1.2.0.Final</version.moditect.plugin>
+        <version.moditect.plugin>1.2.1.Final</version.moditect.plugin>
         <version.sonar.plugin>3.11.0.3922</version.sonar.plugin>
         <version.scripting.plugin>3.0.0</version.scripting.plugin>
         <version.org.apache.groovy.groovy-jsr223>4.0.13</version.org.apache.groovy.groovy-jsr223>
-        <version.com.puppycrawl.tools.checkstyle>10.14.2</version.com.puppycrawl.tools.checkstyle>
+        <version.com.puppycrawl.tools.checkstyle>10.15.0</version.com.puppycrawl.tools.checkstyle>
         <version.versions.plugin>2.16.2</version.versions.plugin>
         <version.maven-wrapper-plugin>3.2.0</version.maven-wrapper-plugin>
         <version.impsort-maven-plugin>1.9.0</version.impsort-maven-plugin>


### PR DESCRIPTION
Bumps the build-dependencies group with 4 updates:

| Package | From | To |
| --- | --- | --- |
| [org.apache.maven.plugins:maven-gpg-plugin](https://github.com/apache/maven-gpg-plugin) | `3.2.1` | `3.2.2` | | [org.apache.maven.plugins:maven-compiler-plugin](https://github.com/apache/maven-compiler-plugin) | `3.12.1` | `3.13.0` | | [org.moditect:moditect-maven-plugin](https://github.com/moditect/moditect) | `1.2.0.Final` | `1.2.1.Final` | | [org.owasp:dependency-check-maven](https://github.com/jeremylong/DependencyCheck) | `9.0.10` | `9.1.0` | | [org.awaitility:awaitility](https://github.com/awaitility/awaitility) | `4.2.0` | `4.2.1` | | [com.puppycrawl.tools:checkstyle](https://github.com/checkstyle/checkstyle) | `10.14.2` | `10.15.0` |

Updates `org.apache.maven.plugins:maven-gpg-plugin` from 3.2.1 to 3.2.2
- [Release notes](https://github.com/apache/maven-gpg-plugin/releases)
- [Commits](https://github.com/apache/maven-gpg-plugin/compare/maven-gpg-plugin-3.2.1...maven-gpg-plugin-3.2.2)

Updates `org.moditect:moditect-maven-plugin` from 1.2.0.Final to 1.2.1.Final
- [Release notes](https://github.com/moditect/moditect/releases)
- [Commits](https://github.com/moditect/moditect/compare/1.2.0.Final...1.2.1.Final)

Updates `org.owasp:dependency-check-maven` from 9.0.10 to 9.1.0
- [Release notes](https://github.com/jeremylong/DependencyCheck/releases)
- [Changelog](https://github.com/jeremylong/DependencyCheck/blob/main/CHANGELOG.md)
- [Commits](https://github.com/jeremylong/DependencyCheck/compare/v9.0.10...v9.1.0)

Updates `com.puppycrawl.tools:checkstyle` from 10.14.2 to 10.15.0
- [Release notes](https://github.com/checkstyle/checkstyle/releases)
- [Commits](https://github.com/checkstyle/checkstyle/compare/checkstyle-10.14.2...checkstyle-10.15.0)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugins:maven-gpg-plugin dependency-type: direct:production update-type: version-update:semver-patch dependency-group: build-dependencies
- dependency-name: org.moditect:moditect-maven-plugin dependency-type: direct:production update-type: version-update:semver-patch dependency-group: build-dependencies
- dependency-name: org.owasp:dependency-check-maven dependency-type: direct:production update-type: version-update:semver-minor dependency-group: build-dependencies
- dependency-name: com.puppycrawl.tools:checkstyle dependency-type: direct:production update-type: version-update:semver-minor dependency-group: build-dependencies ...

<!--
Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HSEARCH.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HSEARCH-<digits>`).
-->