### PR TITLE
DONOTMERGE: removing 1-1 associations and setting values to null

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/AbstractAutomaticIndexingAssociationBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/AbstractAutomaticIndexingAssociationBaseIT.java
@@ -1153,6 +1153,8 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 			// and the deletion even will simply be ignored.
 			containedAssociation.get( containedEntity );
 
+			containedAssociation.set( containedEntity, null );
+			containingAssociation.set( entity1, null );
 			session.remove( containedEntity );
 
 			backendMock.expectWorks( _indexed().indexName() )
@@ -3764,8 +3766,9 @@ public abstract class AbstractAutomaticIndexingAssociationBaseIT<
 			// But DO force loading on contained side:
 			// if the association is lazy and unloaded, it won't be loadable after the deletion
 			// and the deletion even will simply be ignored.
-			containedAssociation.get( containedEntity );
 
+			containedAssociation.set( containedEntity, null );
+			containingAssociation.set( containing, null );
 			session.remove( containedEntity );
 
 			backendMock.expectWorks( _indexed().indexName() )

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
@@ -106,6 +106,12 @@ public final class HibernateSearchEventListener
 
 		Object providedId = typeContext.toIndexingPlanProvidedId( event.getId() );
 		plan.delete( providedId, null, entity );
+
+		BitSet dirtyAssociationPaths = typeContext.dirtyContainingAssociationFilter().all();
+
+		if ( dirtyAssociationPaths != null ) {
+			plan.updateAssociationInverseSide( dirtyAssociationPaths, null, event.getDeletedState() );
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Hey @yrodiere,

I was looking more into https://hibernate.atlassian.net/browse/HHH-18212 and how it affects Search ...

if the user sets both sides to nulls (so that there's no TransientObjectException) we will end up with just a delete event sent to our listener... this delete event will have the entity with the null for the other side of the relation, so we won't be able to identify which entities have to be re-indexed ... if I add this bit to the ondelete handling:
```java
if ( dirtyAssociationPaths != null ) {
	plan.updateAssociationInverseSide( dirtyAssociationPaths, null, event.getDeletedState() );
}
```
Then things would work even if the user set both sides to `null` (which we probably should do regardless of what we end up doing for HHH-18212). But we'll get the same NPE on 6.6 again ... just coming from a different starting point (`event.getDeletedState()`)

cc @mbladel