### PR TITLE
HSEARCH-5192 Make Hibernate Search build produce "reproducible" sources jar / HSEARCH-5193 Add a build step to verify the build reproducibility

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -23,7 +23,7 @@
         <!-- >>> Common -->
         <version.org.jboss.logging.jboss-logging>3.6.0.Final</version.org.jboss.logging.jboss-logging>
         <!--Once the tools version is upgraded see if org.codehaus.plexus can be upgraded as well and update the dependabot config accordingly. -->
-        <version.org.jboss.logging.jboss-logging-tools>2.2.1.Final</version.org.jboss.logging.jboss-logging-tools>
+        <version.org.jboss.logging.jboss-logging-tools>3.0.0.Final</version.org.jboss.logging.jboss-logging-tools>
         <javadoc.org.hibernate.search.url>https://docs.jboss.org/hibernate/search/${parsed-version.org.hibernate.search.majorVersion}.${parsed-version.org.hibernate.search.minorVersion}/api/</javadoc.org.hibernate.search.url>
 
         <!-- >>> Engine -->

--- a/build/parents/public/pom.xml
+++ b/build/parents/public/pom.xml
@@ -27,6 +27,13 @@
         <deploy.skip>true</deploy.skip>
         <!-- This will make sure the build fails if we forget to set <deploy.skip>false</deploy.skip> in a child module -->
         <enforcer.publicModuleIsDeployedRule.skip>false</enforcer.publicModuleIsDeployedRule.skip>
+        <!--
+            We can only add the annotation processor arguments where the annotation processor will be actually executed.
+            If AP is not executed adding arguments will lead to a warning resulting in a build failure.
+
+            So we add it to all public modules, and override it anywhere where we have no logging.
+         -->
+        <logging.processor.skip.generated.annotation.compiler.argument>-Aorg.jboss.logging.tools.addGeneratedAnnotation=false</logging.processor.skip.generated.annotation.compiler.argument>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -363,6 +363,8 @@
 
         <javadoc.generate.jar.phase>none</javadoc.generate.jar.phase>
 
+        <logging.processor.skip.generated.annotation.compiler.argument></logging.processor.skip.generated.annotation.compiler.argument>
+
         <!-- Test settings -->
 
         <!-- Properties overridden in profiles to disable certain tests that only work with specific Java versions -->
@@ -650,6 +652,7 @@
                         <encoding>UTF-8</encoding>
                         <compilerArgs>
                             <compilerArg>-Xlint:unchecked</compilerArg>
+                            <compilerArg>${logging.processor.skip.generated.annotation.compiler.argument}</compilerArg>
                         </compilerArgs>
                     </configuration>
                     <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -322,6 +322,7 @@
             Specific modules will override the setting at their own level.
         -->
         <deploy.skip>true</deploy.skip>
+        <maven-deploy-plugin.skip>true</maven-deploy-plugin.skip>
 
         <!-- Can be overridden by subprojects if dependency convergence cannot be achieved -->
         <enforcer.dependencyconvergence.skip>false</enforcer.dependencyconvergence.skip>
@@ -1071,7 +1072,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
-                    <skip>true</skip>
+                    <skip>${maven-deploy-plugin.skip}</skip>
                 </configuration>
             </plugin>
             <!--
@@ -1758,6 +1759,25 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <!--
+                This profile set some properties to make running repro build easier.
+                Instead of
+                    mvn clean package -Pskip-checks -DskipTests -Dmaven.javadoc.skip -Dgpg.skip \
+                        -Dno-build-cache -Dbuildinfo.detect.skip=false \
+                        -Dbuildinfo.skipModules='**/**internal**,**/**integrationtest**,**/**parent**,**/**documentation**,**/**reports**,**/**build**'
+                We can run
+                    mvn clean package -Pskip-checks -Preproducible -Dno-build-cache
+            -->
+            <id>reproducible</id>
+            <properties>
+                <maven-deploy-plugin.skip>false</maven-deploy-plugin.skip>
+                <maven.javadoc.skip>true</maven.javadoc.skip>
+                <skipTests>true</skipTests>
+                <gpg.skip>true</gpg.skip>
+            </properties>
         </profile>
 
         <!--


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5192
https://hibernate.atlassian.net/browse/HSEARCH-5193

Using the `org.jboss.logging.tools.addGeneratedAnnotation=false` to produce "reproducible" sources jar.
Update Jenkins job to test build reproducibility.
Add a profile to run a reproducible build more easily.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
