### PR TITLE
Follow up on HSEARCH-3906 Update how analyzed strings are treated for ES backend and prefix predicate in tests

### DIFF
--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -472,4 +472,9 @@ public class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 		}
 		return super.rawValueEqualsComparator( fieldType );
 	}
+
+	@Override
+	public boolean normalizesStringArgumentToPrefixPredicateForAnalyzedStringField() {
+		return false;
+	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/PrefixPredicateTestValues.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/PrefixPredicateTestValues.java
@@ -41,7 +41,7 @@ public final class PrefixPredicateTestValues extends AbstractPredicateTestValues
 		value = value.substring( 0, value.length() - 3 );
 		if ( AnalyzedStringFieldTypeDescriptor.INSTANCE.equals( fieldType )
 				&& !TckConfiguration.get().getBackendFeatures()
-						.normalizesStringArgumentToWildcardPredicateForAnalyzedStringField() ) {
+						.normalizesStringArgumentToPrefixPredicateForAnalyzedStringField() ) {
 			// The backend doesn't normalize missing value replacements automatically, we have to do it ourselves
 			value = value.toLowerCase( Locale.ROOT );
 		}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
@@ -188,4 +188,8 @@ public abstract class TckBackendFeatures implements StubMappingBackendFeatures {
 	public Optional<Comparator<? super Object>> rawValueEqualsComparator(FieldTypeDescriptor<?, ?> fieldType) {
 		return Optional.empty();
 	}
+
+	public boolean normalizesStringArgumentToPrefixPredicateForAnalyzedStringField() {
+		return true;
+	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3609

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
