### PR TITLE
HSEARCH-5249 Move a MassIndexingTypeGroupMonitor#indexingCompleted call to right before the indexing completed log message

### DIFF
--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingStreamingLoaderIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/massindexing/MassIndexingStreamingLoaderIT.java
@@ -40,7 +40,7 @@ import org.apache.logging.log4j.Level;
 class MassIndexingStreamingLoaderIT {
 
 	private static final int BOOK_COUNT = 500;
-	private static final int ARTICLE_COUNT = 1500;
+	private static final int ARTICLE_COUNT = 5500;
 
 	@RegisterExtension
 	public final BackendMock backendMock = BackendMock.create();
@@ -75,7 +75,7 @@ class MassIndexingStreamingLoaderIT {
 
 		logged.expectEvent( Level.INFO, "Mass indexed ", ". Speed", "instant, ", "since start",
 				"Remaining: unknown, 1 type(s) pending" );
-		logged.expectEvent( Level.INFO, "Mass indexed", "/2000. Speed", "Remaining: ", ", approx. PT" );
+		logged.expectEvent( Level.INFO, "Mass indexed", "/6000. Speed", "Remaining: ", ", approx. PT" );
 
 		try {
 			mapping.scope( Object.class ).massIndexer()
@@ -108,7 +108,7 @@ class MassIndexingStreamingLoaderIT {
 		expectIndexingWorks();
 
 		logged.expectEvent( Level.INFO, "Mass indexed ", ". Speed", "instant, ", "since start", "Remaining: unknown" );
-		logged.expectEvent( Level.INFO, "Mass indexed", "/2000. Speed", "Remaining: ", ", approx. PT" );
+		logged.expectEvent( Level.INFO, "Mass indexed", "/6000. Speed", "Remaining: ", ", approx. PT" );
 
 		try {
 			mapping.scope( Object.class ).massIndexer()

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingBatchIndexingWorkspace.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingBatchIndexingWorkspace.java
@@ -84,6 +84,7 @@ public class PojoMassIndexingBatchIndexingWorkspace<E, I> extends PojoMassIndexi
 		allFutures.addAll( identifierProducingFutures );
 		allFutures.addAll( indexingFutures );
 		Futures.unwrappedExceptionGet( Futures.firstFailureOrAllOf( allFutures ) );
+		typeGroupMonitor.indexingCompleted();
 		log.debugf( "Indexing for %s is done", typeGroup.notifiedGroupName() );
 	}
 
@@ -144,8 +145,6 @@ public class PojoMassIndexingBatchIndexingWorkspace<E, I> extends PojoMassIndexi
 			for ( int i = 0; i < entityExtractingThreads; i++ ) {
 				indexingFutures.add( Futures.runAsync( runnable, indexingExecutor ) );
 			}
-			CompletableFuture.allOf( indexingFutures.toArray( CompletableFuture[]::new ) )
-					.thenRun( typeGroupMonitor::indexingCompleted );
 		}
 		finally {
 			indexingExecutor.shutdown();


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5249

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
