### PR TITLE
HSEARCH-5156 Address Spring Boot 3.3 upgrade nested JARs test failures

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -177,7 +177,7 @@
 
         <!-- >>> Spring integration tests -->
         <!-- When updating Spring Boot check if it supports JDK23 and enable testing with it if so (see testWithJdk23 profile). -->
-        <version.org.springframework.boot>3.2.0</version.org.springframework.boot>
+        <version.org.springframework.boot>3.3.0</version.org.springframework.boot>
         <!-- Spring Boot 3 Atomikos starter and related libs version: -->
         <version.com.atomikos>6.0.0</version.com.atomikos>
 

--- a/util/common/src/main/java/org/hibernate/search/util/common/jar/impl/CodeSource.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/jar/impl/CodeSource.java
@@ -217,8 +217,7 @@ class CodeSource implements Closeable {
 				afterPathSeparatorIndex = secondPathSeparatorIndex;
 				secondPathSeparatorIndex = spec.indexOf( JAR_URI_PATH_SEPARATOR, afterPathSeparatorIndex );
 			}
-			return classesPathInFileSystem.resolve(
-					spec.substring( afterPathSeparatorIndex, secondPathSeparatorIndex ) );
+			return classesPathInFileSystem.resolve( spec.substring( afterPathSeparatorIndex ) );
 		}
 	}
 

--- a/util/common/src/test/java/org/hibernate/search/util/common/jar/impl/CodeSourceTest.java
+++ b/util/common/src/test/java/org/hibernate/search/util/common/jar/impl/CodeSourceTest.java
@@ -196,7 +196,7 @@ class CodeSourceTest {
 
 		try ( JarFile outerJar = new JarFile( jarPath.toFile() ) ) {
 			@SuppressWarnings("deprecation") // For JDK 20+
-			URL innerJarURL = JarUrl.create( jarPath.toFile(), classesDirRelativeString );
+			URL innerJarURL = JarUrl.create( jarPath.toFile(), null, classesDirRelativeString );
 			try ( URLClassLoader isolatedClassLoader = createIsolatedClassLoader( innerJarURL ) ) {
 				Class<?> classInIsolatedClassLoader = isolatedClassLoader.loadClass( SimpleClass.class.getName() );
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5156

Our integration test with the real app in `hibernate-search-integrationtest-spring-repackaged-application` works fine with the `3.3.0`. There were a few changes in Boot around nested jars and all related. I haven't pinpointed the exact change that caused the issue with the `CodeSourceTest` test, but.... I think it wasn't entirely correct here. `jar_jarScheme_springBoot_classesInSubDirectory` tests a sub-directory, so there is no need to work with a nested jar since it's just a dir within a root jar and not another jar ... 