### PR TITLE
HSEARCH-5287 Test Hibernate Search against JDK 25

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -193,6 +193,9 @@ stage('Configure') {
 							condition: TestCondition.AFTER_MERGE),
 					new JdkBuildEnvironment(version: '24', testCompilerTool: 'OpenJDK 24 Latest',
 							testLauncherArgs: '--enable-preview -Dnet.bytebuddy.experimental=true',
+							condition: TestCondition.AFTER_MERGE),
+					new JdkBuildEnvironment(version: '25', testCompilerTool: 'OpenJDK 25 Latest',
+							testLauncherArgs: '--enable-preview -Dnet.bytebuddy.experimental=true',
 							condition: TestCondition.AFTER_MERGE)
 					// IMPORTANT: Make sure to update the documentation for any newly supported Java versions
 					//            See java-version.main.compatible.expected.text in POMs.


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5287

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
