### PR TITLE
Backport of HSEARCH-5244 to 7.2  -  Upgrade to Hibernate ORM 6.6.1.Final

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -93,7 +93,7 @@
             NOTE: when Hibernate ORM updates Byte Buddy, make sure to check Jenkinsfile to see if
             `net.bytebuddy.experimental` property can be removed.
          -->
-        <version.org.hibernate.orm>6.6.0.Final</version.org.hibernate.orm>
+        <version.org.hibernate.orm>6.6.1.Final</version.org.hibernate.orm>
 
         <javadoc.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/javadocs/</javadoc.org.hibernate.orm.url>
         <documentation.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/userguide/html_single/Hibernate_User_Guide.html</documentation.org.hibernate.orm.url>

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingInheritanceIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingInheritanceIT.java
@@ -245,8 +245,9 @@ class MassIndexingInheritanceIT {
 		statementInspector.hasSelects( 3 )
 				// select count(bv1_0.id) from bedvehicle bv1_0
 				.anyMatch( "select count(_big)?\\([a-z0-9_.]+\\) from bedvehicle [a-z0-9_.]+" )
-				// select bv1_0.id from bedvehicle bv1_0
-				.anyMatch( "select [a-z0-9_.]+ from bedvehicle [a-z0-9_.]+" )
+				// there can be an additional join see https://hibernate.atlassian.net/browse/HHH-18503?focusedCommentId=116667
+				// select bv1_1.id from bedvehicle bv1_0 join baseentity bv1_1 on bv1_0.id=bv1_1.id
+				.anyMatch( "select [a-z0-9_.]+ from bedvehicle [a-z0-9_.]+ join baseentity [a-z0-9_.]+ on [a-z0-9_.=]+" )
 				// select bv1_0.id,bv1_1.type,bv1_2.bodytype,bv1_3.doortype,bv1_0.bedtype,bv1_4.truckroof
 				//   from bedvehicle bv1_0 join baseentity bv1_1 on bv1_0.id=bv1_1.id join basevehicle bv1_2 on bv1_0.id=bv1_2.id join dooredvehicle bv1_3 on bv1_0.id=bv1_3.id left join truck bv1_4 on bv1_0.id=bv1_4.id where bv1_0.id=?
 				.anyMatch( "select [a-z0-9_.,]+ from bedvehicle [a-z0-9_.]+ "
@@ -383,8 +384,9 @@ class MassIndexingInheritanceIT {
 		statementInspector.hasSelects( 3 )
 				// select count(bv1_0.id) from bedvehicle bv1_0
 				.anyMatch( "select count(_big)?\\([a-z0-9_.]+\\) from bedvehicle [a-z0-9_.]+" )
-				// select bv1_0.id from bedvehicle bv1_0
-				.anyMatch( "select [a-z0-9_.]+ from bedvehicle [a-z0-9_.]+" )
+				// there can be an additional join see https://hibernate.atlassian.net/browse/HHH-18503?focusedCommentId=116667
+				// select bv1_1.id from bedvehicle bv1_0 join baseentity bv1_1 on bv1_0.id=bv1_1.id
+				.anyMatch( "select [a-z0-9_.]+ from bedvehicle [a-z0-9_.]+ join baseentity [a-z0-9_.]+ on [a-z0-9_.=]+" )
 				// select bv1_0.id,bv1_1.type,bv1_2.bodytype,bv1_3.doortype,bv1_0.bedtype,bv1_4.truckroof
 				//   from bedvehicle bv1_0 join baseentity bv1_1 on bv1_0.id=bv1_1.id join basevehicle bv1_2 on bv1_0.id=bv1_2.id join dooredvehicle bv1_3 on bv1_0.id=bv1_3.id left join truck bv1_4 on bv1_0.id=bv1_4.id where bv1_0.id=?
 				.anyMatch( "select [a-z0-9_.,]+ from bedvehicle [a-z0-9_.]+ "


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5244

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
