### PR TITLE
Follow up on HSEARCH-5193 - Move the reproducibility check to the nightly build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -485,34 +485,6 @@ stage('Default build') {
 	}
 }
 
-stage('Build reproducibility check') {
-	if (!enableDefaultBuild) {
-		// If we didn't build the default build, there's no artifacts installed, so we don't have what to compare.
-		echo 'Skipping build reproducibility check'
-		helper.markStageSkipped()
-		return
-	}
-	runBuildOnNode {
-		withMavenWorkspace {
-			echo "Unpacking default build cache."
-			dir(helper.configuration.maven.localRepositoryPath) {
-				unstash name:'default-build-cache'
-			}
-
-			echo "Generate the artifacts."
-			mvn "clean install -Pskip-checks -Preproducible"
-
-			echo "Running the reproducibility check."
-			mvn """ \
-				clean verify \
-				artifact:compare -Dreference.repo=hibernate-maven-central \
-				-Pskip-checks -Preproducible -Dno-build-cache \
-				--fail-at-end
-			"""
-		}
-	}
-}
-
 stage('Non-default environments') {
 	Map<String, Closure> executions = [:]
 

--- a/ci/nightly/Jenkinsfile
+++ b/ci/nightly/Jenkinsfile
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+
+@Library('hibernate-jenkins-pipeline-helpers@1.17') _
+
+def withMavenWorkspace(Closure body) {
+	withMaven(jdk: 'OpenJDK 21 Latest', maven: 'Apache Maven 3.9',
+			mavenLocalRepo: env.WORKSPACE_TMP + '/.m2repository',
+			options: [
+					// Artifacts are not needed and take up disk space
+					artifactsPublisher(disabled: true),
+					// stdout/stderr for successful tests is not needed and takes up disk space
+					// we archive test results and stdout/stderr as part of the build scan anyway,
+					// see https://ge.hibernate.org/scans?search.rootProjectNames=Hibernate%20Search
+					junitPublisher(disabled: true)
+			]) {
+		withCredentials([string(credentialsId: 'ge.hibernate.org-access-key',
+				variable: 'DEVELOCITY_ACCESS_KEY')]) {
+			withGradle {
+				// withDevelocity, actually: https://plugins.jenkins.io/gradle/#plugin-content-capturing-build-scans-from-jenkins-pipeline
+				body()
+			}
+		}
+	}
+}
+
+pipeline {
+	agent none
+	triggers {
+		cron '@midnight'
+	}
+	options {
+		buildDiscarder logRotator(daysToKeepStr: '10', numToKeepStr: '3')
+		disableConcurrentBuilds(abortPrevious: true)
+		overrideIndexTriggers(false)
+	}
+	environment {
+		TESTCONTAINERS_REUSE_ENABLE = 'true'
+	}
+	stages {
+		stage('Build reproducibility check') {
+			agent {
+				label 'Worker&&Containers'
+			}
+			steps {
+				// The timeout cannot be in stage options, because that would
+				// include the time needed to provision a node.
+				timeout(time: 30, unit: 'MINUTES') {
+					withMavenWorkspace {
+						echo "Generate the artifacts."
+						sh "mvn clean install -Pskip-checks -Preproducible"
+
+						echo "Running the reproducibility check."
+						sh """mvn clean verify \
+							artifact:compare -Dreference.repo=hibernate-maven-central \
+							-Pskip-checks -Preproducible -Dno-build-cache \
+							--fail-at-end
+						"""
+					}
+				}
+			}
+		}
+	}
+	post {
+		always {
+			notifyBuildResult maintainers: 'marko@hibernate.org'
+		}
+	}
+}

--- a/ci/nightly/Jenkinsfile
+++ b/ci/nightly/Jenkinsfile
@@ -50,12 +50,12 @@ pipeline {
 				timeout(time: 30, unit: 'MINUTES') {
 					withMavenWorkspace {
 						echo "Generate the artifacts."
-						sh "mvn clean install -Pskip-checks -Preproducible"
+						sh "mvn clean install -Pskip-checks -Preproducibility-check"
 
 						echo "Running the reproducibility check."
 						sh """mvn clean verify \
 							artifact:compare -Dreference.repo=hibernate-maven-central \
-							-Pskip-checks -Preproducible -Dno-build-cache \
+							-Pskip-checks -Preproducibility-check -Dno-build-cache \
 							--fail-at-end
 						"""
 					}

--- a/pom.xml
+++ b/pom.xml
@@ -1769,9 +1769,9 @@
                         -Dno-build-cache -Dbuildinfo.detect.skip=false \
                         -Dbuildinfo.skipModules='**/**internal**,**/**integrationtest**,**/**parent**,**/**documentation**,**/**reports**,**/**build**'
                 We can run
-                    mvn clean package -Pskip-checks -Preproducible -Dno-build-cache
+                    mvn clean package -Pskip-checks -Preproducibility-check -Dno-build-cache
             -->
-            <id>reproducible</id>
+            <id>reproducibility-check</id>
             <properties>
                 <maven-deploy-plugin.skip>false</maven-deploy-plugin.skip>
                 <maven.javadoc.skip>true</maven.javadoc.skip>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5193

https://hibernate.zulipchat.com/#narrow/stream/132092-hibernate-search-dev/topic/Build.20reproducibility.20check

We can start with something like this, I guess?

And the test build execution here https://ci.hibernate.org/blue/organizations/jenkins/hibernate-search-personal-marko/detail/build%2FHSEARCH-5193-move-repro-check-to-nightly/2/pipeline/

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
