### PR TITLE
HSEARCH-5270 Upgrade to Elasticsearch client 8.16.0 / HSEARCH-5269   Add Elasticsearch 8.16.0 compatibility

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -265,7 +265,8 @@ stage('Configure') {
 					new LocalElasticsearchBuildEnvironment(version: '8.12.2', condition: TestCondition.ON_DEMAND),
 					new LocalElasticsearchBuildEnvironment(version: '8.13.4', condition: TestCondition.ON_DEMAND),
 					new LocalElasticsearchBuildEnvironment(version: '8.14.3', condition: TestCondition.ON_DEMAND),
-					new LocalElasticsearchBuildEnvironment(version: '8.15.3', condition: TestCondition.BEFORE_MERGE, isDefault: true),
+					new LocalElasticsearchBuildEnvironment(version: '8.15.4', condition: TestCondition.ON_DEMAND),
+					new LocalElasticsearchBuildEnvironment(version: '8.16.0', condition: TestCondition.BEFORE_MERGE, isDefault: true),
 					// IMPORTANT: Make sure to update the documentation for any newly supported Elasticsearch versions
 					//            See version.org.elasticsearch.compatible.expected.text
 					//            and version.org.elasticsearch.compatible.regularly-tested.text in POMs.

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
@@ -200,7 +200,7 @@ public class ElasticsearchDialectFactory {
 	}
 
 	private ElasticsearchProtocolDialect createProtocolDialectElasticV8(ElasticsearchVersion version, int minor) {
-		if ( minor > 15 ) {
+		if ( minor > 16 ) {
 			log.unknownElasticsearchVersion( version );
 		}
 		else if ( minor == 0 ) {

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -273,12 +273,20 @@ class ElasticsearchDialectFactoryTest {
 						ElasticsearchDistributionName.ELASTIC, "8.15.0", "8.15.0",
 						Elasticsearch814ModelDialect.class, Elasticsearch81ProtocolDialect.class
 				),
-				successWithWarning(
+				success(
 						ElasticsearchDistributionName.ELASTIC, "8.16", "8.16.0",
 						Elasticsearch814ModelDialect.class, Elasticsearch81ProtocolDialect.class
 				),
-				successWithWarning(
+				success(
 						ElasticsearchDistributionName.ELASTIC, "8.16.0", "8.16.0",
+						Elasticsearch814ModelDialect.class, Elasticsearch81ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.ELASTIC, "8.17", "8.17.0",
+						Elasticsearch814ModelDialect.class, Elasticsearch81ProtocolDialect.class
+				),
+				successWithWarning(
+						ElasticsearchDistributionName.ELASTIC, "8.17.0", "8.17.0",
 						Elasticsearch814ModelDialect.class, Elasticsearch81ProtocolDialect.class
 				),
 				successWithWarning(

--- a/build/container/search-backend/elastic.Dockerfile
+++ b/build/container/search-backend/elastic.Dockerfile
@@ -5,4 +5,4 @@
 #  * update `version.org.elasticsearch.latest` property in a POM file.
 #  * update the tags for 'elasticsearch-current' and 'elasticsearch-next' builds in ci/dependency-update/Jenkinsfile
 #
-FROM docker.io/elastic/elasticsearch:8.15.3
+FROM docker.io/elastic/elasticsearch:8.16.0

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -48,7 +48,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.5+ -->
-        <version.org.elasticsearch.client>8.15.3</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>8.16.0</version.org.elasticsearch.client>
         <!-- The main compatible version of Elasticsearch, advertised by default. Used in documentation links. -->
         <version.org.elasticsearch.compatible.main>${version.org.elasticsearch.latest}</version.org.elasticsearch.compatible.main>
         <documentation.org.elasticsearch.url>https://www.elastic.co/guide/en/elasticsearch/reference/${parsed-version.org.elasticsearch.compatible.main.majorVersion}.${parsed-version.org.elasticsearch.compatible.main.minorVersion}</documentation.org.elasticsearch.url>

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -56,7 +56,7 @@
         <!-- The versions of Elasticsearch advertised as compatible with Hibernate Search -->
         <!-- Make sure to only mention tested versions here -->
         <!-- Make sure that 7.10 stays explicitly mentioned here, because that's the last open-source version -->
-        <version.org.elasticsearch.compatible.regularly-tested.text>7.10, 7.17 or 8.15</version.org.elasticsearch.compatible.regularly-tested.text>
+        <version.org.elasticsearch.compatible.regularly-tested.text>7.10, 7.17 or 8.16</version.org.elasticsearch.compatible.regularly-tested.text>
         <!-- These are the versions same as above, but pointing only to the major part (used in compatibility section of ES backend documentation
           as versions that Hibernate Search is compatible with. -->
         <!-- NOTE: Adding new major versions would require to update the compatibility table in `backend-elasticsearch-compatibility` section of `backend-elasticsearch.asciidoc`. -->

--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -53,7 +53,7 @@ Map settings() {
 					updateProperties: [],
 					onlyRunTestDependingOn: ['hibernate-search-backend-elasticsearch'],
 					// We want to use the snapshot version of an image from the ES registry since that's where they are publishing their snapshots.
-					additionalMavenArgs: '-Dtest.lucene.skip=true -Dtest.elasticsearch.run.elastic.image.name=docker.elastic.co/elasticsearch/elasticsearch -Dtest.elasticsearch.run.elastic.image.tag=8.15.4-SNAPSHOT',
+					additionalMavenArgs: '-Dtest.lucene.skip=true -Dtest.elasticsearch.run.elastic.image.name=docker.elastic.co/elasticsearch/elasticsearch -Dtest.elasticsearch.run.elastic.image.tag=8.16.1-SNAPSHOT',
 					// This job won't change the versions in the pom. We are passing the latest Elasticsearch version through an additional maven argument `-D`
 					skipSourceModifiedCheck: true
 			]
@@ -65,7 +65,19 @@ Map settings() {
 					updateProperties: [],
 					onlyRunTestDependingOn: ['hibernate-search-backend-elasticsearch'],
 					// We want to use the snapshot version of an image from the ES registry since that's where they are publishing their snapshots.
-					additionalMavenArgs: '-Dtest.lucene.skip=true -Dtest.elasticsearch.run.elastic.image.name=docker.elastic.co/elasticsearch/elasticsearch -Dtest.elasticsearch.run.elastic.image.tag=8.16.0-SNAPSHOT',
+					additionalMavenArgs: '-Dtest.lucene.skip=true -Dtest.elasticsearch.run.elastic.image.name=docker.elastic.co/elasticsearch/elasticsearch -Dtest.elasticsearch.run.elastic.image.tag=8.17.0-SNAPSHOT',
+					// This job won't change the versions in the pom. We are passing the latest Elasticsearch version through an additional maven argument `-D`
+					skipSourceModifiedCheck: true
+			]
+		// Targets the next major release of the of Elasticsearch
+		// (currently not published at all)
+		case 'elasticsearch-future':
+			return [
+					// There are no properties to update in this case.
+					updateProperties: [],
+					onlyRunTestDependingOn: ['hibernate-search-backend-elasticsearch'],
+					// We want to use the snapshot version of an image from the ES registry since that's where they are publishing their snapshots.
+					additionalMavenArgs: '-Dtest.lucene.skip=true -Dtest.elasticsearch.run.elastic.image.name=docker.elastic.co/elasticsearch/elasticsearch -Dtest.elasticsearch.run.elastic.image.tag=9.0.0-SNAPSHOT',
 					// This job won't change the versions in the pom. We are passing the latest Elasticsearch version through an additional maven argument `-D`
 					skipSourceModifiedCheck: true
 			]
@@ -133,7 +145,7 @@ pipeline {
 	parameters {
 		// choice parameter doesn't have a default, but the first value should be treated as a default, if it wasn't specified manually.
 		// Make sure tp update axis and settings() when adding new choice parameter.
-		choice(name: 'UPDATE_JOB', choices: ['all', 'orm6.6plus', 'orm7', 'lucene9.12','lucene9', 'lucene10', 'elasticsearch-current', 'elasticsearch-next'], description: 'Select which update jobs to run. `All` will include all configured update jobs.')
+		choice(name: 'UPDATE_JOB', choices: ['all', 'orm6.6plus', 'orm7', 'lucene9.12','lucene9', 'lucene10', 'elasticsearch-current', 'elasticsearch-next', 'elasticsearch-future'], description: 'Select which update jobs to run. `All` will include all configured update jobs.')
 		string(name: 'ORM_REPOSITORY', defaultValue: '', description: 'Git URL to Hibernate ORM repository. If provided, Hibernate ORM will be built locally. Works only in pair with ORM_BRANCH. Provide an http repository URL rather than an ssh one.')
 		string(name: 'ORM_BRANCH', defaultValue: '', description: 'Hibernate ORM branch to build from. If provided, Hibernate ORM will be built locally. Works only in pair with ORM_REPOSITORY. Either a pull request ID or a branch name should be provided, but not both at the same time. Use branch if you want to build from a fork repository.')
 		string(name: 'ORM_PULL_REQUEST_ID', defaultValue: '', description: 'Hibernate ORM pull request id to build from. If provided, Hibernate ORM will be built locally. Works only in pair with ORM_REPOSITORY. Either a pull request ID or a branch name should be provided, but not both at the same time.')
@@ -231,7 +243,7 @@ pipeline {
 						name 'DEPENDENCY_UPDATE_NAME'
 						// NOTE: Remember to update the settings() method above when changing this.
 						// And also add a new choice parameter in the parameters {} section of the pipeline
-						values 'orm6.6plus', 'orm7', 'lucene9.12','lucene9', 'lucene10', 'elasticsearch-current', 'elasticsearch-next'
+						values 'orm6.6plus', 'orm7', 'lucene9.12','lucene9', 'lucene10', 'elasticsearch-current', 'elasticsearch-next', 'elasticsearch-future'
 					}
 				}
 				stages {

--- a/documentation/src/main/asciidoc/public/reference/_compatibility.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_compatibility.adoc
@@ -65,11 +65,13 @@ as part of your dependency management to keep all its artifact versions aligned:
 ====
 
 [NOTE]
-.Elasticsearch 7.11+ licensing
+.Elasticsearch licensing
 ====
 While Elasticsearch up to 7.10 was distributed under the Apache License 2.0,
-be aware that Elasticsearch 7.11 and later are distributed under the Elastic License and the SSPL,
+be aware that Elasticsearch 7.11-8.15 versions are distributed under the Elastic License and the SSPL,
 which are https://opensource.org/node/1099[not considered open-source by the Open Source Initiative].
+Starting with Elasticsearch 8.16 the AGPL v3 license was added.
+Please refer to https://www.elastic.co/ to learn more on the licensing of Elasticsearch.
 
 Only the low-level Java REST client, which Hibernate Search depends on, remains open-source.
 ====

--- a/pom.xml
+++ b/pom.xml
@@ -376,7 +376,7 @@
 
         <!-- Container images for various integration tests -->
         <!-- The latest version of Elasticsearch tested against by default -->
-        <version.org.elasticsearch.latest>8.15.3</version.org.elasticsearch.latest>
+        <version.org.elasticsearch.latest>8.16.0</version.org.elasticsearch.latest>
         <test.elasticsearch.version></test.elasticsearch.version>
         <test.elasticsearch.distribution>elastic</test.elasticsearch.distribution>
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5269
https://hibernate.atlassian.net/browse/HSEARCH-5270

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
