### PR TITLE
HSEARCH-5200 Bump version.com.fasterxml.jackson from 2.17.1 to 2.17.2

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -83,7 +83,7 @@
         <version.com.google.code.gson>2.11.0</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.26.4</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, by Avro, by the AWS SDK and in tests (wiremock, ...) -->
-        <version.com.fasterxml.jackson>2.17.1</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.17.2</version.com.fasterxml.jackson>
         <!-- slf4j: used by the AWS SDK -->
         <version.org.slf4j>1.7.36</version.org.slf4j>
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5200

Bumps `version.com.fasterxml.jackson` from 2.17.1 to 2.17.2.

Updates `com.fasterxml.jackson.core:jackson-core` from 2.17.1 to 2.17.2
- [Commits](https://github.com/FasterXML/jackson-core/compare/jackson-core-2.17.1...jackson-core-2.17.2)

Updates `com.fasterxml.jackson.core:jackson-annotations` from 2.17.1 to 2.17.2
- [Commits](https://github.com/FasterXML/jackson/commits)

Updates `com.fasterxml.jackson.core:jackson-databind` from 2.17.1 to 2.17.2
- [Commits](https://github.com/FasterXML/jackson/commits)

---
updated-dependencies:
- dependency-name: com.fasterxml.jackson.core:jackson-core dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: com.fasterxml.jackson.core:jackson-annotations dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: com.fasterxml.jackson.core:jackson-databind dependency-type: direct:production update-type: version-update:semver-patch ...

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
