### PR TITLE
Use the version of hibernate-jenkins-pipeline-helpers configured on CI in nightly job

### DIFF
--- a/ci/nightly/Jenkinsfile
+++ b/ci/nightly/Jenkinsfile
@@ -3,7 +3,7 @@
  * Copyright Red Hat Inc. and Hibernate Authors
  */
 
-@Library('hibernate-jenkins-pipeline-helpers@1.17') _
+@Library('hibernate-jenkins-pipeline-helpers') _
 
 def withMavenWorkspace(Closure body) {
 	withMaven(jdk: 'OpenJDK 21 Latest', maven: 'Apache Maven 3.9',


### PR DESCRIPTION
this one slipped when others were updated 🙈 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
