### PR TITLE
Follow up on HSEARCH-5155  - Use a release java version for perf tests

### DIFF
--- a/integrationtest/performance/pom.xml
+++ b/integrationtest/performance/pom.xml
@@ -18,6 +18,14 @@
         <module>backend/elasticsearch</module>
     </modules>
 
+    <properties>
+        <!-- JMH or the annotation processor plugin has some trouble with newer JDKs.
+             Let's not bother, and use the same JDK as Maven, unlike other integration tests. -->
+        <java-version.main.release>11</java-version.main.release>
+        <java-version.main.compiler.java_home>${java.home}</java-version.main.compiler.java_home>
+        <java-version.main.compiler>${java-version.main.compiler.java_home}/bin/javac</java-version.main.compiler>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5155

As the generation plugin does not necessarily work with the latest EA builds of the JDK.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
