### PR TITLE
HSEARCH-5329 Upgrade jboss-logging-tools to 3.0.4.Final / HSEARCH-5330 Upgrade to Jackson 2.18.3

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -84,7 +84,7 @@
         <version.com.google.code.gson>2.12.1</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.30.2</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, by Avro, by the AWS SDK and in tests (wiremock, ...) -->
-        <version.com.fasterxml.jackson>2.18.2</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.18.3</version.com.fasterxml.jackson>
         <!-- slf4j: used by the AWS SDK -->
         <version.org.slf4j>1.7.36</version.org.slf4j>
 

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -23,7 +23,7 @@
         <!-- >>> Common -->
         <version.org.jboss.logging.jboss-logging>3.6.1.Final</version.org.jboss.logging.jboss-logging>
         <!--Once the tools version is upgraded see if org.codehaus.plexus can be upgraded as well and update the dependabot config accordingly. -->
-        <version.org.jboss.logging.jboss-logging-tools>3.0.3.Final</version.org.jboss.logging.jboss-logging-tools>
+        <version.org.jboss.logging.jboss-logging-tools>3.0.4.Final</version.org.jboss.logging.jboss-logging-tools>
         <javadoc.org.hibernate.search.url>https://docs.jboss.org/hibernate/search/${parsed-version.org.hibernate.search.majorVersion}.${parsed-version.org.hibernate.search.minorVersion}/api/</javadoc.org.hibernate.search.url>
 
         <!-- >>> Engine -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5329
https://hibernate.atlassian.net/browse/HSEARCH-5330

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
