### PR TITLE
Backport to 7.2 : HSEARCH-5237 Upgrade Elasticsearch client to 8.15.1 / HSEARCH-5236 Test against latest Elasticsearch 8.15.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -269,7 +269,7 @@ stage('Configure') {
 					new LocalElasticsearchBuildEnvironment(version: '8.12.2', condition: TestCondition.ON_DEMAND),
 					new LocalElasticsearchBuildEnvironment(version: '8.13.4', condition: TestCondition.ON_DEMAND),
 					new LocalElasticsearchBuildEnvironment(version: '8.14.3', condition: TestCondition.ON_DEMAND),
-					new LocalElasticsearchBuildEnvironment(version: '8.15.0', condition: TestCondition.BEFORE_MERGE, isDefault: true),
+					new LocalElasticsearchBuildEnvironment(version: '8.15.1', condition: TestCondition.BEFORE_MERGE, isDefault: true),
 					// IMPORTANT: Make sure to update the documentation for any newly supported Elasticsearch versions
 					//            See version.org.elasticsearch.compatible.expected.text
 					//            and version.org.elasticsearch.compatible.regularly-tested.text in POMs.

--- a/build/container/search-backend/elastic.Dockerfile
+++ b/build/container/search-backend/elastic.Dockerfile
@@ -4,4 +4,4 @@
 # IMPORTANT! When updating the version of Elasticsearch in this Dockerfile,
 # make sure to update `version.org.elasticsearch.latest` property in a POM file.
 #
-FROM docker.io/elastic/elasticsearch:8.15.0
+FROM docker.io/elastic/elasticsearch:8.15.1

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -48,7 +48,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.5+ -->
-        <version.org.elasticsearch.client>8.15.0</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>8.15.1</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <version.org.elasticsearch.compatible.main>${version.org.elasticsearch.latest}</version.org.elasticsearch.compatible.main>
         <documentation.org.elasticsearch.url>https://www.elastic.co/guide/en/elasticsearch/reference/${parsed-version.org.elasticsearch.compatible.main.majorVersion}.${parsed-version.org.elasticsearch.compatible.main.minorVersion}</documentation.org.elasticsearch.url>

--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -34,7 +34,7 @@ Map settings() {
 					updateProperties: [],
 					onlyRunTestDependingOn: ['hibernate-search-backend-elasticsearch'],
 					// We want to use the snapshot version of an image from the ES registry since that's where they are publishing their snapshots.
-					additionalMavenArgs: '-Dtest.lucene.skip=true -Dtest.elasticsearch.run.elastic.image.name=docker.elastic.co/elasticsearch/elasticsearch -Dtest.elasticsearch.run.elastic.image.tag=8.15.1-SNAPSHOT',
+					additionalMavenArgs: '-Dtest.lucene.skip=true -Dtest.elasticsearch.run.elastic.image.name=docker.elastic.co/elasticsearch/elasticsearch -Dtest.elasticsearch.run.elastic.image.tag=8.15.2-SNAPSHOT',
 					// This job won't change the versions in the pom. We are passing the latest Elasticsearch version through an additional maven argument `-D`
 					skipSourceModifiedCheck: true
 			]

--- a/pom.xml
+++ b/pom.xml
@@ -384,7 +384,7 @@
 
         <!-- Container images for various integration tests -->
         <!-- The latest version of Elasticsearch tested against by default -->
-        <version.org.elasticsearch.latest>8.15.0</version.org.elasticsearch.latest>
+        <version.org.elasticsearch.latest>8.15.1</version.org.elasticsearch.latest>
         <test.elasticsearch.version></test.elasticsearch.version>
         <test.elasticsearch.distribution>elastic</test.elasticsearch.distribution>
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5236
https://hibernate.atlassian.net/browse/HSEARCH-5237

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
