### PR TITLE
Downgrade log4j to 2.24.1

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -127,7 +127,7 @@
         <!-- Test dependencies -->
 
         <!-- >>> Common -->
-        <version.log4j>2.24.2</version.log4j>
+        <version.log4j>2.24.1</version.log4j>
         <version.junit>4.13.2</version.junit>
         <version.junit-jupiter>5.11.3</version.junit-jupiter>
         <version.junit-platform-suite-engine>1.10.0</version.junit-platform-suite-engine>


### PR DESCRIPTION
because of the https://github.com/apache/logging-log4j2/issues/3234

We get occasional failures: https://ge.hibernate.org/s/cgbajaw6inj6q/tests/goal/org.hibernate.search:hibernate-search-integrationtest-backend-elasticsearch:failsafe:integration-test@it/details/org.hibernate.search.integrationtest.backend.elasticsearch.client.ElasticsearchClientFactoryImplIT/uris_http%5B1%5D?top-execution=1

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
