### PR TITLE
HSEARCH-5228 Upgrade to JBeret 3.0

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -113,7 +113,7 @@
 
         <!-- >>> Jakarta Batch -->
         <version.jakarta.batch>2.1.1</version.jakarta.batch>
-        <version.org.jberet>2.2.1.Final</version.org.jberet>
+        <version.org.jberet>3.0.0.Final</version.org.jberet>
 
         <!-- >>> Java EE/Jakarta EE dependencies -->
         <!-- This is used to generate a link to the Jakarta EE javadoc -->
@@ -175,7 +175,7 @@
         <version.com.ibm.jbatch>2.1.1</version.com.ibm.jbatch>
 
         <!-- >>> Jakarta Batch: JBeret SE dependencies -->
-        <version.org.jboss.marshalling>2.1.4.Final</version.org.jboss.marshalling>
+        <version.org.jboss.marshalling>2.2.0.Final</version.org.jboss.marshalling>
         <version.org.wildfly.security.wildfly-security-manager>1.1.2.Final</version.org.wildfly.security.wildfly-security-manager>
         <version.org.google.guava>33.3.0-jre</version.org.google.guava>
 

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -177,7 +177,6 @@
         <!-- >>> Jakarta Batch: JBeret SE dependencies -->
         <version.org.jboss.marshalling>2.2.0.Final</version.org.jboss.marshalling>
         <version.org.wildfly.security.wildfly-security-manager>1.1.2.Final</version.org.wildfly.security.wildfly-security-manager>
-        <version.org.google.guava>33.3.0-jre</version.org.google.guava>
 
         <!-- >>> Spring integration tests -->
         <!-- When updating Spring Boot check if it supports JDK23 and enable testing with it if so (see testWithJdk23 profile). -->
@@ -883,12 +882,7 @@
                 <type>pom</type>
             </dependency>
 
-            <!-- We only need these two libs here for testing utils -->
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${version.org.google.guava}</version>
-            </dependency>
+            <!-- We only need this lib here for testing utils -->
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-math3</artifactId>

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexerLargeDocumentsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexerLargeDocumentsIT.java
@@ -51,7 +51,7 @@ class IndexIndexerLargeDocumentsIT {
 	private static final String GREAT_EXPECTATIONS;
 	static {
 		try {
-			GREAT_EXPECTATIONS = TextContent.greatExpectations().read();
+			GREAT_EXPECTATIONS = TextContent.readGreatExpectations();
 		}
 		catch (IOException e) {
 			throw new UncheckedIOException( e );

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/dataset/Datasets.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/dataset/Datasets.java
@@ -9,8 +9,6 @@ import java.util.List;
 
 import org.hibernate.search.util.impl.test.data.TextContent;
 
-import com.google.common.io.CharSource;
-
 public final class Datasets {
 
 	public static final String CONSTANT_TEXT = "constant-text";
@@ -26,14 +24,16 @@ public final class Datasets {
 			case CONSTANT_TEXT:
 				return new ConstantDataset();
 			case GREAT_EXPECTATIONS:
-				return new SampleDataset( parseSimple( TextContent.greatExpectations() ) );
+				return new SampleDataset( parseSimpleGreatExpectations() );
 			default:
 				throw new IllegalArgumentException( "Unknown dataset: " + name );
 		}
 	}
 
-	private static List<SampleDataset.DataSample> parseSimple(CharSource charSource) throws IOException {
-		return charSource.readLines( new SimpleDataSampleParser() );
+	private static List<SampleDataset.DataSample> parseSimpleGreatExpectations() throws IOException {
+		SimpleDataSampleParser parser = new SimpleDataSampleParser();
+		TextContent.greatExpectations( parser::processLine );
+		return parser.getResult();
 	}
 
 }

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/dataset/SimpleDataSampleParser.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/dataset/SimpleDataSampleParser.java
@@ -7,9 +7,7 @@ package org.hibernate.search.integrationtest.performance.backend.base.testsuppor
 import java.util.ArrayList;
 import java.util.List;
 
-import com.google.common.io.LineProcessor;
-
-final class SimpleDataSampleParser implements LineProcessor<List<SampleDataset.DataSample>> {
+final class SimpleDataSampleParser {
 
 	private static final int LINES_PER_SAMPLE = 10;
 
@@ -20,7 +18,6 @@ final class SimpleDataSampleParser implements LineProcessor<List<SampleDataset.D
 	private String currentSampleFirstLine = null;
 	private final StringBuilder currentSampleWholeText = new StringBuilder();
 
-	@Override
 	public boolean processLine(String line) {
 		if ( line.isEmpty() ) {
 			return true;
@@ -39,7 +36,6 @@ final class SimpleDataSampleParser implements LineProcessor<List<SampleDataset.D
 		return true;
 	}
 
-	@Override
 	public List<SampleDataset.DataSample> getResult() {
 		pushCurrentSample();
 		return result;

--- a/integrationtest/performance/backend/base/src/test/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/dataset/SimpleDataSampleParserTest.java
+++ b/integrationtest/performance/backend/base/src/test/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/dataset/SimpleDataSampleParserTest.java
@@ -6,21 +6,19 @@ package org.hibernate.search.integrationtest.performance.backend.base.testsuppor
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
 import java.util.List;
 
 import org.hibernate.search.util.common.annotation.impl.SuppressJQAssistant;
 
 import org.junit.jupiter.api.Test;
 
-import com.google.common.io.CharSource;
-
 @SuppressJQAssistant(reason = "This really is a unit test, not an IT, so we want the 'Test' suffix")
 class SimpleDataSampleParserTest {
 
 	@Test
-	void test() throws IOException {
-		List<SampleDataset.DataSample> samples = CharSource.wrap( "\n"
+	void test() {
+		SimpleDataSampleParser parser = new SimpleDataSampleParser();
+		( "\n"
 				+ "This is the first real line\n"
 				+ "Followed by another one\n"
 				+ "Then a few empty lines:\n"
@@ -34,7 +32,10 @@ class SimpleDataSampleParserTest {
 				+ "\n"
 				+ "Then line 10\n"
 				+ "This is the first line of the next sample" )
-				.readLines( new SimpleDataSampleParser() );
+				.lines()
+				.forEach( parser::processLine );
+
+		List<SampleDataset.DataSample> samples = parser.getResult();
 
 		assertThat( samples ).hasSize( 2 );
 

--- a/util/common/pom.xml
+++ b/util/common/pom.xml
@@ -38,11 +38,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
             <scope>test</scope>

--- a/util/internal/integrationtest/jberet-se/pom.xml
+++ b/util/internal/integrationtest/jberet-se/pom.xml
@@ -62,11 +62,6 @@
             <artifactId>wildfly-security-manager</artifactId>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>compile</scope>
-        </dependency>
 
         <!-- JBeret-SE and additional dependencies -->
         <dependency>

--- a/util/internal/test/common/pom.xml
+++ b/util/internal/test/common/pom.xml
@@ -88,10 +88,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
         </dependency>

--- a/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/SystemHelper.java
+++ b/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/SystemHelper.java
@@ -9,14 +9,13 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import org.hibernate.search.util.impl.test.annotation.SuppressForbiddenApis;
-
-import com.google.common.base.Charsets;
 
 import org.awaitility.Awaitility;
 
@@ -60,7 +59,7 @@ public final class SystemHelper {
 	}
 
 	private static void drain(InputStream stream, Consumer<String> consumer) {
-		try ( InputStreamReader in = new InputStreamReader( stream, Charsets.UTF_8 );
+		try ( InputStreamReader in = new InputStreamReader( stream, StandardCharsets.UTF_8 );
 				BufferedReader bufferedReader = new BufferedReader( in ); ) {
 			bufferedReader.lines().forEach( consumer );
 		}

--- a/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/data/TextContent.java
+++ b/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/data/TextContent.java
@@ -4,21 +4,34 @@
  */
 package org.hibernate.search.util.impl.test.data;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-
-import com.google.common.io.CharSource;
-import com.google.common.io.Resources;
+import java.util.function.Consumer;
 
 public final class TextContent {
 
 	private TextContent() {
 	}
 
-	public static CharSource greatExpectations() {
-		return Resources.asCharSource(
-				TextContent.class.getResource( "/great_expectations.txt" ),
-				StandardCharsets.UTF_8
-		);
+	public static void greatExpectations(Consumer<String> consumer) throws IOException {
+		try ( InputStream resource = TextContent.class.getResourceAsStream( "/great_expectations.txt" ) ) {
+			if ( resource == null ) {
+				throw new IllegalStateException( "Text resource not found" );
+			}
+			try ( InputStreamReader reader = new InputStreamReader( resource, StandardCharsets.UTF_8 );
+					BufferedReader bufferedReader = new BufferedReader( reader ) ) {
+				bufferedReader.lines().forEach( consumer );
+			}
+		}
+	}
+
+	public static String readGreatExpectations() throws IOException {
+		StringBuilder sb = new StringBuilder();
+		greatExpectations( sb::append );
+		return sb.toString();
 	}
 
 }

--- a/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/logging/TestEscapers.java
+++ b/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/logging/TestEscapers.java
@@ -4,8 +4,7 @@
  */
 package org.hibernate.search.util.impl.test.logging;
 
-import com.google.common.escape.Escaper;
-import com.google.common.escape.Escapers;
+import java.util.Map;
 
 /**
  * Escapers to work around various bugs in test tools.
@@ -20,13 +19,19 @@ public final class TestEscapers {
 	private TestEscapers() {
 	}
 
-	private static final Escaper INSTANCE = Escapers.builder()
-			.addEscape( '\u0000', "[\\u0000]" )
-			.addEscape( '\uFFFF', "[\\uFFFF]" )
-			.build();
+	private static final Map<String, String> ESCAPE = Map.of(
+			"\u0000", "[\\u0000]",
+			"\uFFFF", "[\\uFFFF]"
+	);
 
 	public static String escape(String string) {
-		return string == null ? null : INSTANCE.escape( string );
+		if ( string == null ) {
+			return null;
+		}
+		for ( var entry : ESCAPE.entrySet() ) {
+			string = string.replace( entry.getKey(), entry.getValue() );
+		}
+		return string;
 	}
 
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5228

One of the things in the upgrade was a drop of guava in JBeret, and since the note on the versions in pom mentions that guava was used for JBeret testing ... I went ahead and dropped the dependency in our tests as well 🙈 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
