### PR TITLE
HSEARCH-4927 Take into account all integration tests in Sonar reports

### DIFF
--- a/build/reports/pom.xml
+++ b/build/reports/pom.xml
@@ -223,7 +223,7 @@
 
     <profiles>
         <profile>
-            <id>coverage</id>
+            <id>coverage-report</id>
             <build>
                 <plugins>
                     <plugin>
@@ -232,7 +232,7 @@
                         <executions>
                             <execution>
                                 <id>jacoco-report-aggregate</id>
-                                <phase>verify</phase>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>report-aggregate</goal>
                                 </goals>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -24,6 +24,8 @@
         <failsafe.lucene.summaryFile>${failsafe.lucene.reportsDirectory}/failsafe-summary.xml</failsafe.lucene.summaryFile>
         <failsafe.elasticsearch.reportsDirectory>${project.build.directory}/failsafe-reports/elasticsearch</failsafe.elasticsearch.reportsDirectory>
         <failsafe.elasticsearch.summaryFile>${failsafe.elasticsearch.reportsDirectory}/failsafe-summary.xml</failsafe.elasticsearch.summaryFile>
+        <failsafe.jvm.args.jacoco.lucene></failsafe.jvm.args.jacoco.lucene>
+        <failsafe.jvm.args.jacoco.elasticsearch></failsafe.jvm.args.jacoco.elasticsearch>
 
         <asciidoctor.base-output-dir>${project.build.directory}/asciidoctor/</asciidoctor.base-output-dir>
         <asciidoctor.theme-dir>${project.build.directory}/hibernate-asciidoctor-theme</asciidoctor.theme-dir>
@@ -113,42 +115,6 @@
                          This is probably a compiler bug, so here we need to work around it. -->
                     <showDeprecation>false</showDeprecation>
                 </configuration>
-            </plugin>
-            <!-- We need to send the jacoco report of each test execution to a different file,
-                 otherwise Develocity won't be able to cache test executions. -->
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>jacoco-prepare-agent-integration</id>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>jacoco-prepare-agent-integration-lucene</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>prepare-agent-integration</goal>
-                        </goals>
-                        <configuration>
-                            <propertyName>failsafe.jvm.args.jacoco.lucene</propertyName>
-                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/lucene/jacoco.exec</destFile>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>jacoco-prepare-agent-integration-elasticsearch</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>prepare-agent-integration</goal>
-                        </goals>
-                        <configuration>
-                            <propertyName>failsafe.jvm.args.jacoco.elasticsearch</propertyName>
-                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/elasticsearch/jacoco.exec</destFile>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -462,6 +428,49 @@
             <properties>
                 <failsafe.elasticsearch.summaryFile>${rootProject.empty.failsafe.summaryFile}</failsafe.elasticsearch.summaryFile>
             </properties>
+        </profile>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <!-- We need to send the jacoco report of each test execution to a different file,
+                        otherwise Develocity won't be able to cache test executions. -->
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>jacoco-prepare-agent-integration</id>
+                                <configuration>
+                                    <skip>true</skip>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>jacoco-prepare-agent-integration-lucene</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                                <configuration>
+                                    <propertyName>failsafe.jvm.args.jacoco.lucene</propertyName>
+                                    <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/lucene/jacoco.exec</destFile>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>jacoco-prepare-agent-integration-elasticsearch</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                                <configuration>
+                                    <propertyName>failsafe.jvm.args.jacoco.elasticsearch</propertyName>
+                                    <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/elasticsearch/jacoco.exec</destFile>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -134,7 +134,7 @@
                         </goals>
                         <configuration>
                             <propertyName>failsafe.jvm.args.jacoco.lucene</propertyName>
-                            <destFile>${project.build.directory}/lucene/jacoco.exec</destFile>
+                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/lucene/jacoco.exec</destFile>
                         </configuration>
                     </execution>
                     <execution>
@@ -145,7 +145,7 @@
                         </goals>
                         <configuration>
                             <propertyName>failsafe.jvm.args.jacoco.elasticsearch</propertyName>
-                            <destFile>${project.build.directory}/elasticsearch/jacoco.exec</destFile>
+                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/elasticsearch/jacoco.exec</destFile>
                         </configuration>
                     </execution>
                 </executions>

--- a/integrationtest/mapper/orm-jakarta-batch/pom.xml
+++ b/integrationtest/mapper/orm-jakarta-batch/pom.xml
@@ -111,7 +111,7 @@
                         </goals>
                         <configuration>
                             <propertyName>failsafe.jvm.args.jacoco.lucene-jbatch</propertyName>
-                            <destFile>${project.build.directory}/lucene-jbatch/jacoco.exec</destFile>
+                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/lucene-jbatch/jacoco.exec</destFile>
                         </configuration>
                     </execution>
                     <execution>
@@ -122,7 +122,7 @@
                         </goals>
                         <configuration>
                             <propertyName>failsafe.jvm.args.jacoco.lucene-jberet</propertyName>
-                            <destFile>${project.build.directory}/lucene-jberet/jacoco.exec</destFile>
+                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/lucene-jberet/jacoco.exec</destFile>
                         </configuration>
                     </execution>
                     <execution>
@@ -133,7 +133,7 @@
                         </goals>
                         <configuration>
                             <propertyName>failsafe.jvm.args.jacoco.elasticsearch-jbatch</propertyName>
-                            <destFile>${project.build.directory}/elasticsearch-jbatch/jacoco.exec</destFile>
+                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/elasticsearch-jbatch/jacoco.exec</destFile>
                         </configuration>
                     </execution>
                     <execution>
@@ -144,7 +144,7 @@
                         </goals>
                         <configuration>
                             <propertyName>failsafe.jvm.args.jacoco.elasticsearch-jberet</propertyName>
-                            <destFile>${project.build.directory}/elasticsearch-jberet/jacoco.exec</destFile>
+                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/elasticsearch-jberet/jacoco.exec</destFile>
                         </configuration>
                     </execution>
                 </executions>

--- a/integrationtest/mapper/orm-jakarta-batch/pom.xml
+++ b/integrationtest/mapper/orm-jakarta-batch/pom.xml
@@ -26,6 +26,10 @@
         <failsafe.elasticsearch-jbatch.summaryFile>${failsafe.elasticsearch-jbatch.reportsDirectory}/failsafe-summary.xml</failsafe.elasticsearch-jbatch.summaryFile>
         <failsafe.elasticsearch-jberet.reportsDirectory>${project.build.directory}/failsafe-reports/elasticsearch-jberet</failsafe.elasticsearch-jberet.reportsDirectory>
         <failsafe.elasticsearch-jberet.summaryFile>${failsafe.elasticsearch-jberet.reportsDirectory}/failsafe-summary.xml</failsafe.elasticsearch-jberet.summaryFile>
+        <failsafe.jvm.args.jacoco.lucene-jbatch></failsafe.jvm.args.jacoco.lucene-jbatch>
+        <failsafe.jvm.args.jacoco.lucene-jberet></failsafe.jvm.args.jacoco.lucene-jberet>
+        <failsafe.jvm.args.jacoco.elasticsearch-jbatch></failsafe.jvm.args.jacoco.elasticsearch-jbatch>
+        <failsafe.jvm.args.jacoco.elasticsearch-jberet></failsafe.jvm.args.jacoco.elasticsearch-jberet>
     </properties>
 
     <dependencies>
@@ -91,64 +95,6 @@
 
     <build>
         <plugins>
-            <!-- We need to send the jacoco report of each test execution to a different file,
-                 otherwise Develocity won't be able to cache test executions. -->
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>jacoco-prepare-agent-integration</id>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>jacoco-prepare-agent-integration-lucene-jbatch</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>prepare-agent-integration</goal>
-                        </goals>
-                        <configuration>
-                            <propertyName>failsafe.jvm.args.jacoco.lucene-jbatch</propertyName>
-                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/lucene-jbatch/jacoco.exec</destFile>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>jacoco-prepare-agent-integration-lucene-jberet</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>prepare-agent-integration</goal>
-                        </goals>
-                        <configuration>
-                            <propertyName>failsafe.jvm.args.jacoco.lucene-jberet</propertyName>
-                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/lucene-jberet/jacoco.exec</destFile>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>jacoco-prepare-agent-integration-elasticsearch-jbatch</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>prepare-agent-integration</goal>
-                        </goals>
-                        <configuration>
-                            <propertyName>failsafe.jvm.args.jacoco.elasticsearch-jbatch</propertyName>
-                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/elasticsearch-jbatch/jacoco.exec</destFile>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>jacoco-prepare-agent-integration-elasticsearch-jberet</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>prepare-agent-integration</goal>
-                        </goals>
-                        <configuration>
-                            <propertyName>failsafe.jvm.args.jacoco.elasticsearch-jberet</propertyName>
-                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/elasticsearch-jberet/jacoco.exec</destFile>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
@@ -310,6 +256,71 @@
                 <failsafe.elasticsearch-jbatch.summaryFile>${rootProject.empty.failsafe.summaryFile}</failsafe.elasticsearch-jbatch.summaryFile>
                 <failsafe.elasticsearch-jberet.summaryFile>${rootProject.empty.failsafe.summaryFile}</failsafe.elasticsearch-jberet.summaryFile>
             </properties>
+        </profile>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <!-- We need to send the jacoco report of each test execution to a different file,
+                        otherwise Develocity won't be able to cache test executions. -->
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>jacoco-prepare-agent-integration</id>
+                                <configuration>
+                                    <skip>true</skip>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>jacoco-prepare-agent-integration-lucene-jbatch</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                                <configuration>
+                                    <propertyName>failsafe.jvm.args.jacoco.lucene-jbatch</propertyName>
+                                    <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/lucene-jbatch/jacoco.exec</destFile>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>jacoco-prepare-agent-integration-lucene-jberet</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                                <configuration>
+                                    <propertyName>failsafe.jvm.args.jacoco.lucene-jberet</propertyName>
+                                    <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/lucene-jberet/jacoco.exec</destFile>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>jacoco-prepare-agent-integration-elasticsearch-jbatch</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                                <configuration>
+                                    <propertyName>failsafe.jvm.args.jacoco.elasticsearch-jbatch</propertyName>
+                                    <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/elasticsearch-jbatch/jacoco.exec</destFile>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>jacoco-prepare-agent-integration-elasticsearch-jberet</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                                <configuration>
+                                    <propertyName>failsafe.jvm.args.jacoco.elasticsearch-jberet</propertyName>
+                                    <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/elasticsearch-jberet/jacoco.exec</destFile>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 

--- a/integrationtest/mapper/orm-realbackend/pom.xml
+++ b/integrationtest/mapper/orm-realbackend/pom.xml
@@ -22,6 +22,9 @@
         <failsafe.elasticsearch.summaryFile>${failsafe.elasticsearch.reportsDirectory}/failsafe-summary.xml</failsafe.elasticsearch.summaryFile>
         <failsafe.multiplebackends.reportsDirectory>${project.build.directory}/failsafe-reports/multiplebackends</failsafe.multiplebackends.reportsDirectory>
         <failsafe.multiplebackends.summaryFile>${failsafe.multiplebackends.reportsDirectory}/failsafe-summary.xml</failsafe.multiplebackends.summaryFile>
+        <failsafe.jvm.args.jacoco.lucene></failsafe.jvm.args.jacoco.lucene>
+        <failsafe.jvm.args.jacoco.elasticsearch></failsafe.jvm.args.jacoco.elasticsearch>
+        <failsafe.jvm.args.jacoco.multiplebackends></failsafe.jvm.args.jacoco.multiplebackends>
     </properties>
 
     <dependencies>
@@ -74,53 +77,6 @@
 
     <build>
         <plugins>
-            <!-- We need to send the jacoco report of each test execution to a different file,
-                 otherwise Develocity won't be able to cache test executions. -->
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>jacoco-prepare-agent-integration</id>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>jacoco-prepare-agent-integration-lucene</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>prepare-agent-integration</goal>
-                        </goals>
-                        <configuration>
-                            <propertyName>failsafe.jvm.args.jacoco.lucene</propertyName>
-                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/lucene/jacoco.exec</destFile>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>jacoco-prepare-agent-integration-elasticsearch</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>prepare-agent-integration</goal>
-                        </goals>
-                        <configuration>
-                            <propertyName>failsafe.jvm.args.jacoco.elasticsearch</propertyName>
-                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/elasticsearch/jacoco.exec</destFile>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>jacoco-prepare-agent-integration-multiplebackends</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>prepare-agent-integration</goal>
-                        </goals>
-                        <configuration>
-                            <propertyName>failsafe.jvm.args.jacoco.multiplebackends</propertyName>
-                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/multiplebackends/jacoco.exec</destFile>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
@@ -241,6 +197,60 @@
                 <test.multiplebackends.skip>true</test.multiplebackends.skip>
                 <failsafe.multiplebackends.summaryFile>${rootProject.empty.failsafe.summaryFile}</failsafe.multiplebackends.summaryFile>
             </properties>
+        </profile>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <!-- We need to send the jacoco report of each test execution to a different file,
+                         otherwise Develocity won't be able to cache test executions. -->
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>jacoco-prepare-agent-integration</id>
+                                <configuration>
+                                    <skip>true</skip>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>jacoco-prepare-agent-integration-lucene</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                                <configuration>
+                                    <propertyName>failsafe.jvm.args.jacoco.lucene</propertyName>
+                                    <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/lucene/jacoco.exec</destFile>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>jacoco-prepare-agent-integration-elasticsearch</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                                <configuration>
+                                    <propertyName>failsafe.jvm.args.jacoco.elasticsearch</propertyName>
+                                    <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/elasticsearch/jacoco.exec</destFile>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>jacoco-prepare-agent-integration-multiplebackends</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                                <configuration>
+                                    <propertyName>failsafe.jvm.args.jacoco.multiplebackends</propertyName>
+                                    <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/multiplebackends/jacoco.exec</destFile>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/integrationtest/mapper/orm-realbackend/pom.xml
+++ b/integrationtest/mapper/orm-realbackend/pom.xml
@@ -94,7 +94,7 @@
                         </goals>
                         <configuration>
                             <propertyName>failsafe.jvm.args.jacoco.lucene</propertyName>
-                            <destFile>${project.build.directory}/lucene/jacoco.exec</destFile>
+                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/lucene/jacoco.exec</destFile>
                         </configuration>
                     </execution>
                     <execution>
@@ -105,7 +105,7 @@
                         </goals>
                         <configuration>
                             <propertyName>failsafe.jvm.args.jacoco.elasticsearch</propertyName>
-                            <destFile>${project.build.directory}/elasticsearch/jacoco.exec</destFile>
+                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/elasticsearch/jacoco.exec</destFile>
                         </configuration>
                     </execution>
                     <execution>
@@ -116,7 +116,7 @@
                         </goals>
                         <configuration>
                             <propertyName>failsafe.jvm.args.jacoco.multiplebackends</propertyName>
-                            <destFile>${project.build.directory}/multiplebackends/jacoco.exec</destFile>
+                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/multiplebackends/jacoco.exec</destFile>
                         </configuration>
                     </execution>
                 </executions>

--- a/integrationtest/mapper/pojo-standalone-realbackend/pom.xml
+++ b/integrationtest/mapper/pojo-standalone-realbackend/pom.xml
@@ -76,7 +76,7 @@
                         </goals>
                         <configuration>
                             <propertyName>failsafe.jvm.args.jacoco.lucene</propertyName>
-                            <destFile>${project.build.directory}/lucene/jacoco.exec</destFile>
+                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/lucene/jacoco.exec</destFile>
                         </configuration>
                     </execution>
                     <execution>
@@ -87,7 +87,7 @@
                         </goals>
                         <configuration>
                             <propertyName>failsafe.jvm.args.jacoco.elasticsearch</propertyName>
-                            <destFile>${project.build.directory}/elasticsearch/jacoco.exec</destFile>
+                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/elasticsearch/jacoco.exec</destFile>
                         </configuration>
                     </execution>
                 </executions>

--- a/integrationtest/mapper/pojo-standalone-realbackend/pom.xml
+++ b/integrationtest/mapper/pojo-standalone-realbackend/pom.xml
@@ -17,6 +17,8 @@
         <failsafe.lucene.summaryFile>${failsafe.lucene.reportsDirectory}/failsafe-summary.xml</failsafe.lucene.summaryFile>
         <failsafe.elasticsearch.reportsDirectory>${project.build.directory}/failsafe-reports/elasticsearch</failsafe.elasticsearch.reportsDirectory>
         <failsafe.elasticsearch.summaryFile>${failsafe.elasticsearch.reportsDirectory}/failsafe-summary.xml</failsafe.elasticsearch.summaryFile>
+        <failsafe.jvm.args.jacoco.lucene></failsafe.jvm.args.jacoco.lucene>
+        <failsafe.jvm.args.jacoco.elasticsearch></failsafe.jvm.args.jacoco.elasticsearch>
     </properties>
 
     <dependencies>
@@ -56,42 +58,6 @@
 
     <build>
         <plugins>
-            <!-- We need to send the jacoco report of each test execution to a different file,
-                 otherwise Develocity won't be able to cache test executions. -->
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>jacoco-prepare-agent-integration</id>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>jacoco-prepare-agent-integration-lucene</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>prepare-agent-integration</goal>
-                        </goals>
-                        <configuration>
-                            <propertyName>failsafe.jvm.args.jacoco.lucene</propertyName>
-                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/lucene/jacoco.exec</destFile>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>jacoco-prepare-agent-integration-elasticsearch</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>prepare-agent-integration</goal>
-                        </goals>
-                        <configuration>
-                            <propertyName>failsafe.jvm.args.jacoco.elasticsearch</propertyName>
-                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/elasticsearch/jacoco.exec</destFile>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
@@ -186,6 +152,49 @@
             <properties>
                 <failsafe.elasticsearch.summaryFile>${rootProject.empty.failsafe.summaryFile}</failsafe.elasticsearch.summaryFile>
             </properties>
+        </profile>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <!-- We need to send the jacoco report of each test execution to a different file,
+                        otherwise Develocity won't be able to cache test executions. -->
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>jacoco-prepare-agent-integration</id>
+                                <configuration>
+                                    <skip>true</skip>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>jacoco-prepare-agent-integration-lucene</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                                <configuration>
+                                    <propertyName>failsafe.jvm.args.jacoco.lucene</propertyName>
+                                    <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/lucene/jacoco.exec</destFile>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>jacoco-prepare-agent-integration-elasticsearch</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                                <configuration>
+                                    <propertyName>failsafe.jvm.args.jacoco.elasticsearch</propertyName>
+                                    <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/elasticsearch/jacoco.exec</destFile>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 

--- a/integrationtest/showcase/library/pom.xml
+++ b/integrationtest/showcase/library/pom.xml
@@ -20,6 +20,8 @@
         <failsafe.lucene.summaryFile>${failsafe.lucene.reportsDirectory}/failsafe-summary.xml</failsafe.lucene.summaryFile>
         <failsafe.elasticsearch.reportsDirectory>${project.build.directory}/failsafe-reports/elasticsearch</failsafe.elasticsearch.reportsDirectory>
         <failsafe.elasticsearch.summaryFile>${failsafe.elasticsearch.reportsDirectory}/failsafe-summary.xml</failsafe.elasticsearch.summaryFile>
+        <failsafe.jvm.args.jacoco.lucene></failsafe.jvm.args.jacoco.lucene>
+        <failsafe.jvm.args.jacoco.elasticsearch></failsafe.jvm.args.jacoco.elasticsearch>
 
         <!--
             Remove Hibernate system properties from parent settings:
@@ -111,42 +113,6 @@
                         <goals>
                             <goal>jandex</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <!-- We need to send the jacoco report of each test execution to a different file,
-                 otherwise Develocity won't be able to cache test executions. -->
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>jacoco-prepare-agent-integration</id>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>jacoco-prepare-agent-integration-lucene</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>prepare-agent-integration</goal>
-                        </goals>
-                        <configuration>
-                            <propertyName>failsafe.jvm.args.jacoco.lucene</propertyName>
-                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/lucene/jacoco.exec</destFile>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>jacoco-prepare-agent-integration-elasticsearch</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>prepare-agent-integration</goal>
-                        </goals>
-                        <configuration>
-                            <propertyName>failsafe.jvm.args.jacoco.elasticsearch</propertyName>
-                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/elasticsearch/jacoco.exec</destFile>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -261,6 +227,49 @@
             <properties>
                 <failsafe.elasticsearch.summaryFile>${rootProject.empty.failsafe.summaryFile}</failsafe.elasticsearch.summaryFile>
             </properties>
+        </profile>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <!-- We need to send the jacoco report of each test execution to a different file,
+                        otherwise Develocity won't be able to cache test executions. -->
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>jacoco-prepare-agent-integration</id>
+                                <configuration>
+                                    <skip>true</skip>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>jacoco-prepare-agent-integration-lucene</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                                <configuration>
+                                    <propertyName>failsafe.jvm.args.jacoco.lucene</propertyName>
+                                    <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/lucene/jacoco.exec</destFile>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>jacoco-prepare-agent-integration-elasticsearch</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                                <configuration>
+                                    <propertyName>failsafe.jvm.args.jacoco.elasticsearch</propertyName>
+                                    <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/elasticsearch/jacoco.exec</destFile>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 

--- a/integrationtest/showcase/library/pom.xml
+++ b/integrationtest/showcase/library/pom.xml
@@ -134,7 +134,7 @@
                         </goals>
                         <configuration>
                             <propertyName>failsafe.jvm.args.jacoco.lucene</propertyName>
-                            <destFile>${project.build.directory}/lucene/jacoco.exec</destFile>
+                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/lucene/jacoco.exec</destFile>
                         </configuration>
                     </execution>
                     <execution>
@@ -145,7 +145,7 @@
                         </goals>
                         <configuration>
                             <propertyName>failsafe.jvm.args.jacoco.elasticsearch</propertyName>
-                            <destFile>${project.build.directory}/elasticsearch/jacoco.exec</destFile>
+                            <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/elasticsearch/jacoco.exec</destFile>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -423,7 +423,9 @@
         <surefire.jvm.args>${surefire.jvm.args.no-jacoco} @{surefire.jvm.args.jacoco}</surefire.jvm.args>
         <failsafe.jvm.args>${surefire.jvm.args.no-jacoco} @{failsafe.jvm.args.jacoco}</failsafe.jvm.args>
 
-<!-- Disable integration tests selectively. To be set in specific profile, e.g. for a specific JDK version. -->
+        <jacoco.environment.sub-directory>${surefire.environment}</jacoco.environment.sub-directory>
+
+        <!-- Disable integration tests selectively. To be set in specific profile, e.g. for a specific JDK version. -->
         <failsafe.spring.skip>false</failsafe.spring.skip>
 
         <!-- This allows us to distinguish between multiple executions of the same test in test reports. -->
@@ -1520,6 +1522,7 @@
                                 </goals>
                                 <configuration>
                                     <propertyName>failsafe.jvm.args.jacoco</propertyName>
+                                    <destFile>${project.build.directory}/${jacoco.environment.sub-directory}/jacoco.exec</destFile>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4927

I've tried these changes here https://ci.hibernate.org/blue/organizations/jenkins/hibernate-search-personal-marko/detail/build%2Fjacoco-agg-all/5/pipeline/ 
it seems like that worked. 
I've moved some Jacoco configurations into profiles. I think that the change makes sense, but I'll let you @yrodiere confirm if it won't be an issue for build scans. 