### PR TITLE
Backport of HSEARCH-5334 to 6.2 - Better handle advancing to the same parent doc

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/docvalues/impl/DoubleMultiValuesToSingleValuesSource.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/docvalues/impl/DoubleMultiValuesToSingleValuesSource.java
@@ -138,6 +138,7 @@ public abstract class DoubleMultiValuesToSingleValuesSource extends DoubleValues
 
 			int lastSeenParentDoc = -1;
 			double lastEmittedValue = -1;
+			boolean result = false;
 
 			@Override
 			public double doubleValue() {
@@ -148,16 +149,18 @@ public abstract class DoubleMultiValuesToSingleValuesSource extends DoubleValues
 			public boolean advanceExact(int parentDoc) throws IOException {
 				assert parentDoc >= lastSeenParentDoc : "can only evaluate current and upcoming parent docs";
 				if ( parentDoc == lastSeenParentDoc ) {
-					return true;
-				}
-
-				if ( !childDocsWithValues.advanceExactParent( parentDoc ) ) {
-					// No child of this parent has a value
-					return false;
+					return result;
 				}
 
 				lastSeenParentDoc = parentDoc;
+				if ( !childDocsWithValues.advanceExactParent( parentDoc ) ) {
+					// No child of this parent has a value
+					result = false;
+					return false;
+				}
+
 				lastEmittedValue = mode.pick( values, childDocsWithValues );
+				result = true;
 				return true;
 			}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/docvalues/impl/LongMultiValuesToSingleValuesSource.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/docvalues/impl/LongMultiValuesToSingleValuesSource.java
@@ -160,6 +160,7 @@ public abstract class LongMultiValuesToSingleValuesSource extends LongValuesSour
 		return new LongValues() {
 			int lastSeenParentDoc = -1;
 			long lastEmittedValue = -1;
+			boolean result = false;
 
 			@Override
 			public long longValue() {
@@ -170,16 +171,18 @@ public abstract class LongMultiValuesToSingleValuesSource extends LongValuesSour
 			public boolean advanceExact(int parentDoc) throws IOException {
 				assert parentDoc >= lastSeenParentDoc : "can only evaluate current and upcoming parent docs";
 				if ( parentDoc == lastSeenParentDoc ) {
-					return true;
-				}
-
-				if ( !childDocsWithValues.advanceExactParent( parentDoc ) ) {
-					// No child of this parent has a value
-					return false;
+					return result;
 				}
 
 				lastSeenParentDoc = parentDoc;
+				if ( !childDocsWithValues.advanceExactParent( parentDoc ) ) {
+					// No child of this parent has a value
+					result = false;
+					return false;
+				}
+
 				lastEmittedValue = mode.pick( values, childDocsWithValues );
+				result = true;
 				return true;
 			}
 		};

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/docvalues/impl/TextMultiValuesToSingleValuesSource.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/docvalues/impl/TextMultiValuesToSingleValuesSource.java
@@ -120,6 +120,7 @@ public abstract class TextMultiValuesToSingleValuesSource {
 		return new SortedSetDocValuesToSortedDocValuesWrapper( values ) {
 			int lastSeenParentDoc = -1;
 			int lastEmittedOrd = -1;
+			boolean result = false;
 
 			@Override
 			public int ordValue() {
@@ -135,16 +136,18 @@ public abstract class TextMultiValuesToSingleValuesSource {
 			public boolean advanceExact(int parentDoc) throws IOException {
 				assert parentDoc >= lastSeenParentDoc : "can only evaluate current and upcoming parent docs";
 				if ( parentDoc == lastSeenParentDoc ) {
-					return true;
+					return result;
 				}
+				lastSeenParentDoc = parentDoc;
 
 				if ( !childDocsWithValues.advanceExactParent( parentDoc ) ) {
 					// No child of this parent has a value
+					result = false;
 					return false;
 				}
 
-				lastSeenParentDoc = parentDoc;
 				lastEmittedOrd = (int) mode.pick( values, childDocsWithValues );
+				result = true;
 				return true;
 			}
 		};

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSortBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSortBaseIT.java
@@ -9,6 +9,7 @@ package org.hibernate.search.integrationtest.backend.tck.search.sort;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchHitsAssert.assertThatHits;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatResult;
 import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.documentProvider;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
@@ -526,6 +527,22 @@ public class FieldSortBaseIT<F> {
 		assertThatQuery( query )
 				.hasDocRefHitsExactOrder( index.typeName(), dataSet.doc3Id, dataSet.doc2Id, dataSet.doc1Id,
 						dataSet.emptyDoc1Id );
+	}
+
+	@Test
+	public void missingValue_singleElement() {
+		assumeTestParametersWork();
+
+		DataSet<F> dataSet;
+		SearchQuery<DocumentReference> query;
+
+		String fieldPath = getFieldPath();
+
+		// Explicit order with missing().last()
+		dataSet = dataSetForAsc;
+		query = matchNonEmptyAndEmpty1Query( dataSet, f -> f.field( fieldPath ).asc().missing().lowest() );
+		assertThatResult( query.fetch( 0, 1 ) )
+				.hasDocRefHitsExactOrder( index.typeName(), dataSet.emptyDoc1Id );
 	}
 
 	private SearchQuery<DocumentReference> matchNonEmptyQuery(DataSet<F> dataSet,


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5334


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
