### PR TITLE
HSEARCH-5264 Upgrade to Jackson 2.18.1 / HSEARCH-5263 Upgrade to AWS SDK 2.29.2

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -83,7 +83,7 @@
         <version.com.google.code.gson>2.11.0</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.29.2</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, by Avro, by the AWS SDK and in tests (wiremock, ...) -->
-        <version.com.fasterxml.jackson>2.18.0</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.18.1</version.com.fasterxml.jackson>
         <!-- slf4j: used by the AWS SDK -->
         <version.org.slf4j>1.7.36</version.org.slf4j>
 

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -81,7 +81,7 @@
         <documentation.org.opensearch.url>https://opensearch.org/docs/${parsed-version.org.opensearch.compatible.main.majorVersion}.${parsed-version.org.opensearch.compatible.main.minorVersion}</documentation.org.opensearch.url>
 
         <version.com.google.code.gson>2.11.0</version.com.google.code.gson>
-        <version.software.amazon.awssdk>2.28.2</version.software.amazon.awssdk>
+        <version.software.amazon.awssdk>2.29.2</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, by Avro, by the AWS SDK and in tests (wiremock, ...) -->
         <version.com.fasterxml.jackson>2.18.0</version.com.fasterxml.jackson>
         <!-- slf4j: used by the AWS SDK -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5263
https://hibernate.atlassian.net/browse/HSEARCH-5264

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
