### PR TITLE
Bump version.gpg.plugin to 3.2.4 (7.1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@
         <version.japicmp.plugin>0.18.3</version.japicmp.plugin>
         <version.nexus-staging.plugin>1.6.13</version.nexus-staging.plugin>
         <version.deploy.plugin>3.1.1</version.deploy.plugin>
-        <version.gpg.plugin>3.1.0</version.gpg.plugin>
+        <version.gpg.plugin>3.2.4</version.gpg.plugin>
         <version.flatten-maven-plugin>1.6.0</version.flatten-maven-plugin>
         <version.assembly.plugin>3.6.0</version.assembly.plugin>
         <version.buildhelper.plugin>3.5.0</version.buildhelper.plugin>


### PR DESCRIPTION
to possibly address the
```
[INFO] --- gpg:3.1.0:sign (sign-artifacts) @ hibernate-search-bom ---
[INFO] Signing 1 file with default secret key.
gpg: signing failed: No pinentry
gpg: signing failed: No pinentry
```

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
