### PR TITLE
HSEARCH-5265 Use new group id of the develocity extension in the dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,7 +35,7 @@ updates:
         patterns:
           # Maven extensions:
           - "*-maven-extension"
-          - "org.hibernate.search.develocity:*"
+          - "org.hibernate.infra.develocity:*"
           # Maven plugins:
           - "*maven*plugin*"
           - "org.apache.maven*:*"


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5265

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
