### PR TITLE
Use JDK 21 explicitly for report publishing

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -24,10 +24,10 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ github.ref }}
-      - name: Set up Java ${{ matrix.os.java.version }}
+      - name: Set up Java 21
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.os.java.version }}
+          java-version: 21
           distribution: temurin
       # https://github.com/actions/cache/blob/main/examples.md#java---maven
       - name: Cache local Maven repository


### PR DESCRIPTION
since the publish job does not have a matrix

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
