### PR TITLE
HSEARCH-5256 Spotless: use a cache dir per module and not single in the root

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -995,8 +995,8 @@
                     </dependencies>
                 </plugin>
                 <!--
-                   Code formatting configuration:
-               -->
+                    Code formatting configuration:
+                -->
                 <plugin>
                     <groupId>com.diffplug.spotless</groupId>
                     <artifactId>spotless-maven-plugin</artifactId>
@@ -1004,7 +1004,7 @@
                     <configuration>
                         <upToDateChecking>
                             <enabled>true</enabled>
-                            <indexFile>.cache/spotless-index-${version.spotless-maven-plugin}</indexFile>
+                            <indexFile>${project.basedir}/.cache/spotless-index-${version.spotless-maven-plugin}</indexFile>
                         </upToDateChecking>
                         <formats>
                             <format>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5256

As otherwise, we end up with cache misses all the time with the current config. Noticed this while looking into Develocity build cache

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
