### PR TITLE
HSEARCH-5243 Upgrade to AWS SDK 2.28.2

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -81,7 +81,7 @@
         <documentation.org.opensearch.url>https://opensearch.org/docs/${parsed-version.org.opensearch.compatible.main.majorVersion}.${parsed-version.org.opensearch.compatible.main.minorVersion}</documentation.org.opensearch.url>
 
         <version.com.google.code.gson>2.11.0</version.com.google.code.gson>
-        <version.software.amazon.awssdk>2.27.3</version.software.amazon.awssdk>
+        <version.software.amazon.awssdk>2.28.2</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, by Avro, by the AWS SDK and in tests (wiremock, ...) -->
         <version.com.fasterxml.jackson>2.17.2</version.com.fasterxml.jackson>
         <!-- slf4j: used by the AWS SDK -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5243

https://github.com/hibernate/hibernate-search/pull/4319

Bump software.amazon.awssdk:auth from 2.27.3 to 2.28.2

Bumps software.amazon.awssdk:auth from 2.27.3 to 2.28.2.

---
updated-dependencies:
- dependency-name: software.amazon.awssdk:auth dependency-type: direct:production update-type: version-update:semver-minor ...

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HSEARCH.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HSEARCH-<digits>`).
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
