### PR TITLE
Follow up on: HSEARCH-5180 Update log check conditions in tests

### DIFF
--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingStreamingLoaderIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingStreamingLoaderIT.java
@@ -73,9 +73,9 @@ class MassIndexingStreamingLoaderIT {
 
 		expectIndexingWorks();
 
-		logged.expectEvent( Level.INFO, "Mass indexed 50. Speed", "instant, ", "since start",
+		logged.expectEvent( Level.INFO, "Mass indexed ", ". Speed", "instant, ", "since start",
 				"Remaining: unknown, 1 type(s) pending" );
-		logged.expectEvent( Level.INFO, "Mass indexed", "1950/2000. Speed", "Remaining: 50, approx. PT" );
+		logged.expectEvent( Level.INFO, "Mass indexed", "/2000. Speed", "Remaining: ", ", approx. PT" );
 
 		try {
 			mapping.scope( Object.class ).massIndexer()
@@ -107,8 +107,8 @@ class MassIndexingStreamingLoaderIT {
 
 		expectIndexingWorks();
 
-		logged.expectEvent( Level.INFO, "Mass indexed 50. Speed", "instant, ", "since start", "Remaining: unknown" );
-		logged.expectEvent( Level.INFO, "Mass indexed", "1950/2000. Speed", "Remaining: 50, approx. PT" );
+		logged.expectEvent( Level.INFO, "Mass indexed ", ". Speed", "instant, ", "since start", "Remaining: unknown" );
+		logged.expectEvent( Level.INFO, "Mass indexed", "/2000. Speed", "Remaining: ", ", approx. PT" );
 
 		try {
 			mapping.scope( Object.class ).massIndexer()


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5180

it can happen that the log does not get logged, in the "allTogether" case as another thread may have already logged a more "recent" update
see https://ge.hibernate.org/s/iyug3sahpzzxg/tests/goal/org.hibernate.search:hibernate-search-integrationtest-mapper-pojo-base:failsafe:integration-test@it/details/org.hibernate.search.integrationtest.mapper.pojo.massindexing.MassIndexingStreamingLoaderIT?top-execution=1

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
