### PR TITLE
Follow up on HSEARCH-5193  - Add reproducible badge to the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Sonar Coverage](https://img.shields.io/sonar/coverage/org.hibernate.search:hibernate-search-parent?server=https%3A%2F%2Fsonarcloud.io&style=for-the-badge)](https://sonarcloud.io/project/activity?id=org.hibernate.search%3Ahibernate-search-parent&graph=coverage)
 [![Quality gate](https://img.shields.io/sonar/alert_status/org.hibernate.search:hibernate-search-parent?logo=sonarcloud&server=https%3A%2F%2Fsonarcloud.io&style=for-the-badge)](https://sonarcloud.io/dashboard?id=org.hibernate.search%3Ahibernate-search-parent)
 [![Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?style=for-the-badge&logo=gradle)](https://ge.hibernate.org/scans?search.rootProjectNames=Hibernate%20Search)
+[![Reproducible Builds](https://img.shields.io/badge/Reproducible_Builds-ok-success?style=for-the-badge)](https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/hibernate/search/hibernate-search-bom/README.md)
 
 ## Description
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5193

WDYT @yrodiere  ? 🙈 😃 Noticed this here https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/doc/TOOLS.md#4-add-reproducible-builds-badge-to-a-project-with-reproducible-releases and thought ... why not? 😃. It is a static badge so it won't change if the state on reproducible-central change but ... 😃 

![image](https://github.com/user-attachments/assets/54911470-a06d-47fc-9009-29a02a6691fe)


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
