### PR TITLE
Update main version to 8.0

### DIFF
--- a/backend/elasticsearch-aws/pom.xml
+++ b/backend/elasticsearch-aws/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-public</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../build/parents/public</relativePath>
     </parent>
     <artifactId>hibernate-search-backend-elasticsearch-aws</artifactId>

--- a/backend/elasticsearch/pom.xml
+++ b/backend/elasticsearch/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-public</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../build/parents/public</relativePath>
     </parent>
     <artifactId>hibernate-search-backend-elasticsearch</artifactId>

--- a/backend/lucene/pom.xml
+++ b/backend/lucene/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-public</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../build/parents/public</relativePath>
     </parent>
     <artifactId>hibernate-search-backend-lucene</artifactId>

--- a/bom/public/pom.xml
+++ b/bom/public/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/build/config/pom.xml
+++ b/build/config/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-build</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../parents/build</relativePath>
     </parent>
     <artifactId>hibernate-search-build-config</artifactId>

--- a/build/configuration-properties-collector/pom.xml
+++ b/build/configuration-properties-collector/pom.xml
@@ -7,7 +7,7 @@
         <groupId>org.hibernate.search</groupId>
         <!-- Using public parent to reuse the javadoc generation config -->
         <artifactId>hibernate-search-parent-internal</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../parents/internal</relativePath>
     </parent>
 

--- a/build/enforcer/pom.xml
+++ b/build/enforcer/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-build</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../parents/build</relativePath>
     </parent>
     <artifactId>hibernate-search-build-enforcer</artifactId>

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
 

--- a/build/parents/integrationtest/pom.xml
+++ b/build/parents/integrationtest/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-internal</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../internal</relativePath>
     </parent>
     <artifactId>hibernate-search-parent-integrationtest</artifactId>

--- a/build/parents/internal/pom.xml
+++ b/build/parents/internal/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-build</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../build</relativePath>
     </parent>
     <artifactId>hibernate-search-parent-internal</artifactId>

--- a/build/parents/public/pom.xml
+++ b/build/parents/public/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-build</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../build</relativePath>
     </parent>
     <artifactId>hibernate-search-parent-public</artifactId>

--- a/build/parents/relocation/pom.xml
+++ b/build/parents/relocation/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>hibernate-search-parent-relocation</artifactId>

--- a/build/parents/springtest/pom.xml
+++ b/build/parents/springtest/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../integrationtest</relativePath>
     </parent>
     <artifactId>hibernate-search-parent-springtest</artifactId>

--- a/build/reports/pom.xml
+++ b/build/reports/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-build</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../parents/build</relativePath>
     </parent>
     <artifactId>hibernate-search-reports</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hibernate-search-parent-public</artifactId>
         <groupId>org.hibernate.search</groupId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../build/parents/public</relativePath>
     </parent>
 

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../build/parents/integrationtest</relativePath>
     </parent>
     <artifactId>hibernate-search-documentation</artifactId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-public</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../build/parents/public</relativePath>
     </parent>
     <artifactId>hibernate-search-engine</artifactId>

--- a/integrationtest/backend/elasticsearch/pom.xml
+++ b/integrationtest/backend/elasticsearch/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-backend-elasticsearch</artifactId>

--- a/integrationtest/backend/lucene/pom.xml
+++ b/integrationtest/backend/lucene/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-backend-lucene</artifactId>

--- a/integrationtest/backend/tck/pom.xml
+++ b/integrationtest/backend/tck/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-backend-tck</artifactId>

--- a/integrationtest/java/modules/orm-elasticsearch/pom.xml
+++ b/integrationtest/java/modules/orm-elasticsearch/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-java-modules-orm-elasticsearch</artifactId>

--- a/integrationtest/java/modules/orm-lucene/pom.xml
+++ b/integrationtest/java/modules/orm-lucene/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-java-modules-orm-lucene</artifactId>

--- a/integrationtest/java/modules/orm-outbox-polling-elasticsearch/pom.xml
+++ b/integrationtest/java/modules/orm-outbox-polling-elasticsearch/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-java-modules-orm-outbox-polling-elasticsearch</artifactId>

--- a/integrationtest/java/modules/pojo-standalone-elasticsearch/pom.xml
+++ b/integrationtest/java/modules/pojo-standalone-elasticsearch/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-java-modules-pojo-standalone-elasticsearch</artifactId>

--- a/integrationtest/java/modules/pojo-standalone-lucene/pom.xml
+++ b/integrationtest/java/modules/pojo-standalone-lucene/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-java-modules-pojo-standalone-lucene</artifactId>

--- a/integrationtest/mapper/orm-cdi/pom.xml
+++ b/integrationtest/mapper/orm-cdi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-mapper-orm-cdi</artifactId>

--- a/integrationtest/mapper/orm-envers/pom.xml
+++ b/integrationtest/mapper/orm-envers/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-mapper-orm-envers</artifactId>

--- a/integrationtest/mapper/orm-jakarta-batch/pom.xml
+++ b/integrationtest/mapper/orm-jakarta-batch/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-mapper-orm-jakarta-batch</artifactId>

--- a/integrationtest/mapper/orm-outbox-polling/pom.xml
+++ b/integrationtest/mapper/orm-outbox-polling/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-mapper-orm-outbox-polling</artifactId>

--- a/integrationtest/mapper/orm-realbackend/pom.xml
+++ b/integrationtest/mapper/orm-realbackend/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-mapper-orm-realbackend</artifactId>

--- a/integrationtest/mapper/orm-spring-uberjar/application/pom.xml
+++ b/integrationtest/mapper/orm-spring-uberjar/application/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest-spring-repackaged</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-spring-repackaged-application</artifactId>

--- a/integrationtest/mapper/orm-spring-uberjar/model/pom.xml
+++ b/integrationtest/mapper/orm-spring-uberjar/model/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest-spring-repackaged</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-spring-repackaged-model</artifactId>

--- a/integrationtest/mapper/orm-spring-uberjar/pom.xml
+++ b/integrationtest/mapper/orm-spring-uberjar/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-springtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../../build/parents/springtest</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-spring-repackaged</artifactId>

--- a/integrationtest/mapper/orm-spring/pom.xml
+++ b/integrationtest/mapper/orm-spring/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-springtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../../build/parents/springtest</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-mapper-orm-spring</artifactId>

--- a/integrationtest/mapper/orm/pom.xml
+++ b/integrationtest/mapper/orm/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-mapper-orm</artifactId>

--- a/integrationtest/mapper/pojo-base/pom.xml
+++ b/integrationtest/mapper/pojo-base/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-mapper-pojo-base</artifactId>

--- a/integrationtest/mapper/pojo-standalone-realbackend/pom.xml
+++ b/integrationtest/mapper/pojo-standalone-realbackend/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-mapper-pojo-standalone-realbackend</artifactId>

--- a/integrationtest/performance/backend/base/pom.xml
+++ b/integrationtest/performance/backend/base/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest-performance</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-performance-backend-base</artifactId>

--- a/integrationtest/performance/backend/elasticsearch/pom.xml
+++ b/integrationtest/performance/backend/elasticsearch/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest-performance</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-performance-backend-elasticsearch</artifactId>

--- a/integrationtest/performance/backend/lucene/pom.xml
+++ b/integrationtest/performance/backend/lucene/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest-performance</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-performance-backend-lucene</artifactId>

--- a/integrationtest/performance/pom.xml
+++ b/integrationtest/performance/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>hibernate-search-integrationtest-performance</artifactId>
     <packaging>pom</packaging>

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../build/parents/integrationtest</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest</artifactId>

--- a/integrationtest/showcase/library/pom.xml
+++ b/integrationtest/showcase/library/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-springtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../../build/parents/springtest</relativePath>
     </parent>
     <artifactId>hibernate-search-integrationtest-showcase-library</artifactId>

--- a/integrationtest/v5migrationhelper/engine/pom.xml
+++ b/integrationtest/v5migrationhelper/engine/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../../build/parents/integrationtest</relativePath>
     </parent>
 

--- a/integrationtest/v5migrationhelper/orm/pom.xml
+++ b/integrationtest/v5migrationhelper/orm/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../../build/parents/integrationtest</relativePath>
     </parent>
 

--- a/mapper/orm-batch-jsr352/core/pom.xml
+++ b/mapper/orm-batch-jsr352/core/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-relocation</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../../build/parents/relocation</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/mapper/orm-batch-jsr352/jberet/pom.xml
+++ b/mapper/orm-batch-jsr352/jberet/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-relocation</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../../build/parents/relocation</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/mapper/orm-coordination-outbox-polling/pom.xml
+++ b/mapper/orm-coordination-outbox-polling/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-relocation</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../build/parents/relocation</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/mapper/orm-jakarta-batch/core/pom.xml
+++ b/mapper/orm-jakarta-batch/core/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-public</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../../build/parents/public</relativePath>
     </parent>
     <artifactId>hibernate-search-mapper-orm-jakarta-batch-core</artifactId>

--- a/mapper/orm-jakarta-batch/jberet/pom.xml
+++ b/mapper/orm-jakarta-batch/jberet/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-public</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../../build/parents/public</relativePath>
     </parent>
     <artifactId>hibernate-search-mapper-orm-jakarta-batch-jberet</artifactId>

--- a/mapper/orm-outbox-polling/pom.xml
+++ b/mapper/orm-outbox-polling/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-public</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../build/parents/public</relativePath>
     </parent>
     <artifactId>hibernate-search-mapper-orm-outbox-polling</artifactId>

--- a/mapper/orm/pom.xml
+++ b/mapper/orm/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-public</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../build/parents/public</relativePath>
     </parent>
     <artifactId>hibernate-search-mapper-orm</artifactId>

--- a/mapper/pojo-base/pom.xml
+++ b/mapper/pojo-base/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-public</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../build/parents/public</relativePath>
     </parent>
     <artifactId>hibernate-search-mapper-pojo-base</artifactId>

--- a/mapper/pojo-standalone/pom.xml
+++ b/mapper/pojo-standalone/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-public</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../build/parents/public</relativePath>
     </parent>
     <artifactId>hibernate-search-mapper-pojo-standalone</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>org.hibernate.search</groupId>
     <artifactId>hibernate-search-parent</artifactId>
-    <version>7.3.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Hibernate Search</name>
@@ -445,7 +445,7 @@
         <goal.formatter-maven-plugin>format</goal.formatter-maven-plugin>
 
         <!-- For Reproducible Builds -->
-        <project.build.outputTimestamp>2024-08-09T12:47:59Z</project.build.outputTimestamp>
+        <project.build.outputTimestamp>2024-08-13T07:06:30Z</project.build.outputTimestamp>
 
         <!-- Sonar options -->
         <!--

--- a/util/common/pom.xml
+++ b/util/common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-public</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../build/parents/public</relativePath>
     </parent>
     <artifactId>hibernate-search-util-common</artifactId>

--- a/util/internal/integrationtest/backend/elasticsearch/pom.xml
+++ b/util/internal/integrationtest/backend/elasticsearch/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-util-internal-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>hibernate-search-util-internal-integrationtest-backend-elasticsearch</artifactId>

--- a/util/internal/integrationtest/backend/lucene/pom.xml
+++ b/util/internal/integrationtest/backend/lucene/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-util-internal-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>hibernate-search-util-internal-integrationtest-backend-lucene</artifactId>

--- a/util/internal/integrationtest/common/pom.xml
+++ b/util/internal/integrationtest/common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-util-internal-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>hibernate-search-util-internal-integrationtest-common</artifactId>

--- a/util/internal/integrationtest/jbatch-runtime/pom.xml
+++ b/util/internal/integrationtest/jbatch-runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-util-internal-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>hibernate-search-util-internal-integrationtest-jbatch-runtime</artifactId>

--- a/util/internal/integrationtest/jberet-se/pom.xml
+++ b/util/internal/integrationtest/jberet-se/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-util-internal-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>hibernate-search-util-internal-integrationtest-jberet-se</artifactId>

--- a/util/internal/integrationtest/mapper/orm/pom.xml
+++ b/util/internal/integrationtest/mapper/orm/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-util-internal-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>hibernate-search-util-internal-integrationtest-mapper-orm</artifactId>

--- a/util/internal/integrationtest/mapper/pojo-standalone/pom.xml
+++ b/util/internal/integrationtest/mapper/pojo-standalone/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-util-internal-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>hibernate-search-util-internal-integrationtest-mapper-pojo-standalone</artifactId>

--- a/util/internal/integrationtest/mapper/stub/pom.xml
+++ b/util/internal/integrationtest/mapper/stub/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-util-internal-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>hibernate-search-util-internal-integrationtest-mapper-stub</artifactId>

--- a/util/internal/integrationtest/pom.xml
+++ b/util/internal/integrationtest/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-internal</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../../build/parents/internal</relativePath>
     </parent>
     <artifactId>hibernate-search-util-internal-integrationtest</artifactId>

--- a/util/internal/integrationtest/v5migrationhelper/pom.xml
+++ b/util/internal/integrationtest/v5migrationhelper/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-util-internal-integrationtest</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>hibernate-search-util-internal-integrationtest-v5migrationhelper</artifactId>

--- a/util/internal/test/common/pom.xml
+++ b/util/internal/test/common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-internal</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../../../build/parents/internal</relativePath>
     </parent>
     <artifactId>hibernate-search-util-internal-test-common</artifactId>

--- a/util/internal/test/orm/pom.xml
+++ b/util/internal/test/orm/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.hibernate.search</groupId>
         <artifactId>hibernate-search-parent-internal</artifactId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../../../build/parents/internal</relativePath>
     </parent>
     <artifactId>hibernate-search-util-internal-test-orm</artifactId>

--- a/v5migrationhelper/engine/pom.xml
+++ b/v5migrationhelper/engine/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hibernate-search-parent-public</artifactId>
         <groupId>org.hibernate.search</groupId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../build/parents/public</relativePath>
     </parent>
     <artifactId>hibernate-search-v5migrationhelper-engine</artifactId>

--- a/v5migrationhelper/orm/pom.xml
+++ b/v5migrationhelper/orm/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>hibernate-search-parent-public</artifactId>
         <groupId>org.hibernate.search</groupId>
-        <version>7.3.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
         <relativePath>../../build/parents/public</relativePath>
     </parent>
     <artifactId>hibernate-search-v5migrationhelper-orm</artifactId>


### PR DESCRIPTION
After the discussion we had yesterday, @yrodiere, this PR is to bump the version in the main branch to 8.0.

With that... I guess the next step will be to merge the ORM 7.0 update into the main as well.
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
