### PR TITLE
HSEARCH-5182 Add an OpenSearch dialect to address where knn similarity filters can be applied

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
@@ -15,6 +15,7 @@ import org.hibernate.search.backend.elasticsearch.dialect.model.impl.Elasticsear
 import org.hibernate.search.backend.elasticsearch.dialect.model.impl.Elasticsearch8ModelDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.model.impl.ElasticsearchModelDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.model.impl.OpenSearch1ModelDialect;
+import org.hibernate.search.backend.elasticsearch.dialect.model.impl.OpenSearch214ModelDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.model.impl.OpenSearch29ModelDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.model.impl.OpenSearch2ModelDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.protocol.impl.AmazonOpenSearchServerlessProtocolDialect;
@@ -130,10 +131,16 @@ public class ElasticsearchDialectFactory {
 			return new OpenSearch1ModelDialect();
 		}
 		else {
-			if ( major == 2 && ( minorOptional.isEmpty() || minorOptional.getAsInt() < 9 ) ) {
-				return new OpenSearch2ModelDialect();
+			if ( major == 2 ) {
+				if ( ( minorOptional.isEmpty() || minorOptional.getAsInt() < 9 ) ) {
+					return new OpenSearch2ModelDialect();
+				}
+
+				if ( ( minorOptional.getAsInt() < 14 ) ) {
+					return new OpenSearch29ModelDialect();
+				}
 			}
-			return new OpenSearch29ModelDialect();
+			return new OpenSearch214ModelDialect();
 		}
 	}
 
@@ -141,7 +148,7 @@ public class ElasticsearchDialectFactory {
 		if ( !AMAZON_OPENSEARCH_SERVERLESS.equals( version ) ) {
 			throw log.unexpectedAwsOpenSearchServerlessVersion( version, AMAZON_OPENSEARCH_SERVERLESS );
 		}
-		return new OpenSearch29ModelDialect();
+		return new OpenSearch214ModelDialect();
 	}
 
 	public ElasticsearchProtocolDialect createProtocolDialect(ElasticsearchVersion version) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/model/impl/OpenSearch214ModelDialect.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/model/impl/OpenSearch214ModelDialect.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.backend.elasticsearch.dialect.model.impl;
+
+import org.hibernate.search.backend.elasticsearch.types.dsl.provider.impl.ElasticsearchIndexFieldTypeFactoryProvider;
+import org.hibernate.search.backend.elasticsearch.types.dsl.provider.impl.OpenSearch214IndexFieldTypeFactoryProvider;
+import org.hibernate.search.backend.elasticsearch.validation.impl.ElasticsearchPropertyMappingValidatorProvider;
+import org.hibernate.search.backend.elasticsearch.validation.impl.OpenSearch2PropertyMappingValidatorProvider;
+
+import com.google.gson.Gson;
+
+/**
+ * The model dialect for OpenSearch 2.14+.
+ */
+public class OpenSearch214ModelDialect implements ElasticsearchModelDialect {
+
+	@Override
+	public ElasticsearchIndexFieldTypeFactoryProvider createIndexTypeFieldFactoryProvider(Gson userFacingGson) {
+		return new OpenSearch214IndexFieldTypeFactoryProvider( userFacingGson );
+	}
+
+	@Override
+	public ElasticsearchPropertyMappingValidatorProvider createElasticsearchPropertyMappingValidatorProvider() {
+		return new OpenSearch2PropertyMappingValidatorProvider();
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -870,6 +870,11 @@ public interface Log extends BasicLogger {
 					+ " and if you configured the %1$s version in Hibernate Search, update it accordingly.")
 	SearchException searchBackendVersionIncompatibleWithVectorIntegration(String distribution, String version);
 
+	@Message(id = ID_OFFSET + 187,
+			value = "An OpenSearch distribution does not allow specifying the `required minimum similarity` option. "
+					+ "This option is only applicable to an Elastic distribution of an Elasticsearch backend.")
+	SearchException knnRequiredMinimumSimilarityUnsupportedOption();
+
 	@Message(id = ID_OFFSET + 188,
 			value = "The OpenSearch distribution does not allow using %1$s as a space type for a Lucene engine."
 					+ " Try using a different similarity type and refer to the OpenSearch documentation for more details.")

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/provider/impl/OpenSearch214IndexFieldTypeFactoryProvider.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/provider/impl/OpenSearch214IndexFieldTypeFactoryProvider.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.backend.elasticsearch.types.dsl.provider.impl;
+
+import org.hibernate.search.backend.elasticsearch.types.mapping.impl.ElasticsearchVectorFieldTypeMappingContributor;
+import org.hibernate.search.backend.elasticsearch.types.mapping.impl.OpenSearch214VectorFieldTypeMappingContributor;
+
+import com.google.gson.Gson;
+
+/**
+ * The index field type factory provider for OpenSearch 2.14+.
+ */
+public class OpenSearch214IndexFieldTypeFactoryProvider extends AbstractIndexFieldTypeFactoryProvider {
+
+	private final OpenSearch214VectorFieldTypeMappingContributor vectorFieldTypeMappingContributor =
+			new OpenSearch214VectorFieldTypeMappingContributor();
+
+	public OpenSearch214IndexFieldTypeFactoryProvider(Gson userFacingGson) {
+		super( userFacingGson );
+	}
+
+	@Override
+	protected ElasticsearchVectorFieldTypeMappingContributor vectorFieldTypeMappingContributor() {
+		return vectorFieldTypeMappingContributor;
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/mapping/impl/AbstractOpenSearch2VectorFieldTypeMappingContributor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/mapping/impl/AbstractOpenSearch2VectorFieldTypeMappingContributor.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.backend.elasticsearch.types.mapping.impl;
+
+import java.lang.invoke.MethodHandles;
+
+import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
+import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.DataTypes;
+import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.OpenSearchVectorTypeMethod;
+import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.PropertyMapping;
+import org.hibernate.search.backend.elasticsearch.search.common.impl.ElasticsearchSearchIndexScope;
+import org.hibernate.search.backend.elasticsearch.search.common.impl.ElasticsearchSearchIndexValueFieldContext;
+import org.hibernate.search.backend.elasticsearch.types.impl.ElasticsearchIndexValueFieldType;
+import org.hibernate.search.engine.backend.types.VectorSimilarity;
+import org.hibernate.search.engine.search.common.spi.SearchQueryElementFactory;
+import org.hibernate.search.engine.search.predicate.spi.KnnPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.PredicateTypeKeys;
+import org.hibernate.search.util.common.AssertionFailure;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
+
+abstract class AbstractOpenSearch2VectorFieldTypeMappingContributor implements ElasticsearchVectorFieldTypeMappingContributor {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
+	private static final String BYTE_TYPE = "BYTE";
+
+	@Override
+	public final void contribute(PropertyMapping mapping, Context context) {
+		mapping.setType( DataTypes.KNN_VECTOR );
+		mapping.setDimension( context.dimension() );
+		// float type is default and even if passed it is ignored,
+		// we only should pass the byte type:
+		if ( BYTE_TYPE.equalsIgnoreCase( context.type() ) ) {
+			mapping.setDataType( BYTE_TYPE );
+		}
+
+		String resolvedVectorSimilarity = resolveDefault( context.vectorSimilarity() );
+
+		// we want to always set Lucene as an engine:
+		OpenSearchVectorTypeMethod method = new OpenSearchVectorTypeMethod();
+		method.setName( "hnsw" );
+		method.setEngine( "lucene" );
+		if ( resolvedVectorSimilarity != null ) {
+			method.setSpaceType( resolvedVectorSimilarity );
+		}
+		if ( context.m() != null || context.efConstruction() != null ) {
+			OpenSearchVectorTypeMethod.Parameters parameters = new OpenSearchVectorTypeMethod.Parameters();
+			if ( context.m() != null ) {
+				parameters.setM( context.m() );
+			}
+			if ( context.efConstruction() != null ) {
+				parameters.setEfConstruction( context.efConstruction() );
+			}
+			method.setParameters( parameters );
+		}
+
+		mapping.setMethod( method );
+	}
+
+	@Override
+	public final <F> void contribute(ElasticsearchIndexValueFieldType.Builder<F> builder, Context context) {
+		SearchQueryElementFactory<? extends KnnPredicateBuilder,
+				ElasticsearchSearchIndexScope<?>,
+				ElasticsearchSearchIndexValueFieldContext<F>> factory = getKnnPredicateFactory( builder );
+		builder.queryElementFactory( PredicateTypeKeys.KNN, factory );
+
+		builder.contributeAdditionalIndexSettings( settings -> settings.addKnn( true ) );
+	}
+
+	protected abstract <F> SearchQueryElementFactory<? extends KnnPredicateBuilder,
+			ElasticsearchSearchIndexScope<?>,
+			ElasticsearchSearchIndexValueFieldContext<F>> getKnnPredicateFactory(
+					ElasticsearchIndexValueFieldType.Builder<F> builder);
+
+	private static String resolveDefault(VectorSimilarity vectorSimilarity) {
+		switch ( vectorSimilarity ) {
+			case DEFAULT:
+				return null;
+			case L2:
+				return "l2";
+			case COSINE:
+				return "cosinesimil";
+			case DOT_PRODUCT:
+			case MAX_INNER_PRODUCT:
+				throw log.vectorSimilarityNotSupportedByOpenSearchBackend( vectorSimilarity );
+
+			default:
+				throw new AssertionFailure( "Unexpected value for Similarity: " + vectorSimilarity );
+		}
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/mapping/impl/OpenSearch214VectorFieldTypeMappingContributor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/mapping/impl/OpenSearch214VectorFieldTypeMappingContributor.java
@@ -11,13 +11,13 @@ import org.hibernate.search.backend.elasticsearch.types.impl.ElasticsearchIndexV
 import org.hibernate.search.engine.search.common.spi.SearchQueryElementFactory;
 import org.hibernate.search.engine.search.predicate.spi.KnnPredicateBuilder;
 
-public class OpenSearch2VectorFieldTypeMappingContributor extends AbstractOpenSearch2VectorFieldTypeMappingContributor {
+public class OpenSearch214VectorFieldTypeMappingContributor extends AbstractOpenSearch2VectorFieldTypeMappingContributor {
 
 	@Override
 	protected <F> SearchQueryElementFactory<? extends KnnPredicateBuilder,
 			ElasticsearchSearchIndexScope<?>,
 			ElasticsearchSearchIndexValueFieldContext<F>> getKnnPredicateFactory(
 					ElasticsearchIndexValueFieldType.Builder<F> builder) {
-		return new ElasticsearchKnnPredicate.OpenSearch2Factory<>( builder.codec() );
+		return new ElasticsearchKnnPredicate.OpenSearch214Factory<>( builder.codec() );
 	}
 }

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -18,6 +18,7 @@ import org.hibernate.search.backend.elasticsearch.dialect.model.impl.Elasticsear
 import org.hibernate.search.backend.elasticsearch.dialect.model.impl.Elasticsearch8ModelDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.model.impl.ElasticsearchModelDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.model.impl.OpenSearch1ModelDialect;
+import org.hibernate.search.backend.elasticsearch.dialect.model.impl.OpenSearch214ModelDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.model.impl.OpenSearch29ModelDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.model.impl.OpenSearch2ModelDialect;
 import org.hibernate.search.backend.elasticsearch.dialect.protocol.impl.Elasticsearch70ProtocolDialect;
@@ -397,39 +398,39 @@ class ElasticsearchDialectFactoryTest {
 				),
 				success(
 						ElasticsearchDistributionName.OPENSEARCH, "2.14", "2.14.0",
-						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch214ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				success(
 						ElasticsearchDistributionName.OPENSEARCH, "2.14.0", "2.14.0",
-						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch214ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				success(
 						ElasticsearchDistributionName.OPENSEARCH, "2.15", "2.15.0",
-						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch214ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				success(
 						ElasticsearchDistributionName.OPENSEARCH, "2.15.0", "2.15.0",
-						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch214ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				successWithWarning(
 						ElasticsearchDistributionName.OPENSEARCH, "2.16", "2.16.0",
-						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch214ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				successWithWarning(
 						ElasticsearchDistributionName.OPENSEARCH, "2.16.0", "2.16.0",
-						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch214ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				successWithWarning(
 						ElasticsearchDistributionName.OPENSEARCH, "3", "3.0.0",
-						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch214ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				successWithWarning(
 						ElasticsearchDistributionName.OPENSEARCH, "3.0", "3.0.0",
-						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch214ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				successWithWarning(
 						ElasticsearchDistributionName.OPENSEARCH, "3.0.0", "3.0.0",
-						OpenSearch29ModelDialect.class, Elasticsearch70ProtocolDialect.class
+						OpenSearch214ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				)
 		);
 	}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -297,6 +297,15 @@ public class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 	}
 
 	@Override
+	public boolean supportsVectorSearchRequiredMinimumSimilarity() {
+		return isActualVersion(
+				es -> true,
+				os -> !os.isLessThan( "2.14.0" ),
+				aoss -> true
+		);
+	}
+
+	@Override
 	public boolean supportsSimilarity(VectorSimilarity vectorSimilarity) {
 		switch ( vectorSimilarity ) {
 			case DOT_PRODUCT:

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/KnnPredicateSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/KnnPredicateSpecificsIT.java
@@ -966,6 +966,14 @@ class KnnPredicateSpecificsIT {
 			return result;
 		}
 
+		@BeforeAll
+		static void beforeAll() {
+			assumeTrue(
+					TckConfiguration.get().getBackendFeatures().supportsVectorSearchRequiredMinimumSimilarity(),
+					"This test only make sense for backends that have a way to specify the required minimum similarity."
+			);
+		}
+
 		@ParameterizedTest
 		@MethodSource
 		void similarityFilterFloat(SimpleMappedIndex<IndexBinding> index, float similarity, float score, int matches) {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
@@ -139,6 +139,10 @@ public abstract class TckBackendFeatures implements StubMappingBackendFeatures {
 		return true;
 	}
 
+	public boolean supportsVectorSearchRequiredMinimumSimilarity() {
+		return true;
+	}
+
 	public boolean supportsSimilarity(VectorSimilarity vectorSimilarity) {
 		return true;
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5182

This is a follow-up since not all OpenSearch versions that support vector search can do a similarity filter ... 😕 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
