### PR TITLE
HSEARCH-5245 Add compatibility with OpenSearch 2.17.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -293,7 +293,8 @@ stage('Configure') {
 					new LocalOpenSearchBuildEnvironment(version: '2.13.0', condition: TestCondition.ON_DEMAND),
 					new LocalOpenSearchBuildEnvironment(version: '2.14.0', condition: TestCondition.ON_DEMAND),
 					new LocalOpenSearchBuildEnvironment(version: '2.15.0', condition: TestCondition.ON_DEMAND),
-					new LocalOpenSearchBuildEnvironment(version: '2.16.0', condition: TestCondition.BEFORE_MERGE),
+					new LocalOpenSearchBuildEnvironment(version: '2.16.0', condition: TestCondition.ON_DEMAND),
+					new LocalOpenSearchBuildEnvironment(version: '2.17.0', condition: TestCondition.BEFORE_MERGE),
 					// See https://opensearch.org/lines/2x.html for a list of all 2.x versions
 					// IMPORTANT: Make sure to update the documentation for any newly supported OpenSearch versions
 					//            See version.org.opensearch.compatible.expected.text

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
@@ -245,7 +245,7 @@ public class ElasticsearchDialectFactory {
 	}
 
 	private ElasticsearchProtocolDialect createProtocolDialectOpenSearchV2(ElasticsearchVersion version, int minor) {
-		if ( minor > 16 ) {
+		if ( minor > 17 ) {
 			log.unknownElasticsearchVersion( version );
 		}
 		return new Elasticsearch70ProtocolDialect();

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -428,12 +428,20 @@ class ElasticsearchDialectFactoryTest {
 						ElasticsearchDistributionName.OPENSEARCH, "2.16.0", "2.16.0",
 						OpenSearch214ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
-				successWithWarning(
+				success(
 						ElasticsearchDistributionName.OPENSEARCH, "2.17", "2.17.0",
 						OpenSearch214ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
-				successWithWarning(
+				success(
 						ElasticsearchDistributionName.OPENSEARCH, "2.17.0", "2.17.0",
+						OpenSearch214ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.OPENSEARCH, "2.18", "2.18.0",
+						OpenSearch214ModelDialect.class, Elasticsearch70ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.OPENSEARCH, "2.18.0", "2.18.0",
 						OpenSearch214ModelDialect.class, Elasticsearch70ProtocolDialect.class
 				),
 				successWithWarning(

--- a/build/container/search-backend/amazon-opensearch-serverless.Dockerfile
+++ b/build/container/search-backend/amazon-opensearch-serverless.Dockerfile
@@ -4,4 +4,4 @@
 # IMPORTANT! When updating the version of OpenSearch in this Dockerfile,
 # make sure to update `version.org.opensearch.latest` property in a POM file,
 # and to update the version in opensearch.Dockerfile as well.
-FROM docker.io/opensearchproject/opensearch:2.16.0
+FROM docker.io/opensearchproject/opensearch:2.17.0

--- a/build/container/search-backend/opensearch.Dockerfile
+++ b/build/container/search-backend/opensearch.Dockerfile
@@ -4,4 +4,4 @@
 # IMPORTANT! When updating the version of OpenSearch in this Dockerfile,
 # make sure to update `version.org.opensearch.latest` property in a POM file,
 # and to update the version in amazon-opensearch-serverless.Dockerfile as well.
-FROM docker.io/opensearchproject/opensearch:2.16.0
+FROM docker.io/opensearchproject/opensearch:2.17.0

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -69,13 +69,13 @@
         -->
         <!-- The versions of OpenSearch advertised as compatible with Hibernate Search -->
         <!-- Make sure to only mention tested versions here -->
-        <version.org.opensearch.compatible.regularly-tested.text>1.3 or 2.16</version.org.opensearch.compatible.regularly-tested.text>
+        <version.org.opensearch.compatible.regularly-tested.text>1.3 or 2.17</version.org.opensearch.compatible.regularly-tested.text>
         <!-- These are the versions same as above, but pointing only to the major part (used in compatibility section of ES backend documentation
           as versions that Hibernate Search is compatible with. -->
         <!-- NOTE: Adding new major versions would require to update the compatibility table in `backend-elasticsearch-compatibility` section of `backend-elasticsearch.asciidoc`. -->
         <version.org.opensearch.compatible.expected.text>1.3 or 2.x</version.org.opensearch.compatible.expected.text>
         <!-- The latest version of OpenSearch tested against by default -->
-        <version.org.opensearch.latest>2.16.0</version.org.opensearch.latest>
+        <version.org.opensearch.latest>2.17.0</version.org.opensearch.latest>
         <!-- The main compatible version of OpenSearch, advertised by default. Used in documentation links. -->
         <version.org.opensearch.compatible.main>${version.org.opensearch.latest}</version.org.opensearch.compatible.main>
         <documentation.org.opensearch.url>https://opensearch.org/docs/${parsed-version.org.opensearch.compatible.main.majorVersion}.${parsed-version.org.opensearch.compatible.main.minorVersion}</documentation.org.opensearch.url>

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -485,7 +485,7 @@ public class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 		//  leading to routes, being ignored and incorrect counts produced in the results:
 		return isActualVersion(
 				es -> true,
-				os -> os.isLessThan( "2.16.0" ),
+				os -> !os.isMatching( "2.16.0" ),
 				aoss -> false
 		);
 	}

--- a/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/LibraryShowcaseSearchIT.java
+++ b/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/LibraryShowcaseSearchIT.java
@@ -469,7 +469,7 @@ class LibraryShowcaseSearchIT extends AbstractLibraryShowcaseSearchIT {
 						|| isActualVersion(
 								es -> true,
 								// See https://github.com/opensearch-project/OpenSearch/issues/15169
-								os -> os.isLessThan( "2.16.0" ),
+								os -> !os.isMatching( "2.16.0" ),
 								aoss -> false
 						)
 		);


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5245

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
