### PR TITLE
Don't tar build-scan-data in GitHub actions workflows

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -56,11 +56,11 @@ jobs:
         run: |
           shopt -s nullglob # Don't run the loop below if there are no artifacts
           status=0
+          mkdir -p ~/.m2/.develocity/
           for build_scan_data_directory in /tmp/downloaded-build-scan-data/*
           do
             rm -rf ~/.m2/.develocity/build-scan-data
-            mkdir -p ~/.m2/.develocity/build-scan-data
-            tar -xzf "$build_scan_data_directory/build-scan-data.tgz" -C ~/.m2/.develocity/build-scan-data \
+            mv "$build_scan_data_directory" ~/.m2/.develocity/build-scan-data \
             && ./mvnw $MAVEN_ARGS develocity:build-scan-publish-previous || status=1
           done
           exit $status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,18 +119,15 @@ jobs:
           -Pjqassistant -Pdist -Pci-build -DskipITs
         env:
           DEVELOCITY_ACCESS_KEY: "${{ secrets.DEVELOCITY_ACCESS_KEY || '' }}"
-      # For jobs running on 'pull_request', tar and upload build scan data.
+      # For jobs running on 'pull_request', upload build scan data.
       # The actual publishing must be done in a separate job (see ci-report.yml).
       # We don't write to the remote cache as that would be unsafe.
-      - name: Tar build scan content pushed to subsequent jobs
-        if: "${{ github.event_name == 'pull_request' && !cancelled() }}"
-        run: tar -czf build-scan-data.tgz -C ~/.m2/.develocity/build-scan-data .
       - name: Upload GitHub Actions artifact for the Develocity build scan
         uses: actions/upload-artifact@v4
         if: "${{ github.event_name == 'pull_request' && !cancelled() }}"
         with:
           name: build-scan-data-initial-${{ matrix.os.name }}
-          path: build-scan-data.tgz
+          path: ~/.m2/.develocity/build-scan-data
 
       - name: Run integration tests in the default environment
         run: |
@@ -140,15 +137,12 @@ jobs:
         env:
           DEVELOCITY_ACCESS_KEY: "${{ secrets.DEVELOCITY_ACCESS_KEY || '' }}"
       # Same as above, but for the build scan of the latest Maven run.
-      - name: Tar build scan content pushed to subsequent jobs
-        if: "${{ github.event_name == 'pull_request' && !cancelled() }}"
-        run: tar -czf build-scan-data.tgz -C ~/.m2/.develocity/build-scan-data .
       - name: Upload GitHub Actions artifact for the Develocity build scan
         uses: actions/upload-artifact@v4
         if: "${{ github.event_name == 'pull_request' && !cancelled() }}"
         with:
           name: build-scan-data-integrationtest-${{ matrix.os.name }}
-          path: build-scan-data.tgz
+          path: ~/.m2/.develocity/build-scan-data
 
       - name: Docker cleanup
         run: ./ci/docker-cleanup.sh


### PR DESCRIPTION
We don't need tars, as workflow artifacts are already zipped.

This is to align on ORM: https://github.com/hibernate/hibernate-orm/pull/9173
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
