### PR TITLE
HSEARCH-5344 Upgrade to Hibernate ORM 7.0.0.Beta5 / HSEARCH-5346 Reuse ORM's ClassDetailsRegistry and ignore the BootstrapContext#getJandexView 

### DIFF
--- a/build/config/pom.xml
+++ b/build/config/pom.xml
@@ -244,7 +244,7 @@
                                 <argument>^org\.hibernate\.metamodel\.mapping\.SelectablePath$</argument>
                                 <argument>^org\.hibernate\.metamodel\.model\.domain\.JpaMetamodel$</argument>
 
-                                <argument>^org\.hibernate\.boot\.spi\.BootstrapContext$</argument>
+                                <argument>^org\.hibernate\.boot\.spi\.BootstrapContext\b.*+$</argument>
                                 <argument>^org\.hibernate\.boot\.spi\.AdditionalMappingContributor$</argument>
                                 <argument>^org\.hibernate\.boot\.spi\.AdditionalMappingContributions$</argument>
                                 <argument>^org\.hibernate\.collection\.spi\.PersistentCollection$</argument>

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -130,7 +130,7 @@
         <!-- >>> Common -->
         <version.log4j>2.24.3</version.log4j>
         <version.junit>4.13.2</version.junit>
-        <version.junit-jupiter>5.11.4</version.junit-jupiter>
+        <version.junit-jupiter>5.12.0</version.junit-jupiter>
         <version.junit-platform-suite-engine>1.10.0</version.junit-platform-suite-engine>
         <version.org.osgi.core>6.0.0</version.org.osgi.core>
         <!-- Make sure to update Ryuk container version in `ryuk.Dockerfile` whenever updating testcontainers to align it with the lib. -->

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -94,7 +94,7 @@
             NOTE: when Hibernate ORM updates Byte Buddy, make sure to check Jenkinsfile to see if
             `net.bytebuddy.experimental` property can be removed.
          -->
-        <version.org.hibernate.orm>7.0.0.Beta4</version.org.hibernate.orm>
+        <version.org.hibernate.orm>7.0.0.Beta5</version.org.hibernate.orm>
         <version.org.hibernate.models>0.9.3</version.org.hibernate.models>
 
         <javadoc.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/javadocs/</javadoc.org.hibernate.orm.url>

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToHibernateOrmScrollableResultsIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToHibernateOrmScrollableResultsIT.java
@@ -87,7 +87,7 @@ class ToHibernateOrmScrollableResultsIT {
 			try ( ScrollableResults<?> scroll = createSimpleQuery( session ).scroll() ) {
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( 0 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -98,7 +98,7 @@ class ToHibernateOrmScrollableResultsIT {
 					assertThat( scroll.next() ).isTrue();
 					backendMock.verifyExpectationsMet();
 
-					assertThat( scroll.getRowNumber() ).isEqualTo( i );
+					assertThat( scroll.getPosition() ).isEqualTo( i + 1 );
 					assertThat( scroll.isFirst() ).isEqualTo( i == 0 );
 					assertThat( scroll.isLast() ).isEqualTo( i == ( ENTITY_COUNT - 1 ) );
 					assertThat( scroll.get() )
@@ -106,7 +106,7 @@ class ToHibernateOrmScrollableResultsIT {
 				}
 
 				assertThat( scroll.next() ).isFalse();
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( -1 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -114,7 +114,7 @@ class ToHibernateOrmScrollableResultsIT {
 				// Call next() again after reaching the end: should not do anything
 				assertThat( scroll.next() ).isFalse();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( -1 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -131,7 +131,7 @@ class ToHibernateOrmScrollableResultsIT {
 			try ( ScrollableResults<?> scroll = createSimpleQuery( session ).scroll() ) {
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( 0 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -144,7 +144,7 @@ class ToHibernateOrmScrollableResultsIT {
 								"Ensure you always increment the scroll position, and never decrement it" );
 
 				// We're still on the same element
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( 0 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -154,7 +154,7 @@ class ToHibernateOrmScrollableResultsIT {
 				assertThat( scroll.next() ).isTrue();
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( 0 );
+				assertThat( scroll.getPosition() ).isEqualTo( 1 );
 				assertThat( scroll.isFirst() ).isTrue();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
@@ -168,7 +168,7 @@ class ToHibernateOrmScrollableResultsIT {
 								"Ensure you always increment the scroll position, and never decrement it" );
 
 				// We're still on the same element
-				assertThat( scroll.getRowNumber() ).isEqualTo( 0 );
+				assertThat( scroll.getPosition() ).isEqualTo( 1 );
 				assertThat( scroll.isFirst() ).isTrue();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
@@ -230,7 +230,7 @@ class ToHibernateOrmScrollableResultsIT {
 					.scroll() ) {
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( 0 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -240,7 +240,7 @@ class ToHibernateOrmScrollableResultsIT {
 					assertThat( scroll.next() ).isTrue();
 					backendMock.verifyExpectationsMet();
 
-					assertThat( scroll.getRowNumber() ).isEqualTo( i );
+					assertThat( scroll.getPosition() ).isEqualTo( i + 1 );
 					assertThat( scroll.isFirst() ).isEqualTo( i == 0 );
 					assertThat( scroll.isLast() ).isEqualTo( i == ( ENTITY_COUNT - 1 ) );
 					assertThat( scroll.get() )
@@ -248,7 +248,7 @@ class ToHibernateOrmScrollableResultsIT {
 				}
 
 				assertThat( scroll.next() ).isFalse();
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( -1 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -271,7 +271,7 @@ class ToHibernateOrmScrollableResultsIT {
 			try ( ScrollableResults<?> scroll = query.scroll() ) {
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( 0 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -281,7 +281,7 @@ class ToHibernateOrmScrollableResultsIT {
 					assertThat( scroll.next() ).isTrue();
 					backendMock.verifyExpectationsMet();
 
-					assertThat( scroll.getRowNumber() ).isEqualTo( i );
+					assertThat( scroll.getPosition() ).isEqualTo( i + 1 );
 					assertThat( scroll.isFirst() ).isEqualTo( i == 0 );
 					assertThat( scroll.isLast() ).isEqualTo( i == ( maxResults - 1 ) );
 					assertThat( scroll.get() )
@@ -289,7 +289,7 @@ class ToHibernateOrmScrollableResultsIT {
 				}
 
 				assertThat( scroll.next() ).isFalse();
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( -1 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -306,7 +306,7 @@ class ToHibernateOrmScrollableResultsIT {
 			try ( ScrollableResults<?> scroll = createSimpleQuery( session ).scroll() ) {
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( 0 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -316,7 +316,7 @@ class ToHibernateOrmScrollableResultsIT {
 				assertThat( scroll.scroll( 10 ) ).isTrue();
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( 9 );
+				assertThat( scroll.getPosition() ).isEqualTo( 10 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
@@ -326,7 +326,7 @@ class ToHibernateOrmScrollableResultsIT {
 				assertThat( scroll.scroll( 0 ) ).isTrue();
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( 9 );
+				assertThat( scroll.getPosition() ).isEqualTo( 10 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
@@ -336,7 +336,7 @@ class ToHibernateOrmScrollableResultsIT {
 				assertThat( scroll.scroll( 50 ) ).isTrue();
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( 59 );
+				assertThat( scroll.getPosition() ).isEqualTo( 60 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
@@ -351,7 +351,7 @@ class ToHibernateOrmScrollableResultsIT {
 				assertThat( scroll.scroll( 200 ) ).isTrue();
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( 259 );
+				assertThat( scroll.getPosition() ).isEqualTo( 260 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
@@ -383,7 +383,7 @@ class ToHibernateOrmScrollableResultsIT {
 				assertThat( scroll.scroll( 10000 ) ).isFalse();
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( -1 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -391,14 +391,14 @@ class ToHibernateOrmScrollableResultsIT {
 				// Calling scroll(<positive number>) again after reaching the end should not do anything
 				assertThat( scroll.scroll( 0 ) ).isFalse();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( -1 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
 
 				assertThat( scroll.scroll( 1 ) ).isFalse();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( -1 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -415,7 +415,7 @@ class ToHibernateOrmScrollableResultsIT {
 			try ( ScrollableResults<?> scroll = createSimpleQuery( session ).scroll() ) {
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( 0 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -428,7 +428,7 @@ class ToHibernateOrmScrollableResultsIT {
 								"Ensure you always increment the scroll position, and never decrement it" );
 
 				// We're still on the same element
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( 0 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -438,7 +438,7 @@ class ToHibernateOrmScrollableResultsIT {
 				assertThat( scroll.scroll( 10 ) ).isTrue();
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( 9 );
+				assertThat( scroll.getPosition() ).isEqualTo( 10 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
@@ -452,7 +452,7 @@ class ToHibernateOrmScrollableResultsIT {
 								"Ensure you always increment the scroll position, and never decrement it" );
 
 				// We're still on the same element
-				assertThat( scroll.getRowNumber() ).isEqualTo( 9 );
+				assertThat( scroll.getPosition() ).isEqualTo( 10 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
@@ -463,6 +463,8 @@ class ToHibernateOrmScrollableResultsIT {
 		} );
 	}
 
+	@SuppressWarnings("removal")
+	@Deprecated(forRemoval = true)
 	@Test
 	void setRowNumber() {
 		with( sessionFactory ).runInTransaction( session -> {
@@ -470,7 +472,7 @@ class ToHibernateOrmScrollableResultsIT {
 			try ( ScrollableResults<?> scroll = createSimpleQuery( session ).scroll() ) {
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( 0 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -547,6 +549,8 @@ class ToHibernateOrmScrollableResultsIT {
 		} );
 	}
 
+	@SuppressWarnings("removal")
+	@Deprecated(forRemoval = true)
 	@Test
 	void setRowNumber_backwards() {
 		with( sessionFactory ).runInTransaction( session -> {
@@ -589,6 +593,8 @@ class ToHibernateOrmScrollableResultsIT {
 		} );
 	}
 
+	@SuppressWarnings("removal")
+	@Deprecated(forRemoval = true)
 	@Test
 	void setRowNumber_relativeToEnd() {
 		with( sessionFactory ).runInTransaction( session -> {
@@ -638,7 +644,7 @@ class ToHibernateOrmScrollableResultsIT {
 			try ( ScrollableResults<?> scroll = createSimpleQuery( session ).scroll() ) {
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( 0 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -648,21 +654,21 @@ class ToHibernateOrmScrollableResultsIT {
 				assertThat( scroll.position( 10 ) ).isTrue();
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( 10 );
+				assertThat( scroll.getPosition() ).isEqualTo( 10 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
-						.isEqualTo( session.getReference( IndexedEntity.class, 10 ) );
+						.isEqualTo( session.getReference( IndexedEntity.class, 9 ) );
 
 				// No call to the underlying scroll.next() is expected here
 				assertThat( scroll.position( 50 ) ).isTrue();
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( 50 );
+				assertThat( scroll.getPosition() ).isEqualTo( 50 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
-						.isEqualTo( session.getReference( IndexedEntity.class, 50 ) );
+						.isEqualTo( session.getReference( IndexedEntity.class, 49 ) );
 
 				backendMock.expectNextScroll( Collections.singletonList( IndexedEntity.NAME ),
 						StubNextScrollWorkBehavior.of( ENTITY_COUNT,
@@ -673,11 +679,11 @@ class ToHibernateOrmScrollableResultsIT {
 				assertThat( scroll.position( 220 ) ).isTrue();
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( 220 );
+				assertThat( scroll.getPosition() ).isEqualTo( 220 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
-						.isEqualTo( session.getReference( IndexedEntity.class, 220 ) );
+						.isEqualTo( session.getReference( IndexedEntity.class, 219 ) );
 
 				backendMock.expectNextScroll( Collections.singletonList( IndexedEntity.NAME ),
 						StubNextScrollWorkBehavior.of( ENTITY_COUNT,
@@ -705,7 +711,7 @@ class ToHibernateOrmScrollableResultsIT {
 				assertThat( scroll.position( 10000 ) ).isFalse();
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( -1 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -722,7 +728,7 @@ class ToHibernateOrmScrollableResultsIT {
 			try ( ScrollableResults<?> scroll = createSimpleQuery( session ).scroll() ) {
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( 0 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -732,11 +738,11 @@ class ToHibernateOrmScrollableResultsIT {
 				assertThat( scroll.position( 10 ) ).isTrue();
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( 10 );
+				assertThat( scroll.getPosition() ).isEqualTo( 10 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
-						.isEqualTo( session.getReference( IndexedEntity.class, 10 ) );
+						.isEqualTo( session.getReference( IndexedEntity.class, 9 ) );
 
 				// position(<previous row number>) means going backwards: it's forbidden
 				assertThatThrownBy( () -> scroll.position( 5 ) )
@@ -746,11 +752,11 @@ class ToHibernateOrmScrollableResultsIT {
 								"Ensure you always increment the scroll position, and never decrement it" );
 
 				// We're still on the same element
-				assertThat( scroll.getRowNumber() ).isEqualTo( 10 );
+				assertThat( scroll.getPosition() ).isEqualTo( 10 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
-						.isEqualTo( session.getReference( IndexedEntity.class, 10 ) );
+						.isEqualTo( session.getReference( IndexedEntity.class, 9 ) );
 
 				expectScrollClose();
 			}
@@ -764,7 +770,7 @@ class ToHibernateOrmScrollableResultsIT {
 			try ( ScrollableResults<?> scroll = createSimpleQuery( session ).scroll() ) {
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( 0 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -774,11 +780,11 @@ class ToHibernateOrmScrollableResultsIT {
 				assertThat( scroll.position( 10 ) ).isTrue();
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( 10 );
+				assertThat( scroll.getPosition() ).isEqualTo( 10 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
-						.isEqualTo( session.getReference( IndexedEntity.class, 10 ) );
+						.isEqualTo( session.getReference( IndexedEntity.class, 9 ) );
 
 				// position(<negative integer>) means going to a position relative to the end: it's forbidden
 				assertThatThrownBy( () -> scroll.position( -500 ) )
@@ -788,11 +794,11 @@ class ToHibernateOrmScrollableResultsIT {
 								"Ensure you always pass a positive number to position()" );
 
 				// We're still on the same element
-				assertThat( scroll.getRowNumber() ).isEqualTo( 10 );
+				assertThat( scroll.getPosition() ).isEqualTo( 10 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
-						.isEqualTo( session.getReference( IndexedEntity.class, 10 ) );
+						.isEqualTo( session.getReference( IndexedEntity.class, 9 ) );
 
 				expectScrollClose();
 			}
@@ -806,7 +812,7 @@ class ToHibernateOrmScrollableResultsIT {
 			try ( ScrollableResults<?> scroll = createSimpleQuery( session ).scroll() ) {
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( 0 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -814,7 +820,7 @@ class ToHibernateOrmScrollableResultsIT {
 				// Calling beforeFirst() when we're before the first element should not do anything
 				scroll.beforeFirst();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( 0 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -825,7 +831,7 @@ class ToHibernateOrmScrollableResultsIT {
 				assertThat( scroll.next() ).isTrue();
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( 0 );
+				assertThat( scroll.getPosition() ).isEqualTo( 1 );
 				assertThat( scroll.isFirst() ).isTrue();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
@@ -843,7 +849,7 @@ class ToHibernateOrmScrollableResultsIT {
 			try ( ScrollableResults<?> scroll = createSimpleQuery( session ).scroll() ) {
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( 0 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -854,7 +860,7 @@ class ToHibernateOrmScrollableResultsIT {
 				backendMock.verifyExpectationsMet();
 
 				// We're now on the first element
-				assertThat( scroll.getRowNumber() ).isEqualTo( 0 );
+				assertThat( scroll.getPosition() ).isEqualTo( 1 );
 				assertThat( scroll.isFirst() ).isTrue();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
@@ -879,7 +885,7 @@ class ToHibernateOrmScrollableResultsIT {
 			try ( ScrollableResults<?> scroll = createSimpleQuery( session ).scroll() ) {
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( 0 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -890,7 +896,7 @@ class ToHibernateOrmScrollableResultsIT {
 				backendMock.verifyExpectationsMet();
 
 				// We're now on the first element
-				assertThat( scroll.getRowNumber() ).isEqualTo( 0 );
+				assertThat( scroll.getPosition() ).isEqualTo( 1 );
 				assertThat( scroll.isFirst() ).isTrue();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
@@ -899,7 +905,7 @@ class ToHibernateOrmScrollableResultsIT {
 				// Calling first() when we're on the first element should not do anything
 				scroll.first();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( 0 );
+				assertThat( scroll.getPosition() ).isEqualTo( 1 );
 				assertThat( scroll.isFirst() ).isTrue();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
@@ -908,7 +914,7 @@ class ToHibernateOrmScrollableResultsIT {
 				// next() still works after a call to first()
 				assertThat( scroll.next() ).isTrue();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( 1 );
+				assertThat( scroll.getPosition() ).isEqualTo( 2 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
@@ -939,7 +945,7 @@ class ToHibernateOrmScrollableResultsIT {
 				assertThat( scroll.next() ).isTrue();
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( 1 );
+				assertThat( scroll.getPosition() ).isEqualTo( 2 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
@@ -999,7 +1005,7 @@ class ToHibernateOrmScrollableResultsIT {
 				backendMock.verifyExpectationsMet();
 
 				// We're now on the last element
-				assertThat( scroll.getRowNumber() ).isEqualTo( ENTITY_COUNT - 1 );
+				assertThat( scroll.getPosition() ).isEqualTo( ENTITY_COUNT );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isTrue();
 				assertThat( scroll.get() )
@@ -1008,7 +1014,7 @@ class ToHibernateOrmScrollableResultsIT {
 				// Calling last() when we're on the last element should not do anything
 				scroll.last();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( ENTITY_COUNT - 1 );
+				assertThat( scroll.getPosition() ).isEqualTo( ENTITY_COUNT );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isTrue();
 				assertThat( scroll.get() )
@@ -1017,7 +1023,7 @@ class ToHibernateOrmScrollableResultsIT {
 				// next() still works after a call to last()
 				assertThat( scroll.next() ).isFalse();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( -1 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -1046,7 +1052,7 @@ class ToHibernateOrmScrollableResultsIT {
 				assertThat( scroll.scroll( 10 ) ).isTrue();
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( 9 );
+				assertThat( scroll.getPosition() ).isEqualTo( 10 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() )
@@ -1054,7 +1060,7 @@ class ToHibernateOrmScrollableResultsIT {
 
 				scroll.afterLast();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( -1 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -1105,7 +1111,7 @@ class ToHibernateOrmScrollableResultsIT {
 				assertThat( scroll.scroll( ENTITY_COUNT + 1 ) ).isFalse();
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( -1 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -1113,7 +1119,7 @@ class ToHibernateOrmScrollableResultsIT {
 				scroll.afterLast();
 
 				// We're still on the same element
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( -1 );
 				assertThat( scroll.isFirst() ).isFalse();
 				assertThat( scroll.isLast() ).isFalse();
 				assertThat( scroll.get() ).isNull();
@@ -1174,7 +1180,7 @@ class ToHibernateOrmScrollableResultsIT {
 					.scroll() ) {
 				backendMock.verifyExpectationsMet();
 
-				assertThat( scroll.getRowNumber() ).isEqualTo( -1 );
+				assertThat( scroll.getPosition() ).isEqualTo( 0 );
 
 				SearchTimeoutException timeoutException = new SearchTimeoutException( "Timed out" );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingGraphIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingGraphIT.java
@@ -175,7 +175,7 @@ public class SearchQueryEntityLoadingGraphIT<T> extends AbstractSearchQueryEntit
 						.toQuery()
 		) )
 				.isInstanceOf( IllegalArgumentException.class )
-				.hasMessageContainingAll( "Could not locate EntityGraph with given name", "invalidGraphName" );
+				.hasMessageContainingAll( "No EntityGraph with given name", "invalidGraphName" );
 	}
 
 	@Test

--- a/mapper/orm-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/outboxpolling/mapping/impl/AdditionalMappingBuilder.java
+++ b/mapper/orm-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/outboxpolling/mapping/impl/AdditionalMappingBuilder.java
@@ -134,8 +134,7 @@ public class AdditionalMappingBuilder {
 	}
 
 	public ClassDetails build() {
-		SourceModelBuildingContext context = buildingContext.getMetadataCollector()
-				.getSourceModelBuildingContext();
+		SourceModelBuildingContext context = buildingContext.getBootstrapContext().getModelsContext();
 		final MutableClassDetails classDetails = JdkBuilders.buildClassDetailsStatic(
 				type,
 				context

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/bootstrap/impl/HibernateOrmIntegrationBooterImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/bootstrap/impl/HibernateOrmIntegrationBooterImpl.java
@@ -4,8 +4,6 @@
  */
 package org.hibernate.search.mapper.orm.bootstrap.impl;
 
-import static org.hibernate.search.mapper.orm.common.impl.HibernateOrmUtils.createModelBuildingContext;
-
 import java.lang.invoke.MethodHandles;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -30,13 +28,10 @@ import org.hibernate.search.util.common.impl.SuppressingCloser;
 import org.hibernate.search.util.common.reflect.spi.ValueHandleFactory;
 import org.hibernate.service.ServiceRegistry;
 
-import org.jboss.jandex.IndexView;
-
 public class HibernateOrmIntegrationBooterImpl implements HibernateOrmIntegrationBooter {
 
 
 	private final Metadata metadata;
-	private final IndexView jandexIndex;
 	private final ValueHandleFactory valueHandleFactory;
 	private final HibernateSearchPreIntegrationService preIntegrationService;
 	private final Optional<EnvironmentSynchronizer> environmentSynchronizer;
@@ -46,7 +41,6 @@ public class HibernateOrmIntegrationBooterImpl implements HibernateOrmIntegratio
 	private HibernateOrmIntegrationBooterImpl(BuilderImpl builder) {
 		this.metadata = builder.metadata;
 		ServiceRegistry serviceRegistry = builder.bootstrapContext.getServiceRegistry();
-		this.jandexIndex = (IndexView) builder.bootstrapContext.getJandexView();
 		this.valueHandleFactory = builder.valueHandleFactory != null
 				? builder.valueHandleFactory
 				: ValueHandleFactory.usingMethodHandle( MethodHandles.publicLookup() );
@@ -78,7 +72,7 @@ public class HibernateOrmIntegrationBooterImpl implements HibernateOrmIntegratio
 				this.environmentSynchronizer = Optional.empty();
 			}
 		}
-		this.classDetailsRegistry = createModelBuildingContext( builder.bootstrapContext ).getClassDetailsRegistry();
+		this.classDetailsRegistry = builder.bootstrapContext.getModelsContext().getClassDetailsRegistry();
 	}
 
 	@Override
@@ -90,7 +84,7 @@ public class HibernateOrmIntegrationBooterImpl implements HibernateOrmIntegratio
 			);
 		}
 
-		preIntegrationService.doBootFirstPhase( metadata, jandexIndex, classDetailsRegistry, valueHandleFactory )
+		preIntegrationService.doBootFirstPhase( metadata, classDetailsRegistry, valueHandleFactory )
 				.set( propertyCollector );
 	}
 
@@ -174,7 +168,7 @@ public class HibernateOrmIntegrationBooterImpl implements HibernateOrmIntegratio
 
 	private HibernateSearchContextProviderService bootNow(SessionFactoryImplementor sessionFactoryImplementor) {
 		HibernateOrmIntegrationPartialBuildState partialBuildState =
-				preIntegrationService.doBootFirstPhase( metadata, jandexIndex, classDetailsRegistry, valueHandleFactory );
+				preIntegrationService.doBootFirstPhase( metadata, classDetailsRegistry, valueHandleFactory );
 
 		try {
 			return partialBuildState.doBootSecondPhase( sessionFactoryImplementor,

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/bootstrap/impl/HibernateSearchPreIntegrationService.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/bootstrap/impl/HibernateSearchPreIntegrationService.java
@@ -43,8 +43,6 @@ import org.hibernate.service.ServiceRegistry;
 import org.hibernate.service.spi.ServiceContributor;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 
-import org.jboss.jandex.IndexView;
-
 /**
  * A service that can perform the earliest steps of the integration of Hibernate Search into Hibernate ORM,
  * before {@link HibernateSearchIntegrator} is even called.
@@ -224,7 +222,7 @@ public abstract class HibernateSearchPreIntegrationService implements Service, A
 	abstract BeanResolver beanResolver();
 
 	abstract HibernateOrmIntegrationPartialBuildState doBootFirstPhase(Metadata metadata,
-			IndexView jandexIndex, ClassDetailsRegistry classDetailsRegistry,
+			ClassDetailsRegistry classDetailsRegistry,
 			ValueHandleFactory valueHandleFactory);
 
 	static class NotBooted extends HibernateSearchPreIntegrationService {
@@ -259,7 +257,7 @@ public abstract class HibernateSearchPreIntegrationService implements Service, A
 
 		@Override
 		HibernateOrmIntegrationPartialBuildState doBootFirstPhase(Metadata metadata,
-				IndexView jandexIndex, ClassDetailsRegistry classDetailsRegistry,
+				ClassDetailsRegistry classDetailsRegistry,
 				ValueHandleFactory valueHandleFactory) {
 			HibernateOrmMappingInitiator mappingInitiator = null;
 			SearchIntegrationPartialBuildState searchIntegrationPartialBuildState = null;
@@ -267,7 +265,7 @@ public abstract class HibernateSearchPreIntegrationService implements Service, A
 				SearchIntegration.Builder builder = SearchIntegration.builder( environment );
 
 				HibernateOrmMappingKey mappingKey = new HibernateOrmMappingKey();
-				mappingInitiator = HibernateOrmMappingInitiator.create( metadata, jandexIndex, classDetailsRegistry,
+				mappingInitiator = HibernateOrmMappingInitiator.create( metadata, classDetailsRegistry,
 						valueHandleFactory, serviceRegistry );
 				builder.addMappingInitiator( mappingKey, mappingInitiator );
 
@@ -318,7 +316,7 @@ public abstract class HibernateSearchPreIntegrationService implements Service, A
 		}
 
 		@Override
-		HibernateOrmIntegrationPartialBuildState doBootFirstPhase(Metadata metadata, IndexView jandexIndex,
+		HibernateOrmIntegrationPartialBuildState doBootFirstPhase(Metadata metadata,
 				ClassDetailsRegistry classDetailsRegistry, ValueHandleFactory valueHandleFactory) {
 			return partialBuildState;
 		}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/common/impl/HibernateOrmUtils.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/common/impl/HibernateOrmUtils.java
@@ -18,10 +18,6 @@ import jakarta.persistence.EntityManagerFactory;
 import org.hibernate.Session;
 import org.hibernate.binder.internal.TenantIdBinder;
 import org.hibernate.boot.Metadata;
-import org.hibernate.boot.models.internal.ClassLoaderServiceLoading;
-import org.hibernate.boot.models.internal.ModelsHelper;
-import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
-import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.mapping.PersistentClass;
@@ -29,9 +25,6 @@ import org.hibernate.mapping.Property;
 import org.hibernate.metamodel.MappingMetamodel;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.model.domain.EntityDomainType;
-import org.hibernate.models.internal.BasicModelBuildingContextImpl;
-import org.hibernate.models.jandex.internal.JandexModelBuildingContextImpl;
-import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.search.mapper.orm.logging.impl.OrmMiscLog;
 import org.hibernate.search.mapper.pojo.loading.spi.PojoLoadingTypeContext;
 import org.hibernate.search.util.common.AssertionFailure;
@@ -40,8 +33,6 @@ import org.hibernate.service.Service;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.service.spi.ServiceBinding;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
-
-import org.jboss.jandex.IndexView;
 
 public final class HibernateOrmUtils {
 
@@ -188,26 +179,6 @@ public final class HibernateOrmUtils {
 
 	public static boolean isDiscriminatorMultiTenancyEnabled(Metadata metadata) {
 		return metadata.getFilterDefinition( TenantIdBinder.FILTER_NAME ) != null;
-	}
-
-	public static SourceModelBuildingContext createModelBuildingContext(BootstrapContext bootstrapContext) {
-		ClassLoaderService classLoaderService =
-				getServiceOrEmpty( bootstrapContext.getServiceRegistry(), ClassLoaderService.class )
-						.orElseThrow();
-		ClassLoaderServiceLoading classLoading = new ClassLoaderServiceLoading( classLoaderService );
-		if ( bootstrapContext.getJandexView() == null ) {
-			return new BasicModelBuildingContextImpl(
-					classLoading,
-					ModelsHelper::preFillRegistries
-			);
-		}
-		else {
-			return new JandexModelBuildingContextImpl(
-					(IndexView) bootstrapContext.getJandexView(),
-					classLoading,
-					ModelsHelper::preFillRegistries
-			);
-		}
 	}
 
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMappingInitiator.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMappingInitiator.java
@@ -40,8 +40,6 @@ import org.hibernate.search.util.common.impl.Closer;
 import org.hibernate.search.util.common.reflect.spi.ValueHandleFactory;
 import org.hibernate.service.ServiceRegistry;
 
-import org.jboss.jandex.IndexView;
-
 public class HibernateOrmMappingInitiator extends AbstractPojoMappingInitiator<HibernateOrmMappingPartialBuildState>
 		implements HibernateOrmMappingConfigurationContext {
 
@@ -72,7 +70,7 @@ public class HibernateOrmMappingInitiator extends AbstractPojoMappingInitiator<H
 							.multivalued()
 							.build();
 
-	public static HibernateOrmMappingInitiator create(Metadata metadata, IndexView jandexIndex,
+	public static HibernateOrmMappingInitiator create(Metadata metadata,
 			ClassDetailsRegistry classDetailsRegistry,
 			ValueHandleFactory valueHandleFactory, ServiceRegistry serviceRegistry) {
 		HibernateOrmBasicTypeMetadataProvider basicTypeMetadataProvider =
@@ -85,7 +83,7 @@ public class HibernateOrmMappingInitiator extends AbstractPojoMappingInitiator<H
 		boolean multiTenancyEnabled = ( (MetadataImplementor) metadata ).getMetadataBuildingOptions().isMultiTenancyEnabled()
 				|| isDiscriminatorMultiTenancyEnabled( metadata );
 
-		return new HibernateOrmMappingInitiator( basicTypeMetadataProvider, jandexIndex, introspector,
+		return new HibernateOrmMappingInitiator( basicTypeMetadataProvider, introspector,
 				preIntegrationService, multiTenancyEnabled );
 	}
 
@@ -98,14 +96,11 @@ public class HibernateOrmMappingInitiator extends AbstractPojoMappingInitiator<H
 
 	private HibernateOrmMappingInitiator(
 			HibernateOrmBasicTypeMetadataProvider basicTypeMetadataProvider,
-			IndexView jandexIndex, HibernateOrmBootstrapIntrospector introspector,
+			HibernateOrmBootstrapIntrospector introspector,
 			HibernateSearchPreIntegrationService preIntegrationService, boolean multiTenancyEnabled) {
 		super( introspector, HibernateOrmMapperHints.INSTANCE );
 
 		this.basicTypeMetadataProvider = basicTypeMetadataProvider;
-		if ( jandexIndex != null ) {
-			annotationMapping().addJandexIndex( jandexIndex );
-		}
 		this.introspector = introspector;
 
 		tenancyMode( multiTenancyEnabled ? TenancyMode.MULTI_TENANCY : TenancyMode.SINGLE_TENANCY );

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/query/spi/HibernateOrmSearchScrollableResultsAdapter.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/query/spi/HibernateOrmSearchScrollableResultsAdapter.java
@@ -162,6 +162,8 @@ public class HibernateOrmSearchScrollableResultsAdapter<R, H>
 		}
 	}
 
+	@SuppressWarnings("removal")
+	@Deprecated(since = "8.0", forRemoval = true)
 	@Override
 	public int getRowNumber() {
 		if ( afterLast ) {
@@ -172,9 +174,19 @@ public class HibernateOrmSearchScrollableResultsAdapter<R, H>
 
 	@Override
 	public boolean position(int position) {
-		return setRowNumber( position );
+		return setRowNumber( position - 1 );
 	}
 
+	@Override
+	public int getPosition() {
+		if ( afterLast ) {
+			return -1;
+		}
+		return currentIndexInScroll + 1;
+	}
+
+	@SuppressWarnings("removal")
+	@Deprecated(since = "8.0", forRemoval = true)
 	@Override
 	public boolean setRowNumber(int rowNumber) {
 		checkNotClosed();

--- a/mapper/orm/src/test/java/org/hibernate/search/mapper/orm/model/impl/AbstractHibernateOrmBootstrapIntrospectorPerReflectionStrategyTest.java
+++ b/mapper/orm/src/test/java/org/hibernate/search/mapper/orm/model/impl/AbstractHibernateOrmBootstrapIntrospectorPerReflectionStrategyTest.java
@@ -4,7 +4,7 @@
  */
 package org.hibernate.search.mapper.orm.model.impl;
 
-import static org.hibernate.search.mapper.orm.common.impl.HibernateOrmUtils.createModelBuildingContext;
+import static org.hibernate.search.mapper.orm.common.impl.HibernateOrmUtils.getServiceOrEmpty;
 
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
@@ -13,11 +13,17 @@ import java.util.List;
 
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.models.internal.ClassLoaderServiceLoading;
+import org.hibernate.boot.models.internal.ModelsHelper;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.H2Dialect;
+import org.hibernate.models.internal.BasicModelBuildingContextImpl;
+import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.search.util.common.impl.Closer;
 import org.hibernate.search.util.common.reflect.spi.ValueHandleFactory;
 
@@ -65,6 +71,17 @@ public abstract class AbstractHibernateOrmBootstrapIntrospectorPerReflectionStra
 
 		return HibernateOrmBootstrapIntrospector.create( basicTypeMetadataProvider, context.getClassDetailsRegistry(),
 				valueHandleFactory
+		);
+	}
+
+	public static SourceModelBuildingContext createModelBuildingContext(BootstrapContext bootstrapContext) {
+		ClassLoaderService classLoaderService =
+				getServiceOrEmpty( bootstrapContext.getServiceRegistry(), ClassLoaderService.class )
+						.orElseThrow();
+		ClassLoaderServiceLoading classLoading = new ClassLoaderServiceLoading( classLoaderService );
+		return new BasicModelBuildingContextImpl(
+				classLoading,
+				ModelsHelper::preFillRegistries
 		);
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5344
https://hibernate.atlassian.net/browse/HSEARCH-5346
https://hibernate.atlassian.net/browse/HSEARCH-5345

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
