### PR TITLE
Move snakeyaml to build dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -87,6 +87,8 @@ updates:
           - "org.eclipse.jdt:*"
           # We only use the version of WildFly for a link in the documentation
           - "org.wildfly.bom:wildfly"
+          # Used to generate reports during build time:
+          - "org.yaml:snakeyaml"
     ignore:
       # These dependencies are updated manually
       - dependency-name: "org.hibernate:*"


### PR DESCRIPTION
as it is only used to create build reports for logging categories

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
