### PR TITLE
Update Develocity env variable name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,14 +129,14 @@ jobs:
           -Pjqassistant -Pdist -Pci-build -DskipITs
         env:
           # WARNING: exposes secrets, so must only be passed to a step that doesn't run unapproved code.
-          GRADLE_ENTERPRISE_ACCESS_KEY: "${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}"
+          DEVELOCITY_ACCESS_KEY: "${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}"
       - name: Publish Develocity build scan for previous build (pull request)
         if: "${{ !cancelled() && github.event_name == 'pull_request_target' && github.repository == 'hibernate/hibernate-search' }}"
         run: |
           ./mvnw $MAVEN_ARGS gradle-enterprise:build-scan-publish-previous
         env:
           # WARNING: exposes secrets, so must only be passed to a step that doesn't run unapproved code.
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY_PR }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY_PR }}
 
       - name: Run integration tests in the default environment
         run: |
@@ -145,14 +145,14 @@ jobs:
           ${{ github.event.pull_request.base.ref && format('-Dincremental -Dgib.referenceBranch=refs/remotes/origin/{0}', github.event.pull_request.base.ref) || '' }}
         env:
           # WARNING: exposes secrets, so must only be passed to a step that doesn't run unapproved code.
-          GRADLE_ENTERPRISE_ACCESS_KEY: "${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}"
+          DEVELOCITY_ACCESS_KEY: "${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}"
       - name: Publish Develocity build scan for previous build (pull request)
         if: "${{ !cancelled() && github.event_name == 'pull_request_target' && github.repository == 'hibernate/hibernate-search' }}"
         run: |
           ./mvnw $MAVEN_ARGS gradle-enterprise:build-scan-publish-previous
         env:
           # WARNING: exposes secrets, so must only be passed to a step that doesn't run unapproved code.
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY_PR }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY_PR }}
 
       - name: Docker cleanup
         run: ./ci/docker-cleanup.sh

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -25,7 +25,7 @@
         </local>
         <remote>
             <enabled>#{properties['no-build-cache'] == null}</enabled>
-            <storeEnabled>#{env['CI'] != null and (env['CHANGE_ID']?:'').isBlank() and (env['GITHUB_BASE_REF']?:'').isBlank() and !(env['GRADLE_ENTERPRISE_ACCESS_KEY']?:'').isBlank()}</storeEnabled>
+            <storeEnabled>#{env['CI'] != null and (env['CHANGE_ID']?:'').isBlank() and (env['GITHUB_BASE_REF']?:'').isBlank() and !(env['DEVELOCITY_ACCESS_KEY']?:'').isBlank()}</storeEnabled>
         </remote>
     </buildCache>
 </develocity>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,11 +134,11 @@ import org.hibernate.jenkins.pipeline.helpers.alternative.AlternativeMultiMap
  *     develocity:
  *       credentials:
  *         # String containing the ID of Develocity credentials used on "main" (non-PR) builds. Optional.
- *         # Expects something valid for the GRADLE_ENTERPRISE_ACCESS_KEY environment variable.
+ *         # Expects something valid for the DEVELOCITY_ACCESS_KEY environment variable.
  *         # See https://docs.gradle.com/enterprise/gradle-plugin/#via_environment_variable
  *         main: ...
  *         # String containing the ID of Develocity credentials used on PR builds. Optional.
- *         # Expects something valid for the GRADLE_ENTERPRISE_ACCESS_KEY environment variable.
+ *         # Expects something valid for the DEVELOCITY_ACCESS_KEY environment variable.
  *         # See https://docs.gradle.com/enterprise/gradle-plugin/#via_environment_variable
  *         # WARNING: These credentials should not give write access to the build cache!
  *         pr: ...
@@ -931,7 +931,7 @@ void mvn(String args) {
 		// Not a PR: we can pass credentials to the build, allowing it to populate the build cache
 		// and to publish build scans directly.
 		withCredentials([string(credentialsId: develocityMainCredentialsId,
-				variable: 'GRADLE_ENTERPRISE_ACCESS_KEY')]) {
+				variable: 'DEVELOCITY_ACCESS_KEY')]) {
 			withGradle { // withDevelocity, actually: https://plugins.jenkins.io/gradle/#plugin-content-capturing-build-scans-from-jenkins-pipeline
 				sh "mvn $args"
 			}
@@ -944,7 +944,7 @@ void mvn(String args) {
 			sh "mvn $args"
 		}, { // Finally
 			withCredentials([string(credentialsId: develocityPrCredentialsId,
-					variable: 'GRADLE_ENTERPRISE_ACCESS_KEY')]) {
+					variable: 'DEVELOCITY_ACCESS_KEY')]) {
 				withGradle { // withDevelocity, actually: https://plugins.jenkins.io/gradle/#plugin-content-capturing-build-scans-from-jenkins-pipeline
 					sh 'mvn gradle-enterprise:build-scan-publish-previous'
 				}

--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -93,7 +93,7 @@ def withMavenWorkspace(Closure body) {
 					junitPublisher(disabled: true)
 			]) {
 		withCredentials([string(credentialsId: 'ge.hibernate.org-access-key',
-				variable: 'GRADLE_ENTERPRISE_ACCESS_KEY')]) {
+				variable: 'DEVELOCITY_ACCESS_KEY')]) {
 			withGradle { // withDevelocity, actually: https://plugins.jenkins.io/gradle/#plugin-content-capturing-build-scans-from-jenkins-pipeline
 				body()
 			}


### PR DESCRIPTION
```
[WARNING] The following functionality has been deprecated and will be removed in the next major release of the Develocity Maven extension: 
[WARNING] - The deprecated "GRADLE_ENTERPRISE_ACCESS_KEY" environment variable has been replaced by "DEVELOCITY_ACCESS_KEY"
```
^ noticed in the logs for both CI and GH