### PR TITLE
Update Spring repackage configuration for uber-jar tests

### DIFF
--- a/integrationtest/mapper/orm-spring-uberjar/application/pom.xml
+++ b/integrationtest/mapper/orm-spring-uberjar/application/pom.xml
@@ -87,13 +87,9 @@
                 </executions>
                 <configuration>
                     <outputDirectory>${project.build.directory}</outputDirectory>
-                    <finalName>app-repackaged</finalName>
                     <mainClass>
                         org.hibernate.search.integrationtest.spring.repackaged.application.Application
                     </mainClass>
-                    <!-- Not critical here as it's just for tests.
-                         This hardcoded value allows us to cache integration tests in Develocity. -->
-                    <outputTimestamp>2017-11-06T19:19:00+01:00</outputTimestamp>
                 </configuration>
             </plugin>
             <plugin>
@@ -113,7 +109,7 @@
                     </environmentVariables>
                     <systemPropertyVariables>
                         <test.launcher-command>${java-version.test.launcher}</test.launcher-command>
-                        <test.repackaged-jar-path>${project.build.directory}/app-repackaged.jar</test.repackaged-jar-path>
+                        <test.repackaged-jar-path>${project.build.directory}/hibernate-search-integrationtest-spring-repackaged-application-${project.version}.jar</test.repackaged-jar-path>
                     </systemPropertyVariables>
                 </configuration>
                 <executions>


### PR DESCRIPTION
I've noticed this warning in the build logs:

> [WARNING]  Parameter 'finalName' is read-only, must not be used in configuration

- `finalName` turns out to be a read-only property, even though it does work with our current config 🤷🏻 ... what the plugin suggests is to set the final name at the build level: https://docs.spring.io/spring-boot/maven-plugin/packaging.html#packaging.examples.custom-name rather than inside of the configuration. I've removed the property entirely and just updated the `test.repackaged-jar-path` instead. 
- `outputTimestamp` is now unnecessary, as the `project.build.outputTimestamp` is used by default (the one we set in the root pom)

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
