### PR TITLE
Update list of JDK bundles in the forbidden APIs plugin

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -1003,9 +1003,6 @@
                                     <bundledSignature>jdk-unsafe</bundledSignature>
 
                                     <!-- All following signatures should be replicated for each target JDK version we intend to support -->
-                                    <bundledSignature>jdk-deprecated-1.8</bundledSignature>
-                                    <bundledSignature>jdk-deprecated-9</bundledSignature>
-                                    <bundledSignature>jdk-deprecated-10</bundledSignature>
                                     <bundledSignature>jdk-deprecated-11</bundledSignature>
                                     <bundledSignature>jdk-deprecated-12</bundledSignature>
                                     <bundledSignature>jdk-deprecated-13</bundledSignature>
@@ -1014,10 +1011,11 @@
                                     <bundledSignature>jdk-deprecated-16</bundledSignature>
                                     <bundledSignature>jdk-deprecated-17</bundledSignature>
                                     <bundledSignature>jdk-deprecated-18</bundledSignature>
+                                    <bundledSignature>jdk-deprecated-19</bundledSignature>
+                                    <bundledSignature>jdk-deprecated-20</bundledSignature>
+                                    <bundledSignature>jdk-deprecated-21</bundledSignature>
+                                    <bundledSignature>jdk-deprecated-22</bundledSignature>
 
-                                    <bundledSignature>jdk-internal-1.8</bundledSignature>
-                                    <bundledSignature>jdk-internal-9</bundledSignature>
-                                    <bundledSignature>jdk-internal-10</bundledSignature>
                                     <bundledSignature>jdk-internal-11</bundledSignature>
                                     <bundledSignature>jdk-internal-12</bundledSignature>
                                     <bundledSignature>jdk-internal-13</bundledSignature>
@@ -1026,6 +1024,10 @@
                                     <bundledSignature>jdk-internal-16</bundledSignature>
                                     <bundledSignature>jdk-internal-17</bundledSignature>
                                     <bundledSignature>jdk-internal-18</bundledSignature>
+                                    <bundledSignature>jdk-internal-19</bundledSignature>
+                                    <bundledSignature>jdk-internal-20</bundledSignature>
+                                    <bundledSignature>jdk-internal-21</bundledSignature>
+                                    <bundledSignature>jdk-internal-22</bundledSignature>
                                 </bundledSignatures>
                                 <signaturesArtifacts>
                                     <signaturesArtifact>

--- a/engine/src/main/java/org/hibernate/search/engine/environment/classpath/spi/DefaultResourceResolver.java
+++ b/engine/src/main/java/org/hibernate/search/engine/environment/classpath/spi/DefaultResourceResolver.java
@@ -4,8 +4,11 @@
  */
 package org.hibernate.search.engine.environment.classpath.spi;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+
+import org.hibernate.search.util.common.annotation.impl.SuppressForbiddenApis;
 
 /**
  * Default implementation of {@code ClassResolver} relying on an {@link AggregatedClassLoader}.
@@ -40,10 +43,7 @@ public final class DefaultResourceResolver implements ResourceResolver {
 
 		if ( stripped != null ) {
 			try {
-				@SuppressWarnings("deprecation")
-				// TODO: HSEARCH-4765 address the URL -> URI constructor change once the URLClassLoader stops using the URL constructor
-				InputStream resourceStream = new URL( stripped ).openStream();
-				return resourceStream;
+				return toInputStream( stripped );
 			}
 			catch (Exception ignore) {
 				// Ignore
@@ -61,6 +61,13 @@ public final class DefaultResourceResolver implements ResourceResolver {
 		}
 
 		return null;
+	}
+
+	@SuppressForbiddenApis(reason = "We don't want to replace the constructor at this point. See HSEARCH-4765")
+	@SuppressWarnings("deprecation")
+	private static InputStream toInputStream(String url) throws IOException {
+		// TODO: HSEARCH-4765 address the URL -> URI constructor change once the URLClassLoader stops using the URL constructor
+		return new URL( url ).openStream();
 	}
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -203,8 +203,12 @@
 
         <!-- JDK version required for the build; we target 11 but require at least 17 for the build -->
         <jdk.min.version>17</jdk.min.version>
-        <!-- The lowest supported version of Java for applications using Hibernate Search -->
-        <!-- Set statically, independently from the current JDK: we want our code to comply with this version -->
+        <!--
+            The lowest supported version of Java for applications using Hibernate Search
+            Set statically, independently from the current JDK: we want our code to comply with this version
+
+            Note: when updating this version, consider reviewing the list of JDKs the forbidden API plugin is targeting.
+        -->
         <java-version.main.release>11</java-version.main.release>
         <java-version.main.compiler.java_home>${java.home}</java-version.main.compiler.java_home>
         <java-version.main.compiler>${java-version.main.compiler.java_home}/bin/javac</java-version.main.compiler>
@@ -280,6 +284,7 @@
         <!-- Check dependencies for security vulnerabilities -->
         <version.dependency-check.plugin>9.2.0</version.dependency-check.plugin>
         <version.exec.plugin>3.3.0</version.exec.plugin>
+        <!-- Note: when updating this version, consider reviewing the list of JDKs the forbidden API plugin is targeting. -->
         <version.forbiddenapis.plugin>3.7</version.forbiddenapis.plugin>
         <!-- Make sure that upgraded Jandex plugin aligns with the Jandex version imported from the ORM platform pom -->
         <version.jandex.plugin>3.1.7</version.jandex.plugin>


### PR DESCRIPTION
The new bundle files didn't result in any new reports, except for the two URL constructors that we've already identified and planned to update when possible.

I've moved the constructors to small methods so that we can suppress the warnings just on them and leave everything else still scanned.

Otherwise I guess it's ok to drop the JDKs that are lower than the min one and add the others that are now available.