### PR TITLE
Follow-up on HSEARCH-4930 - Don't use the default purge operation for the mass indexer multitenancy test

### DIFF
--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/multitenant/RealBackendDatabaseMultitenancyIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/multitenant/RealBackendDatabaseMultitenancyIT.java
@@ -211,6 +211,10 @@ class RealBackendDatabaseMultitenancyIT {
 		scope.schemaManager().dropAndCreate();
 
 		scope.massIndexer( asSet( tenant1, tenant2, tenant3 ) )
+				// as we've dropped the schema just above,
+				// we don't want any of these clean-up operations to be applied:
+				.dropAndCreateSchemaOnStart( false )
+				.purgeAllOnStart( false )
 				.startAndWait();
 
 		with( sessionFactory, tenant1 ).runInTransaction( session -> setupHelper.assertions()


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4930