### PR TITLE
Do not use "net.bytebuddy.experimental=true" on JDK 23 build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -200,7 +200,7 @@ stage('Configure') {
 					// Make sure to remove that argument as soon as possible
 					// -- generally that requires upgrading bytebuddy in Hibernate ORM after the JDK goes GA.
 					new JdkBuildEnvironment(version: '23', testCompilerTool: 'OpenJDK 23 Latest',
-							testLauncherArgs: '--enable-preview -Dnet.bytebuddy.experimental=true',
+							testLauncherArgs: '--enable-preview',
 							condition: TestCondition.AFTER_MERGE),
 					new JdkBuildEnvironment(version: '24', testCompilerTool: 'OpenJDK 24 Latest',
 							testLauncherArgs: '--enable-preview -Dnet.bytebuddy.experimental=true',


### PR DESCRIPTION


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
