### PR TITLE
HSEARCH-5238 Upgrade to JBoss logging 3.6.1.Final

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -21,7 +21,7 @@
         <!-- Main dependencies -->
 
         <!-- >>> Common -->
-        <version.org.jboss.logging.jboss-logging>3.6.0.Final</version.org.jboss.logging.jboss-logging>
+        <version.org.jboss.logging.jboss-logging>3.6.1.Final</version.org.jboss.logging.jboss-logging>
         <!--Once the tools version is upgraded see if org.codehaus.plexus can be upgraded as well and update the dependabot config accordingly. -->
         <version.org.jboss.logging.jboss-logging-tools>3.0.1.Final</version.org.jboss.logging.jboss-logging-tools>
         <javadoc.org.hibernate.search.url>https://docs.jboss.org/hibernate/search/${parsed-version.org.hibernate.search.majorVersion}.${parsed-version.org.hibernate.search.minorVersion}/api/</javadoc.org.hibernate.search.url>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5238

https://github.com/hibernate/hibernate-search/pull/4312

Bump org.jboss.logging:jboss-logging from 3.6.0.Final to 3.6.1.Final

Bumps [org.jboss.logging:jboss-logging](https://github.com/jboss-logging/jboss-logging) from 3.6.0.Final to 3.6.1.Final.
- [Release notes](https://github.com/jboss-logging/jboss-logging/releases)
- [Commits](https://github.com/jboss-logging/jboss-logging/compare/3.6.0.Final...3.6.1.Final)

---
updated-dependencies:
- dependency-name: org.jboss.logging:jboss-logging dependency-type: direct:production update-type: version-update:semver-patch ...

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HSEARCH.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HSEARCH-<digits>`).
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
