### PR TITLE
Upgrade to hibernate-jenkins-pipeline-helpers 1.18 -- and configure the version on CI instead of in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@
 /*
  * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
  */
-@Library('hibernate-jenkins-pipeline-helpers@1.18') _
+@Library('hibernate-jenkins-pipeline-helpers') _
 
 import groovy.transform.Field
 import org.hibernate.jenkins.pipeline.helpers.job.JobHelper

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@
 /*
  * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
  */
-@Library('hibernate-jenkins-pipeline-helpers@1.13') _
+@Library('hibernate-jenkins-pipeline-helpers@1.18') _
 
 import groovy.transform.Field
 import org.hibernate.jenkins.pipeline.helpers.job.JobHelper

--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -3,7 +3,7 @@
  * Copyright Red Hat Inc. and Hibernate Authors
  */
 
-@Library('hibernate-jenkins-pipeline-helpers@1.18') _
+@Library('hibernate-jenkins-pipeline-helpers') _
 
 // NOTE: Remember to update the matrix axes below when adding/removing entries here.
 // Also make sure to update the parameters in the parameters {} section of the pipeline.

--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -3,7 +3,7 @@
  * Copyright Red Hat Inc. and Hibernate Authors
  */
 
-@Library('hibernate-jenkins-pipeline-helpers@1.13') _
+@Library('hibernate-jenkins-pipeline-helpers@1.18') _
 
 // NOTE: Remember to update the matrix axes below when adding/removing entries here.
 // Also make sure to update the parameters in the parameters {} section of the pipeline.

--- a/ci/performance/elasticsearch/Jenkinsfile
+++ b/ci/performance/elasticsearch/Jenkinsfile
@@ -6,7 +6,7 @@
 /*
  * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
  */
-@Library('hibernate-jenkins-pipeline-helpers@1.18') _
+@Library('hibernate-jenkins-pipeline-helpers') _
 
 import groovy.transform.Field
 import org.hibernate.jenkins.pipeline.helpers.job.JobHelper

--- a/ci/performance/elasticsearch/Jenkinsfile
+++ b/ci/performance/elasticsearch/Jenkinsfile
@@ -6,7 +6,7 @@
 /*
  * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
  */
-@Library('hibernate-jenkins-pipeline-helpers@1.13') _
+@Library('hibernate-jenkins-pipeline-helpers@1.18') _
 
 import groovy.transform.Field
 import org.hibernate.jenkins.pipeline.helpers.job.JobHelper

--- a/ci/performance/lucene/Jenkinsfile
+++ b/ci/performance/lucene/Jenkinsfile
@@ -6,7 +6,7 @@
 /*
  * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
  */
-@Library('hibernate-jenkins-pipeline-helpers@1.18') _
+@Library('hibernate-jenkins-pipeline-helpers') _
 
 import groovy.transform.Field
 import org.hibernate.jenkins.pipeline.helpers.job.JobHelper

--- a/ci/performance/lucene/Jenkinsfile
+++ b/ci/performance/lucene/Jenkinsfile
@@ -6,7 +6,7 @@
 /*
  * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
  */
-@Library('hibernate-jenkins-pipeline-helpers@1.13') _
+@Library('hibernate-jenkins-pipeline-helpers@1.18') _
 
 import groovy.transform.Field
 import org.hibernate.jenkins.pipeline.helpers.job.JobHelper

--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -3,7 +3,7 @@
  * Copyright Red Hat Inc. and Hibernate Authors
  */
 
-@Library('hibernate-jenkins-pipeline-helpers@1.18') _
+@Library('hibernate-jenkins-pipeline-helpers') _
 
 import org.hibernate.jenkins.pipeline.helpers.version.Version
 

--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -3,7 +3,7 @@
  * Copyright Red Hat Inc. and Hibernate Authors
  */
 
-@Library('hibernate-jenkins-pipeline-helpers@1.13') _
+@Library('hibernate-jenkins-pipeline-helpers@1.18') _
 
 import org.hibernate.jenkins.pipeline.helpers.version.Version
 


### PR DESCRIPTION
Upgrade to 1.18 to avoid buggy notifications.
See https://hibernate.zulipchat.com/#narrow/channel/132096-hibernate-user/topic/Jenkins.20Notifications
Full changeset: https://github.com/hibernate/hibernate-jenkins-pipeline-helpers/compare/1.13..1.18

Don't configure the version in Jenkinsfile so that it's easier to upgrade next time.
See https://ci.hibernate.org/manage/configure#global-untrusted-pipeline-libraries to change the (default) version globally for all projects.


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
