### PR TITLE
Use the develocity:build-scan-publish-previous to publish build scans

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
         continue-on-error: true
         if: "${{ !cancelled() && github.event_name == 'pull_request_target' && github.repository == 'hibernate/hibernate-search' }}"
         run: |
-          ./mvnw $MAVEN_ARGS gradle-enterprise:build-scan-publish-previous
+          ./mvnw $MAVEN_ARGS develocity:build-scan-publish-previous
         env:
           # WARNING: exposes secrets, so must only be passed to a step that doesn't run unapproved code.
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY_PR }}
@@ -156,7 +156,7 @@ jobs:
         continue-on-error: true
         if: "${{ !cancelled() && github.event_name == 'pull_request_target' && github.repository == 'hibernate/hibernate-search' }}"
         run: |
-          ./mvnw $MAVEN_ARGS gradle-enterprise:build-scan-publish-previous
+          ./mvnw $MAVEN_ARGS develocity:build-scan-publish-previous
         env:
           # WARNING: exposes secrets, so must only be passed to a step that doesn't run unapproved code.
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY_PR }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -986,7 +986,7 @@ void mvn(String args) {
 			withCredentials([string(credentialsId: develocityPrCredentialsId,
 					variable: 'DEVELOCITY_ACCESS_KEY')]) {
 				withGradle { // withDevelocity, actually: https://plugins.jenkins.io/gradle/#plugin-content-capturing-build-scans-from-jenkins-pipeline
-					sh 'mvn gradle-enterprise:build-scan-publish-previous || true'
+					sh 'mvn develocity:build-scan-publish-previous || true'
 				}
 			}
 		})


### PR DESCRIPTION
- the previously used `gradle-enterprise:build-scan-publish-previous` command is for the "deprecated plugin" that is now replaced with `develocity:build-scan-publish-previous`

And hopefully, this will remove the warnings like:
```
[WARNING] The artifact com.gradle:gradle-enterprise-maven-extension:jar:1.21.6 has been relocated to com.gradle:develocity-maven-extension:jar:1.21.6
```
from the logs 🤞🏻 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
