### PR TITLE
HSEARCH-5045 Raise various default max-connection config properties for the Elasticsearch backend

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchBackendSettings.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchBackendSettings.java
@@ -166,7 +166,7 @@ public final class ElasticsearchBackendSettings {
 	 * The maximum number of simultaneous connections to the Elasticsearch cluster,
 	 * all hosts taken together.
 	 * <p>
-	 * Expects a positive Integer value, such as {@code 20},
+	 * Expects a positive Integer value, such as {@code 40},
 	 * or a String that can be parsed into such Integer value.
 	 * <p>
 	 * Defaults to {@link Defaults#MAX_CONNECTIONS}.
@@ -176,7 +176,7 @@ public final class ElasticsearchBackendSettings {
 	/**
 	 * The maximum number of simultaneous connections to each host of the Elasticsearch cluster.
 	 * <p>
-	 * Expects a positive Integer value, such as {@code 10},
+	 * Expects a positive Integer value, such as {@code 20},
 	 * or a String that can be parsed into such Integer value.
 	 * <p>
 	 * Defaults to {@link Defaults#MAX_CONNECTIONS_PER_ROUTE}.
@@ -331,8 +331,8 @@ public final class ElasticsearchBackendSettings {
 		public static final String PATH_PREFIX = "";
 		public static final int READ_TIMEOUT = 30000;
 		public static final int CONNECTION_TIMEOUT = 1000;
-		public static final int MAX_CONNECTIONS = 20;
-		public static final int MAX_CONNECTIONS_PER_ROUTE = 10;
+		public static final int MAX_CONNECTIONS = 40;
+		public static final int MAX_CONNECTIONS_PER_ROUTE = 20;
 		public static final boolean DISCOVERY_ENABLED = false;
 		public static final int DISCOVERY_REFRESH_INTERVAL = 10;
 		public static final boolean LOG_JSON_PRETTY_PRINTING = false;

--- a/documentation/src/main/asciidoc/migration/index.adoc
+++ b/documentation/src/main/asciidoc/migration/index.adoc
@@ -81,7 +81,11 @@ no database schema update is necessary for these tables.
 == Configuration
 
 The configuration properties in Hibernate Search {hibernateSearchVersion}
-are backward-compatible with Hibernate Search {hibernateSearchPreviousStableVersionShort}.
+, in general, are backward-compatible with Hibernate Search {hibernateSearchPreviousStableVersionShort}.
+But some default values have changed:
+
+- The default value of the Elasticsearch backend property `hibernate.search.backend.max_connections` is now set to `40` instead of `20`.
+- The default value of the Elasticsearch backend property `hibernate.search.backend.max_connections_per_route` is now set to `20` instead of `10`.
 
 [[api]]
 == API

--- a/documentation/src/main/asciidoc/public/reference/_backend-elasticsearch.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_backend-elasticsearch.adoc
@@ -372,13 +372,29 @@ hibernate.search.backend.max_connections_per_route = 10
 
 * `max_connections` defines maximum number of simultaneous connections
 to the Elasticsearch cluster, all hosts taken together.
-The default for this property is `20`.
+The default for this property is `40`.
 * `max_connections_per_route` defines maximum number of simultaneous connections
 to each host of the Elasticsearch cluster.
 The default for this property is `10`.
 
 +
 These properties expect a positive <<configuration-property-types,Integer value>>, such as `20`.
+
++
+[NOTE]
+====
+When working with an Elasticsearch backend cluster, multiple cluster nodes might exist.
+If so, the REST client communicating with the cluster will try to distribute the requests among the nodes.
+That’s why the maximum number of connections can be set per route (cluster node)
+and then limited by the general number of maximum connections.
+
+When modifying the maximum connection values, it is worth remembering the number
+of <<backend-elasticsearch-indexing-queues,indexing queues>> configured for the backend
+With an application performing a lot of indexing operations, having a subpar configuration of the maximum connections may
+result in all connections primarily being consumed by the indexing processes, resulting in the degrading performance of search operations,
+as those would be struggling to get a connection.
+To prevent that from happening consider having the maximum number of connections greater than the number of active indexing queues.
+====
 
 Keep Alive::
 +


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5045

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
