### PR TITLE
Backport of HSEARCH-5285 to 7.0 Clean up the list of sources to include in the Javadoc bundle

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -167,12 +167,13 @@
                                 ${basedir}/../util/common/src/main/java;
                                 ${basedir}/../mapper/pojo-base/src/main/java;
                                 ${basedir}/../mapper/orm/src/main/java;
+                                ${basedir}/../mapper/pojo-standalone/src/main/java;
                                 ${basedir}/../backend/elasticsearch/src/main/java;
                                 ${basedir}/../backend/elasticsearch-aws/src/main/java;
                                 ${basedir}/../backend/lucene/src/main/java;
-                                ${basedir}/../mapper/lucene/src/main/java;
                                 ${basedir}/../mapper/orm-outbox-polling/src/main/java;
                                 ${basedir}/../mapper/orm-jakarta-batch/core/src/main/java;
+                                ${basedir}/../mapper/orm-jakarta-batch/jberet/src/main/java;
                             </sourcepath>
                             <docfilessubdirs>true</docfilessubdirs>
                             <packagesheader>Hibernate Search Packages</packagesheader>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5285

(cherry picked from commit 12b9dda67e4de06ef84567f8b7192b4974d03a51)


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
