### PR TITLE
HSEARCH-5182 Enable knn similarity filter for the OpenSearch backend / HSEARCH-5183 Add a score based alternative to similarity filter in the knn predicate

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -870,11 +870,6 @@ public interface Log extends BasicLogger {
 					+ " and if you configured the %1$s version in Hibernate Search, update it accordingly.")
 	SearchException searchBackendVersionIncompatibleWithVectorIntegration(String distribution, String version);
 
-	@Message(id = ID_OFFSET + 187,
-			value = "An OpenSearch distribution does not allow specifying the `required minimum similarity` option. "
-					+ "This option is only applicable to an Elastic distribution of an Elasticsearch backend.")
-	SearchException knnRequiredMinimumSimilarityUnsupportedOption();
-
 	@Message(id = ID_OFFSET + 188,
 			value = "The OpenSearch distribution does not allow using %1$s as a space type for a Lucene engine."
 					+ " Try using a different similarity type and refer to the OpenSearch documentation for more details.")

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/AbstractElasticsearchVectorFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/AbstractElasticsearchVectorFieldCodec.java
@@ -15,8 +15,8 @@ import com.google.gson.JsonNull;
 
 public abstract class AbstractElasticsearchVectorFieldCodec<F> implements ElasticsearchVectorFieldCodec<F> {
 
-	private final VectorSimilarity similarity;
-	private final int dimension;
+	protected final VectorSimilarity similarity;
+	protected final int dimension;
 	private final Integer m;
 	private final Integer efConstruction;
 	private final F indexNullAs;

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchByteVectorFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchByteVectorFieldCodec.java
@@ -5,6 +5,7 @@
 package org.hibernate.search.backend.elasticsearch.types.codec.impl;
 
 import org.hibernate.search.engine.backend.types.VectorSimilarity;
+import org.hibernate.search.util.common.AssertionFailure;
 
 import com.google.gson.JsonArray;
 
@@ -37,5 +38,28 @@ public class ElasticsearchByteVectorFieldCodec extends AbstractElasticsearchVect
 	@Override
 	public Class<?> vectorElementsType() {
 		return byte.class;
+	}
+
+	@Override
+	public float scoreToSimilarity(float score) {
+		switch ( similarity ) {
+			case DEFAULT:
+			case L2:
+				return (float) Math.sqrt( 1.0f / score - 1.0f );
+			case DOT_PRODUCT:
+				// 0.5f + similarity / (float) (dim * (1 << 15));
+				return ( score - 0.5f ) * (float) ( dimension * ( 1 << 15 ) );
+			case COSINE:
+				return 2.0f * score - 1.0f;
+			case MAX_INNER_PRODUCT:
+				if ( score < 1 ) {
+					return -1.0f * ( 1.0f / score - 1.0f );
+				}
+				else {
+					return score - 1.0f;
+				}
+			default:
+				throw new AssertionFailure( "Unknown similarity function: " + similarity );
+		}
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchFloatVectorFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchFloatVectorFieldCodec.java
@@ -5,6 +5,7 @@
 package org.hibernate.search.backend.elasticsearch.types.codec.impl;
 
 import org.hibernate.search.engine.backend.types.VectorSimilarity;
+import org.hibernate.search.util.common.AssertionFailure;
 
 import com.google.gson.JsonArray;
 
@@ -37,5 +38,26 @@ public class ElasticsearchFloatVectorFieldCodec extends AbstractElasticsearchVec
 	@Override
 	public Class<?> vectorElementsType() {
 		return float.class;
+	}
+
+	@Override
+	public float scoreToSimilarity(float score) {
+		switch ( similarity ) {
+			case DEFAULT:
+			case L2:
+				return (float) Math.sqrt( 1.0f / score - 1.0f );
+			case DOT_PRODUCT:
+			case COSINE:
+				return 2.0f * score - 1.0f;
+			case MAX_INNER_PRODUCT:
+				if ( score < 1 ) {
+					return -1.0f * ( 1.0f / score - 1.0f );
+				}
+				else {
+					return score - 1.0f;
+				}
+			default:
+				throw new AssertionFailure( "Unknown similarity function: " + similarity );
+		}
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchVectorFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchVectorFieldCodec.java
@@ -15,4 +15,9 @@ public interface ElasticsearchVectorFieldCodec<F> extends ElasticsearchFieldCode
 	 * @return The number of dimensions (array length) of vectors to be indexed that this codec can process.
 	 */
 	int getConfiguredDimensions();
+
+	/**
+	 * Convert the score vale to the similarity to be passed to the knn filter.
+	 */
+	float scoreToSimilarity(float score);
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/query/impl/VectorSimilarityFilterQuery.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/query/impl/VectorSimilarityFilterQuery.java
@@ -30,20 +30,12 @@ public class VectorSimilarityFilterQuery extends Query {
 	private final Query query;
 	private final float similarityAsScore;
 
-	public static VectorSimilarityFilterQuery create(KnnByteVectorQuery query, float similarityLimit, int dimension,
-			VectorSimilarityFunction vectorSimilarityFunction) {
-		// We assume that `similarityLimit` is a distance so we need to convert it to the score using a formula from a
-		// similarity function:
-		return new VectorSimilarityFilterQuery(
-				query, byteSimilarityDistanceToScore( similarityLimit, dimension, vectorSimilarityFunction ) );
+	public static VectorSimilarityFilterQuery create(KnnByteVectorQuery query, float requiredMinimumScore) {
+		return new VectorSimilarityFilterQuery( query, requiredMinimumScore );
 	}
 
-	public static VectorSimilarityFilterQuery create(KnnFloatVectorQuery query, float similarityLimit,
-			VectorSimilarityFunction vectorSimilarityFunction) {
-		// We assume that `similarityLimit` is a distance so we need to convert it to the score using a formula from a
-		// similarity function:
-		return new VectorSimilarityFilterQuery(
-				query, floatSimilarityDistanceToScore( similarityLimit, vectorSimilarityFunction ) );
+	public static VectorSimilarityFilterQuery create(KnnFloatVectorQuery query, float requiredMinimumScore) {
+		return new VectorSimilarityFilterQuery( query, requiredMinimumScore );
 	}
 
 	private VectorSimilarityFilterQuery(Query query, float similarityAsScore) {
@@ -98,7 +90,7 @@ public class VectorSimilarityFilterQuery extends Query {
 		return Objects.hash( query, similarityAsScore );
 	}
 
-	private static float floatSimilarityDistanceToScore(float distance, VectorSimilarityFunction similarityFunction) {
+	public static float floatSimilarityDistanceToScore(float distance, VectorSimilarityFunction similarityFunction) {
 		switch ( similarityFunction ) {
 			case EUCLIDEAN:
 				return 1.0f / ( 1.0f + distance * distance );
@@ -112,7 +104,7 @@ public class VectorSimilarityFilterQuery extends Query {
 		}
 	}
 
-	private static float byteSimilarityDistanceToScore(float distance, int dimension,
+	public static float byteSimilarityDistanceToScore(float distance, int dimension,
 			VectorSimilarityFunction similarityFunction) {
 		switch ( similarityFunction ) {
 			case EUCLIDEAN:

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/query/impl/VectorSimilarityFilterQuery.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/query/impl/VectorSimilarityFilterQuery.java
@@ -7,10 +7,7 @@ package org.hibernate.search.backend.lucene.lowlevel.query.impl;
 import java.io.IOException;
 import java.util.Objects;
 
-import org.hibernate.search.util.common.AssertionFailure;
-
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.FilterWeight;
@@ -23,7 +20,6 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
-import org.apache.lucene.util.VectorUtil;
 
 public class VectorSimilarityFilterQuery extends Query {
 
@@ -88,36 +84,6 @@ public class VectorSimilarityFilterQuery extends Query {
 	@Override
 	public int hashCode() {
 		return Objects.hash( query, similarityAsScore );
-	}
-
-	public static float floatSimilarityDistanceToScore(float distance, VectorSimilarityFunction similarityFunction) {
-		switch ( similarityFunction ) {
-			case EUCLIDEAN:
-				return 1.0f / ( 1.0f + distance * distance );
-			case DOT_PRODUCT:
-			case COSINE:
-				return ( 1.0f + distance ) / 2.0f;
-			case MAXIMUM_INNER_PRODUCT:
-				return VectorUtil.scaleMaxInnerProductScore( distance );
-			default:
-				throw new AssertionFailure( "Unknown similarity function: " + similarityFunction );
-		}
-	}
-
-	public static float byteSimilarityDistanceToScore(float distance, int dimension,
-			VectorSimilarityFunction similarityFunction) {
-		switch ( similarityFunction ) {
-			case EUCLIDEAN:
-				return 1.0f / ( 1.0f + distance * distance );
-			case DOT_PRODUCT:
-				return 0.5f + distance / (float) ( dimension * ( 1 << 15 ) );
-			case COSINE:
-				return ( 1.0f + distance ) / 2.0f;
-			case MAXIMUM_INNER_PRODUCT:
-				return VectorUtil.scaleMaxInnerProductScore( distance );
-			default:
-				throw new AssertionFailure( "Unknown similarity function: " + similarityFunction );
-		}
 	}
 
 	private static class SimilarityWeight extends FilterWeight {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneFloatVectorCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneFloatVectorCodec.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.function.Consumer;
 
 import org.hibernate.search.backend.lucene.lowlevel.codec.impl.HibernateSearchKnnVectorsFormat;
+import org.hibernate.search.util.common.AssertionFailure;
 
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.IndexableField;
@@ -59,6 +60,21 @@ public class LuceneFloatVectorCodec extends AbstractLuceneVectorFieldCodec<float
 	@Override
 	public Class<?> vectorElementsType() {
 		return float.class;
+	}
+
+	@Override
+	public float similarityDistanceToScore(float distance) {
+		switch ( vectorSimilarity ) {
+			case EUCLIDEAN:
+				return 1.0f / ( 1.0f + distance * distance );
+			case DOT_PRODUCT:
+			case COSINE:
+				return ( 1.0f + distance ) / 2.0f;
+			case MAXIMUM_INNER_PRODUCT:
+				return VectorUtil.scaleMaxInnerProductScore( distance );
+			default:
+				throw new AssertionFailure( "Unknown similarity function: " + vectorSimilarity );
+		}
 	}
 
 	private static Consumer<float[]> check(VectorSimilarityFunction similarityFunction) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneVectorFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneVectorFieldCodec.java
@@ -35,4 +35,5 @@ public interface LuceneVectorFieldCodec<F> extends LuceneStandardFieldCodec<F, F
 	 */
 	VectorSimilarityFunction getVectorSimilarity();
 
+	float similarityDistanceToScore(float similarity);
 }

--- a/documentation/src/main/asciidoc/public/reference/_search-dsl-predicate.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_search-dsl-predicate.adoc
@@ -1611,11 +1611,26 @@ include::{sourcedir}/org/hibernate/search/documentation/search/predicate/Predica
 <2> Specify the required minimum similarity value, to filter out irrelevant results.
 ====
 
-NOTE: This configuration is only available for a <<backend-lucene, Lucene backend>>
-and for the <<backend-elasticsearch-compatibility-elasticsearch,Elastic>> distribution of
+Alternatively, since in case of the `knn` predicate score and similarity are tight together
+as explained in <<mapping-directfieldmapping-vectorSimilarity,this table>>, it maybe be sometimes simpler to apply
+a score based filter instead.
+
+.Filtering out irrelevant results with score
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java[tags=knn-score]
+----
+<1> Create a knn predicate as usual.
+<2> Specify the required minimum score value, to filter out irrelevant results.
+====
+
+NOTE: This configuration has a slightly different behavior with the
+<<backend-elasticsearch-compatibility-opensearch,OpenSearch>> distribution of
 an <<backend-elasticsearch,Elasticsearch backend>>.
-<<backend-elasticsearch-compatibility-opensearch,OpenSearch>> does not have this option available,
-and trying to use it will lead to an exception being thrown.
+This distribution allows to use only one of the following options at the same time: `k`, minimum score, minimum similarity.
+Hence, if either `requiredMinimumSimilarity(..)` or `requiredMinimumScore(..)` is applied, then `k` value will be ignored
+and will not be sent in the request to the OpenSearch cluster.
 
 [[search-dsl-predicate-knn-limitations]]
 === Backend specifics and limitations

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
@@ -1384,6 +1384,22 @@ class PredicateDslIT {
 						.extracting( Book::getId )
 						.containsExactlyInAnyOrder( BOOK1_ID );
 			} );
+
+			withinSearchSession( searchSession -> {
+				// tag::knn-score[]
+				float[] coverImageEmbeddingsVector = /*...*/
+						// end::knn-score[]
+						floats( 128, 1.0f );
+				// tag::knn-score[]
+				List<Book> hits = searchSession.search( Book.class )
+						.where( f -> f.knn( 5 ).field( "coverImageEmbeddings" ).matching( coverImageEmbeddingsVector ) // <1>
+								.requiredMinimumScore( 0.5f ) ) // <2>
+						.fetchHits( 20 );
+				// end::knn-score[]
+				assertThat( hits )
+						.extracting( Book::getId )
+						.containsExactlyInAnyOrder( BOOK1_ID );
+			} );
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/KnnPredicateOptionsStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/KnnPredicateOptionsStep.java
@@ -7,6 +7,7 @@ package org.hibernate.search.engine.search.predicate.dsl;
 import java.util.function.Function;
 
 import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.util.common.annotation.Incubating;
 
 /**
  * The final step in a "knn" predicate definition, where optional parameters can be set.
@@ -28,5 +29,8 @@ public interface KnnPredicateOptionsStep
 	 * @return {@code this}, for method chaining.
 	 */
 	KnnPredicateOptionsStep requiredMinimumSimilarity(float similarity);
+
+	@Incubating
+	KnnPredicateOptionsStep requiredMinimumScore(float score);
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/KnnPredicateOptionsStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/KnnPredicateOptionsStep.java
@@ -30,6 +30,14 @@ public interface KnnPredicateOptionsStep
 	 */
 	KnnPredicateOptionsStep requiredMinimumSimilarity(float similarity);
 
+	/**
+	 * @param score The minimum sore limit: documents with vectors for which the similarity score is lower than the limit
+	 * will be filtered out from the results.
+	 * <p>
+	 * This is an alternative to the {@link #requiredMinimumSimilarity(float)} where the score is used for filtering
+	 * instead of the similarity. For the knn predicate the score and similarity are derived from each other.
+	 * @return {@code this}, for method chaining.
+	 */
 	@Incubating
 	KnnPredicateOptionsStep requiredMinimumScore(float score);
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/impl/KnnPredicateFieldStepImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/impl/KnnPredicateFieldStepImpl.java
@@ -80,6 +80,12 @@ public class KnnPredicateFieldStepImpl
 	}
 
 	@Override
+	public KnnPredicateOptionsStep requiredMinimumScore(float score) {
+		this.builder.requiredMinimumScore( score );
+		return this;
+	}
+
+	@Override
 	public KnnPredicateOptionsStep boost(float boost) {
 		this.builder.boost( boost );
 		return this;

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/KnnPredicateBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/KnnPredicateBuilder.java
@@ -18,6 +18,8 @@ public interface KnnPredicateBuilder extends SearchPredicateBuilder {
 
 	void requiredMinimumSimilarity(float similarity);
 
+	void requiredMinimumScore(float score);
+
 	/**
 	 * @return An implementation-specific view of this builder,
 	 * allowing the backend to call a {@code build()} method in particular.

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -267,15 +267,6 @@ public class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 	}
 
 	@Override
-	public boolean supportsVectorSearchRequiredMinimumSimilarity() {
-		return isActualVersion(
-				es -> true,
-				os -> false,
-				aoss -> false
-		);
-	}
-
-	@Override
 	public boolean supportsSimilarity(VectorSimilarity vectorSimilarity) {
 		switch ( vectorSimilarity ) {
 			case DOT_PRODUCT:
@@ -335,6 +326,15 @@ public class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 
 	@Override
 	public boolean queryStringFailOnPatternQueries() {
+		return isActualVersion(
+				es -> true,
+				os -> false,
+				aoss -> false
+		);
+	}
+
+	@Override
+	public boolean vectorSearchRequiredMinimumSimilarityAsLucene() {
 		return isActualVersion(
 				es -> true,
 				os -> false,

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/KnnPredicateSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/KnnPredicateSpecificsIT.java
@@ -988,8 +988,8 @@ class KnnPredicateSpecificsIT {
 		}
 
 		/*
-		* index, similarity, score, number of hits
-		*/
+		 * index, similarity, score, number of hits
+		 */
 		public static List<? extends Arguments> similarityFilterFloat() {
 			List<Arguments> args = new ArrayList<>();
 			SimpleMappedIndex<IndexBinding> index = indexes.get( VectorSimilarity.L2 );
@@ -1150,6 +1150,122 @@ class KnnPredicateSpecificsIT {
 			args.add( Arguments.of( index, 40.9993216f, 0.5006256f, 4 ) );
 			args.add( Arguments.of( index, 42.00005632f, 0.50064087f, 2 ) );
 			args.add( Arguments.of( index, 30.998528f, 0.500473f, 8 ) );
+
+			return args;
+		}
+
+		@ParameterizedTest
+		@MethodSource
+		void scoreFilterFloat(SimpleMappedIndex<IndexBinding> index, float minScore, float score, int matches) {
+			assertThat( index.createScope().query()
+					.select( SearchProjectionFactory::score )
+					.where( f -> f.knn( 10 )
+							.field( "location" )
+							.matching( noramlize( 5f, 4f ) )
+							.requiredMinimumScore( minScore )
+					).fetchAll().hits() )
+					.hasSizeLessThanOrEqualTo( matches )
+					.allSatisfy( s -> assertThat( s ).isGreaterThanOrEqualTo( score ) );
+		}
+
+		/*
+		 * index, similarity, score, number of hits
+		 */
+		public static List<? extends Arguments> scoreFilterFloat() {
+			List<Arguments> args = new ArrayList<>();
+			SimpleMappedIndex<IndexBinding> index = indexes.get( VectorSimilarity.L2 );
+
+			// L2 scores for vector [5f, 4f]
+			// ES 8.14:
+			// [0.9995646, 0.99923563, 0.9990471, 0.9961991, 0.9760502, 0.9664738, 0.93500495, 0.9266528, 0.9165927, 0.8885436]
+			// ES 8.13:
+			// [0.9995734, 0.9992435, 0.9990251, 0.99538076, 0.9762654, 0.9665131, 0.9355144, 0.92745376, 0.91767627, 0.8887709]
+			// Lucene:
+			// [0.9995734, 0.9992435, 0.9990251, 0.99538076, 0.9762654, 0.9665131, 0.9355144, 0.92745376, 0.91767627, 0.8887709]
+			args.add( Arguments.of( index, 0.995f, 0.995f, 4 ) );
+			args.add( Arguments.of( index, 0.976f, 0.976f, 5 ) );
+			args.add( Arguments.of( index, 0.935f, 0.935f, 7 ) );
+
+			index = indexes.get( VectorSimilarity.COSINE );
+
+			// COSINE scores for vector [5f, 4f]
+			// [0.9998933, 0.9998107, 0.99975604, 0.9988398, 0.9939221, 0.99133825, 0.98276734, 0.9804448, 0.9775728, 0.9687127]
+			args.add( Arguments.of( index, 0.998f, 0.998f, 4 ) );
+			args.add( Arguments.of( index, 0.9998f, 0.9998f, 2 ) );
+			args.add( Arguments.of( index, 0.980f, 0.980f, 8 ) );
+
+			index = indexes.get( VectorSimilarity.DOT_PRODUCT );
+
+			// DOT_PRODUCT scores for vector [5f, 4f]
+			// [0.9998933, 0.9998107, 0.99975604, 0.99883986, 0.9939221, 0.9913382, 0.9827673, 0.9804448, 0.9775728, 0.9687127]
+			args.add( Arguments.of( index, 0.998f, 0.998f, 4 ) );
+			args.add( Arguments.of( index, 0.999f, 0.999f, 3 ) );
+			args.add( Arguments.of( index, 0.980f, 0.980f, 8 ) );
+
+			index = indexes.get( VectorSimilarity.MAX_INNER_PRODUCT );
+
+			// MAX_INNER_PRODUCT scores for vector [5f, 4f]
+			// [1.9997866, 1.9996214, 1.9995121, 1.9976797, 1.9878442, 1.9826764, 1.9655346, 1.9608896, 1.9551456, 1.9374254]
+			args.add( Arguments.of( index, 1.997f, 1.997f, 4 ) );
+			args.add( Arguments.of( index, 1.999f, 1.999f, 3 ) );
+			args.add( Arguments.of( index, 1.960f, 1.960f, 8 ) );
+
+			return args;
+		}
+
+		@ParameterizedTest
+		@MethodSource
+		void scoreFilterByte(SimpleMappedIndex<IndexBinding> index, float minScore, float score, int matches) {
+			assertThat( index.createScope().query()
+					.select( SearchProjectionFactory::score )
+					.where( f -> f.knn( 10 )
+							.field( "bytes" )
+							.matching( noramlize( index.binding().similarity, 5, 4 ) )
+							.requiredMinimumScore( minScore )
+					).fetchAll().hits() )
+					.hasSize( matches )
+					.allSatisfy( s -> assertThat( s ).isGreaterThanOrEqualTo( score ) );
+		}
+
+		/*
+		 * index, similarity, score, number of hits
+		 */
+		public static List<? extends Arguments> scoreFilterByte() {
+			List<Arguments> args = new ArrayList<>();
+			SimpleMappedIndex<IndexBinding> index = indexes.get( VectorSimilarity.L2 );
+
+			// L2 scores for vector [5f, 4f]
+			// [1.0, 0.5, 0.5, 0.33333334, 0.33333334, 0.2, 0.16666667, 0.11111111, 0.1, 0.1]
+			// score is 1/(1+d*d) and we are passing d here: d = sqrt( 1/s - 1 )
+			args.add( Arguments.of( index, 0.5f, 0.5f, 3 ) );
+			args.add( Arguments.of( index, 0.2f, 0.2f, 6 ) );
+			args.add( Arguments.of( index, 0.16666667f, 0.16666667f, 7 ) );
+
+			index = indexes.get( VectorSimilarity.COSINE );
+
+			// COSINE scores for vector [5f, 4f]
+			// [1.0, 0.99975604, 0.9981203, 0.99694186, 0.9954962, 0.9889012, 0.98625576, 0.98413867, 0.9764629, 0.95397973]
+			// score is ( 1.0f + d ) / 2.0f and we are passing d here: d = 2s-1
+			args.add( Arguments.of( index, 0.99694186f, 0.99694186f, 4 ) );
+			args.add( Arguments.of( index, 0.99975604f, 0.99975604f, 2 ) );
+			args.add( Arguments.of( index, 0.98413867f, 0.98413867f, 8 ) );
+
+			index = indexes.get( VectorSimilarity.DOT_PRODUCT );
+
+			// DOT_PRODUCT scores for vector [5f, 4f]
+			// [0.5010834, 0.5006714, 0.50064087, 0.5006256, 0.5005646, 0.5005493, 0.5004883, 0.500473, 0.5004425, 0.5003967]
+			// score is 0.5f + d / (float) ( 2 * ( 1 << 15 ) ) and we are passing d here: d = (s - 0.5) * 65536.0
+			args.add( Arguments.of( index, 0.5006256f, 0.5006256f, 4 ) );
+			args.add( Arguments.of( index, 0.50064087f, 0.50064087f, 3 ) );
+			args.add( Arguments.of( index, 0.500473f, 0.500473f, 8 ) );
+
+			index = indexes.get( VectorSimilarity.MAX_INNER_PRODUCT );
+
+			// MAX_INNER_PRODUCT scores for vector [5f, 4f]
+			// [72.0f, 45.0f, 43.0f, 42.0f, 38.0f, 37.0f, 33.0f, 32.0f, 30.0f, 27.0f]
+			args.add( Arguments.of( index, 42.0f, 42.0f, 4 ) );
+			args.add( Arguments.of( index, 45.0f, 45.0f, 2 ) );
+			args.add( Arguments.of( index, 32.0f, 32.0f, 8 ) );
 
 			return args;
 		}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
@@ -136,10 +136,6 @@ public abstract class TckBackendFeatures implements StubMappingBackendFeatures {
 		return true;
 	}
 
-	public boolean supportsVectorSearchRequiredMinimumSimilarity() {
-		return true;
-	}
-
 	public boolean supportsSimilarity(VectorSimilarity vectorSimilarity) {
 		return true;
 	}
@@ -161,6 +157,10 @@ public abstract class TckBackendFeatures implements StubMappingBackendFeatures {
 	}
 
 	public boolean queryStringFailOnPatternQueries() {
+		return true;
+	}
+
+	public boolean vectorSearchRequiredMinimumSimilarityAsLucene() {
 		return true;
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5182
https://hibernate.atlassian.net/browse/HSEARCH-5183

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
