### PR TITLE
Backport of HSEARCH-5334 to 7.2 - Better handle advancing to the same parent doc

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/docvalues/impl/DoubleMultiValuesToSingleValuesSource.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/docvalues/impl/DoubleMultiValuesToSingleValuesSource.java
@@ -136,6 +136,7 @@ public abstract class DoubleMultiValuesToSingleValuesSource extends DoubleValues
 
 			int lastSeenParentDoc = -1;
 			double lastEmittedValue = -1;
+			boolean result = false;
 
 			@Override
 			public double doubleValue() {
@@ -146,16 +147,18 @@ public abstract class DoubleMultiValuesToSingleValuesSource extends DoubleValues
 			public boolean advanceExact(int parentDoc) throws IOException {
 				assert parentDoc >= lastSeenParentDoc : "can only evaluate current and upcoming parent docs";
 				if ( parentDoc == lastSeenParentDoc ) {
-					return true;
-				}
-
-				if ( !childDocsWithValues.advanceExactParent( parentDoc ) ) {
-					// No child of this parent has a value
-					return false;
+					return result;
 				}
 
 				lastSeenParentDoc = parentDoc;
+				if ( !childDocsWithValues.advanceExactParent( parentDoc ) ) {
+					// No child of this parent has a value
+					result = false;
+					return false;
+				}
+
 				lastEmittedValue = mode.pick( values, childDocsWithValues );
+				result = true;
 				return true;
 			}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/docvalues/impl/LongMultiValuesToSingleValuesSource.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/docvalues/impl/LongMultiValuesToSingleValuesSource.java
@@ -158,6 +158,7 @@ public abstract class LongMultiValuesToSingleValuesSource extends LongValuesSour
 		return new LongValues() {
 			int lastSeenParentDoc = -1;
 			long lastEmittedValue = -1;
+			boolean result = false;
 
 			@Override
 			public long longValue() {
@@ -168,16 +169,18 @@ public abstract class LongMultiValuesToSingleValuesSource extends LongValuesSour
 			public boolean advanceExact(int parentDoc) throws IOException {
 				assert parentDoc >= lastSeenParentDoc : "can only evaluate current and upcoming parent docs";
 				if ( parentDoc == lastSeenParentDoc ) {
-					return true;
-				}
-
-				if ( !childDocsWithValues.advanceExactParent( parentDoc ) ) {
-					// No child of this parent has a value
-					return false;
+					return result;
 				}
 
 				lastSeenParentDoc = parentDoc;
+				if ( !childDocsWithValues.advanceExactParent( parentDoc ) ) {
+					// No child of this parent has a value
+					result = false;
+					return false;
+				}
+
 				lastEmittedValue = mode.pick( values, childDocsWithValues );
+				result = true;
 				return true;
 			}
 		};

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/docvalues/impl/TextMultiValuesToSingleValuesSource.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/docvalues/impl/TextMultiValuesToSingleValuesSource.java
@@ -118,6 +118,7 @@ public abstract class TextMultiValuesToSingleValuesSource {
 		return new SortedSetDocValuesToSortedDocValuesWrapper( values ) {
 			int lastSeenParentDoc = -1;
 			int lastEmittedOrd = -1;
+			boolean result = false;
 
 			@Override
 			public int ordValue() {
@@ -133,16 +134,18 @@ public abstract class TextMultiValuesToSingleValuesSource {
 			public boolean advanceExact(int parentDoc) throws IOException {
 				assert parentDoc >= lastSeenParentDoc : "can only evaluate current and upcoming parent docs";
 				if ( parentDoc == lastSeenParentDoc ) {
-					return true;
+					return result;
 				}
+				lastSeenParentDoc = parentDoc;
 
 				if ( !childDocsWithValues.advanceExactParent( parentDoc ) ) {
 					// No child of this parent has a value
+					result = false;
 					return false;
 				}
 
-				lastSeenParentDoc = parentDoc;
 				lastEmittedOrd = (int) mode.pick( values, childDocsWithValues );
+				result = true;
 				return true;
 			}
 		};


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5334

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
