### PR TITLE
HSEARCH-5285 Add Pojo Standalone mapper Javadocs to the bundle

### DIFF
--- a/build/enforcer/src/main/java/org/hibernate/search/build/enforcer/JavadocSourcePathIncludesAllPublicArtifactsRule.java
+++ b/build/enforcer/src/main/java/org/hibernate/search/build/enforcer/JavadocSourcePathIncludesAllPublicArtifactsRule.java
@@ -1,0 +1,112 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.build.enforcer;
+
+import static org.hibernate.search.build.enforcer.MavenProjectUtils.isAnyParentPublicParent;
+import static org.hibernate.search.build.enforcer.MavenProjectUtils.isAnyParentRelocationParent;
+import static org.hibernate.search.build.enforcer.MavenProjectUtils.isProjectDeploySkipped;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
+@Named("javadocSourcePathIncludesAllPublicArtifactsRule") // rule name - must start with lowercase character
+public class JavadocSourcePathIncludesAllPublicArtifactsRule extends AbstractEnforcerRule {
+
+	private static final String JAVADOC_PLUGIN = "org.apache.maven.plugins:maven-javadoc-plugin";
+	private static final String EXECUTION_GENERATE_JAVADOC = "generate-javadoc";
+	// Inject needed Maven components
+	@Inject
+	private MavenSession session;
+
+	/**
+	 * Rule parameter as list of items.
+	 */
+	private Set<String> pathsToSkip;
+
+	public void execute() throws EnforcerRuleException {
+		Plugin plugin = session.getCurrentProject().getPlugin( JAVADOC_PLUGIN );
+		if ( plugin == null ) {
+			throw new EnforcerRuleException( "Project %s:%s does not configure the Javadoc plugin (%s)!"
+					.formatted( session.getCurrentProject().getGroupId(), session.getCurrentProject().getArtifactId(),
+							JAVADOC_PLUGIN ) );
+		}
+
+		PluginExecution execution = plugin.getExecutionsAsMap().get( EXECUTION_GENERATE_JAVADOC );
+		if ( execution == null ) {
+			throw new EnforcerRuleException( "Project %s:%s does not configure the Javadoc plugin (%s) execution \"%s\"!"
+					.formatted( session.getCurrentProject().getGroupId(), session.getCurrentProject().getArtifactId(),
+							JAVADOC_PLUGIN, EXECUTION_GENERATE_JAVADOC ) );
+		}
+
+		if ( execution.getConfiguration() instanceof Xpp3Dom configuration ) {
+			Xpp3Dom sourcePaths = configuration.getChild( "sourcepath" );
+			if ( sourcePaths == null ) {
+				throw new EnforcerRuleException(
+						"Project %s:%s does not specify the Javadoc plugin (%s) execution \"%s\" sourcepath configuration attribute!"
+								.formatted( session.getCurrentProject().getGroupId(),
+										session.getCurrentProject().getArtifactId(),
+										JAVADOC_PLUGIN, EXECUTION_GENERATE_JAVADOC ) );
+			}
+			Path rootProjectPath = getRootProjectPath( session.getCurrentProject() );
+
+			List<Path> configuredPaths = Arrays.stream( sourcePaths.getValue().split( ";" ) )
+					.map( String::trim )
+					.map( Path::of )
+					.map( Path::normalize )
+					.toList();
+
+			Set<Path> expectations = expectedJavaDocPaths( rootProjectPath );
+
+			configuredPaths.forEach( expectations::remove );
+			if ( !expectations.isEmpty() ) {
+				throw new EnforcerRuleException( "Expected Javadoc source paths are missing: %s".formatted( expectations ) );
+			}
+		}
+	}
+
+	private Path getRootProjectPath(MavenProject project) {
+		return project.getParent() == null ? project.getBasedir().toPath() : getRootProjectPath( project.getParent() );
+	}
+
+	private Set<Path> expectedJavaDocPaths(Path rootProjectPath) {
+		Set<Path> expectations = new HashSet<>();
+		Set<Path> checkPaths = pathsToSkip.stream().map( Path::of ).collect( Collectors.toSet() );
+
+		for ( MavenProject project : session.getAllProjects() ) {
+			boolean publicParent = isAnyParentPublicParent( project );
+			boolean relocationParent = isAnyParentRelocationParent( project );
+			boolean canContainSourcesWithPublishableJavadoc = publicParent && !relocationParent;
+			boolean deploySkipped = isProjectDeploySkipped( project );
+
+			if ( canContainSourcesWithPublishableJavadoc && !deploySkipped ) {
+				Path path = project.getBasedir().toPath();
+
+				for ( String sourceRoot : project.getCompileSourceRoots() ) {
+					Path source = path.resolve( sourceRoot ).normalize();
+					if ( !checkPaths.contains( rootProjectPath.relativize( path.resolve( sourceRoot ) ) ) ) {
+						expectations.add( source );
+					}
+				}
+			}
+		}
+
+		return expectations;
+	}
+}

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -165,12 +165,13 @@
                                 ${basedir}/../util/common/src/main/java;
                                 ${basedir}/../mapper/pojo-base/src/main/java;
                                 ${basedir}/../mapper/orm/src/main/java;
+                                ${basedir}/../mapper/pojo-standalone/src/main/java;
                                 ${basedir}/../backend/elasticsearch/src/main/java;
                                 ${basedir}/../backend/elasticsearch-aws/src/main/java;
                                 ${basedir}/../backend/lucene/src/main/java;
-                                ${basedir}/../mapper/lucene/src/main/java;
                                 ${basedir}/../mapper/orm-outbox-polling/src/main/java;
                                 ${basedir}/../mapper/orm-jakarta-batch/core/src/main/java;
+                                ${basedir}/../mapper/orm-jakarta-batch/jberet/src/main/java;
                             </sourcepath>
                             <docfilessubdirs>true</docfilessubdirs>
                             <packagesheader>Hibernate Search Packages</packagesheader>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -160,6 +160,8 @@
                         <configuration>
                             <!-- We don't include the v5migrationhelper modules here,
                                  so as not to confuse the documentation with obsolete API -->
+                            <!-- While the generated sources will unlikely contain any public classes for which we
+                                 have to generate any JavaDocs, we still include them for completeness -->
                             <sourcepath>
                                 ${basedir}/../engine/src/main/java;
                                 ${basedir}/../util/common/src/main/java;
@@ -172,6 +174,18 @@
                                 ${basedir}/../mapper/orm-outbox-polling/src/main/java;
                                 ${basedir}/../mapper/orm-jakarta-batch/core/src/main/java;
                                 ${basedir}/../mapper/orm-jakarta-batch/jberet/src/main/java;
+                                ${basedir}/../engine/target/generated-sources/annotations;
+                                ${basedir}/../util/common/target/generated-sources/annotations;
+                                ${basedir}/../mapper/pojo-base/target/generated-sources/annotations;
+                                ${basedir}/../mapper/orm/target/generated-sources/annotations;
+                                ${basedir}/../mapper/pojo-standalone/target/generated-sources/annotations;
+                                ${basedir}/../backend/elasticsearch/target/generated-sources/annotations;
+                                ${basedir}/../backend/elasticsearch-aws/target/generated-sources/annotations;
+                                ${basedir}/../backend/lucene/target/generated-sources/annotations;
+                                ${basedir}/../mapper/orm-outbox-polling/src/main/avro/generated;
+                                ${basedir}/../mapper/orm-outbox-polling/target/generated-sources/annotations;
+                                ${basedir}/../mapper/orm-jakarta-batch/core/target/generated-sources/annotations;
+                                ${basedir}/../mapper/orm-jakarta-batch/jberet/target/generated-sources/annotations;
                             </sourcepath>
                             <docfilessubdirs>true</docfilessubdirs>
                             <packagesheader>Hibernate Search Packages</packagesheader>
@@ -219,6 +233,8 @@
                                     <pathsToSkip>
                                         <path>v5migrationhelper/engine/src/main/java</path>
                                         <path>v5migrationhelper/orm/src/main/java</path>
+                                        <path>v5migrationhelper/orm/target/generated-sources/annotations</path>
+                                        <path>v5migrationhelper/engine/target/generated-sources/annotations</path>
                                     </pathsToSkip>
                                 </javadocSourcePathIncludesAllPublicArtifactsRule>
                             </rules>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -202,6 +202,37 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-custom-javadoc-bundle-rules</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <javadocSourcePathIncludesAllPublicArtifactsRule>
+                                    <!-- We don't include the v5migrationhelper modules here,
+                                        so as not to confuse the documentation with obsolete API -->
+                                    <pathsToSkip>
+                                        <path>v5migrationhelper/engine/src/main/java</path>
+                                        <path>v5migrationhelper/orm/src/main/java</path>
+                                    </pathsToSkip>
+                                </javadocSourcePathIncludesAllPublicArtifactsRule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.hibernate.search</groupId>
+                        <artifactId>hibernate-search-build-enforcer</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5285

While really the config was missing `mapper/pojo-standalone/src/main/java` and had a redundant `mapper/lucene/src/main/java`  this PR also adds an enforcer check, and while adding it it pointed out that the generated sources aren't included. So I've added those too, just in case.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
