### PR TITLE
HSEARCH-5284 Upgrade to Hibernate ORM 7.0.0.Beta3 / HSEARCH-5271 Reenable the ORM tests related to bytecode enhancement

### DIFF
--- a/build/config/pom.xml
+++ b/build/config/pom.xml
@@ -252,6 +252,7 @@
                                 <argument>^org\.hibernate\.query\.spi\.ScrollableResultsImplementor$</argument>
                                 <argument>^org\.hibernate\.query\.spi\.QueryParameterBindingTypeResolver$</argument>
                                 <argument>^org\.hibernate\.query\.sqm\.spi\.SqmCreationContext$</argument>
+                                <argument>^org\.hibernate\.sql\.results\.graph\.Fetchable$</argument>
                             </arguments>
                             <!--
                                 While this will include more than we really need, it is easier to do so.

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -93,7 +93,7 @@
             NOTE: when Hibernate ORM updates Byte Buddy, make sure to check Jenkinsfile to see if
             `net.bytebuddy.experimental` property can be removed.
          -->
-        <version.org.hibernate.orm>7.0.0.Beta2</version.org.hibernate.orm>
+        <version.org.hibernate.orm>7.0.0.Beta3</version.org.hibernate.orm>
         <version.org.hibernate.models>0.9.3</version.org.hibernate.models>
 
         <javadoc.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/javadocs/</javadoc.org.hibernate.orm.url>
@@ -396,6 +396,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- To be removed with the next snapshot builds: -->
+            <dependency>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-scan-jandex</artifactId>
+                <version>${version.org.hibernate.orm}</version>
+            </dependency>
             <!-- Imported dependencies that we want to override -->
             <dependency>
                 <groupId>org.jboss.logging</groupId>
@@ -406,17 +412,6 @@
                 <groupId>org.hibernate.models</groupId>
                 <artifactId>hibernate-models-jandex</artifactId>
                 <version>${version.org.hibernate.models}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.orm</groupId>
-                <artifactId>hibernate-core</artifactId>
-                <version>${version.org.hibernate.orm}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.hibernate.orm</groupId>
-                        <artifactId>hibernate-scan-jandex</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <!-- Other public dependencies -->

--- a/integrationtest/mapper/orm-jakarta-batch/pom.xml
+++ b/integrationtest/mapper/orm-jakarta-batch/pom.xml
@@ -33,6 +33,11 @@
     </properties>
 
     <dependencies>
+        <!-- Need to have a dependency on scanner if we want to rely on automatic entity discovery in tests: -->
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-scan-jandex</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-mapper-orm-jakarta-batch-core</artifactId>
@@ -48,7 +53,6 @@
             <artifactId>hibernate-search-util-internal-integrationtest-mapper-orm</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-backend-lucene</artifactId>

--- a/integrationtest/mapper/orm-jakarta-batch/src/test/java/org/hibernate/search/integrationtest/jakarta/batch/massindexing/EntityManagerFactoryRetrievalIT.java
+++ b/integrationtest/mapper/orm-jakarta-batch/src/test/java/org/hibernate/search/integrationtest/jakarta/batch/massindexing/EntityManagerFactoryRetrievalIT.java
@@ -23,13 +23,11 @@ import org.hibernate.search.jakarta.batch.core.massindexing.MassIndexingJob;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
  * @author Mincong Huang
  */
-@Disabled("Requires next Hibernate ORM 7 release.")
 class EntityManagerFactoryRetrievalIT {
 
 	private static final String PERSISTENCE_UNIT_NAME = PersistenceUnitTestUtil.getPersistenceUnitName();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedLazyOnContainedSideIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedLazyOnContainedSideIT.java
@@ -45,7 +45,6 @@ import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
 import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -54,7 +53,6 @@ import org.junit.jupiter.api.Test;
  * with a {@code @OneToOne} association owned by the contained side,
  * and with lazy associations on the contained side.
  */
-@Disabled("Requires next Hibernate ORM 7 release.")
 @BytecodeEnhanced // So that we can have lazy *ToOne associations
 @EnhancementOptions(lazyLoading = true)
 @TestForIssue(jiraKey = "HSEARCH-4305")

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedLazyOnContainingSideIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontained/AutomaticIndexingOneToOneOwnedByContainedLazyOnContainingSideIT.java
@@ -45,7 +45,6 @@ import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
 import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -54,7 +53,6 @@ import org.junit.jupiter.api.Test;
  * with a {@code @OneToOne} association owned by the contained side,
  * and with lazy associations on the containing side.
  */
-@Disabled("Requires next Hibernate ORM 7 release.")
 @BytecodeEnhanced // So that we can have lazy *ToOne associations
 @EnhancementOptions(lazyLoading = true)
 @TestForIssue(jiraKey = "HSEARCH-4305")

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontaining/AutomaticIndexingOneToOneOwnedByContainingLazyOnContainedSideIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontaining/AutomaticIndexingOneToOneOwnedByContainingLazyOnContainedSideIT.java
@@ -45,7 +45,6 @@ import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
 import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -54,7 +53,6 @@ import org.junit.jupiter.api.Test;
  * with a {@code @OneToOne} association owned by the containing side,
  * and with lazy associations on the contained side.
  */
-@Disabled("Requires next Hibernate ORM 7 release.")
 @BytecodeEnhanced // So that we can have lazy *ToOne associations
 @EnhancementOptions(lazyLoading = true)
 class AutomaticIndexingOneToOneOwnedByContainingLazyOnContainedSideIT

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontaining/AutomaticIndexingOneToOneOwnedByContainingLazyOnContainingSideIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/bytype/onetoone/ownedbycontaining/AutomaticIndexingOneToOneOwnedByContainingLazyOnContainingSideIT.java
@@ -45,7 +45,6 @@ import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
 import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -54,7 +53,6 @@ import org.junit.jupiter.api.Test;
  * with a {@code @OneToOne} association owned by the containing side,
  * and with lazy associations on the containing side.
  */
-@Disabled("Requires next Hibernate ORM 7 release.")
 @BytecodeEnhanced // So that we can have lazy *ToOne associations
 @EnhancementOptions(lazyLoading = true)
 class AutomaticIndexingOneToOneOwnedByContainingLazyOnContainingSideIT

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingErrorIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingErrorIT.java
@@ -16,7 +16,7 @@ import java.util.function.Consumer;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 
-import org.hibernate.BaseSessionEventListener;
+import org.hibernate.SessionEventListener;
 import org.hibernate.SessionFactory;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
@@ -585,7 +585,7 @@ public abstract class AbstractMassIndexingErrorIT {
 		}
 	}
 
-	public static class JdbcStatementErrorOnIdLoadingThreadListener extends BaseSessionEventListener {
+	public static class JdbcStatementErrorOnIdLoadingThreadListener implements SessionEventListener {
 		private static final String MESSAGE = "Simulated JDBC statement error on ID loading";
 
 		@Override
@@ -596,7 +596,7 @@ public abstract class AbstractMassIndexingErrorIT {
 		}
 	}
 
-	public static class JdbcStatementErrorOnEntityLoadingThreadListener extends BaseSessionEventListener {
+	public static class JdbcStatementErrorOnEntityLoadingThreadListener implements SessionEventListener {
 		private static final String MESSAGE = "Simulated JDBC statement error on entity loading";
 
 		@Override

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingFailureIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingFailureIT.java
@@ -17,7 +17,7 @@ import java.util.function.Consumer;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 
-import org.hibernate.BaseSessionEventListener;
+import org.hibernate.SessionEventListener;
 import org.hibernate.SessionFactory;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
@@ -888,7 +888,7 @@ public abstract class AbstractMassIndexingFailureIT {
 		}
 	}
 
-	public static class JdbcStatementFailureOnIdLoadingThreadListener extends BaseSessionEventListener {
+	public static class JdbcStatementFailureOnIdLoadingThreadListener implements SessionEventListener {
 		private static final String MESSAGE = "Simulated JDBC statement failure on ID loading";
 
 		@Override
@@ -899,7 +899,7 @@ public abstract class AbstractMassIndexingFailureIT {
 		}
 	}
 
-	public static class JdbcStatementFailureOnEntityLoadingThreadListener extends BaseSessionEventListener {
+	public static class JdbcStatementFailureOnEntityLoadingThreadListener implements SessionEventListener {
 		private static final String MESSAGE = "Simulated JDBC statement failure on entity loading";
 
 		@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/common/impl/HibernateOrmUtils.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/common/impl/HibernateOrmUtils.java
@@ -18,7 +18,7 @@ import jakarta.persistence.EntityManagerFactory;
 import org.hibernate.Session;
 import org.hibernate.binder.internal.TenantIdBinder;
 import org.hibernate.boot.Metadata;
-import org.hibernate.boot.models.categorize.internal.ClassLoaderServiceLoading;
+import org.hibernate.boot.models.internal.ClassLoaderServiceLoading;
 import org.hibernate.boot.models.internal.ModelsHelper;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.BootstrapContext;

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmSoftAssertions.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmSoftAssertions.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
-import org.hibernate.BaseSessionEventListener;
 import org.hibernate.Session;
 import org.hibernate.SessionEventListener;
 import org.hibernate.SessionFactory;
@@ -45,7 +44,7 @@ public class OrmSoftAssertions extends AutoCloseableSoftAssertions {
 		statistics = sessionFactory.getStatistics();
 		statistics.setStatisticsEnabled( true );
 		statistics.clear();
-		sessionEventListener = new BaseSessionEventListener() {
+		sessionEventListener = new SessionEventListener() {
 			@Override
 			public void jdbcPrepareStatementStart() {
 				++statementExecutionCount;

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/SlowerLoadingListener.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/SlowerLoadingListener.java
@@ -6,11 +6,11 @@ package org.hibernate.search.util.impl.integrationtest.mapper.orm;
 
 import static org.assertj.core.api.Assertions.fail;
 
-import org.hibernate.BaseSessionEventListener;
 import org.hibernate.Session;
+import org.hibernate.SessionEventListener;
 import org.hibernate.engine.spi.SessionImplementor;
 
-public class SlowerLoadingListener extends BaseSessionEventListener {
+public class SlowerLoadingListener implements SessionEventListener {
 
 	public static void registerSlowerLoadingListener(Session session, long delay) {
 		session.unwrap( SessionImplementor.class ).addEventListeners( new SlowerLoadingListener( delay ) );

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/TimeoutLoadingListener.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/TimeoutLoadingListener.java
@@ -4,12 +4,12 @@
  */
 package org.hibernate.search.util.impl.integrationtest.mapper.orm;
 
-import org.hibernate.BaseSessionEventListener;
 import org.hibernate.QueryTimeoutException;
 import org.hibernate.Session;
+import org.hibernate.SessionEventListener;
 import org.hibernate.engine.spi.SessionImplementor;
 
-public class TimeoutLoadingListener extends BaseSessionEventListener {
+public class TimeoutLoadingListener implements SessionEventListener {
 
 	public static void registerTimingOutLoadingListener(Session session) {
 		session.unwrap( SessionImplementor.class ).addEventListeners( new TimeoutLoadingListener() );


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5284
https://hibernate.atlassian.net/browse/HSEARCH-5271

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
