### PR TITLE
Add to .git-blame-ignore-revs the commits related to the switch to spotless plugin

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -31,3 +31,7 @@ a422a266a66907ffb4c3bde135f2f5f74e0f79d8
 7b6b15c04f0ce6ec98e8d4983605b97f36d34fd5
 # HSEARCH-4394 Move main code from Java EE to Jakarta EE
 044a03d329f0005d089552995af8287cfa2f2ffc
+# switch to spotless and more formatting updates:
+77eb97fb72cb19b4bd2610a0cc4077cb66dc7681
+f655ea4d7872d568832821c89299dd2380e1d877
+2baaf0404a07866c24843e141739b2b1e17e9cc1


### PR DESCRIPTION
…
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HSEARCH.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HSEARCH-<digits>`).
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
