### PR TITLE
HSEARCH-3906 Add prefix predicate

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchStringIndexFieldTypeOptionsStep.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchStringIndexFieldTypeOptionsStep.java
@@ -26,6 +26,7 @@ import org.hibernate.search.backend.elasticsearch.types.predicate.impl.Elasticse
 import org.hibernate.search.backend.elasticsearch.types.predicate.impl.ElasticsearchTermsPredicate;
 import org.hibernate.search.backend.elasticsearch.types.predicate.impl.ElasticsearchTextMatchPredicate;
 import org.hibernate.search.backend.elasticsearch.types.predicate.impl.ElasticsearchTextPhrasePredicate;
+import org.hibernate.search.backend.elasticsearch.types.predicate.impl.ElasticsearchTextPrefixPredicate;
 import org.hibernate.search.backend.elasticsearch.types.predicate.impl.ElasticsearchTextRegexpPredicate;
 import org.hibernate.search.backend.elasticsearch.types.predicate.impl.ElasticsearchTextWildcardPredicate;
 import org.hibernate.search.backend.elasticsearch.types.sort.impl.ElasticsearchStandardFieldSort;
@@ -207,6 +208,7 @@ class ElasticsearchStringIndexFieldTypeOptionsStep
 			builder.queryElementFactory( PredicateTypeKeys.RANGE, new ElasticsearchRangePredicate.Factory<>( codec ) );
 			builder.queryElementFactory( PredicateTypeKeys.EXISTS, new ElasticsearchExistsPredicate.Factory<>() );
 			builder.queryElementFactory( PredicateTypeKeys.PHRASE, new ElasticsearchTextPhrasePredicate.Factory() );
+			builder.queryElementFactory( PredicateTypeKeys.PREFIX, new ElasticsearchTextPrefixPredicate.Factory() );
 			builder.queryElementFactory( PredicateTypeKeys.WILDCARD, new ElasticsearchTextWildcardPredicate.Factory() );
 			builder.queryElementFactory( PredicateTypeKeys.REGEXP, new ElasticsearchTextRegexpPredicate.Factory() );
 			builder.queryElementFactory( PredicateTypeKeys.TERMS, new ElasticsearchTermsPredicate.Factory<>( codec ) );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextPrefixPredicate.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextPrefixPredicate.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.backend.elasticsearch.types.predicate.impl;
+
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonAccessor;
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonObjectAccessor;
+import org.hibernate.search.backend.elasticsearch.search.common.impl.AbstractElasticsearchValueFieldSearchQueryElementFactory;
+import org.hibernate.search.backend.elasticsearch.search.common.impl.ElasticsearchSearchIndexScope;
+import org.hibernate.search.backend.elasticsearch.search.common.impl.ElasticsearchSearchIndexValueFieldContext;
+import org.hibernate.search.backend.elasticsearch.search.predicate.impl.AbstractElasticsearchSingleFieldPredicate;
+import org.hibernate.search.backend.elasticsearch.search.predicate.impl.PredicateRequestContext;
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.engine.search.predicate.spi.PrefixPredicateBuilder;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+public class ElasticsearchTextPrefixPredicate extends AbstractElasticsearchSingleFieldPredicate {
+
+	private static final JsonObjectAccessor PREFIX_ACCESSOR = JsonAccessor.root().property( "prefix" ).asObject();
+
+	private static final JsonAccessor<JsonElement> VALUE_ACCESSOR = JsonAccessor.root().property( "value" );
+
+	private final JsonPrimitive prefix;
+
+	private ElasticsearchTextPrefixPredicate(Builder builder) {
+		super( builder );
+		this.prefix = builder.prefix;
+	}
+
+	@Override
+	protected JsonObject doToJsonQuery(PredicateRequestContext context, JsonObject outerObject, JsonObject innerObject) {
+		VALUE_ACCESSOR.set( innerObject, prefix );
+
+		JsonObject middleObject = new JsonObject();
+		middleObject.add( absoluteFieldPath, innerObject );
+
+		PREFIX_ACCESSOR.set( outerObject, middleObject );
+		return outerObject;
+	}
+
+	public static class Factory
+			extends AbstractElasticsearchValueFieldSearchQueryElementFactory<PrefixPredicateBuilder, String> {
+		@Override
+		public PrefixPredicateBuilder create(ElasticsearchSearchIndexScope<?> scope,
+				ElasticsearchSearchIndexValueFieldContext<String> field) {
+			return new Builder( scope, field );
+		}
+	}
+
+	private static class Builder extends AbstractBuilder implements PrefixPredicateBuilder {
+		private JsonPrimitive prefix;
+
+		private Builder(ElasticsearchSearchIndexScope<?> scope, ElasticsearchSearchIndexValueFieldContext<String> field) {
+			super( scope, field );
+		}
+
+		@Override
+		public void prefix(String prefix) {
+			this.prefix = new JsonPrimitive( prefix );
+		}
+
+		@Override
+		public SearchPredicate build() {
+			return new ElasticsearchTextPrefixPredicate( this );
+		}
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexFieldTypeOptionsStep.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexFieldTypeOptionsStep.java
@@ -25,6 +25,7 @@ import org.hibernate.search.backend.lucene.types.predicate.impl.LuceneCommonQuer
 import org.hibernate.search.backend.lucene.types.predicate.impl.LuceneExistsPredicate;
 import org.hibernate.search.backend.lucene.types.predicate.impl.LuceneTextMatchPredicate;
 import org.hibernate.search.backend.lucene.types.predicate.impl.LuceneTextPhrasePredicate;
+import org.hibernate.search.backend.lucene.types.predicate.impl.LuceneTextPrefixPredicate;
 import org.hibernate.search.backend.lucene.types.predicate.impl.LuceneTextRangePredicate;
 import org.hibernate.search.backend.lucene.types.predicate.impl.LuceneTextRegexpPredicate;
 import org.hibernate.search.backend.lucene.types.predicate.impl.LuceneTextTermsPredicate;
@@ -207,6 +208,7 @@ class LuceneStringIndexFieldTypeOptionsStep
 							? new LuceneExistsPredicate.DocValuesOrNormsBasedFactory<>()
 							: new LuceneExistsPredicate.DefaultFactory<>() );
 			builder.queryElementFactory( PredicateTypeKeys.PHRASE, new LuceneTextPhrasePredicate.Factory<>() );
+			builder.queryElementFactory( PredicateTypeKeys.PREFIX, new LuceneTextPrefixPredicate.Factory<>() );
 			builder.queryElementFactory( PredicateTypeKeys.WILDCARD, new LuceneTextWildcardPredicate.Factory<>() );
 			builder.queryElementFactory( PredicateTypeKeys.REGEXP, new LuceneTextRegexpPredicate.Factory<>() );
 			builder.queryElementFactory( LucenePredicateTypeKeys.SIMPLE_QUERY_STRING,

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextPrefixPredicate.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextPrefixPredicate.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.backend.lucene.types.predicate.impl;
+
+import org.hibernate.search.backend.lucene.search.common.impl.AbstractLuceneValueFieldSearchQueryElementFactory;
+import org.hibernate.search.backend.lucene.search.common.impl.LuceneSearchIndexScope;
+import org.hibernate.search.backend.lucene.search.common.impl.LuceneSearchIndexValueFieldContext;
+import org.hibernate.search.backend.lucene.search.predicate.impl.AbstractLuceneLeafSingleFieldPredicate;
+import org.hibernate.search.backend.lucene.search.predicate.impl.PredicateRequestContext;
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.engine.search.predicate.spi.PrefixPredicateBuilder;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.PrefixQuery;
+import org.apache.lucene.search.Query;
+
+public class LuceneTextPrefixPredicate extends AbstractLuceneLeafSingleFieldPredicate {
+
+	private LuceneTextPrefixPredicate(Builder<?> builder) {
+		super( builder );
+	}
+
+	public static class Factory<F> extends AbstractLuceneValueFieldSearchQueryElementFactory<PrefixPredicateBuilder, F> {
+		@Override
+		public PrefixPredicateBuilder create(LuceneSearchIndexScope<?> scope, LuceneSearchIndexValueFieldContext<F> field) {
+			return new Builder<>( scope, field );
+		}
+	}
+
+	private static class Builder<F> extends AbstractBuilder<F> implements PrefixPredicateBuilder {
+
+		private final Analyzer analyzerOrNormalizer;
+
+		private String prefix;
+
+		private Builder(LuceneSearchIndexScope<?> scope, LuceneSearchIndexValueFieldContext<F> field) {
+			super( scope, field );
+			this.analyzerOrNormalizer = field.type().searchAnalyzerOrNormalizer();
+		}
+
+		@Override
+		public void prefix(String prefix) {
+			this.prefix = prefix;
+		}
+
+		@Override
+		public SearchPredicate build() {
+			return new LuceneTextPrefixPredicate( this );
+		}
+
+		@Override
+		protected Query buildQuery(PredicateRequestContext context) {
+			return new PrefixQuery(
+					new Term( absoluteFieldPath, analyzerOrNormalizer.normalize( absoluteFieldPath, prefix ) ) );
+		}
+	}
+}

--- a/documentation/src/main/asciidoc/public/reference/_search-dsl-predicate.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_search-dsl-predicate.adoc
@@ -1865,6 +1865,47 @@ or for the whole predicate with a call to `.boost(...)` after `.matching(...)`.
 of targeted fields to analyze searched text by default,
 but this can be <<search-dsl-predicate-common-overriding-analysis,overridden>>.
 
+[[search-dsl-predicate-prefix]]
+== `prefix`: match documents based on what a field starts with
+
+The `prefix` predicate matches documents for which a given field has a value starting with a given string.
+
+.Matching a simple prefix
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java[tags=prefix]
+----
+====
+
+[IMPORTANT]
+====
+If a normalizer has been defined on the field, the prefix used in prefix predicates
+will be normalized.
+
+If an analyzer has been defined on the field:
+
+* when using the Elasticsearch backend, the prefixes won't be analyzed nor normalized,
+and will be expected to match a *single* indexed token.
+This may behave differently on an older versions of the underlying search engine
+Hence, please refer to the documentation of your particular backend version for the exact behaviour.
+* when using the Lucene backend the prefixes will be normalized.
+
+When the goal is to match user-provided query strings,
+the <<search-dsl-predicate-simple-query-string,simple query string predicate>> should be preferred.
+
+This predicate may also not be ideal for autocomplete purposes. Refer to your particular backend documentation
+to determine the best option to achieve autocomplete functionality.
+====
+
+[[search-dsl-predicate-prefix-multiple-fields]]
+=== Targeting multiple fields
+
+Optionally, the predicate can target multiple fields.
+In that case, the predicate will match documents for which _any_ of the given fields matches.
+
+See <<search-dsl-predicate-common-multiple-fields>>.
+
 [[search-dsl-predicate-named]]
 == [[query-filter-fulltext]] `named`: call a predicate defined in the mapping
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
@@ -1092,6 +1092,21 @@ class PredicateDslIT {
 	}
 
 	@Test
+	void prefix() {
+		withinSearchSession( searchSession -> {
+			// tag::prefix[]
+			List<Book> hits = searchSession.search( Book.class )
+					.where( f -> f.prefix().field( "description" )
+							.matching( "rob" ) )
+					.fetchHits( 20 );
+			// end::prefix[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID, BOOK3_ID, BOOK4_ID );
+		} );
+	}
+
+	@Test
 	void regexp() {
 		withinSearchSession( searchSession -> {
 			// tag::regexp[]

--- a/engine/src/main/java/org/hibernate/search/engine/backend/types/IndexFieldTraits.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/types/IndexFieldTraits.java
@@ -42,6 +42,7 @@ public final class IndexFieldTraits {
 		public static final String MATCH = "predicate:match";
 		public static final String NESTED = "predicate:nested";
 		public static final String PHRASE = "predicate:phrase";
+		public static final String PREFIX = "predicate:prefix";
 		public static final String RANGE = "predicate:range";
 		public static final String QUERY_STRING = "predicate:query-string";
 		public static final String REGEXP = "predicate:regexp";

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/PrefixPredicateFieldMoreStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/PrefixPredicateFieldMoreStep.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.engine.search.predicate.dsl;
+
+/**
+ * The step in a "prefix" predicate definition where the pattern to match can be set
+ * (see the superinterface {@link PrefixPredicateMatchingStep}),
+ * or optional parameters for the last targeted field(s) can be set,
+ * or more target fields can be added.
+ *
+ * @param <S> The "self" type (the actual exposed type of this step).
+ * @param <N> The type of the next step.
+ */
+public interface PrefixPredicateFieldMoreStep<
+		S extends PrefixPredicateFieldMoreStep<?, N>,
+		N extends PrefixPredicateOptionsStep<?>>
+		extends PrefixPredicateMatchingStep<N>, MultiFieldPredicateFieldBoostStep<S> {
+
+	/**
+	 * Target the given field in the prefix predicate,
+	 * as an alternative to the already-targeted fields.
+	 * <p>
+	 * Only text fields are supported.
+	 * <p>
+	 * See {@link PrefixPredicateFieldStep#field(String)} for more information on targeted fields.
+	 *
+	 * @param fieldPath The <a href="SearchPredicateFactory.html#field-paths">path</a> to the index field
+	 * to apply the predicate on.
+	 * @return The next step.
+	 *
+	 * @see PrefixPredicateFieldStep#field(String)
+	 */
+	default S field(String fieldPath) {
+		return fields( fieldPath );
+	}
+
+	/**
+	 * Target the given fields in the prefix predicate,
+	 * as an alternative to the already-targeted fields.
+	 * <p>
+	 * Only text fields are supported.
+	 * <p>
+	 * See {@link PrefixPredicateFieldStep#fields(String...)} for more information on targeted fields.
+	 *
+	 * @param fieldPaths The <a href="SearchPredicateFactory.html#field-paths">paths</a> to the index fields
+	 * to apply the predicate on.
+	 * @return The next step.
+	 *
+	 * @see PrefixPredicateFieldStep#fields(String...)
+	 */
+	S fields(String... fieldPaths);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/PrefixPredicateFieldStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/PrefixPredicateFieldStep.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.engine.search.predicate.dsl;
+
+/**
+ * The initial step in a "prefix" predicate definition, where the target field can be set.
+ *
+ * @param <N> The type of the next step.
+ */
+public interface PrefixPredicateFieldStep<N extends PrefixPredicateFieldMoreStep<?, ?>> {
+
+	/**
+	 * Target the given field in the prefix predicate.
+	 * <p>
+	 * Only text fields are supported.
+	 * <p>
+	 * Multiple fields may be targeted by the same predicate:
+	 * the predicate will match if <em>any</em> targeted field matches.
+	 * <p>
+	 * When targeting multiple fields, those fields must have compatible types.
+	 * Please refer to the reference documentation for more information.
+	 *
+	 * @param fieldPath The <a href="SearchPredicateFactory.html#field-paths">path</a> to the index field
+	 * to apply the predicate on.
+	 * @return The next step.
+	 */
+	default N field(String fieldPath) {
+		return fields( fieldPath );
+	}
+
+	/**
+	 * Target the given fields in the prefix predicate.
+	 * <p>
+	 * Only text fields are supported.
+	 * <p>
+	 * Equivalent to {@link #field(String)} followed by multiple calls to
+	 * {@link PrefixPredicateFieldMoreStep#field(String)},
+	 * the only difference being that calls to {@link PrefixPredicateFieldMoreStep#boost(float)}
+	 * and other field-specific settings on the returned step will only need to be done once
+	 * and will apply to all the fields passed to this method.
+	 *
+	 * @param fieldPaths The <a href="SearchPredicateFactory.html#field-paths">paths</a> to the index fields
+	 * to apply the predicate on.
+	 * @return The next step.
+	 *
+	 * @see #field(String)
+	 */
+	N fields(String... fieldPaths);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/PrefixPredicateMatchingStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/PrefixPredicateMatchingStep.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.engine.search.predicate.dsl;
+
+/**
+ * The step in a "prefix" predicate definition where the prefix string to match can be set.
+ *
+ * @param <N> The type of the next step.
+ */
+public interface PrefixPredicateMatchingStep<N extends PrefixPredicateOptionsStep<?>> {
+
+	/**
+	 * Require at least one of the targeted fields to start with the given prefix string.
+	 *
+	 * @param prefix The prefix a matched field should start with.
+	 * @return The next step.
+	 */
+	N matching(String prefix);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/PrefixPredicateOptionsStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/PrefixPredicateOptionsStep.java
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.engine.search.predicate.dsl;
+
+/**
+ * The final step in a "prefix" predicate definition, where optional parameters can be set.
+ *
+ * @param <S> The "self" type (the actual exposed type of this step).
+ */
+public interface PrefixPredicateOptionsStep<S extends PrefixPredicateOptionsStep<?>>
+		extends PredicateFinalStep, PredicateScoreStep<S> {
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/SearchPredicateFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/SearchPredicateFactory.java
@@ -193,6 +193,14 @@ public interface SearchPredicateFactory {
 	WildcardPredicateFieldStep<?> wildcard();
 
 	/**
+	 * Match documents where targeted fields have a value that starts with a given string.
+	 *
+	 * @return The initial step of a DSL where the "prefix" predicate can be defined.
+	 * @see PrefixPredicateFieldStep
+	 */
+	PrefixPredicateFieldStep<?> prefix();
+
+	/**
 	 * Match documents where targeted fields contain a term that matches a given regular expression.
 	 *
 	 * @return The initial step of a DSL where the "regexp" predicate can be defined.

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/impl/PrefixPredicateFieldMoreStepImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/impl/PrefixPredicateFieldMoreStepImpl.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.engine.search.predicate.dsl.impl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.hibernate.search.engine.search.common.spi.SearchIndexScope;
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.engine.search.predicate.dsl.PrefixPredicateFieldMoreStep;
+import org.hibernate.search.engine.search.predicate.dsl.PrefixPredicateOptionsStep;
+import org.hibernate.search.engine.search.predicate.dsl.spi.SearchPredicateDslContext;
+import org.hibernate.search.engine.search.predicate.spi.PredicateTypeKeys;
+import org.hibernate.search.engine.search.predicate.spi.PrefixPredicateBuilder;
+import org.hibernate.search.util.common.impl.Contracts;
+
+class PrefixPredicateFieldMoreStepImpl
+		implements PrefixPredicateFieldMoreStep<PrefixPredicateFieldMoreStepImpl, PrefixPredicateOptionsStep<?>>,
+		AbstractBooleanMultiFieldPredicateCommonState.FieldSetState {
+
+	private final CommonState commonState;
+
+	private final List<PrefixPredicateBuilder> predicateBuilders = new ArrayList<>();
+
+	private Float fieldSetBoost;
+
+	PrefixPredicateFieldMoreStepImpl(CommonState commonState, List<String> fieldPaths) {
+		this.commonState = commonState;
+		this.commonState.add( this );
+		SearchIndexScope<?> scope = commonState.scope();
+		for ( String fieldPath : fieldPaths ) {
+			predicateBuilders.add( scope.fieldQueryElement( fieldPath, PredicateTypeKeys.PREFIX ) );
+		}
+	}
+
+	@Override
+	public PrefixPredicateFieldMoreStepImpl fields(String... fieldPaths) {
+		return new PrefixPredicateFieldMoreStepImpl( commonState, Arrays.asList( fieldPaths ) );
+	}
+
+	@Override
+	public PrefixPredicateFieldMoreStepImpl boost(float boost) {
+		this.fieldSetBoost = boost;
+		return this;
+	}
+
+	@Override
+	public PrefixPredicateOptionsStep<?> matching(String prefixPattern) {
+		return commonState.matching( prefixPattern );
+	}
+
+	@Override
+	public void contributePredicates(Consumer<SearchPredicate> collector) {
+		for ( PrefixPredicateBuilder predicateBuilder : predicateBuilders ) {
+			// Perform last-minute changes, since it's the last call that will be made on this field set state
+			commonState.applyBoostAndConstantScore( fieldSetBoost, predicateBuilder );
+
+			collector.accept( predicateBuilder.build() );
+		}
+	}
+
+	static class CommonState
+			extends AbstractBooleanMultiFieldPredicateCommonState<CommonState, PrefixPredicateFieldMoreStepImpl>
+			implements PrefixPredicateOptionsStep<CommonState> {
+
+		CommonState(SearchPredicateDslContext<?> dslContext) {
+			super( dslContext );
+		}
+
+		private PrefixPredicateOptionsStep<?> matching(String prefix) {
+			Contracts.assertNotNull( prefix, "prefix" );
+			for ( PrefixPredicateFieldMoreStepImpl fieldSetState : getFieldSetStates() ) {
+				for ( PrefixPredicateBuilder predicateBuilder : fieldSetState.predicateBuilders ) {
+					predicateBuilder.prefix( prefix );
+				}
+			}
+			return this;
+		}
+
+		@Override
+		protected CommonState thisAsS() {
+			return this;
+		}
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/impl/PrefixPredicateFieldStepImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/impl/PrefixPredicateFieldStepImpl.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.engine.search.predicate.dsl.impl;
+
+import java.util.Arrays;
+
+import org.hibernate.search.engine.search.predicate.dsl.PrefixPredicateFieldMoreStep;
+import org.hibernate.search.engine.search.predicate.dsl.PrefixPredicateFieldStep;
+import org.hibernate.search.engine.search.predicate.dsl.spi.SearchPredicateDslContext;
+
+public final class PrefixPredicateFieldStepImpl
+		implements PrefixPredicateFieldStep<PrefixPredicateFieldMoreStep<?, ?>> {
+
+	private final PrefixPredicateFieldMoreStepImpl.CommonState commonState;
+
+	public PrefixPredicateFieldStepImpl(SearchPredicateDslContext<?> dslContext) {
+		this.commonState = new PrefixPredicateFieldMoreStepImpl.CommonState( dslContext );
+	}
+
+	@Override
+	public PrefixPredicateFieldMoreStep<?, ?> fields(String... fieldPaths) {
+		return new PrefixPredicateFieldMoreStepImpl( commonState, Arrays.asList( fieldPaths ) );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/spi/AbstractSearchPredicateFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/spi/AbstractSearchPredicateFactory.java
@@ -27,6 +27,7 @@ import org.hibernate.search.engine.search.predicate.dsl.NestedPredicateClausesSt
 import org.hibernate.search.engine.search.predicate.dsl.NotPredicateFinalStep;
 import org.hibernate.search.engine.search.predicate.dsl.PhrasePredicateFieldStep;
 import org.hibernate.search.engine.search.predicate.dsl.PredicateFinalStep;
+import org.hibernate.search.engine.search.predicate.dsl.PrefixPredicateFieldStep;
 import org.hibernate.search.engine.search.predicate.dsl.QueryStringPredicateFieldStep;
 import org.hibernate.search.engine.search.predicate.dsl.RangePredicateFieldStep;
 import org.hibernate.search.engine.search.predicate.dsl.RegexpPredicateFieldStep;
@@ -49,6 +50,7 @@ import org.hibernate.search.engine.search.predicate.dsl.impl.NamedPredicateOptio
 import org.hibernate.search.engine.search.predicate.dsl.impl.NestedPredicateClausesStepImpl;
 import org.hibernate.search.engine.search.predicate.dsl.impl.NotPredicateFinalStepImpl;
 import org.hibernate.search.engine.search.predicate.dsl.impl.PhrasePredicateFieldStepImpl;
+import org.hibernate.search.engine.search.predicate.dsl.impl.PrefixPredicateFieldStepImpl;
 import org.hibernate.search.engine.search.predicate.dsl.impl.QueryStringPredicateFieldStepImpl;
 import org.hibernate.search.engine.search.predicate.dsl.impl.RangePredicateFieldStepImpl;
 import org.hibernate.search.engine.search.predicate.dsl.impl.RegexpPredicateFieldStepImpl;
@@ -164,6 +166,11 @@ public abstract class AbstractSearchPredicateFactory<
 	@Override
 	public WildcardPredicateFieldStep<?> wildcard() {
 		return new WildcardPredicateFieldStepImpl( dslContext );
+	}
+
+	@Override
+	public PrefixPredicateFieldStep<?> prefix() {
+		return new PrefixPredicateFieldStepImpl( dslContext );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/PredicateTypeKeys.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/PredicateTypeKeys.java
@@ -27,6 +27,7 @@ public final class PredicateTypeKeys {
 	public static final SearchQueryElementTypeKey<RangePredicateBuilder> RANGE = of( IndexFieldTraits.Predicates.RANGE );
 	public static final SearchQueryElementTypeKey<ExistsPredicateBuilder> EXISTS = of( IndexFieldTraits.Predicates.EXISTS );
 	public static final SearchQueryElementTypeKey<PhrasePredicateBuilder> PHRASE = of( IndexFieldTraits.Predicates.PHRASE );
+	public static final SearchQueryElementTypeKey<PrefixPredicateBuilder> PREFIX = of( IndexFieldTraits.Predicates.PREFIX );
 	public static final SearchQueryElementTypeKey<WildcardPredicateBuilder> WILDCARD =
 			of( IndexFieldTraits.Predicates.WILDCARD );
 	public static final SearchQueryElementTypeKey<RegexpPredicateBuilder> REGEXP = of( IndexFieldTraits.Predicates.REGEXP );

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/PrefixPredicateBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/PrefixPredicateBuilder.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.engine.search.predicate.spi;
+
+public interface PrefixPredicateBuilder extends SearchPredicateBuilder {
+
+	void prefix(String prefix);
+
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/PrefixPredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/PrefixPredicateBaseIT.java
@@ -1,0 +1,484 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.integrationtest.backend.tck.search.predicate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.search.engine.backend.types.dsl.SearchableProjectableIndexFieldTypeOptionsStep;
+import org.hibernate.search.engine.search.predicate.dsl.PredicateFinalStep;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.extension.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.provider.Arguments;
+
+//CHECKSTYLE:OFF HideUtilityClassConstructor ignore the rule since it is a class with nested test classes.
+// cannot make a private constructor.
+class PrefixPredicateBaseIT {
+	//CHECKSTYLE:ON
+
+	private static final List<
+			FieldTypeDescriptor<String, ? extends SearchableProjectableIndexFieldTypeOptionsStep<?, ?>>> supportedFieldTypes =
+					new ArrayList<>();
+	private static final List<
+			FieldTypeDescriptor<?, ? extends SearchableProjectableIndexFieldTypeOptionsStep<?, ?>>> unsupportedFieldTypes =
+					new ArrayList<>();
+	static {
+		for ( FieldTypeDescriptor<?, ?> fieldType : FieldTypeDescriptor.getAll() ) {
+			if ( String.class.equals( fieldType.getJavaType() ) ) {
+				@SuppressWarnings("unchecked")
+				FieldTypeDescriptor<String, ?> casted = (FieldTypeDescriptor<String, ?>) fieldType;
+				supportedFieldTypes.add( casted );
+			}
+			else {
+				unsupportedFieldTypes.add( fieldType );
+			}
+		}
+	}
+
+	@RegisterExtension
+	public static SearchSetupHelper setupHelper = SearchSetupHelper.create();
+
+	@BeforeAll
+	static void setup() {
+		setupHelper.start()
+				.withIndexes(
+						SingleFieldConfigured.index, MultiFieldConfigured.index,
+						InObjectFieldConfigured.mainIndex, InObjectFieldConfigured.missingFieldIndex,
+						ScoreConfigured.index,
+						InvalidFieldConfigured.index, UnsupportedTypeConfigured.index,
+						SearchableConfigured.searchableDefaultIndex, SearchableConfigured.searchableYesIndex,
+						SearchableConfigured.searchableNoIndex,
+						ArgumentCheckingConfigured.index,
+						TypeCheckingNoConversionConfigured.index, TypeCheckingNoConversionConfigured.compatibleIndex,
+						TypeCheckingNoConversionConfigured.rawFieldCompatibleIndex,
+						TypeCheckingNoConversionConfigured.missingFieldIndex,
+						TypeCheckingNoConversionConfigured.incompatibleIndex
+				)
+				.setup();
+
+		final BulkIndexer singleFieldIndexer = SingleFieldConfigured.index.bulkIndexer();
+		SingleFieldConfigured.dataSets.forEach( d -> d.contribute( SingleFieldConfigured.index, singleFieldIndexer ) );
+
+		final BulkIndexer multiFieldIndexer = MultiFieldConfigured.index.bulkIndexer();
+		MultiFieldConfigured.dataSets.forEach( d -> d.contribute( MultiFieldConfigured.index, multiFieldIndexer ) );
+
+		final BulkIndexer inObjectFieldMainIndexer = InObjectFieldConfigured.mainIndex.bulkIndexer();
+		final BulkIndexer inObjectFieldMissingFieldIndexer = InObjectFieldConfigured.missingFieldIndex.bulkIndexer();
+		InObjectFieldConfigured.dataSets
+				.forEach( d -> d.contribute( InObjectFieldConfigured.mainIndex, inObjectFieldMainIndexer,
+						InObjectFieldConfigured.missingFieldIndex, inObjectFieldMissingFieldIndexer ) );
+
+		final BulkIndexer scoreIndexer = ScoreConfigured.index.bulkIndexer();
+		ScoreConfigured.dataSets.forEach( d -> d.contribute( ScoreConfigured.index, scoreIndexer ) );
+
+		final BulkIndexer typeCheckingMainIndexer = TypeCheckingNoConversionConfigured.index.bulkIndexer();
+		final BulkIndexer typeCheckingCompatibleIndexer = TypeCheckingNoConversionConfigured.compatibleIndex.bulkIndexer();
+		final BulkIndexer typeCheckingRawFieldCompatibleIndexer =
+				TypeCheckingNoConversionConfigured.rawFieldCompatibleIndex.bulkIndexer();
+		final BulkIndexer typeCheckingMissingFieldIndexer = TypeCheckingNoConversionConfigured.missingFieldIndex.bulkIndexer();
+		TypeCheckingNoConversionConfigured.dataSets
+				.forEach( d -> d.contribute( TypeCheckingNoConversionConfigured.index, typeCheckingMainIndexer,
+						TypeCheckingNoConversionConfigured.compatibleIndex, typeCheckingCompatibleIndexer,
+						TypeCheckingNoConversionConfigured.rawFieldCompatibleIndex, typeCheckingRawFieldCompatibleIndexer,
+						TypeCheckingNoConversionConfigured.missingFieldIndex, typeCheckingMissingFieldIndexer ) );
+
+
+		singleFieldIndexer.join(
+				multiFieldIndexer, inObjectFieldMainIndexer, inObjectFieldMissingFieldIndexer,
+				scoreIndexer,
+				typeCheckingMainIndexer, typeCheckingCompatibleIndexer,
+				typeCheckingRawFieldCompatibleIndexer, typeCheckingMissingFieldIndexer
+		);
+	}
+
+	private static PrefixPredicateTestValues testValues(FieldTypeDescriptor<String, ?> fieldType) {
+		return new PrefixPredicateTestValues( fieldType );
+	}
+
+	@Nested
+	class SingleFieldIT extends SingleFieldConfigured {
+		// JDK 11 does not allow static fields in non-static inner class and JUnit does not allow running @Nested tests in static inner classes...
+	}
+
+	abstract static class SingleFieldConfigured extends AbstractPredicateSingleFieldIT<PrefixPredicateTestValues> {
+		private static final SimpleMappedIndex<IndexBinding> index =
+				SimpleMappedIndex.of( root -> new IndexBinding( root, supportedFieldTypes ) )
+						.name( "singleField" );
+		private static final List<DataSet<String, PrefixPredicateTestValues>> dataSets = new ArrayList<>();
+		private static final List<Arguments> parameters = new ArrayList<>();
+		static {
+			for ( FieldTypeDescriptor<String, ?> fieldType : supportedFieldTypes ) {
+				DataSet<String, PrefixPredicateTestValues> dataSet = new DataSet<>( testValues( fieldType ) );
+				dataSets.add( dataSet );
+				parameters.add( Arguments.of( index, dataSet ) );
+			}
+		}
+
+		public static List<? extends Arguments> params() {
+			return parameters;
+		}
+
+		@Override
+		protected PredicateFinalStep predicate(SearchPredicateFactory f, String fieldPath, int matchingDocOrdinal,
+				DataSet<?, PrefixPredicateTestValues> dataSet) {
+			return f.prefix().field( fieldPath ).matching( dataSet.values.matchingArg( matchingDocOrdinal ) );
+		}
+
+		@Override
+		protected PredicateFinalStep predicate(SearchPredicateFactory f, String fieldPath, String paramName,
+				DataSet<?, PrefixPredicateTestValues> dataSet) {
+			return f.withParameters( params -> f.prefix().field( fieldPath )
+					.matching( params.get( paramName, String.class ) ) );
+		}
+
+		@Override
+		protected Map<String, Object> parameterValues(int matchingDocOrdinal, DataSet<?, PrefixPredicateTestValues> dataSet,
+				String paramName) {
+			return Map.of( paramName, dataSet.values.matchingArg( matchingDocOrdinal ) );
+		}
+	}
+
+	@Nested
+	class MultiFieldIT extends MultiFieldConfigured {
+		// JDK 11 does not allow static fields in non-static inner class and JUnit does not allow running @Nested tests in static inner classes...
+	}
+
+	abstract static class MultiFieldConfigured extends AbstractPredicateMultiFieldIT<PrefixPredicateTestValues> {
+		private static final SimpleMappedIndex<IndexBinding> index =
+				SimpleMappedIndex.of( root -> new IndexBinding( root, supportedFieldTypes ) )
+						.name( "multiField" );
+
+		private static final List<DataSet<String, PrefixPredicateTestValues>> dataSets = new ArrayList<>();
+		private static final List<Arguments> parameters = new ArrayList<>();
+		static {
+			for ( FieldTypeDescriptor<String, ?> fieldType : supportedFieldTypes ) {
+				DataSet<String, PrefixPredicateTestValues> dataSet = new DataSet<>( testValues( fieldType ) );
+				dataSets.add( dataSet );
+				parameters.add( Arguments.of( index, dataSet ) );
+			}
+		}
+
+		public static List<? extends Arguments> params() {
+			return parameters;
+		}
+
+		@Override
+		protected PredicateFinalStep predicateOnFieldAndField(SearchPredicateFactory f, String fieldPath,
+				String otherFieldPath, int matchingDocOrdinal, DataSet<?, PrefixPredicateTestValues> dataSet) {
+			return f.prefix().field( fieldPath ).field( otherFieldPath )
+					.matching( dataSet.values.matchingArg( matchingDocOrdinal ) );
+		}
+
+		@Override
+		protected PredicateFinalStep predicateOnFields(SearchPredicateFactory f, String[] fieldPaths, int matchingDocOrdinal,
+				DataSet<?, PrefixPredicateTestValues> dataSet) {
+			return f.prefix().fields( fieldPaths ).matching( dataSet.values.matchingArg( matchingDocOrdinal ) );
+		}
+
+		@Override
+		protected PredicateFinalStep predicateOnFieldAndFields(SearchPredicateFactory f, String fieldPath,
+				String[] fieldPaths, int matchingDocOrdinal, DataSet<?, PrefixPredicateTestValues> dataSet) {
+			return f.prefix().field( fieldPath ).fields( fieldPaths )
+					.matching( dataSet.values.matchingArg( matchingDocOrdinal ) );
+		}
+	}
+
+	@Nested
+	class InObjectFieldIT extends InObjectFieldConfigured {
+		// JDK 11 does not allow static fields in non-static inner class and JUnit does not allow running @Nested tests in static inner classes...
+	}
+
+	abstract static class InObjectFieldConfigured extends AbstractPredicateFieldInObjectFieldIT<PrefixPredicateTestValues> {
+		private static final SimpleMappedIndex<IndexBinding> mainIndex =
+				SimpleMappedIndex.of( root -> new IndexBinding( root, supportedFieldTypes ) )
+						.name( "nesting" );
+
+		private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+				SimpleMappedIndex.of( root -> new MissingFieldIndexBinding( root, supportedFieldTypes ) )
+						.name( "nesting_missingField" );
+
+		private static final List<DataSet<?, ?>> dataSets = new ArrayList<>();
+		private static final List<Arguments> parameters = new ArrayList<>();
+		static {
+			for ( FieldTypeDescriptor<String, ?> fieldType : supportedFieldTypes ) {
+				DataSet<?, ?> dataSet = new DataSet<>( testValues( fieldType ) );
+				dataSets.add( dataSet );
+				parameters.add( Arguments.of( mainIndex, missingFieldIndex, dataSet ) );
+			}
+		}
+
+		public static List<? extends Arguments> params() {
+			return parameters;
+		}
+
+		@Override
+		protected PredicateFinalStep predicate(SearchPredicateFactory f, String fieldPath, int matchingDocOrdinal,
+				DataSet<?, PrefixPredicateTestValues> dataSet) {
+			return f.prefix().field( fieldPath ).matching( dataSet.values.matchingArg( matchingDocOrdinal ) );
+		}
+	}
+
+	@Nested
+	class ScoreIT extends ScoreConfigured {
+		// JDK 11 does not allow static fields in non-static inner class and JUnit does not allow running @Nested tests in static inner classes...
+	}
+
+	abstract static class ScoreConfigured extends AbstractPredicateFieldScoreIT<PrefixPredicateTestValues> {
+		private static final SimpleMappedIndex<IndexBinding> index =
+				SimpleMappedIndex.of( root -> new IndexBinding( root, supportedFieldTypes ) )
+						.name( "score" );
+
+		private static final List<DataSet<String, PrefixPredicateTestValues>> dataSets = new ArrayList<>();
+		private static final List<Arguments> parameters = new ArrayList<>();
+		static {
+			for ( FieldTypeDescriptor<String, ?> fieldType : supportedFieldTypes ) {
+				DataSet<String, PrefixPredicateTestValues> dataSet = new DataSet<>( testValues( fieldType ) );
+				dataSets.add( dataSet );
+				parameters.add( Arguments.of( index, dataSet ) );
+			}
+		}
+
+		public static List<? extends Arguments> params() {
+			return parameters;
+		}
+
+		@Override
+		protected PredicateFinalStep predicate(SearchPredicateFactory f, String fieldPath, int matchingDocOrdinal,
+				DataSet<?, PrefixPredicateTestValues> dataSet) {
+			return f.prefix().field( fieldPath ).matching( dataSet.values.matchingArg( matchingDocOrdinal ) );
+		}
+
+		@Override
+		protected PredicateFinalStep predicateWithConstantScore(SearchPredicateFactory f, String[] fieldPaths,
+				int matchingDocOrdinal, DataSet<?, PrefixPredicateTestValues> dataSet) {
+			return f.prefix().fields( fieldPaths ).matching( dataSet.values.matchingArg( matchingDocOrdinal ) )
+					.constantScore();
+		}
+
+		@Override
+		protected PredicateFinalStep predicateWithPredicateLevelBoost(SearchPredicateFactory f, String[] fieldPaths,
+				int matchingDocOrdinal, float predicateBoost, DataSet<?, PrefixPredicateTestValues> dataSet) {
+			return f.prefix().fields( fieldPaths ).matching( dataSet.values.matchingArg( matchingDocOrdinal ) )
+					.boost( predicateBoost );
+		}
+
+		@Override
+		protected PredicateFinalStep predicateWithConstantScoreAndPredicateLevelBoost(SearchPredicateFactory f,
+				String[] fieldPaths, int matchingDocOrdinal, float predicateBoost,
+				DataSet<?, PrefixPredicateTestValues> dataSet) {
+			return f.prefix().fields( fieldPaths ).matching( dataSet.values.matchingArg( matchingDocOrdinal ) )
+					.constantScore().boost( predicateBoost );
+		}
+
+		@Override
+		protected PredicateFinalStep predicateWithFieldLevelBoost(SearchPredicateFactory f, String fieldPath,
+				float fieldBoost, int matchingDocOrdinal, DataSet<?, PrefixPredicateTestValues> dataSet) {
+			return f.prefix().field( fieldPath ).boost( fieldBoost )
+					.matching( dataSet.values.matchingArg( matchingDocOrdinal ) );
+		}
+
+		@Override
+		protected PredicateFinalStep predicateWithFieldLevelBoostAndConstantScore(SearchPredicateFactory f,
+				String fieldPath, float fieldBoost, int matchingDocOrdinal, DataSet<?, PrefixPredicateTestValues> dataSet) {
+			return f.prefix().field( fieldPath ).boost( fieldBoost )
+					.matching( dataSet.values.matchingArg( matchingDocOrdinal ) ).constantScore();
+		}
+
+		@Override
+		protected PredicateFinalStep predicateWithFieldLevelBoostAndPredicateLevelBoost(SearchPredicateFactory f,
+				String fieldPath, float fieldBoost, int matchingDocOrdinal, float predicateBoost,
+				DataSet<?, PrefixPredicateTestValues> dataSet) {
+			return f.prefix().field( fieldPath ).boost( fieldBoost )
+					.matching( dataSet.values.matchingArg( matchingDocOrdinal ) ).boost( predicateBoost );
+		}
+	}
+
+	@Nested
+	class InvalidFieldIT extends InvalidFieldConfigured {
+		// JDK 11 does not allow static fields in non-static inner class and JUnit does not allow running @Nested tests in static inner classes...
+	}
+
+	abstract static class InvalidFieldConfigured extends AbstractPredicateInvalidFieldIT {
+		private static final SimpleMappedIndex<IndexBinding> index = SimpleMappedIndex.of( IndexBinding::new )
+				.name( "invalidField" );
+
+		protected InvalidFieldConfigured() {
+			super( index );
+		}
+
+		@Override
+		protected void tryPredicate(SearchPredicateFactory f, String fieldPath) {
+			f.prefix().field( fieldPath );
+		}
+
+		@Override
+		protected String predicateTrait() {
+			return "predicate:prefix";
+		}
+	}
+
+	@Nested
+	class UnsupportedTypeIT extends UnsupportedTypeConfigured {
+		// JDK 11 does not allow static fields in non-static inner class and JUnit does not allow running @Nested tests in static inner classes...
+	}
+
+	abstract static class UnsupportedTypeConfigured extends AbstractPredicateUnsupportedTypeIT {
+		private static final SimpleMappedIndex<IndexBinding> index =
+				SimpleMappedIndex.of( root -> new IndexBinding( root, unsupportedFieldTypes ) )
+						.name( "unsupportedType" );
+
+		private static final List<Arguments> parameters = new ArrayList<>();
+		static {
+			for ( FieldTypeDescriptor<?, ?> fieldType : unsupportedFieldTypes ) {
+				parameters.add( Arguments.of( index, fieldType ) );
+			}
+		}
+
+		public static List<? extends Arguments> params() {
+			return parameters;
+		}
+
+		@Override
+		protected void tryPredicate(SearchPredicateFactory f, String fieldPath) {
+			f.prefix().field( fieldPath );
+		}
+
+		@Override
+		protected String predicateTrait() {
+			return "predicate:prefix";
+		}
+	}
+
+	@Nested
+	class SearchableIT extends SearchableConfigured {
+		// JDK 11 does not allow static fields in non-static inner class and JUnit does not allow running @Nested tests in static inner classes...
+	}
+
+	abstract static class SearchableConfigured extends AbstractPredicateSearchableIT {
+		private static final SimpleMappedIndex<SearchableDefaultIndexBinding> searchableDefaultIndex =
+				SimpleMappedIndex.of( root -> new SearchableDefaultIndexBinding( root, supportedFieldTypes ) )
+						.name( "searchableDefault" );
+		private static final SimpleMappedIndex<SearchableYesIndexBinding> searchableYesIndex =
+				SimpleMappedIndex.of( root -> new SearchableYesIndexBinding( root, supportedFieldTypes ) )
+						.name( "searchableYes" );
+
+		private static final SimpleMappedIndex<SearchableNoIndexBinding> searchableNoIndex =
+				SimpleMappedIndex.of( root -> new SearchableNoIndexBinding( root, supportedFieldTypes ) )
+						.name( "searchableNo" );
+
+		private static final List<Arguments> parameters = new ArrayList<>();
+		static {
+			for ( FieldTypeDescriptor<?, ?> fieldType : supportedFieldTypes ) {
+				parameters.add( Arguments.of( searchableDefaultIndex, searchableYesIndex, searchableNoIndex, fieldType ) );
+			}
+		}
+
+		public static List<? extends Arguments> params() {
+			return parameters;
+		}
+
+		@Override
+		protected void tryPredicate(SearchPredicateFactory f, String fieldPath, FieldTypeDescriptor<?, ?> fieldType) {
+			f.prefix().field( fieldPath );
+		}
+
+		@Override
+		protected String predicateTrait() {
+			return "predicate:prefix";
+		}
+	}
+
+	@Nested
+	class ArgumentCheckingIT extends ArgumentCheckingConfigured {
+		// JDK 11 does not allow static fields in non-static inner class and JUnit does not allow running @Nested tests in static inner classes...
+	}
+
+	abstract static class ArgumentCheckingConfigured extends AbstractPredicateArgumentCheckingIT {
+		private static final SimpleMappedIndex<IndexBinding> index =
+				SimpleMappedIndex.of( root -> new IndexBinding( root, supportedFieldTypes ) )
+						.name( "argumentChecking" );
+
+		private static final List<Arguments> parameters = new ArrayList<>();
+		static {
+			for ( FieldTypeDescriptor<?, ?> fieldType : supportedFieldTypes ) {
+				parameters.add( Arguments.of( index, fieldType ) );
+			}
+		}
+
+		public static List<? extends Arguments> params() {
+			return parameters;
+		}
+
+		@Override
+		protected void tryPredicateWithNullMatchingParam(SearchPredicateFactory f, String fieldPath) {
+			f.prefix().field( fieldPath ).matching( null );
+		}
+	}
+
+	@Nested
+	class TypeCheckingNoConversionIT extends TypeCheckingNoConversionConfigured {
+		// JDK 11 does not allow static fields in non-static inner class and JUnit does not allow running @Nested tests in static inner classes...
+	}
+
+	abstract static class TypeCheckingNoConversionConfigured
+			extends AbstractPredicateTypeCheckingNoConversionIT<PrefixPredicateTestValues> {
+		private static final SimpleMappedIndex<IndexBinding> index =
+				SimpleMappedIndex.of( root -> new IndexBinding( root, supportedFieldTypes ) )
+						.name( "typeChecking_main" );
+		private static final SimpleMappedIndex<CompatibleIndexBinding> compatibleIndex =
+				SimpleMappedIndex.of( root -> new CompatibleIndexBinding( root, supportedFieldTypes ) )
+						.name( "typeChecking_compatible" );
+		private static final SimpleMappedIndex<RawFieldCompatibleIndexBinding> rawFieldCompatibleIndex =
+				SimpleMappedIndex.of( root -> new RawFieldCompatibleIndexBinding( root, supportedFieldTypes ) )
+						.name( "typeChecking_rawFieldCompatible" );
+		private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+				SimpleMappedIndex.of( root -> new MissingFieldIndexBinding( root, supportedFieldTypes ) )
+						.name( "typeChecking_missingField" );
+		private static final SimpleMappedIndex<IncompatibleIndexBinding> incompatibleIndex =
+				SimpleMappedIndex.of( root -> new IncompatibleIndexBinding( root, supportedFieldTypes ) )
+						.name( "typeChecking_incompatible" );
+
+		private static final List<DataSet<String, PrefixPredicateTestValues>> dataSets = new ArrayList<>();
+		private static final List<Arguments> parameters = new ArrayList<>();
+		static {
+			for ( FieldTypeDescriptor<String, ?> fieldType : supportedFieldTypes ) {
+				DataSet<String, PrefixPredicateTestValues> dataSet = new DataSet<>( testValues( fieldType ) );
+				dataSets.add( dataSet );
+				parameters.add( Arguments.of( index, compatibleIndex, rawFieldCompatibleIndex, missingFieldIndex,
+						incompatibleIndex, dataSet ) );
+			}
+		}
+
+		public static List<? extends Arguments> params() {
+			return parameters;
+		}
+
+		@Override
+		protected PredicateFinalStep predicate(SearchPredicateFactory f, String fieldPath, int matchingDocOrdinal,
+				DataSet<?, PrefixPredicateTestValues> dataSet) {
+			return f.prefix().field( fieldPath ).matching( dataSet.values.matchingArg( matchingDocOrdinal ) );
+		}
+
+		@Override
+		protected PredicateFinalStep predicate(SearchPredicateFactory f, String field0Path, String field1Path,
+				int matchingDocOrdinal, DataSet<?, PrefixPredicateTestValues> dataSet) {
+			return f.prefix().field( field0Path ).field( field1Path )
+					.matching( dataSet.values.matchingArg( matchingDocOrdinal ) );
+		}
+
+		@Override
+		protected String predicateTrait() {
+			return "predicate:prefix";
+		}
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/PrefixPredicateTestValues.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/PrefixPredicateTestValues.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.integrationtest.backend.tck.search.predicate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.AnalyzedStringFieldTypeDescriptor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
+
+public final class PrefixPredicateTestValues extends AbstractPredicateTestValues<String> {
+	private final List<String> values;
+
+	public PrefixPredicateTestValues(FieldTypeDescriptor<String, ?> fieldType) {
+		super( fieldType );
+		List<String> single = fieldType.getAscendingUniqueTermValues().getSingle();
+		List<String> values = new ArrayList<>( single );
+		for ( String value : single ) {
+			Set<String> samePrefix = single.stream()
+					.filter( s -> !s.equals( value ) )
+					.filter( s -> s.toLowerCase( Locale.ROOT ).startsWith( value.toLowerCase( Locale.ROOT ) ) )
+					.collect( Collectors.toSet() );
+			values.removeAll( samePrefix );
+		}
+		this.values = values;
+	}
+
+	@Override
+	public String fieldValue(int docOrdinal) {
+		return values.get( docOrdinal );
+	}
+
+	public String matchingArg(int docOrdinal) {
+		String value = fieldValue( docOrdinal );
+		value = value.substring( 0, value.length() - 3 );
+		if ( AnalyzedStringFieldTypeDescriptor.INSTANCE.equals( fieldType )
+				&& !TckConfiguration.get().getBackendFeatures()
+						.normalizesStringArgumentToWildcardPredicateForAnalyzedStringField() ) {
+			// The backend doesn't normalize missing value replacements automatically, we have to do it ourselves
+			value = value.toLowerCase( Locale.ROOT );
+		}
+		return value;
+	}
+
+	@Override
+	public int size() {
+		return values.size();
+	}
+}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubSearchPredicate.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubSearchPredicate.java
@@ -27,6 +27,7 @@ import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.NamedPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.NestedPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.PrefixPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.QueryStringPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.RegexpPredicateBuilder;
@@ -159,7 +160,8 @@ public class StubSearchPredicate implements SearchPredicate {
 			SpatialWithinCirclePredicateBuilder,
 			SpatialWithinPolygonPredicateBuilder,
 			SpatialWithinBoundingBoxPredicateBuilder,
-			NamedPredicateBuilder {
+			NamedPredicateBuilder,
+			PrefixPredicateBuilder {
 		private boolean hasClause = false;
 
 		@Override
@@ -301,6 +303,11 @@ public class StubSearchPredicate implements SearchPredicate {
 		@Override
 		public void param(String name, Object value) {
 			// No-op, just simulates a call on this object
+		}
+
+		@Override
+		public void prefix(String prefix) {
+			// No-op
 		}
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3906

Adds a prefix predicate to the search DSL.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
