### PR TITLE
Upgrade to develocity-maven-extension 1.21 / hibernate-search-develocity-extension 2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ nbactions.xml
 
 # Gradle Enterprise/Develocity
 /.mvn/.gradle-enterprise
+/.mvn/.develocity

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,18 +1,11 @@
-<gradleEnterprise
-        xmlns="https://www.gradle.com/gradle-enterprise-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://www.gradle.com/gradle-enterprise-maven https://www.gradle.com/schema/gradle-enterprise-maven.xsd">
+<develocity
+        xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
     <server>
         <url>https://ge.hibernate.org</url>
         <allowUntrusted>false</allowUntrusted>
     </server>
     <buildScan>
-        <!-- adjust conditions ?
-        mvn gradle-enterprise:provision-access-key
-        https://docs.gradle.com/enterprise/maven-extension/#publishing_based_on_criteria
-         -->
-        <!-- build scan publication is configured in gradle-enterprise-custom-user-data.groovy
-        to leverage options to disable build scan publication for test builds
-        -->
         <!--
         Expression support is documented here: https://docs.gradle.com/enterprise/maven-extension/#expression_support
         -->
@@ -21,7 +14,7 @@
           <ipAddresses>#{{'0.0.0.0'}}</ipAddresses>
         </obfuscation>
         <capture>
-          <goalInputFiles>true</goalInputFiles>
+          <fileFingerprints>true</fileFingerprints>
         </capture>
         <!-- https://docs.gradle.com/enterprise/maven-extension/#manual_access_key_configuration -->
         <backgroundBuildScanUpload>#{env['CI'] == null}</backgroundBuildScanUpload>
@@ -35,4 +28,4 @@
             <storeEnabled>#{env['CI'] != null and (env['CHANGE_ID']?:'').isBlank() and (env['GITHUB_BASE_REF']?:'').isBlank() and !(env['GRADLE_ENTERPRISE_ACCESS_KEY']?:'').isBlank()}</storeEnabled>
         </remote>
     </buildCache>
-</gradleEnterprise>
+</develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,17 +1,17 @@
 <extensions>
     <extension>
         <groupId>com.gradle</groupId>
-        <artifactId>gradle-enterprise-maven-extension</artifactId>
-        <version>1.20.1</version>
+        <artifactId>develocity-maven-extension</artifactId>
+        <version>1.21</version>
     </extension>
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>common-custom-user-data-maven-extension</artifactId>
-        <version>1.13</version>
+        <version>2.0</version>
     </extension>
     <extension>
         <groupId>org.hibernate.search.develocity</groupId>
         <artifactId>hibernate-search-develocity-extension</artifactId>
-        <version>1.0.13.Final</version>
+        <version>2.0.0.Final</version>
     </extension>
 </extensions>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ To publish build scans for your local builds,
 and once you have one, run this from the root of your local clone of Hibernate Search:
 
 ```shell
-./mvnw gradle-enterprise:provision-access-key
+./mvnw com.gradle:develocity-maven-extension:provision-access-key
 ```
 
 To opt out from build scans for a particular build (e.g. when working on a security vulnerability),


### PR DESCRIPTION
Local build scans and build caching seem to work fine... Let's merge and see if this holds for CI and remote caches :)