### PR TITLE
Rebuild engine for Lucene 10 upgrade to address API/SPI change

### DIFF
--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -47,7 +47,7 @@ Map settings() {
 					testCompilerTool: 'OpenJDK 21 Latest',
 					updateProperties: ['version.org.apache.lucene'],
 					onlyRunTestDependingOn: ['hibernate-search-backend-lucene'],
-					additionalMavenArgs: '-Dtest.elasticsearch.skip=true -pl :hibernate-search-backend-lucene,:hibernate-search-util-internal-integrationtest-backend-lucene,:hibernate-search-v5migrationhelper-engine'
+					additionalMavenArgs: '-Dtest.elasticsearch.skip=true -pl :hibernate-search-engine,:hibernate-search-backend-lucene,:hibernate-search-util-internal-integrationtest-backend-lucene,:hibernate-search-v5migrationhelper-engine'
 			]
 		case 'elasticsearch-latest':
 			return [


### PR DESCRIPTION
Lucene 10 keeps updating the API 😃. Since there's a  change `Character[] -> char[]` now in highlighter code, let's also make it available to the users (in the Lucene 10 branch) and rebuild engine to make things work