### PR TITLE
Update CockroachDB configuration

### DIFF
--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/DatabaseContainer.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/DatabaseContainer.java
@@ -284,7 +284,7 @@ public final class DatabaseContainer {
 								.forPort( 8080 )
 								.forStatusCode( 200 ),
 						8080
-				).withCommand( "start-single-node --insecure" )
+				).withCommand( "start-single-node --insecure --store=type=mem,size=0.25 --advertise-addr=localhost" )
 						.withStartupTimeout( EXTENDED_TIMEOUT )
 						.withCreateContainerCmdModifier( cmd -> {
 							HostConfig hostConfig = cmd.getHostConfig();


### PR DESCRIPTION
https://www.cockroachlabs.com/docs/stable/local-testing#use-a-local-single-node-cluster-with-in-memory-storage

I tried it on `AutomaticIndexingEmbeddableIT` locally and had a 9 sec vs 12 sec execution time compared to the current command. 