### PR TITLE
Dependabot config updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,14 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: monthly
+    groups:
+      workflow-actions:
+        patterns:
+          - "*"
+    allow:
+      - dependency-name: "actions/*"
+      - dependency-name: "redhat-actions/*"
   - package-ecosystem: "maven"
     directory: "/"
     schedule:

--- a/.github/hibernate-github-bot.yml
+++ b/.github/hibernate-github-bot.yml
@@ -4,7 +4,7 @@ jira:
   ignore:
     # See the `build-dependencies` group in the Dependabot's configuration file
     - user: dependabot[bot]
-      titlePattern: "Bump.*the build-dependencies group( across \\d+ director(ies|y))?( with \\d+ updates?)?"
+      titlePattern: "Bump.*the (build-dependencies|database-containers|build-containers|workflow-actions) group.*+"
   ignoreFiles:
     # Git
     - ".git*"
@@ -68,4 +68,4 @@ licenseAgreement:
   ignore:
     # See the `build-dependencies` group in the Dependabot's configuration file
     - user: dependabot[bot]
-      titlePattern: "Bump.*the build-dependencies group( across \\d+ director(ies|y))?( with \\d+ updates?)?"
+      titlePattern: "Bump.*"


### PR DESCRIPTION
- Group GH actions updates and limit which particular actions are updateable.
- Simplify ignore patterns 
  - We can skip license checks for any PRs opened by dependabot. 
  - since we have more update groups that do not require JIRA keys we can include the groups in the pattern and simplify the remaining part as `.*`

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
