### PR TITLE
Downgrade test containers to 1.19

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -132,7 +132,7 @@
         <version.junit-platform-suite-engine>1.10.0</version.junit-platform-suite-engine>
         <version.org.osgi.core>6.0.0</version.org.osgi.core>
         <!-- Make sure to update Ryuk container version in `ryuk.Dockerfile` whenever updating testcontainers to align it with the lib. -->
-        <version.testcontainers>1.20.0</version.testcontainers>
+        <version.testcontainers>1.19.8</version.testcontainers>
 
         <version.org.hamcrest>2.2</version.org.hamcrest>
         <version.org.mockito>5.12.0</version.org.mockito>


### PR DESCRIPTION
so that we are not affected by the Awaitility 4.2.1 upgrade having problems running on JDK 23+

Related to the https://github.com/hibernate/hibernate-search/pull/4237 upgrades.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
