### PR TITLE
Follow up on HSEARCH-5187 - Add a migration note on a deprecated ValueConvert enum

### DIFF
--- a/documentation/src/main/asciidoc/migration/index.adoc
+++ b/documentation/src/main/asciidoc/migration/index.adoc
@@ -44,12 +44,13 @@ and only then to later versions (which will be significantly easier).
 == Requirements
 
 The requirements of Hibernate Search {hibernateSearchVersion}
-are the same as those of Hibernate Search {hibernateSearchPreviousStableVersionShort}:
+are mostly the same as those of Hibernate Search {hibernateSearchPreviousStableVersionShort},
+with the only difference being Hibernate ORM version upgrade:
 
 - JDK 11 or later;
 - Lucene 9 for its Lucene backend;
 - Elasticsearch 7.10+ or OpenSearch 1.3+ for its Elasticsearch backend;
-- Hibernate ORM 6.4.x for the Hibernate ORM integration.
+- Hibernate ORM 6.6.x for the Hibernate ORM integration.
 
 [[artifact-changes]]
 == Artifacts

--- a/documentation/src/main/asciidoc/migration/index.adoc
+++ b/documentation/src/main/asciidoc/migration/index.adoc
@@ -115,6 +115,10 @@ With Hibernate ORM allowing non-`String` tenant identifiers, some of the Hiberna
 * `org.hibernate.search.mapper.orm.outboxpolling.mapping.OutboxPollingSearchMapping#clearAllAbortedEvents(String tenantId)` deprecated in favor of
 `org.hibernate.search.mapper.orm.outboxpolling.mapping.OutboxPollingSearchMapping#clearAllAbortedEvents(Object tenantId)`
 
+This version deprecates the `ValueConvert` enum used in various Search DSL methods and replaces it with a new `ValueModel` enum.
+For each deprecated method accepting the `ValueConvert` input, there is now an alternative that accepts `ValueModel` instead.
+Replace `ValueConvert.YES` with `ValueModel.MAPPING` and `ValueConvert.NO` with `ValueModel.INDEX` in your code where the values were set explicitly.
+
 [[spi]]
 == SPI
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5187

So we don't forget to add it before the release... 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
