### PR TITLE
Use specific Jenkins nodes for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Red Hat Inc. and Hibernate Authors
 
-# The main CI of Hibernate Search is https://ci.hibernate.org/job/hibernate-search/.
-# However, Hibernate Search builds run on GitHub actions regularly
-# to build on Windows
-# and check that both the Linux and Windows workflows still work
-# and can be used in GitHub forks.
-# See https://docs.github.com/en/actions
-# for more information about GitHub actions.
+# This is not the main CI job, but it is useful on forks.
+# See MAINTAINERS.md for details about all available CI jobs.
 
 name: GH Actions CI
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -507,7 +507,6 @@ For primary branches, it may also re-execute the same build in different environ
 See [this section](#building-from-source) for information on how to execute similar builds from the commandline.
 
 The job can be triggered manually, which is particularly useful to test more environments on a pull request.
-
 ### Release pipeline
 
 https://ci.hibernate.org/job/hibernate-search/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -481,54 +481,8 @@ The Neo4j web UI will be accessible from http://localhost:7474/.
 
 ## <a id="ci"></a> Continuous integration
 
-Continuous integration happens on a self-hosted Jenkins instance at https://ci.hibernate.org.
+See [MAINTAINERS.md](MAINTAINERS.md#ci) for information about CI.
 
-Several multi-branch pipelines are available.
-
-### Main pipeline
-
-https://ci.hibernate.org/job/hibernate-search/
-
-See [Jenkinsfile](Jenkinsfile).
-
-This job takes care of:
-
-* Primary branch builds
-* Pull request builds
-
-It executes the build in a default environment, at the very least.
-For primary branches, it may also re-execute the same build in different environments:
-
-* Newer JDKs
-* Different database vendors (PostgreSQL, Oracle, ...)
-* Different versions of Elasticsearch/OpenSearch
-* AWS Elasticsearch/OpenSearch Service
-
-See [this section](#building-from-source) for information on how to execute similar builds from the commandline.
-
-The job can be triggered manually, which is particularly useful to test more environments on a pull request.
-### Release pipeline
-
-https://ci.hibernate.org/job/hibernate-search/
-
-See [Jenkinsfile](Jenkinsfile).
-
-This job takes care of:
-
-* Primary branch builds
-* Pull request builds
-
-It executes the build in a default environment, at the very least.
-For primary branches, it may also re-execute the same build in different environments:
-
-* Newer JDKs
-* Different database vendors (PostgreSQL, Oracle, ...)
-* Different versions of Elasticsearch/OpenSearch
-* AWS Elasticsearch/OpenSearch Service
-
-See [this section](#building-from-source) for information on how to execute similar builds from the commandline.
-
-The job can be triggered manually, which is particularly useful to test more environments on a pull request.
 ## More conventions
 
 ### Naming and architecture rules

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,11 +8,12 @@ i.e. anybody with direct push access to the git repository.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## Continuous integration
+## <a id="ci"></a> Continuous integration
 
-Continuous integration happens on a self-hosted Jenkins instance at https://ci.hibernate.org.
+Continuous integration happens on a self-hosted Jenkins instance at https://ci.hibernate.org,
+and to a smaller extent on GitHub Actions.
 
-Several multi-branch pipelines are available.
+Below is a list of all notable workflows/jobs.
 
 ### Main pipeline
 
@@ -39,6 +40,15 @@ For primary branches, it may also re-execute the same build in different environ
 
 See [CONTRIBUTING.md](CONTRIBUTING.md#building-from-source)
 for information about how to execute similar builds from the commandline.
+
+### GitHub Actions workflow
+
+A GitHub Actions workflow is set up, mainly to build/test on Windows,
+and to help contributors build Hibernate Search from their own GitHub fork.
+
+See [.github/workflows](.github/workflows) for the workflow definition.
+
+See https://docs.github.com/en/actions for more information about GitHub actions.
 
 ### Snapshot publishing pipeline
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -40,6 +40,17 @@ For primary branches, it may also re-execute the same build in different environ
 See [CONTRIBUTING.md](CONTRIBUTING.md#building-from-source)
 for information about how to execute similar builds from the commandline.
 
+### Snapshot publishing pipeline
+
+https://ci.hibernate.org/job/hibernate-search-publish-snapshot/
+
+This job takes care of publishing snapshots for primary branches.
+
+It is triggered automatically on push to each branch, but throttled
+to avoid problems when multiple PRs get merged in short span of time.
+
+See [ci/snapshot-publish/Jenkinsfile](ci/snapshot-publish/Jenkinsfile) for the job definition.
+
 ### Release pipeline
 
 https://ci.hibernate.org/job/hibernate-search-release/

--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -9,7 +9,7 @@ import org.hibernate.jenkins.pipeline.helpers.version.Version
 
 pipeline {
 	agent {
-		label 'Worker&&Containers'
+		label 'Release'
 	}
 	tools {
 		maven 'Apache Maven 3.9'

--- a/ci/snapshot-publish/Jenkinsfile
+++ b/ci/snapshot-publish/Jenkinsfile
@@ -14,7 +14,7 @@ if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
 
 pipeline {
 	agent {
-		label 'Worker&&Containers'
+		label 'Release'
 	}
 	tools {
 		maven 'Apache Maven 3.9'

--- a/ci/snapshot-publish/Jenkinsfile
+++ b/ci/snapshot-publish/Jenkinsfile
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+
+@Library('hibernate-jenkins-pipeline-helpers') _
+
+// Avoid running the pipeline on branch indexing
+if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
+	print "INFO: Build skipped due to trigger being Branch Indexing"
+	currentBuild.result = 'NOT_BUILT'
+	return
+}
+
+pipeline {
+	agent {
+		label 'Worker&&Containers'
+	}
+	tools {
+		maven 'Apache Maven 3.9'
+		jdk 'OpenJDK 21 Latest'
+	}
+	options {
+		// Wait for 1h before publishing snapshots, in case there's more commits.
+		quietPeriod 3600
+		// In any case, never publish snapshots more than once per hour.
+		rateLimitBuilds(throttle: [count: 1, durationName: 'hour', userBoost: true])
+
+		buildDiscarder(logRotator(numToKeepStr: '3', artifactNumToKeepStr: '3'))
+		disableConcurrentBuilds(abortPrevious: false)
+	}
+	stages {
+		stage('Publish') {
+			steps {
+				script {
+					withMaven(mavenSettingsConfig: 'ci-hibernate.deploy.settings.maven',
+							mavenLocalRepo: env.WORKSPACE_TMP + '/.m2repository') {
+						sh """mvn \
+								-Pci-build \
+								-DskipTests \
+								clean deploy \
+						"""
+					}
+				}
+			}
+		}
+	}
+	post {
+		always {
+			notifyBuildResult notifySuccessAfterSuccess: false, maintainers: 'marko@hibernate.org'
+		}
+	}
+}


### PR DESCRIPTION
This should be safer. 

It requires moving the snapshot publishing to a dedicated job, but ORM already does that, so we might as well align.

I took this opportunity to clean up sections about CI in `CONTRIBUTING.md`/`MAINTAINERS.md`.

We'll need to backport this to all branches where we want to perform releases or publish snapshots...

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
