### PR TITLE
Use https for hibernate.org URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,7 +241,7 @@ Here are some notable sub-directories:
 * `mapper`: The mappers, i.e. the modules that expose APIs to index and search user entities,
 and do the work of converting between user entities and documents to be indexed.
   * `pojo-base`: Contains base classes and APIs that are re-used in other POJO-based mapper.
-  * `orm`: A mapper for [Hibernate ORM](http://hibernate.org/orm/) entities.
+  * `orm`: A mapper for [Hibernate ORM](https://hibernate.org/orm/) entities.
   * `orm-outbox-polling`: An implementation of indexing coordination between nodes
   in the orm mapper (see above) using an outbox, i.e. an event table in the database. 
   * `pojo-standalone`: A mapper for POJOs in standalone mode, i.e. without Hibernate ORM.

--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ Getting started guides are available
 
 Fore more information, refer to the Hibernate Search website:
 
-* [Available versions and compatibility matrix](http://hibernate.org/search/releases/)
-* [Reference documentation for all versions (current and past)](http://hibernate.org/search/documentation/)
+* [Available versions and compatibility matrix](https://hibernate.org/search/releases/)
+* [Reference documentation for all versions (current and past)](https://hibernate.org/search/documentation/)
 
 For offline use, distribution bundles downloaded from [SourceForge](https://sourceforge.net/projects/hibernate/files/hibernate-search/)
 also include the reference documentation for the downloaded version in PDF and HTML format. 
@@ -149,7 +149,7 @@ also include the reference documentation for the downloaded version in PDF and H
 
 ### Latest Documentation
 
-See <http://hibernate.org/search/documentation/>.
+See <https://hibernate.org/search/documentation/>.
 
 ### Bug Reports
 
@@ -157,7 +157,7 @@ See the HSEARCH project on the Hibernate JIRA instance: <https://hibernate.atlas
 
 ### Community Support
 
-See <http://hibernate.org/community/>.
+See <https://hibernate.org/community/>.
 
 ## Contributing
 

--- a/build/parents/public/pom.xml
+++ b/build/parents/public/pom.xml
@@ -49,7 +49,7 @@
                                 <Implementation-Version>${project.version}</Implementation-Version>
                                 <Implementation-Vendor>hibernate.org</Implementation-Vendor>
                                 <Implementation-Vendor-Id>hibernate.org</Implementation-Vendor-Id>
-                                <Implementation-URL>http://hibernate.org/search/</Implementation-URL>
+                                <Implementation-URL>https://hibernate.org/search/</Implementation-URL>
                                 <Automatic-Module-Name>${java.module.name}</Automatic-Module-Name>
                             </manifestEntries>
                         </archive>

--- a/documentation/src/main/asciidoc/public/getting-started/orm/index.adoc
+++ b/documentation/src/main/asciidoc/public/getting-started/orm/index.adoc
@@ -24,7 +24,7 @@
 :numbered:
 
 This guide will walk you through the initial steps required
-to index and query your http://hibernate.org/orm/[Hibernate ORM] entities using http://hibernate.org/search/[Hibernate Search].
+to index and query your https://hibernate.org/orm/[Hibernate ORM] entities using https://hibernate.org/search/[Hibernate Search].
 
 // Note as relfile -prefix/-suffix are just prepended/appended to the string created based on the file location we reference to
 // in some cases we need to get rid of some of the leading/trailing `..` in those strings. That is when we use `just-to-be-removed`.
@@ -150,7 +150,7 @@ it's time to have a look at the configuration file.
 
 [TIP]
 ====
-If you are new to Hibernate ORM, we recommend you start link:http://hibernate.org/quick-start.html[there]
+If you are new to Hibernate ORM, we recommend you start link:https://hibernate.org/quick-start.html[there]
 to implement entity persistence in your application,
 and only then come back here to add Hibernate Search indexing.
 ====

--- a/documentation/src/main/asciidoc/public/getting-started/standalone/index.adoc
+++ b/documentation/src/main/asciidoc/public/getting-started/standalone/index.adoc
@@ -26,8 +26,8 @@
 include::../../components/_incubating-warning.adoc[]
 
 This guide will walk you through the initial steps required
-to index and query your entities using http://hibernate.org/search/[Hibernate Search],
-when your entities are **not** defined in http://hibernate.org/orm/[Hibernate ORM].
+to index and query your entities using https://hibernate.org/search/[Hibernate Search],
+when your entities are **not** defined in https://hibernate.org/orm/[Hibernate ORM].
 
 // Note as relfile -prefix/-suffix are just prepended/appended to the string created based on the file location we reference to
 // in some cases we need to get rid of some of the leading/trailing `..` in those strings. That is when we use `just-to-be-removed`.

--- a/documentation/src/main/asciidoc/public/reference/_further-reading.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_further-reading.adoc
@@ -48,8 +48,8 @@ Otherwise, you can always try your luck with link:{luceneJavadocUrl}[Lucene's Ja
 == [[_hibernate_orm]] Hibernate ORM
 
 If you want to deepen your knowledge of Hibernate ORM,
-start with the link:$$http://hibernate.org/orm/documentation/$$[online documentation] or get hold
-of a copy of link:$$http://www.manning.com/bauer3/$$[Java Persistence with Hibernate, Second Edition].
+start with the link:$$https://hibernate.org/orm/documentation/$$[online documentation] or get hold
+of a copy of link:$$https://www.manning.com/bauer3/$$[Java Persistence with Hibernate, Second Edition].
 
 [[further-reading-other]]
 == Other

--- a/documentation/src/main/asciidoc/public/reference/_migrating.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_migrating.adoc
@@ -4,7 +4,7 @@
 = [[getting-started-migrating]] Migrating
 
 If you are upgrading an existing application from an earlier version of Hibernate Search to the latest release,
-make sure to check out the http://hibernate.org/search/documentation/migrate/[migration guide].
+make sure to check out the https://hibernate.org/search/documentation/migrate/[migration guide].
 
 [WARNING]
 ====

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <name>Hibernate Search</name>
     <description>Hibernate Search Root POM</description>
 
-    <url>http://hibernate.org/search/</url>
+    <url>https://hibernate.org/search/</url>
 
     <inceptionYear>2006</inceptionYear>
 


### PR DESCRIPTION
It'll get redirected to https anyway, so why not give an https URL to start with ... 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
