### PR TITLE
Backport HSEARCH-5128 to branch 7.1 - Update the supported versions of Java in the documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ nbactions.xml
 
 # Cache folders for formatting plugins:
 .cache
+
+# Gradle Enterprise/Develocity
+/.mvn/.gradle-enterprise
+/.mvn/.develocity

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -190,6 +190,8 @@ stage('Configure') {
 					new JdkBuildEnvironment(version: '23', testCompilerTool: 'OpenJDK 23 Latest',
 							testLauncherArgs: '--enable-preview -Dnet.bytebuddy.experimental=true',
 							condition: TestCondition.AFTER_MERGE)
+					// IMPORTANT: Make sure to update the documentation for any newly supported Java versions
+					//            See java-version.main.compatible.expected.text in POMs.
 			],
 			compiler: [
 					new CompilerBuildEnvironment(name: 'eclipse', mavenProfile: 'compiler-eclipse',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -249,6 +249,9 @@ stage('Configure') {
 					new LocalElasticsearchBuildEnvironment(version: '8.11.4', condition: TestCondition.ON_DEMAND),
 					new LocalElasticsearchBuildEnvironment(version: '8.12.2', condition: TestCondition.ON_DEMAND),
 					new LocalElasticsearchBuildEnvironment(version: '8.13.2', condition: TestCondition.BEFORE_MERGE, isDefault: true),
+					// IMPORTANT: Make sure to update the documentation for any newly supported Elasticsearch versions
+					//            See version.org.elasticsearch.compatible.expected.text
+					//            and version.org.elasticsearch.compatible.regularly-tested.text in POMs.
 
 					// --------------------------------------------
 					// OpenSearch
@@ -270,6 +273,9 @@ stage('Configure') {
 					new LocalOpenSearchBuildEnvironment(version: '2.12.0', condition: TestCondition.ON_DEMAND),
 					new LocalOpenSearchBuildEnvironment(version: '2.13.0', condition: TestCondition.BEFORE_MERGE),
 					// See https://opensearch.org/lines/2x.html for a list of all 2.x versions
+					// IMPORTANT: Make sure to update the documentation for any newly supported OpenSearch versions
+					//            See version.org.opensearch.compatible.expected.text
+					//            and version.org.opensearch.compatible.regularly-tested.text in POMs.
 
 					// --------------------------------------------
 					// Amazon OpenSearch Serverless dialect running against a local OpenSearch instance

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -284,6 +284,7 @@
                         <hibernateVersion>${version.org.hibernate.orm}</hibernateVersion>
                         <hibernateDocUrl>${documentation.org.hibernate.orm.url}</hibernateDocUrl>
                         <hibernateJavadocUrl>${javadoc.org.hibernate.orm.url}</hibernateJavadocUrl>
+                        <javaCompatibleVersions>${java-version.main.compatible.expected.text}</javaCompatibleVersions>
                         <javaeeUrl>https://www.oracle.com/java/technologies/java-ee-glance.html</javaeeUrl>
                         <jakartaUrl>https://jakarta.ee/</jakartaUrl>
                         <jakartaPersistenceVersion>${parsed-version.jakarta.persistence.majorVersion}.${parsed-version.jakarta.persistence.minorVersion}</jakartaPersistenceVersion>

--- a/documentation/src/main/asciidoc/public/reference/_compatibility.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_compatibility.adoc
@@ -9,7 +9,7 @@
 |===============
 | h|Version h|Note
 |Java Runtime
-|8, 11 or 17
+|{javaCompatibleVersions}
 |
 |Hibernate ORM (for the <<mapper-orm,Hibernate ORM mapper>>
 |{hibernateVersion}

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,8 @@
         <java-version.main.release>11</java-version.main.release>
         <java-version.main.compiler.java_home>${java.home}</java-version.main.compiler.java_home>
         <java-version.main.compiler>${java-version.main.compiler.java_home}/bin/javac</java-version.main.compiler>
+        <!-- The versions of Java documented as supported for applications using Hibernate Search -->
+        <java-version.main.compatible.expected.text>11, 17 or 21</java-version.main.compatible.expected.text>
         <!-- The version of test bytecode, useful for testing compatibility with newer JDKs -->
         <!-- Set to the expected version of the JDK running Maven by default, but overridden on CI -->
         <java-version.test.release>${jdk.min.version}</java-version.test.release>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5128

Backport of #4109 to branch 7.1.