### PR TITLE
Allow continuing Lucene 9.11 upgrade build even if snapshot version was not updated

### DIFF
--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -27,7 +27,11 @@ Map settings() {
 			return [
 					updateProperties: ['version.org.apache.lucene'],
 					onlyRunTestDependingOn: ['hibernate-search-backend-lucene'],
-					additionalMavenArgs: '-Dtest.elasticsearch.skip=true'
+					additionalMavenArgs: '-Dtest.elasticsearch.skip=true',
+					// With Lucene adding 9.12 Snapshot the 11 branch seems stale, and we are not getting any updates,
+					// resulting in the update step failing. Let's allow the build continue,
+					// just in case there are any new snapshots for 9.11 branch:
+					skipSourceModifiedCheck: true
 			]
 		case 'lucene9':
 			return [


### PR DESCRIPTION
just in case there are any new snapshots for 9.11 branch in the future

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
