### PR TITLE
HSEARCH-5096 Update plugin configuration for reproducible builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -441,6 +441,9 @@
         <goal.impsort-maven-plugin>sort</goal.impsort-maven-plugin>
         <goal.formatter-maven-plugin>format</goal.formatter-maven-plugin>
 
+        <!-- For Reproducible Builds -->
+        <project.build.outputTimestamp>2024-05-01T00:00:00Z</project.build.outputTimestamp>
+
         <!-- Sonar options -->
         <!--
             We want to take into account coverage data from integration tests from other projects as well.


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5096

We actually wouldn't need to update the release script because of https://github.com/mojohaus/versions/commit/04afc2c4b9c98cb9ff7cf4f8e0b7d5678cf58fe7 . Since 2.12 versions plugin will automatically update the timestamp on the `version:set`. I've tested it locally and updating the version updates the timestamp as well 🥳 

And we also don't need the `notimestamp` for javadocs since https://maven.apache.org/plugins/maven-javadoc-plugin/javadoc-mojo.html#notimestamp 🥳 (also double checked it locally 😃)

I have tried the git plugin as well, but it is just a timestamp of the last commit, so ... since with version plugin doing all the updates for us and no need in release script update, we don't need the git plugin.