### PR TITLE
HSEARCH-5335 Test against latest Elasticsearch 7.17.28

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -236,7 +236,7 @@ stage('Configure') {
 					// so we don't test them
 					// See https://hibernate.atlassian.net/browse/HSEARCH-4340
 					new LocalElasticsearchBuildEnvironment(version: '7.16.3', condition: TestCondition.ON_DEMAND),
-					new LocalElasticsearchBuildEnvironment(version: '7.17.27', condition: TestCondition.AFTER_MERGE),
+					new LocalElasticsearchBuildEnvironment(version: '7.17.28', condition: TestCondition.AFTER_MERGE),
 					// Not testing 8.0 because we know there are problems in 8.0.1 (see https://hibernate.atlassian.net/browse/HSEARCH-4497)
 					// Not testing 8.1-8.6 to make the build quicker.
 					new LocalElasticsearchBuildEnvironment(version: '8.1.3', condition: TestCondition.ON_DEMAND),


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5335

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
