### PR TITLE
HSEARCH-5239 Take advantage of ORM's SchemaManager.truncateMappedObjects() in tests

### DIFF
--- a/integrationtest/mapper/orm-jakarta-batch/src/test/java/org/hibernate/search/integrationtest/jakarta/batch/massindexing/MassIndexingJobIT.java
+++ b/integrationtest/mapper/orm-jakarta-batch/src/test/java/org/hibernate/search/integrationtest/jakarta/batch/massindexing/MassIndexingJobIT.java
@@ -84,7 +84,6 @@ class MassIndexingJobIT {
 				.withAnnotatedTypes( Company.class, Person.class, WhoAmI.class, CompanyGroup.class )
 				.withProperty( "hibernate.jpa.compliance.query", jpaCompliance )
 				.withProperty( HibernateOrmMapperSettings.INDEXING_LISTENERS_ENABLED, false )
-				.dataClearing( config -> config.clearOrder( CompanyGroup.class, Company.class ) )
 				.setup();
 	}
 

--- a/integrationtest/mapper/orm-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingEdgeCasesIT.java
+++ b/integrationtest/mapper/orm-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingEdgeCasesIT.java
@@ -66,7 +66,6 @@ class OutboxPollingAutomaticIndexingEdgeCasesIT {
 						new TestingOutboxPollingInternalConfigurer().outboxEventFilter( eventFilter )
 				)
 				.withAnnotatedTypes( IndexedEntity.class, IndexedAndContainedEntity.class )
-				.dataClearing( config -> config.clearOrder( IndexedAndContainedEntity.class, IndexedEntity.class ) )
 				.setup();
 	}
 

--- a/integrationtest/mapper/orm-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingEventSendingIT.java
+++ b/integrationtest/mapper/orm-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/outboxpolling/automaticindexing/OutboxPollingAutomaticIndexingEventSendingIT.java
@@ -89,8 +89,6 @@ class OutboxPollingAutomaticIndexingEventSendingIT {
 				.withAnnotatedTypes( IndexedEntity.class, AnotherIndexedEntity.class, RoutedIndexedEntity.class,
 						IndexedAndContainingEntity.class, ContainedEntity.class, IndexedAndContainedEntity.class
 				)
-				.dataClearing( config -> config.clearOrder( ContainedEntity.class, IndexedAndContainedEntity.class,
-						IndexedAndContainingEntity.class ) )
 				.setup();
 	}
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingEmbeddableIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingEmbeddableIT.java
@@ -114,13 +114,7 @@ class AutomaticIndexingEmbeddableIT {
 						IndexedEntity.class,
 						ContainingEntity.class,
 						ContainedEntity.class
-				)
-				.dataClearing( config -> config.preClear( ContainedEntity.class, contained -> {
-					contained.getContainingAsElementCollection().clear();
-					contained.getContainingAsSingleWithInverseSideEmbedded().setContainingAsSingle( null );
-				} )
-						.clearOrder( ContainingEntity.class, IndexedEntity.class, ContainedEntity.class ) )
-				.setup();
+				).setup();
 	}
 
 	@Test

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingAssociationDeletionIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingAssociationDeletionIT.java
@@ -67,9 +67,7 @@ public class AutomaticIndexingAssociationDeletionIT {
 		backendMock.expectAnySchema( AssociationOwner.NAME );
 		backendMock.expectAnySchema( AssociationNonOwner.NAME );
 		OrmSetupHelper.SetupContext setupContext = ormSetupHelper.start().withAnnotatedTypes(
-				AssociationOwner.class, AssociationNonOwner.class )
-				.dataClearing( config -> config.clearOrder( AssociationOwner.class,
-						AssociationNonOwner.class ) );
+				AssociationOwner.class, AssociationNonOwner.class );
 
 		sessionFactory = additionalSetup( setupContext ).setup();
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingGenericPolymorphicAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingGenericPolymorphicAssociationIT.java
@@ -60,16 +60,7 @@ class AutomaticIndexingGenericPolymorphicAssociationIT {
 				MiddleContainingEntity.class,
 				UnrelatedContainingEntity.class,
 				ContainedEntity.class
-		).dataClearing(
-				config -> config
-						.clearOrder( IndexedEntity.class, ContainingEntity.class, MiddleContainingEntity.class,
-								UnrelatedContainingEntity.class, ContainedEntity.class )
-						.preClear( session -> session.createQuery( "select e from indexed e ", IndexedEntity.class )
-								.getResultList().forEach( e -> {
-									e.getChild().setParent( null );
-									e.setChild( null );
-								} ) ) )
-				.setup();
+		).setup();
 	}
 
 	@Test

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingPolymorphicAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingPolymorphicAssociationIT.java
@@ -45,7 +45,6 @@ class AutomaticIndexingPolymorphicAssociationIT {
 	void setup() {
 		backendMock.expectAnySchema( Level1.NAME );
 		sessionFactory = ormSetupHelper.start()
-				.dataClearing( config -> config.clearOrder( Level3.class, DerivedLevel2.class, Level2.class, Level1.class ) )
 				.setup( Level1.class, Level2.class, DerivedLevel2.class, Level3.class );
 	}
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingPolymorphicAssociationPropertyAccessIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingPolymorphicAssociationPropertyAccessIT.java
@@ -48,7 +48,6 @@ class AutomaticIndexingPolymorphicAssociationPropertyAccessIT {
 		backendMock.expectAnySchema( DerivedLevel2.NAME );
 		backendMock.expectAnySchema( Level3.NAME );
 		sessionFactory = ormSetupHelper.start()
-				.dataClearing( config -> config.clearOrder( Level3.class, DerivedLevel2.class, Level2.class, Level1.class ) )
 				.setup( Level1.class, Level2.class, DerivedLevel2.class, Level3.class );
 	}
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingPolymorphicInverseSideAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingPolymorphicInverseSideAssociationIT.java
@@ -63,10 +63,7 @@ class AutomaticIndexingPolymorphicInverseSideAssociationIT {
 				FirstMiddleContainingEntity.class,
 				SecondMiddleContainingEntity.class,
 				ContainedEntity.class
-		).dataClearing( config -> config.clearOrder( IndexedEntity.class, ContainingEntity.class,
-				UnrelatedContainingEntity.class,
-				FirstMiddleContainingEntity.class, SecondMiddleContainingEntity.class, ContainedEntity.class
-		) ).setup();
+		).setup();
 	}
 
 	/**

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/proxy/IndexingProcessorProxiedAssociatedEntityIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/proxy/IndexingProcessorProxiedAssociatedEntityIT.java
@@ -55,11 +55,6 @@ public class IndexingProcessorProxiedAssociatedEntityIT {
 
 		sessionFactory = ormSetupHelper.start()
 				.withAnnotatedTypes( IndexedEntity.class, ContainedEntity.class )
-				.dataClearing( config -> config.clearOrder( ContainedEntity.class, IndexedEntity.class )
-						.preClear( IndexedEntity.class, entity -> {
-							entity.containedSingle = null;
-							entity.containedList = new ArrayList<>();
-						} ) )
 				.setup();
 	}
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/proxy/ReindexingResolverProxiedAssociatedEntityIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/proxy/ReindexingResolverProxiedAssociatedEntityIT.java
@@ -58,9 +58,7 @@ class ReindexingResolverProxiedAssociatedEntityIT {
 				IndexedEntity.class,
 				ContainedLevel1Entity.class,
 				ContainedLevel2Entity.class
-		).dataClearing(
-				config -> config.clearOrder( IndexedEntity.class, ContainedLevel2Entity.class, ContainedLevel1Entity.class ) )
-				.setup();
+		).setup();
 	}
 
 	@Test

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToHibernateOrmQueryIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToHibernateOrmQueryIT.java
@@ -65,9 +65,6 @@ class ToHibernateOrmQueryIT {
 		backendMock.expectAnySchema( IndexedEntity.NAME );
 		sessionFactory = ormSetupHelper.start().withAnnotatedTypes(
 				IndexedEntity.class, ContainedEntity.class )
-				.dataClearing( config -> config
-						.preClear( ContainedEntity.class, c -> c.setContainingLazy( null ) )
-						.clearOrder( IndexedEntity.class, ContainedEntity.class ) )
 				.setup();
 	}
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToJpaQueryIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToJpaQueryIT.java
@@ -68,9 +68,6 @@ class ToJpaQueryIT {
 		sessionFactory = ormSetupHelper.start()
 				.withProperty( AvailableSettings.JPA_QUERY_COMPLIANCE, true )
 				.withAnnotatedTypes( IndexedEntity.class, ContainedEntity.class )
-				.dataClearing( config -> config
-						.preClear( ContainedEntity.class, c -> c.setContainingLazy( null ) )
-						.clearOrder( IndexedEntity.class, ContainedEntity.class ) )
 				.setup();
 	}
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/SearchQueryBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/SearchQueryBaseIT.java
@@ -89,10 +89,7 @@ class SearchQueryBaseIT {
 		backendMock.expectAnySchema( Book.NAME );
 		backendMock.expectAnySchema( Author.NAME );
 
-		sessionFactory = ormSetupHelper.start().withAnnotatedTypes( Book.class, Author.class, NotIndexed.class )
-				.dataClearing(
-						config -> config.clearOrder( Book.class, Author.class, NotIndexed.class ) )
-				.setup();
+		sessionFactory = ormSetupHelper.start().withAnnotatedTypes( Book.class, Author.class, NotIndexed.class ).setup();
 	}
 
 	@BeforeEach

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingGraphIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingGraphIT.java
@@ -80,11 +80,7 @@ public class SearchQueryEntityLoadingGraphIT<T> extends AbstractSearchQueryEntit
 		this.model = model;
 		this.mapping = mapping;
 		backendMock.expectAnySchema( model.getIndexName() );
-		sessionFactory = ormSetupHelper.start().withConfiguration( c -> mapping.configure( c, model ) )
-				.dataClearing( true, config -> config
-						.preClear( model.getIndexedClass(), model::clearContainedEager )
-						.clearOrder( model.getContainedClass(), model.getIndexedClass() ) )
-				.setup();
+		sessionFactory = ormSetupHelper.start().withConfiguration( c -> mapping.configure( c, model ) ).setup();
 	}
 
 	@ParameterizedSetupBeforeTest

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/DataClearConfig.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/DataClearConfig.java
@@ -16,12 +16,6 @@ public interface DataClearConfig {
 
 	<T> DataClearConfig preClear(Class<T> entityType, Consumer<T> preClear);
 
-	/**
-	 * @deprecated No longer needed as we now use truncate
-	 */
-	@Deprecated
-	DataClearConfig clearOrder(Class<?>... entityClasses);
-
 	DataClearConfig clearIndexData(boolean clear);
 
 	default DataClearConfig clearDatabaseData(boolean clear) {

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/DataClearConfig.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/DataClearConfig.java
@@ -16,6 +16,10 @@ public interface DataClearConfig {
 
 	<T> DataClearConfig preClear(Class<T> entityType, Consumer<T> preClear);
 
+	/**
+	 * @deprecated No longer needed as we now use truncate
+	 */
+	@Deprecated
 	DataClearConfig clearOrder(Class<?>... entityClasses);
 
 	DataClearConfig clearIndexData(boolean clear);

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmSetupHelperCleaner.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmSetupHelperCleaner.java
@@ -323,11 +323,6 @@ class OrmSetupHelperCleaner {
 		}
 
 		@Override
-		public DataClearConfig clearOrder(Class<?>... entityClasses) {
-			return this;
-		}
-
-		@Override
 		public DataClearConfig clearIndexData(boolean clear) {
 			this.clearIndexData = clear;
 			return this;

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/multitenancy/impl/MultitenancyTestHelperSchemaManagementTool.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/multitenancy/impl/MultitenancyTestHelperSchemaManagementTool.java
@@ -17,6 +17,7 @@ import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.tool.schema.internal.HibernateSchemaManagementTool;
 import org.hibernate.tool.schema.internal.SchemaCreatorImpl;
 import org.hibernate.tool.schema.internal.SchemaDropperImpl;
+import org.hibernate.tool.schema.internal.SchemaTruncatorImpl;
 import org.hibernate.tool.schema.internal.exec.GenerationTargetToDatabase;
 import org.hibernate.tool.schema.spi.ContributableMatcher;
 import org.hibernate.tool.schema.spi.DelayedDropAction;
@@ -27,6 +28,7 @@ import org.hibernate.tool.schema.spi.SchemaCreator;
 import org.hibernate.tool.schema.spi.SchemaDropper;
 import org.hibernate.tool.schema.spi.SchemaManagementTool;
 import org.hibernate.tool.schema.spi.SchemaMigrator;
+import org.hibernate.tool.schema.spi.SchemaTruncator;
 import org.hibernate.tool.schema.spi.SchemaValidator;
 import org.hibernate.tool.schema.spi.SourceDescriptor;
 import org.hibernate.tool.schema.spi.TargetDescriptor;
@@ -133,6 +135,19 @@ class MultitenancyTestHelperSchemaManagementTool
 	@Override
 	public SchemaValidator getSchemaValidator(Map<String, Object> options) {
 		throw notSupported();
+	}
+
+	@Override
+	public SchemaTruncator getSchemaTruncator(Map<String, Object> options) {
+		return new SchemaTruncator() {
+			final SchemaTruncatorImpl delegate = (SchemaTruncatorImpl) toolDelegate.getSchemaTruncator( options );
+
+			@Override
+			public void doTruncate(Metadata metadata, ExecutionOptions options,
+					ContributableMatcher contributableInclusionFilter, TargetDescriptor targetDescriptor) {
+				delegate.doTruncate( metadata, true, generationTargets );
+			}
+		};
 	}
 
 	@Override


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HSEARCH.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HSEARCH-<digits>`).
-->

https://hibernate.atlassian.net/browse/HSEARCH-5239

Sorry this took so long, I know the update of ORM that included the necessary changes has been around for a while but whenever I was ready to come back to this I got sidetracked. Let me know what you think.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
