### PR TITLE
Use JDK 23 to run dependency update test for Lucene 11

### DIFF
--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -40,6 +40,7 @@ Map settings() {
 			]
 		case 'lucene-future':
 			return [
+					testCompilerTool: 'OpenJDK 23 Latest',
 					updateProperties: ['version.org.apache.lucene.next.updatable'],
 					onlyRunTestDependingOn: ['hibernate-search-backend-lucene-next'],
 					additionalMavenArgs: '-Dtest.elasticsearch.skip=true -pl :hibernate-search-backend-lucene-next,:hibernate-search-util-internal-integrationtest-backend-lucene-next'


### PR DESCRIPTION
as Lucene 11 requires JDK 23

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
