### PR TITLE
HSEARCH-5223 Regenerate avro Dtos / add a sources-not-modified check to the build

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -151,6 +151,7 @@
                 - make sure to create a new payload in EventPayloadSerializationUtilsTest
                 - check the commons-codec version to see if it is aligned with the one used in elasticsearch-rest-client-sniffer
                   and if so - remove the commons-codec management.
+                - remove and generate the files in mapper/orm-outbox-polling/src/main/avro/generated
         -->
         <version.org.apache.avro>1.12.0</version.org.apache.avro>
         <version.org.jboss.weld>5.1.2.Final</version.org.jboss.weld>

--- a/mapper/orm-outbox-polling/src/main/avro/generated/org/hibernate/search/mapper/orm/outboxpolling/avro/generated/impl/PojoIndexingQueueEventPayloadDto.java
+++ b/mapper/orm-outbox-polling/src/main/avro/generated/org/hibernate/search/mapper/orm/outboxpolling/avro/generated/impl/PojoIndexingQueueEventPayloadDto.java
@@ -5,7 +5,6 @@
  */
 package org.hibernate.search.mapper.orm.outboxpolling.avro.generated.impl;
 
-import org.apache.avro.generic.GenericArray;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.util.Utf8;
 import org.apache.avro.message.BinaryMessageEncoder;


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5223

I've tried the change in this job https://ci.hibernate.org/blue/organizations/jenkins/hibernate-search-personal-marko/detail/build%2FHSEARCH-5223-add-source-update-check/3/pipeline/

I'm not sure what's going on with the Avro plugin... when I reverted the changes committed by CI and tried running a build, the Dtos were not updated. Only when I just removed them entirely did they get regenerated, and the imports changed...

so the source modification check won't catch this problem.

I thought about dropping them from git and letting them be generated into target each time, but looking at the comments here https://hibernate.atlassian.net/browse/HSEARCH-4638 .. 😖 

I thought about printing the diff if the check fails but then thought that it may be potentially dangerous, so didn't do that 😄 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
