### PR TITLE
HSEARCH-5299 Upgrade to commons-codec 1.17.2

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -147,7 +147,7 @@
         <version.org.apache.commons.lang3>3.17.0</version.org.apache.commons.lang3>
         <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
         <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
-        <version.commons-codec>1.17.1</version.commons-codec>
+        <version.commons-codec>1.17.2</version.commons-codec>
         <!--
             When upgrading Avro:
                 - make sure to create a new payload in EventPayloadSerializationUtilsTest


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5299

Bump commons-codec:commons-codec from 1.17.1 to 1.17.2

Bumps [commons-codec:commons-codec](https://github.com/apache/commons-codec) from 1.17.1 to 1.17.2.
- [Changelog](https://github.com/apache/commons-codec/blob/master/RELEASE-NOTES.txt)
- [Commits](https://github.com/apache/commons-codec/compare/rel/commons-codec-1.17.1...rel/commons-codec-1.17.2)

---
updated-dependencies:
- dependency-name: commons-codec:commons-codec dependency-type: direct:production update-type: version-update:semver-patch ...

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HSEARCH.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HSEARCH-<digits>`).
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
