### PR TITLE
Rebuild modules that are modified with patches from a wip Lucene 10 upgrade branch

### DIFF
--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -45,7 +45,7 @@ Map settings() {
 					testCompilerTool: 'OpenJDK 21 Latest',
 					updateProperties: ['version.org.apache.lucene'],
 					onlyRunTestDependingOn: ['hibernate-search-backend-lucene'],
-					additionalMavenArgs: '-Dtest.elasticsearch.skip=true -pl :hibernate-search-backend-lucene,:hibernate-search-util-internal-integrationtest-backend-lucene'
+					additionalMavenArgs: '-Dtest.elasticsearch.skip=true -pl :hibernate-search-backend-lucene,:hibernate-search-util-internal-integrationtest-backend-lucene,:hibernate-search-v5migrationhelper-engine'
 			]
 		case 'elasticsearch-latest':
 			return [


### PR DESCRIPTION
migration helper has some code affected by the Lucene 10 changes so we need to rebuild it as well...