### PR TITLE
Follow up on HSEARCH-5144 - Add a migration note on JBoss Logging upgrade

### DIFF
--- a/documentation/src/main/asciidoc/migration/index.adoc
+++ b/documentation/src/main/asciidoc/migration/index.adoc
@@ -52,6 +52,14 @@ with the only difference being Hibernate ORM version upgrade:
 - Elasticsearch 7.10+ or OpenSearch 1.3+ for its Elasticsearch backend;
 - Hibernate ORM 6.6.x for the Hibernate ORM integration.
 
+[WARNING]
+====
+Hibernate Search 7.2 depends on JBoss Logging 3.6 and uses its most recent APIs.
+If the application is using the JBoss Logging library either explicitly as a direct dependency
+or implicitly as a transient dependency of, e.g. Hibernate ORM or any other library,
+make sure that the resolved JBoss Logging version is 3.6; otherwise, you may see errors on startup.
+====
+
 [[artifact-changes]]
 == Artifacts
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5144

Earlier, I've added a similar note to the hibernate.org, this one is to mention it in the migration guide as probably more people read the migration guide than the version page on hibernate.org.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
