### PR TITLE
HSEARCH-4720 Throw exceptions instead of logging warnings for failures to configure association inverse path resolution

### DIFF
--- a/documentation/src/main/asciidoc/migration/index.adoc
+++ b/documentation/src/main/asciidoc/migration/index.adoc
@@ -111,4 +111,7 @@ to reflect the changes in the `org.hibernate.search.mapper.pojo.standalone.loadi
 The behavior of Hibernate Search {hibernateSearchVersion}
 is, in general, backward-compatible with Hibernate Search {hibernateSearchPreviousStableVersionShort}.
 
-The default mass indexer logging monitor updated the format of the logged messages to provide the information in a more condense form.
+* The default mass indexer logging monitor updated the format of the logged messages to provide the information in a more condense form.
+* In a few places related to the discovery of the inverse side of an association (in the ORM mapper)
+that previously logged warnings, Hibernate Search now will throw exceptions instead.
+This is related to https://hibernate.atlassian.net/browse/HSEARCH-4708[HSEARCH-4708].

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
@@ -271,15 +271,14 @@ public interface Log extends BasicLogger {
 			+ " Valid Hibernate ORM names for mapped entities are: %2$s")
 	SearchException unknownHibernateOrmEntityNameForMappedEntityType(String invalidName, Collection<String> validNames);
 
-	@LogMessage(level = Logger.Level.WARN)
 	@Message(id = ID_OFFSET + 121,
 			value = "An unexpected failure occurred while resolving the representation of path '%1$s' in the entity state array,"
 					+ " which is necessary to configure resolution of association inverse side for reindexing."
-					+ " This may lead to incomplete reindexing and thus out-of-sync indexes."
-					+ " The exception is being ignored to preserve backwards compatibility with earlier versions of Hibernate Search."
+					+ " Cannot proceed further as this may lead to incomplete reindexing and thus out-of-sync indexes."
 					+ " Failure: %3$s"
 					+ " %2$s") // Context
-	void failedToResolveStateRepresentation(String path, @FormatWith(EventContextFormatter.class) EventContext context,
+	SearchException failedToResolveStateRepresentation(String path,
+			@FormatWith(EventContextFormatter.class) EventContext context,
 			String causeMessage,
 			@Cause Exception cause);
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmPathInterpreter.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmPathInterpreter.java
@@ -214,14 +214,11 @@ final class HibernateOrmPathInterpreter
 				tryResolveStateRepresentation( wholePathStringRepresentation );
 			}
 			catch (RuntimeException e) {
-				// TODO HSEARCH-4720 when we can afford breaking changes (in the next major), we should probably throw an exception
-				//  instead of just logging a warning here?
-				log.failedToResolveStateRepresentation(
+				throw log.failedToResolveStateRepresentation(
 						wholePathStringRepresentation,
 						EventContexts.fromType( typeModel ).append( PojoEventContexts.fromPath( wholePath ) ),
 						e.getMessage(), e
 				);
-				disableStateRepresentation();
 			}
 		}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/PojoImplicitReindexingResolverBuildingHelper.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/PojoImplicitReindexingResolverBuildingHelper.java
@@ -189,19 +189,10 @@ public final class PojoImplicitReindexingResolverBuildingHelper {
 						entityStateRepresentation.pathFromStateArrayElement(), inversePathByInverseType );
 			}
 			catch (RuntimeException e) {
-				// We're logging instead of re-throwing for backwards compatibility,
-				// as we don't want this feature to cause errors in existing applications.
-				// TODO HSEARCH-4720 when we can afford breaking changes (in the next major), we should probably throw an exception
-				//  instead of just logging a warning here?
-				// Wrap the failure to append a message "please report this bug"
-				AssertionFailure assertionFailure = e instanceof AssertionFailure
-						? (AssertionFailure) e
-						: new AssertionFailure( e.getMessage(), e );
-				log.failedToCreateImplicitReindexingAssociationInverseSideResolverNode(
+				throw log.failedToCreateImplicitReindexingAssociationInverseSideResolverNode(
 						inversePathByInverseType,
 						EventContexts.fromType( typeModel ).append( PojoEventContexts.fromPath( path ) ),
-						assertionFailure.getMessage(), assertionFailure );
-				continue;
+						e.getMessage(), e );
 			}
 			List<PojoImplicitReindexingAssociationInverseSideResolverNode<Object>> nodesForOrdinal = result.get( ordinal );
 			if ( nodesForOrdinal == null ) {

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
@@ -744,7 +744,6 @@ public interface Log extends BasicLogger {
 			value = "Invalid ObjectPath encountered '%1$s': %2$s")
 	SearchException invalidObjectPath(ObjectPath path, String causeMessage, @Cause Exception cause);
 
-	@LogMessage(level = Logger.Level.WARN)
 	@Message(id = ID_OFFSET + 122,
 			value = "An unexpected failure occurred while configuring resolution of association inverse side for reindexing."
 					+ " This may lead to incomplete reindexing and thus out-of-sync indexes."
@@ -752,7 +751,7 @@ public interface Log extends BasicLogger {
 					+ " Failure: %3$s"
 					+ " %2$s" // Context
 					+ " Association inverse side: %1$s.")
-	void failedToCreateImplicitReindexingAssociationInverseSideResolverNode(
+	SearchException failedToCreateImplicitReindexingAssociationInverseSideResolverNode(
 			Map<PojoRawTypeModel<?>, PojoModelPathValueNode> inversePathByInverseType,
 			@FormatWith(EventContextFormatter.class) EventContext context,
 			String causeMessage, @Cause Exception cause);


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4720

In one of the places marked to throw an exception, the code can enter the condition for valid reasons. I've tried to describe that with an example and kept the code simply returning early as before instead of throwing an exception. 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
