### PR TITLE
Add narayana and agroal spring starters to the build dependencies group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,6 +70,8 @@ updates:
           - "org.jboss.marshalling:jboss-marshalling" # JBeret IT dependency
           - "org.wildfly.security:wildfly-security-manager" # JBeret IT dependency
           - "org.springframework.boot:*" # Spring is only for ITs
+          - "io.agroal:agroal-spring-boot-starter" # part of Spring dependencies, is only for ITs
+          - "dev.snowdrop:narayana-spring-boot-starter" # part of Spring dependencies, is only for ITs
           - "org.mockito:*"
           - "org.hamcrest:*"
           - "org.apache.logging.log4j:*"


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HSEARCH.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HSEARCH-<digits>`).
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
