### PR TITLE
Bump the build-dependencies group with 3 updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -126,6 +126,9 @@ updates:
       #  with which jboss-logging annotation processor can still work.
       #  To be removed once we update the AP to the one with a fix.
       - dependency-name: "org.codehaus.plexus:*"
+      # Because of https://github.com/awaitility/awaitility/issues/277 :
+      - dependency-name: "org.awaitility:awaitility"
+        versions: [ "4.2.1" ]
   - package-ecosystem: "docker"
     registries:
       - dockerhub

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -141,6 +141,7 @@
         <version.org.hamcrest>2.2</version.org.hamcrest>
         <version.org.mockito>5.11.0</version.org.mockito>
         <version.org.assertj.assertj-core>3.25.3</version.org.assertj.assertj-core>
+        <!-- NOTE: Remove a Dependabot rule for 4.2.1 once the upgrade can be applied -->
         <version.org.awaitily>4.2.0</version.org.awaitily>
         <version.org.skyscreamer.jsonassert>1.5.1</version.org.skyscreamer.jsonassert>
         <version.io.takari.junit>1.2.7</version.io.takari.junit>

--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
         <version.buildhelper.plugin>3.5.0</version.buildhelper.plugin>
         <version.checkstyle.plugin>3.3.1</version.checkstyle.plugin>
         <version.bundle.plugin>5.1.9</version.bundle.plugin>
-        <version.compiler.plugin>3.12.1</version.compiler.plugin>
+        <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <version.dependency.plugin>3.6.1</version.dependency.plugin>
         <!-- Check dependencies for security vulnerabilities -->
         <version.dependency-check.plugin>9.1.0</version.dependency-check.plugin>
@@ -288,11 +288,11 @@
         <version.processor.plugin>5.0</version.processor.plugin>
         <version.resources.plugin>3.3.1</version.resources.plugin>
         <version.shade.plugin>3.5.2</version.shade.plugin>
-        <version.source.plugin>3.3.0</version.source.plugin>
+        <version.source.plugin>3.3.1</version.source.plugin>
         <!-- Surefire versions are a minefield of bugs: be careful with upgrades -->
         <version.surefire.plugin>3.2.5</version.surefire.plugin>
         <version.surefire.plugin.java-version.asm>9.7</version.surefire.plugin.java-version.asm>
-        <version.jacoco.plugin>0.8.11</version.jacoco.plugin>
+        <version.jacoco.plugin>0.8.12</version.jacoco.plugin>
         <version.com.buschmais.jqassistant.plugin>2.1.0</version.com.buschmais.jqassistant.plugin>
         <version.moditect.plugin>1.2.1.Final</version.moditect.plugin>
         <version.sonar.plugin>3.11.0.3922</version.sonar.plugin>


### PR DESCRIPTION
Bumps the build-dependencies group with 3 updates: [org.apache.maven.plugins:maven-compiler-plugin](https://github.com/apache/maven-compiler-plugin), [org.apache.maven.plugins:maven-source-plugin](https://github.com/apache/maven-source-plugin), [org.jacoco:jacoco-maven-plugin](https://github.com/jacoco/jacoco).

Updates `org.apache.maven.plugins:maven-compiler-plugin` from 3.12.1 to 3.13.0
- [Release notes](https://github.com/apache/maven-compiler-plugin/releases)
- [Commits](https://github.com/apache/maven-compiler-plugin/compare/maven-compiler-plugin-3.12.1...maven-compiler-plugin-3.13.0)

Updates `org.apache.maven.plugins:maven-source-plugin` from 3.3.0 to 3.3.1
- [Commits](https://github.com/apache/maven-source-plugin/compare/maven-source-plugin-3.3.0...maven-source-plugin-3.3.1)

Updates `org.jacoco:jacoco-maven-plugin` from 0.8.11 to 0.8.12
- [Release notes](https://github.com/jacoco/jacoco/releases)
- [Commits](https://github.com/jacoco/jacoco/compare/v0.8.11...v0.8.12)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugins:maven-compiler-plugin dependency-type: direct:production update-type: version-update:semver-minor dependency-group: build-dependencies
- dependency-name: org.apache.maven.plugins:maven-source-plugin dependency-type: direct:production update-type: version-update:semver-patch dependency-group: build-dependencies
- dependency-name: org.jacoco:jacoco-maven-plugin dependency-type: direct:production update-type: version-update:semver-patch dependency-group: build-dependencies ...