### PR TITLE
HSEARCH-5358 Fail faster if an enclosing instance parameter is encountered in a projection constructor on JDK 25+

### DIFF
--- a/integrationtest/mapper/pojo-base/src/test/java-noparameters/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/noparameters/ProjectionConstructorClassNoParametersCompilerFlagIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java-noparameters/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/noparameters/ProjectionConstructorClassNoParametersCompilerFlagIT.java
@@ -48,51 +48,29 @@ class ProjectionConstructorClassNoParametersCompilerFlagIT extends AbstractProje
 
 	@Test
 	void implicitInnerMapping() {
-		@ProjectionConstructor
-		class MyProjection {
-			private final String someText;
-			private final Integer someInteger;
-			private final InnerProjection someContained;
-
-			MyProjection(String someText, Integer someInteger, InnerProjection someContained) {
-				this.someText = someText;
-				this.someInteger = someInteger;
-				this.someContained = someContained;
-			}
-
-			@ProjectionConstructor
-			static class InnerProjection {
-				private final String someText2;
-				private final Integer someInteger2;
-
-				InnerProjection(String someText2, Integer someInteger2) {
-					this.someText2 = someText2;
-					this.someInteger2 = someInteger2;
-				}
-			}
-		}
 		assertThatThrownBy( () -> setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class, MyProjection.InnerProjection.class )
+				.withAnnotatedTypes( ImplicitInnerMappingMyProjection.class,
+						ImplicitInnerMappingMyProjection.InnerProjection.class )
 				.setup( IndexedEntity.class ) )
 				.isInstanceOf( SearchException.class )
 				.satisfies( FailureReportUtils.hasFailureReport()
-						.typeContext( MyProjection.class.getName() )
-						.constructorContext( ProjectionConstructorClassNoParametersCompilerFlagIT.class, String.class,
+						.typeContext( ImplicitInnerMappingMyProjection.class.getName() )
+						.constructorContext( String.class,
 								Integer.class,
-								MyProjection.InnerProjection.class )
-						.methodParameterContext( 1 )
+								ImplicitInnerMappingMyProjection.InnerProjection.class )
+						.methodParameterContext( 0 )
 						.failure( "Missing parameter names in Java metadata for projection constructor",
 								"When inferring inner projections from constructor parameters,"
 										+ " constructor parameter names must be known",
 								"Either make sure this class was compiled with the '-parameters' compiler flag",
 								"or set the path explicitly with '@FieldProjection(path = ...)'" )
-						.methodParameterContext( 2 )
+						.methodParameterContext( 1 )
 						.failure( "Missing parameter names in Java metadata for projection constructor",
 								"When inferring inner projections from constructor parameters,"
 										+ " constructor parameter names must be known",
 								"Either make sure this class was compiled with the '-parameters' compiler flag",
 								"or set the path explicitly with '@FieldProjection(path = ...)' or '@ObjectProjection(path = ...)'" )
-						.methodParameterContext( 3 )
+						.methodParameterContext( 2 )
 						.failure( "Missing parameter names in Java metadata for projection constructor",
 								"When inferring inner projections from constructor parameters,"
 										+ " constructor parameter names must be known",
@@ -100,43 +78,48 @@ class ProjectionConstructorClassNoParametersCompilerFlagIT extends AbstractProje
 								"or set the path explicitly with '@FieldProjection(path = ...)' or '@ObjectProjection(path = ...)'" ) );
 	}
 
-	@Test
-	void explicitInnerMapping_implicitPath() {
+	@ProjectionConstructor
+	static class ImplicitInnerMappingMyProjection {
+		private final String someText;
+		private final Integer someInteger;
+		private final InnerProjection someContained;
+
+		ImplicitInnerMappingMyProjection(String someText, Integer someInteger, InnerProjection someContained) {
+			this.someText = someText;
+			this.someInteger = someInteger;
+			this.someContained = someContained;
+		}
+
 		@ProjectionConstructor
-		class MyProjection {
-			private final String someText;
-			private final Integer someInteger;
-			private final InnerProjection someContained;
+		static class InnerProjection {
+			private final String someText2;
+			private final Integer someInteger2;
 
-			MyProjection(@FieldProjection String someText,
-					@FieldProjection Integer someInteger,
-					@ObjectProjection InnerProjection someContained) {
-				this.someText = someText;
-				this.someInteger = someInteger;
-				this.someContained = someContained;
-			}
-
-			@ProjectionConstructor
-			static class InnerProjection {
-				private final String someText2;
-				private final Integer someInteger2;
-
-				InnerProjection(@FieldProjection String someText2,
-						@FieldProjection Integer someInteger2) {
-					this.someText2 = someText2;
-					this.someInteger2 = someInteger2;
-				}
+			InnerProjection(String someText2, Integer someInteger2) {
+				this.someText2 = someText2;
+				this.someInteger2 = someInteger2;
 			}
 		}
+	}
+
+	@Test
+	void explicitInnerMapping_implicitPath() {
 		assertThatThrownBy( () -> setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class, MyProjection.InnerProjection.class )
+				.withAnnotatedTypes( ExplicitInnerMapping_implicitPathMyProjection.class,
+						ExplicitInnerMapping_implicitPathMyProjection.InnerProjection.class )
 				.setup( IndexedEntity.class ) )
 				.isInstanceOf( SearchException.class )
 				.satisfies( FailureReportUtils.hasFailureReport()
-						.typeContext( MyProjection.class.getName() )
-						.constructorContext( ProjectionConstructorClassNoParametersCompilerFlagIT.class, String.class,
+						.typeContext( ExplicitInnerMapping_implicitPathMyProjection.class.getName() )
+						.constructorContext( String.class,
 								Integer.class,
-								MyProjection.InnerProjection.class )
+								ExplicitInnerMapping_implicitPathMyProjection.InnerProjection.class )
+						.methodParameterContext( 0 )
+						.failure( "Missing parameter names in Java metadata for projection constructor",
+								"When mapping a projection constructor parameter to a field projection without providing a field path,"
+										+ " constructor parameter names must be known",
+								"Either make sure this class was compiled with the '-parameters' compiler flag",
+								"or set the path explicitly with '@FieldProjection(path = ...)'" )
 						.methodParameterContext( 1 )
 						.failure( "Missing parameter names in Java metadata for projection constructor",
 								"When mapping a projection constructor parameter to a field projection without providing a field path,"
@@ -145,52 +128,48 @@ class ProjectionConstructorClassNoParametersCompilerFlagIT extends AbstractProje
 								"or set the path explicitly with '@FieldProjection(path = ...)'" )
 						.methodParameterContext( 2 )
 						.failure( "Missing parameter names in Java metadata for projection constructor",
-								"When mapping a projection constructor parameter to a field projection without providing a field path,"
-										+ " constructor parameter names must be known",
-								"Either make sure this class was compiled with the '-parameters' compiler flag",
-								"or set the path explicitly with '@FieldProjection(path = ...)'" )
-						.methodParameterContext( 3 )
-						.failure( "Missing parameter names in Java metadata for projection constructor",
 								"When mapping a projection constructor parameter to an object projection without providing a field path,"
 										+ " constructor parameter names must be known",
 								"Either make sure this class was compiled with the '-parameters' compiler flag",
 								"or set the path explicitly with '@ObjectProjection(path = ...)'" ) );
 	}
 
-	@Test
-	void explicitInnerMapping_explicitPath() {
+	@ProjectionConstructor
+	static class ExplicitInnerMapping_implicitPathMyProjection {
+		private final String someText;
+		private final Integer someInteger;
+		private final InnerProjection someContained;
+
+		ExplicitInnerMapping_implicitPathMyProjection(@FieldProjection String someText,
+				@FieldProjection Integer someInteger,
+				@ObjectProjection InnerProjection someContained) {
+			this.someText = someText;
+			this.someInteger = someInteger;
+			this.someContained = someContained;
+		}
+
 		@ProjectionConstructor
-		class MyProjection {
-			private final String someText;
-			private final Integer someInteger;
-			private final InnerProjection someContained;
+		static class InnerProjection {
+			private final String someText2;
+			private final Integer someInteger2;
 
-			MyProjection(@FieldProjection(path = "text") String someText,
-					@FieldProjection(path = "integer") Integer someInteger,
-					@ObjectProjection(path = "contained") InnerProjection someContained) {
-				this.someText = someText;
-				this.someInteger = someInteger;
-				this.someContained = someContained;
-			}
-
-			@ProjectionConstructor
-			static class InnerProjection {
-				private final String someText2;
-				private final Integer someInteger2;
-
-				InnerProjection(@FieldProjection(path = "text2") String someText2,
-						@FieldProjection(path = "integer2") Integer someInteger2) {
-					this.someText2 = someText2;
-					this.someInteger2 = someInteger2;
-				}
+			InnerProjection(@FieldProjection String someText2,
+					@FieldProjection Integer someInteger2) {
+				this.someText2 = someText2;
+				this.someInteger2 = someInteger2;
 			}
 		}
+	}
+
+	@Test
+	void explicitInnerMapping_explicitPath() {
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class, MyProjection.InnerProjection.class )
+				.withAnnotatedTypes( ExplicitInnerMapping_explicitPathMyProjection.class,
+						ExplicitInnerMapping_explicitPathMyProjection.InnerProjection.class )
 				.setup( IndexedEntity.class, ContainedEntity.class );
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, ExplicitInnerMapping_explicitPathMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "result1", 1, Arrays.asList( "result1_1", 11 ) ),
 						Arrays.asList( "result2", 2, Arrays.asList( "result2_1", 21 ) ),
@@ -198,7 +177,6 @@ class ProjectionConstructorClassNoParametersCompilerFlagIT extends AbstractProje
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "text", String.class ),
 								f.field( "integer", Integer.class ),
 								f.object( "contained" )
@@ -210,14 +188,41 @@ class ProjectionConstructorClassNoParametersCompilerFlagIT extends AbstractProje
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( "result1", 1,
-								new MyProjection.InnerProjection( "result1_1", 11 ) ),
-						new MyProjection( "result2", 2,
-								new MyProjection.InnerProjection( "result2_1", 21 ) ),
-						new MyProjection( "result3", 3,
-								new MyProjection.InnerProjection( "result3_1", 31 ) )
+						new ExplicitInnerMapping_explicitPathMyProjection( "result1", 1,
+								new ExplicitInnerMapping_explicitPathMyProjection.InnerProjection( "result1_1", 11 ) ),
+						new ExplicitInnerMapping_explicitPathMyProjection( "result2", 2,
+								new ExplicitInnerMapping_explicitPathMyProjection.InnerProjection( "result2_1", 21 ) ),
+						new ExplicitInnerMapping_explicitPathMyProjection( "result3", 3,
+								new ExplicitInnerMapping_explicitPathMyProjection.InnerProjection( "result3_1", 31 ) )
 				)
 		);
+	}
+
+	@ProjectionConstructor
+	static class ExplicitInnerMapping_explicitPathMyProjection {
+		private final String someText;
+		private final Integer someInteger;
+		private final InnerProjection someContained;
+
+		ExplicitInnerMapping_explicitPathMyProjection(@FieldProjection(path = "text") String someText,
+				@FieldProjection(path = "integer") Integer someInteger,
+				@ObjectProjection(path = "contained") InnerProjection someContained) {
+			this.someText = someText;
+			this.someInteger = someInteger;
+			this.someContained = someContained;
+		}
+
+		@ProjectionConstructor
+		static class InnerProjection {
+			private final String someText2;
+			private final Integer someInteger2;
+
+			InnerProjection(@FieldProjection(path = "text2") String someText2,
+					@FieldProjection(path = "integer2") Integer someInteger2) {
+				this.someText2 = someText2;
+				this.someInteger2 = someInteger2;
+			}
+		}
 	}
 
 	@Indexed(index = INDEX_NAME)

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/AbstractProjectionConstructorIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/AbstractProjectionConstructorIT.java
@@ -16,6 +16,7 @@ import org.hibernate.search.mapper.pojo.standalone.session.SearchSession;
 import org.hibernate.search.util.impl.integrationtest.common.extension.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.common.extension.StubSearchWorkBehavior;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public abstract class AbstractProjectionConstructorIT {
@@ -24,10 +25,6 @@ public abstract class AbstractProjectionConstructorIT {
 
 	@RegisterExtension
 	public BackendMock backendMock = BackendMock.create();
-
-	protected final ProjectionFinalStep<?> dummyProjectionForEnclosingClassInstance(SearchProjectionFactory<?, ?> f) {
-		return f.constant( null );
-	}
 
 	protected final <P> void testSuccessfulRootProjectionExecutionOnly(SearchMapping mapping, Class<?> indexedType,
 			Class<P> projectionType,
@@ -77,5 +74,10 @@ public abstract class AbstractProjectionConstructorIT {
 
 	protected SearchSession createSession(SearchMapping mapping) {
 		return mapping.createSession();
+	}
+
+	@Test
+	void name() {
+
 	}
 }

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorBaseIT.java
@@ -6,6 +6,7 @@ package org.hibernate.search.integrationtest.mapper.pojo.mapping.definition;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
@@ -51,35 +52,36 @@ class ProjectionConstructorBaseIT extends AbstractProjectionConstructorIT {
 			@GenericField
 			public Integer integer;
 		}
-		@ProjectionConstructor
-		class MyProjection {
-			public final String text;
-			public final Integer integer;
-
-			public MyProjection(String text, Integer integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( TypeLevelAnnotationMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjectionExecutionOnly(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, TypeLevelAnnotationMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "result1", 1 ),
 						Arrays.asList( "result2", 2 ),
 						Arrays.asList( "result3", 3 )
 				),
 				Arrays.asList(
-						new MyProjection( "result1", 1 ),
-						new MyProjection( "result2", 2 ),
-						new MyProjection( "result3", 3 )
+						new TypeLevelAnnotationMyProjection( "result1", 1 ),
+						new TypeLevelAnnotationMyProjection( "result2", 2 ),
+						new TypeLevelAnnotationMyProjection( "result3", 3 )
 				)
 		);
+	}
+
+	@ProjectionConstructor
+	static class TypeLevelAnnotationMyProjection {
+		public final String text;
+		public final Integer integer;
+
+		public TypeLevelAnnotationMyProjection(String text, Integer integer) {
+			this.text = text;
+			this.integer = integer;
+		}
 	}
 
 	@Test
@@ -93,31 +95,33 @@ class ProjectionConstructorBaseIT extends AbstractProjectionConstructorIT {
 			@GenericField
 			public Integer integer;
 		}
-		@ProjectionConstructor
-		class MyProjection {
-			public final String text;
-			public final Integer integer;
-
-			public MyProjection(String text, Integer integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-
-			public MyProjection(String text, Integer integer, String somethingElse) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
 
 		assertThatThrownBy( () -> setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( TypeLevelAnnotation_multipleConstructorsMyProjection.class )
 				.setup( IndexedEntity.class ) )
 				.isInstanceOf( SearchException.class )
 				.satisfies( FailureReportUtils.hasFailureReport()
-						.typeContext( MyProjection.class.getName() )
+						.typeContext( TypeLevelAnnotation_multipleConstructorsMyProjection.class.getName() )
 						.annotationContextAnyParameters( ProjectionConstructor.class )
 						.failure( "No main constructor for type",
-								MyProjection.class.getName(), "this type does not declare exactly one constructor" ) );
+								TypeLevelAnnotation_multipleConstructorsMyProjection.class.getName(),
+								"this type does not declare exactly one constructor" ) );
+	}
+
+	@ProjectionConstructor
+	static class TypeLevelAnnotation_multipleConstructorsMyProjection {
+		public final String text;
+		public final Integer integer;
+
+		public TypeLevelAnnotation_multipleConstructorsMyProjection(String text, Integer integer) {
+			this.text = text;
+			this.integer = integer;
+		}
+
+		public TypeLevelAnnotation_multipleConstructorsMyProjection(String text, Integer integer, String somethingElse) {
+			this.text = text;
+			this.integer = integer;
+		}
 	}
 
 	@Test
@@ -131,45 +135,46 @@ class ProjectionConstructorBaseIT extends AbstractProjectionConstructorIT {
 			@GenericField
 			public Integer integer;
 		}
-		class MyProjection {
-			public final String text;
-			public final Integer integer;
-
-			public MyProjection() {
-				this.text = "foo";
-				this.integer = 42;
-			}
-
-			@ProjectionConstructor
-			public MyProjection(String text, Integer integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-
-			public MyProjection(String text, Integer integer, String somethingElse) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( ConstructorLevelAnnotationMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjectionExecutionOnly(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, ConstructorLevelAnnotationMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "result1", 1 ),
 						Arrays.asList( "result2", 2 ),
 						Arrays.asList( "result3", 3 )
 				),
 				Arrays.asList(
-						new MyProjection( "result1", 1 ),
-						new MyProjection( "result2", 2 ),
-						new MyProjection( "result3", 3 )
+						new ConstructorLevelAnnotationMyProjection( "result1", 1 ),
+						new ConstructorLevelAnnotationMyProjection( "result2", 2 ),
+						new ConstructorLevelAnnotationMyProjection( "result3", 3 )
 				)
 		);
+	}
+
+	static class ConstructorLevelAnnotationMyProjection {
+		public final String text;
+		public final Integer integer;
+
+		public ConstructorLevelAnnotationMyProjection() {
+			this.text = "foo";
+			this.integer = 42;
+		}
+
+		@ProjectionConstructor
+		public ConstructorLevelAnnotationMyProjection(String text, Integer integer) {
+			this.text = text;
+			this.integer = integer;
+		}
+
+		public ConstructorLevelAnnotationMyProjection(String text, Integer integer, String somethingElse) {
+			this.text = text;
+			this.integer = integer;
+		}
 	}
 
 	@Test
@@ -183,75 +188,80 @@ class ProjectionConstructorBaseIT extends AbstractProjectionConstructorIT {
 			@GenericField
 			public Integer integer;
 		}
-		abstract class MyAbstractProjection {
-			public final String text;
-			public final Integer integer;
-
-			@ProjectionConstructor
-			public MyAbstractProjection(String text, Integer integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-
-			public MyAbstractProjection(String text, Integer integer, String somethingElse) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
 
 		assertThatThrownBy( () -> setupHelper.start()
-				.withAnnotatedTypes( MyAbstractProjection.class )
+				.withAnnotatedTypes( AbstractTypeMyAbstractProjection.class )
 				.setup( IndexedEntity.class ) )
 				.isInstanceOf( SearchException.class )
 				.satisfies( FailureReportUtils.hasFailureReport()
-						.typeContext( MyAbstractProjection.class.getName() )
-						.constructorContext( ProjectionConstructorBaseIT.class, String.class, Integer.class )
+						.typeContext( AbstractTypeMyAbstractProjection.class.getName() )
+						.constructorContext( String.class, Integer.class )
 						.failure( "Invalid declaring type for projection constructor",
-								MyAbstractProjection.class.getName(), "is abstract",
+								AbstractTypeMyAbstractProjection.class.getName(), "is abstract",
 								"Projection constructors can only be declared on concrete types" ) );
+	}
+
+	abstract static class AbstractTypeMyAbstractProjection {
+		public final String text;
+		public final Integer integer;
+
+		@ProjectionConstructor
+		public AbstractTypeMyAbstractProjection(String text, Integer integer) {
+			this.text = text;
+			this.integer = integer;
+		}
+
+		public AbstractTypeMyAbstractProjection(String text, Integer integer, String somethingElse) {
+			this.text = text;
+			this.integer = integer;
+		}
 	}
 
 	@Test
 	void entityAndProjection() {
-		@Indexed(index = INDEX_NAME)
-		class IndexedEntity {
-			@DocumentId
-			public Integer id;
-			@FullTextField
-			public String text;
-			@GenericField
-			public Integer integer;
-
-			public IndexedEntity() {
-			}
-
-			@ProjectionConstructor
-			public IndexedEntity(String text, Integer integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
-
 		backendMock.expectAnySchema( INDEX_NAME );
-		SearchMapping mapping = setupHelper.start().setup( IndexedEntity.class );
+		SearchMapping mapping = setupHelper.start().setup( EntityAndProjectionIndexedEntity.class );
 
 		testSuccessfulRootProjectionExecutionOnly(
-				mapping, IndexedEntity.class, IndexedEntity.class,
+				mapping, EntityAndProjectionIndexedEntity.class, EntityAndProjectionIndexedEntity.class,
 				Arrays.asList(
 						Arrays.asList( "result1", 1 ),
 						Arrays.asList( "result2", 2 ),
 						Arrays.asList( "result3", 3 )
 				),
 				Arrays.asList(
-						new IndexedEntity( "result1", 1 ),
-						new IndexedEntity( "result2", 2 ),
-						new IndexedEntity( "result3", 3 )
+						new EntityAndProjectionIndexedEntity( "result1", 1 ),
+						new EntityAndProjectionIndexedEntity( "result2", 2 ),
+						new EntityAndProjectionIndexedEntity( "result3", 3 )
 				)
 		);
 	}
 
+	@Indexed(index = INDEX_NAME)
+	static class EntityAndProjectionIndexedEntity {
+		@DocumentId
+		public Integer id;
+		@FullTextField
+		public String text;
+		@GenericField
+		public Integer integer;
+
+		public EntityAndProjectionIndexedEntity() {
+		}
+
+		@ProjectionConstructor
+		public EntityAndProjectionIndexedEntity(String text, Integer integer) {
+			this.text = text;
+			this.integer = integer;
+		}
+	}
+
 	@Test
 	void noArgConstructor() {
+		assumeTrue(
+				Runtime.version().feature() < 25,
+				"With JDK 25+ nonstatic (inner class) projections are not supported."
+		);
 		@Indexed(index = INDEX_NAME)
 		class IndexedEntity {
 			@DocumentId
@@ -261,40 +271,41 @@ class ProjectionConstructorBaseIT extends AbstractProjectionConstructorIT {
 			@GenericField
 			public Integer integer;
 		}
-		class MyProjection {
-			public final String text;
-			public final Integer integer;
-
-			@ProjectionConstructor
-			public MyProjection() {
-				this.text = "foo";
-				this.integer = 42;
-			}
-
-			public MyProjection(String text, Integer integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( NoArgConstructorMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjectionExecutionOnly(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, NoArgConstructorMyProjection.class,
 				Arrays.asList(
 						Arrays.asList(),
 						Arrays.asList(),
 						Arrays.asList()
 				),
 				Arrays.asList(
-						new MyProjection(),
-						new MyProjection(),
-						new MyProjection()
+						new NoArgConstructorMyProjection(),
+						new NoArgConstructorMyProjection(),
+						new NoArgConstructorMyProjection()
 				)
 		);
+	}
+
+	class NoArgConstructorMyProjection {
+		public final String text;
+		public final Integer integer;
+
+		@ProjectionConstructor
+		public NoArgConstructorMyProjection() {
+			this.text = "foo";
+			this.integer = 42;
+		}
+
+		public NoArgConstructorMyProjection(String text, Integer integer) {
+			this.text = text;
+			this.integer = integer;
+		}
 	}
 
 	@Test
@@ -308,34 +319,35 @@ class ProjectionConstructorBaseIT extends AbstractProjectionConstructorIT {
 			@GenericField
 			public Integer integer;
 		}
-		class MyNonProjection {
-			public final String text;
-			public final Integer integer;
-
-			public MyNonProjection() {
-				this.text = "foo";
-				this.integer = 42;
-			}
-
-			public MyNonProjection(String text, Integer integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyNonProjection.class )
+				.withAnnotatedTypes( NoProjectionConstructorMyNonProjection.class )
 				.setup( IndexedEntity.class );
 
 		try ( SearchSession session = mapping.createSession() ) {
 			assertThatThrownBy( () -> session.search( IndexedEntity.class )
-					.select( MyNonProjection.class ) )
+					.select( NoProjectionConstructorMyNonProjection.class ) )
 					.isInstanceOf( SearchException.class )
 					.hasMessageContainingAll( "Invalid object class for projection",
-							MyNonProjection.class.getName(),
+							NoProjectionConstructorMyNonProjection.class.getName(),
 							"Make sure that this class is mapped correctly, "
 									+ "either through annotations (@ProjectionConstructor) or programmatic mapping" );
+		}
+	}
+
+	static class NoProjectionConstructorMyNonProjection {
+		public final String text;
+		public final Integer integer;
+
+		public NoProjectionConstructorMyNonProjection() {
+			this.text = "foo";
+			this.integer = 42;
+		}
+
+		public NoProjectionConstructorMyNonProjection(String text, Integer integer) {
+			this.text = text;
+			this.integer = integer;
 		}
 	}
 
@@ -351,21 +363,6 @@ class ProjectionConstructorBaseIT extends AbstractProjectionConstructorIT {
 			@GenericField
 			public Integer integer;
 		}
-		class MyProjection {
-			public final String text;
-			public final Integer integer;
-
-			public MyProjection() {
-				this.text = "foo";
-				this.integer = 42;
-			}
-
-			@ProjectionConstructor
-			public MyProjection(String text, Integer integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
@@ -375,14 +372,30 @@ class ProjectionConstructorBaseIT extends AbstractProjectionConstructorIT {
 
 		try ( SearchSession session = mapping.createSession() ) {
 			assertThatThrownBy( () -> session.search( IndexedEntity.class )
-					.select( MyProjection.class ) )
+					.select( AnnotationNotProcessedMyProjection.class ) )
 					.isInstanceOf( SearchException.class )
 					.hasMessageContainingAll( "Invalid object class for projection",
-							MyProjection.class.getName(),
+							AnnotationNotProcessedMyProjection.class.getName(),
 							"Make sure that this class is mapped correctly, "
 									+ "either through annotations (@ProjectionConstructor) or programmatic mapping",
 							"If it is, make sure the class is included in a Jandex index"
 									+ " made available to Hibernate Search" );
+		}
+	}
+
+	static class AnnotationNotProcessedMyProjection {
+		public final String text;
+		public final Integer integer;
+
+		public AnnotationNotProcessedMyProjection() {
+			this.text = "foo";
+			this.integer = 42;
+		}
+
+		@ProjectionConstructor
+		public AnnotationNotProcessedMyProjection(String text, Integer integer) {
+			this.text = text;
+			this.integer = integer;
 		}
 	}
 
@@ -397,66 +410,80 @@ class ProjectionConstructorBaseIT extends AbstractProjectionConstructorIT {
 			@GenericField
 			public Integer integer;
 		}
-		class MyNonProjection {
-			public final String text;
-			public final Integer integer;
-
-			public MyNonProjection() {
-				this.text = "foo";
-				this.integer = 42;
-			}
-
-			public MyNonProjection(String text, Integer integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-
-			public MyNonProjection(String text, Integer integer, String somethingElse) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
-		class MyProjectionSubclass extends MyNonProjection {
-			public MyProjectionSubclass() {
-				super();
-			}
-
-			@ProjectionConstructor
-			public MyProjectionSubclass(String text, Integer integer) {
-				super( text + "_fromSubclass", integer );
-			}
-
-			public MyProjectionSubclass(String text, Integer integer, String somethingElse) {
-				super( text, integer, somethingElse );
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyNonProjection.class, MyProjectionSubclass.class )
+				.withAnnotatedTypes(
+						Inheritance_sameConstructorParameters_subclassOnlyWithProjectionConstructorMyNonProjection.class,
+						Inheritance_sameConstructorParameters_subclassOnlyWithProjectionConstructorMyProjectionSubclass.class )
 				.setup( IndexedEntity.class );
 
 		try ( SearchSession session = mapping.createSession() ) {
 			assertThatThrownBy( () -> session.search( IndexedEntity.class )
-					.select( MyNonProjection.class ) )
+					.select( Inheritance_sameConstructorParameters_subclassOnlyWithProjectionConstructorMyNonProjection.class ) )
 					.isInstanceOf( SearchException.class )
 					.hasMessageContainingAll( "Invalid object class for projection",
-							MyNonProjection.class.getName() );
+							Inheritance_sameConstructorParameters_subclassOnlyWithProjectionConstructorMyNonProjection.class
+									.getName() );
 		}
 
 		testSuccessfulRootProjectionExecutionOnly(
-				mapping, IndexedEntity.class, MyProjectionSubclass.class,
+				mapping, IndexedEntity.class,
+				Inheritance_sameConstructorParameters_subclassOnlyWithProjectionConstructorMyProjectionSubclass.class,
 				Arrays.asList(
 						Arrays.asList( "result1", 1 ),
 						Arrays.asList( "result2", 2 ),
 						Arrays.asList( "result3", 3 )
 				),
 				Arrays.asList(
-						new MyProjectionSubclass( "result1", 1 ),
-						new MyProjectionSubclass( "result2", 2 ),
-						new MyProjectionSubclass( "result3", 3 )
+						new Inheritance_sameConstructorParameters_subclassOnlyWithProjectionConstructorMyProjectionSubclass(
+								"result1", 1 ),
+						new Inheritance_sameConstructorParameters_subclassOnlyWithProjectionConstructorMyProjectionSubclass(
+								"result2", 2 ),
+						new Inheritance_sameConstructorParameters_subclassOnlyWithProjectionConstructorMyProjectionSubclass(
+								"result3", 3 )
 				)
 		);
+	}
+
+	static class Inheritance_sameConstructorParameters_subclassOnlyWithProjectionConstructorMyNonProjection {
+		public final String text;
+		public final Integer integer;
+
+		public Inheritance_sameConstructorParameters_subclassOnlyWithProjectionConstructorMyNonProjection() {
+			this.text = "foo";
+			this.integer = 42;
+		}
+
+		public Inheritance_sameConstructorParameters_subclassOnlyWithProjectionConstructorMyNonProjection(String text,
+				Integer integer) {
+			this.text = text;
+			this.integer = integer;
+		}
+
+		public Inheritance_sameConstructorParameters_subclassOnlyWithProjectionConstructorMyNonProjection(String text,
+				Integer integer, String somethingElse) {
+			this.text = text;
+			this.integer = integer;
+		}
+	}
+
+	static class Inheritance_sameConstructorParameters_subclassOnlyWithProjectionConstructorMyProjectionSubclass
+			extends Inheritance_sameConstructorParameters_subclassOnlyWithProjectionConstructorMyNonProjection {
+		public Inheritance_sameConstructorParameters_subclassOnlyWithProjectionConstructorMyProjectionSubclass() {
+			super();
+		}
+
+		@ProjectionConstructor
+		public Inheritance_sameConstructorParameters_subclassOnlyWithProjectionConstructorMyProjectionSubclass(String text,
+				Integer integer) {
+			super( text + "_fromSubclass", integer );
+		}
+
+		public Inheritance_sameConstructorParameters_subclassOnlyWithProjectionConstructorMyProjectionSubclass(String text,
+				Integer integer, String somethingElse) {
+			super( text, integer, somethingElse );
+		}
 	}
 
 	@Test
@@ -470,65 +497,79 @@ class ProjectionConstructorBaseIT extends AbstractProjectionConstructorIT {
 			@GenericField
 			public Integer integer;
 		}
-		class MyProjection {
-			public final String text;
-			public final Integer integer;
-
-			public MyProjection() {
-				this.text = "foo";
-				this.integer = 42;
-			}
-
-			@ProjectionConstructor
-			public MyProjection(String text, Integer integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-
-			public MyProjection(String text, Integer integer, String somethingElse) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
-		class MyNonProjectionSubclass extends MyProjection {
-			public MyNonProjectionSubclass() {
-				super();
-			}
-
-			public MyNonProjectionSubclass(String text, Integer integer) {
-				super( text + "_fromSubclass", integer );
-			}
-
-			public MyNonProjectionSubclass(String text, Integer integer, String somethingElse) {
-				super( text, integer, somethingElse );
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class, MyNonProjectionSubclass.class )
+				.withAnnotatedTypes(
+						Inheritance_sameConstructorParameters_superclassOnlyWithProjectionConstructorMyProjection.class,
+						Inheritance_sameConstructorParameters_superclassOnlyWithProjectionConstructorMyNonProjectionSubclass.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjectionExecutionOnly(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class,
+				Inheritance_sameConstructorParameters_superclassOnlyWithProjectionConstructorMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "result1", 1 ),
 						Arrays.asList( "result2", 2 ),
 						Arrays.asList( "result3", 3 )
 				),
 				Arrays.asList(
-						new MyProjection( "result1", 1 ),
-						new MyProjection( "result2", 2 ),
-						new MyProjection( "result3", 3 )
+						new Inheritance_sameConstructorParameters_superclassOnlyWithProjectionConstructorMyProjection(
+								"result1", 1 ),
+						new Inheritance_sameConstructorParameters_superclassOnlyWithProjectionConstructorMyProjection(
+								"result2", 2 ),
+						new Inheritance_sameConstructorParameters_superclassOnlyWithProjectionConstructorMyProjection(
+								"result3", 3 )
 				)
 		);
 
 		try ( SearchSession session = mapping.createSession() ) {
 			assertThatThrownBy( () -> session.search( IndexedEntity.class )
-					.select( MyNonProjectionSubclass.class ) )
+					.select( Inheritance_sameConstructorParameters_superclassOnlyWithProjectionConstructorMyNonProjectionSubclass.class ) )
 					.isInstanceOf( SearchException.class )
 					.hasMessageContainingAll( "Invalid object class for projection",
-							MyNonProjectionSubclass.class.getName() );
+							Inheritance_sameConstructorParameters_superclassOnlyWithProjectionConstructorMyNonProjectionSubclass.class
+									.getName() );
+		}
+	}
+
+	static class Inheritance_sameConstructorParameters_superclassOnlyWithProjectionConstructorMyProjection {
+		public final String text;
+		public final Integer integer;
+
+		public Inheritance_sameConstructorParameters_superclassOnlyWithProjectionConstructorMyProjection() {
+			this.text = "foo";
+			this.integer = 42;
+		}
+
+		@ProjectionConstructor
+		public Inheritance_sameConstructorParameters_superclassOnlyWithProjectionConstructorMyProjection(String text,
+				Integer integer) {
+			this.text = text;
+			this.integer = integer;
+		}
+
+		public Inheritance_sameConstructorParameters_superclassOnlyWithProjectionConstructorMyProjection(String text,
+				Integer integer, String somethingElse) {
+			this.text = text;
+			this.integer = integer;
+		}
+	}
+
+	static class Inheritance_sameConstructorParameters_superclassOnlyWithProjectionConstructorMyNonProjectionSubclass
+			extends Inheritance_sameConstructorParameters_superclassOnlyWithProjectionConstructorMyProjection {
+		public Inheritance_sameConstructorParameters_superclassOnlyWithProjectionConstructorMyNonProjectionSubclass() {
+			super();
+		}
+
+		public Inheritance_sameConstructorParameters_superclassOnlyWithProjectionConstructorMyNonProjectionSubclass(String text,
+				Integer integer) {
+			super( text + "_fromSubclass", integer );
+		}
+
+		public Inheritance_sameConstructorParameters_superclassOnlyWithProjectionConstructorMyNonProjectionSubclass(String text,
+				Integer integer, String somethingElse) {
+			super( text, integer, somethingElse );
 		}
 	}
 
@@ -543,73 +584,90 @@ class ProjectionConstructorBaseIT extends AbstractProjectionConstructorIT {
 			@GenericField
 			public Integer integer;
 		}
-		class MyProjection {
-			public final String text;
-			public final Integer integer;
-
-			public MyProjection() {
-				this.text = "foo";
-				this.integer = 42;
-			}
-
-			@ProjectionConstructor
-			public MyProjection(String text, Integer integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-
-			public MyProjection(String text, Integer integer, String somethingElse) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
-		class MyProjectionSubclass extends MyProjection {
-			public MyProjectionSubclass() {
-				super();
-			}
-
-			@ProjectionConstructor
-			public MyProjectionSubclass(String text, Integer integer) {
-				super( text + "_fromSubclass", integer );
-			}
-
-			public MyProjectionSubclass(String text, Integer integer, String somethingElse) {
-				super( text, integer, somethingElse );
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class, MyProjectionSubclass.class )
+				.withAnnotatedTypes(
+						Inheritance_sameConstructorParameters_bothClassesWithProjectionConstructorMyProjection.class,
+						Inheritance_sameConstructorParameters_bothClassesWithProjectionConstructorMyProjectionSubclass.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjectionExecutionOnly(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class,
+				Inheritance_sameConstructorParameters_bothClassesWithProjectionConstructorMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "result1", 1 ),
 						Arrays.asList( "result2", 2 ),
 						Arrays.asList( "result3", 3 )
 				),
 				Arrays.asList(
-						new MyProjection( "result1", 1 ),
-						new MyProjection( "result2", 2 ),
-						new MyProjection( "result3", 3 )
+						new Inheritance_sameConstructorParameters_bothClassesWithProjectionConstructorMyProjection( "result1",
+								1 ),
+						new Inheritance_sameConstructorParameters_bothClassesWithProjectionConstructorMyProjection( "result2",
+								2 ),
+						new Inheritance_sameConstructorParameters_bothClassesWithProjectionConstructorMyProjection( "result3",
+								3 )
 				)
 		);
 
 		testSuccessfulRootProjectionExecutionOnly(
-				mapping, IndexedEntity.class, MyProjectionSubclass.class,
+				mapping, IndexedEntity.class,
+				Inheritance_sameConstructorParameters_bothClassesWithProjectionConstructorMyProjectionSubclass.class,
 				Arrays.asList(
 						Arrays.asList( "result1", 1 ),
 						Arrays.asList( "result2", 2 ),
 						Arrays.asList( "result3", 3 )
 				),
 				Arrays.asList(
-						new MyProjectionSubclass( "result1", 1 ),
-						new MyProjectionSubclass( "result2", 2 ),
-						new MyProjectionSubclass( "result3", 3 )
+						new Inheritance_sameConstructorParameters_bothClassesWithProjectionConstructorMyProjectionSubclass(
+								"result1", 1 ),
+						new Inheritance_sameConstructorParameters_bothClassesWithProjectionConstructorMyProjectionSubclass(
+								"result2", 2 ),
+						new Inheritance_sameConstructorParameters_bothClassesWithProjectionConstructorMyProjectionSubclass(
+								"result3", 3 )
 				)
 		);
+	}
+
+	static class Inheritance_sameConstructorParameters_bothClassesWithProjectionConstructorMyProjection {
+		public final String text;
+		public final Integer integer;
+
+		public Inheritance_sameConstructorParameters_bothClassesWithProjectionConstructorMyProjection() {
+			this.text = "foo";
+			this.integer = 42;
+		}
+
+		@ProjectionConstructor
+		public Inheritance_sameConstructorParameters_bothClassesWithProjectionConstructorMyProjection(String text,
+				Integer integer) {
+			this.text = text;
+			this.integer = integer;
+		}
+
+		public Inheritance_sameConstructorParameters_bothClassesWithProjectionConstructorMyProjection(String text,
+				Integer integer, String somethingElse) {
+			this.text = text;
+			this.integer = integer;
+		}
+	}
+
+	static class Inheritance_sameConstructorParameters_bothClassesWithProjectionConstructorMyProjectionSubclass
+			extends Inheritance_sameConstructorParameters_bothClassesWithProjectionConstructorMyProjection {
+		public Inheritance_sameConstructorParameters_bothClassesWithProjectionConstructorMyProjectionSubclass() {
+			super();
+		}
+
+		@ProjectionConstructor
+		public Inheritance_sameConstructorParameters_bothClassesWithProjectionConstructorMyProjectionSubclass(String text,
+				Integer integer) {
+			super( text + "_fromSubclass", integer );
+		}
+
+		public Inheritance_sameConstructorParameters_bothClassesWithProjectionConstructorMyProjectionSubclass(String text,
+				Integer integer, String somethingElse) {
+			super( text, integer, somethingElse );
+		}
 	}
 
 	// This checks that everything works correctly when a constructor projection
@@ -634,20 +692,10 @@ class ProjectionConstructorBaseIT extends AbstractProjectionConstructorIT {
 			@IndexedEmbedded
 			public Contained contained;
 		}
-		class MyProjection {
-			public final String text;
-			public final Integer integer;
-
-			@ProjectionConstructor
-			public MyProjection(String text, Integer integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( NonRootMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		try ( SearchSession session = mapping.createSession() ) {
@@ -661,16 +709,27 @@ class ProjectionConstructorBaseIT extends AbstractProjectionConstructorIT {
 			);
 
 			assertThat( session.search( IndexedEntity.class )
-					.select( f -> f.object( "contained" ).as( MyProjection.class ) )
+					.select( f -> f.object( "contained" ).as( NonRootMyProjection.class ) )
 					.where( f -> f.matchAll() )
 					.fetchAllHits() )
 					.usingRecursiveComparison()
 					.isEqualTo( Arrays.asList(
-							new MyProjection( "text1", 1 ),
-							new MyProjection( "text2", 2 )
+							new NonRootMyProjection( "text1", 1 ),
+							new NonRootMyProjection( "text2", 2 )
 					) );
 		}
 		backendMock.verifyExpectationsMet();
+	}
+
+	static class NonRootMyProjection {
+		public final String text;
+		public final Integer integer;
+
+		@ProjectionConstructor
+		public NonRootMyProjection(String text, Integer integer) {
+			this.text = text;
+			this.integer = integer;
+		}
 	}
 
 	@Test
@@ -715,52 +774,56 @@ class ProjectionConstructorBaseIT extends AbstractProjectionConstructorIT {
 
 		}
 
-		@ProjectionConstructor
-		class MyProjectionAuthor {
-			public final String firstName;
-			public final String lastName;
-			// Extra property that is part of projection but is not present in the index.
-			public final String email;
-
-			MyProjectionAuthor(String firstName, String lastName, String email) {
-				this.firstName = firstName;
-				this.lastName = lastName;
-				this.email = email;
-			}
-		}
-		@ProjectionConstructor
-		class MyProjectionBook {
-			public final String title;
-			public final List<MyProjectionAuthor> authors;
-
-			MyProjectionBook(String title, List<MyProjectionAuthor> authors) {
-				this.title = title;
-				this.authors = authors;
-			}
-		}
-
 		backendMock.expectAnySchema( Book.INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjectionBook.class )
+				.withAnnotatedTypes( IncompatibleProjectionWithExtraPropertiesMissingMyProjectionBook.class )
 				.setup( Book.class );
 
 		try ( SearchSession session = mapping.createSession() ) {
 			assertThatThrownBy( () -> session.search( Book.class )
-					.select( MyProjectionBook.class )
+					.select( IncompatibleProjectionWithExtraPropertiesMissingMyProjectionBook.class )
 					.where( f -> f.matchAll() )
 					.fetchAllHits()
 			).isInstanceOf( SearchException.class )
 					.hasMessageContainingAll(
 							"Could not apply projection constructor",
 							"Unknown field 'authors.email'",
-							"for parameter #2 in"
+							"for parameter #1 in"
 					).hasMessageFindingMatch(
 							// constructor string as per `PojoConstructorModelFormatter`
-							Pattern.quote( MyProjectionAuthor.class.getName() ) + "\\(.+\\)"
+							Pattern.quote( IncompatibleProjectionWithExtraPropertiesMissingMyProjectionAuthor.class.getName() )
+									+ "\\(.+\\)"
 					).hasMessageFindingMatch(
 							// constructor string as per `PojoConstructorModelFormatter`
-							Pattern.quote( MyProjectionBook.class.getName() ) + "\\(.+\\*java\\.util\\.List\\*\\)"
+							Pattern.quote( IncompatibleProjectionWithExtraPropertiesMissingMyProjectionBook.class.getName() )
+									+ "\\(.+\\*java\\.util\\.List\\*\\)"
 					);
+		}
+	}
+
+	@ProjectionConstructor
+	static class IncompatibleProjectionWithExtraPropertiesMissingMyProjectionAuthor {
+		public final String firstName;
+		public final String lastName;
+		// Extra property that is part of projection but is not present in the index.
+		public final String email;
+
+		IncompatibleProjectionWithExtraPropertiesMissingMyProjectionAuthor(String firstName, String lastName, String email) {
+			this.firstName = firstName;
+			this.lastName = lastName;
+			this.email = email;
+		}
+	}
+
+	@ProjectionConstructor
+	static class IncompatibleProjectionWithExtraPropertiesMissingMyProjectionBook {
+		public final String title;
+		public final List<IncompatibleProjectionWithExtraPropertiesMissingMyProjectionAuthor> authors;
+
+		IncompatibleProjectionWithExtraPropertiesMissingMyProjectionBook(String title,
+				List<IncompatibleProjectionWithExtraPropertiesMissingMyProjectionAuthor> authors) {
+			this.title = title;
+			this.authors = authors;
 		}
 	}
 
@@ -774,7 +837,7 @@ class ProjectionConstructorBaseIT extends AbstractProjectionConstructorIT {
 				public Integer id;
 			}
 
-			class MyProjection {
+			static class MyProjection {
 				public final Integer id;
 
 				@ProjectionConstructor
@@ -790,8 +853,8 @@ class ProjectionConstructorBaseIT extends AbstractProjectionConstructorIT {
 				.isInstanceOf( SearchException.class )
 				.satisfies( FailureReportUtils.hasFailureReport()
 						.typeContext( Model.MyProjection.class.getName() )
-						.constructorContext( Model.class, Integer.class )
-						.methodParameterContext( 1, "id" )
+						.constructorContext( Integer.class )
+						.methodParameterContext( 0, "id" )
 						.failure(
 								"Multiple projections are mapped for this parameter",
 								"At most one projection is allowed for each parameter" ) );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorDocumentReferenceProjectionIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorDocumentReferenceProjectionIT.java
@@ -41,37 +41,37 @@ class ProjectionConstructorDocumentReferenceProjectionIT extends AbstractProject
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final DocumentReference documentReference;
-
-			@ProjectionConstructor
-			public MyProjection(@DocumentReferenceProjection DocumentReference documentReference) {
-				this.documentReference = documentReference;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( NoArgMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, NoArgMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( reference( INDEX_NAME, "1" ) ),
 						Arrays.asList( reference( INDEX_NAME, "2" ) )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.documentReference()
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( reference( INDEX_NAME, "1" ) ),
-						new MyProjection( reference( INDEX_NAME, "2" ) )
+						new NoArgMyProjection( reference( INDEX_NAME, "1" ) ),
+						new NoArgMyProjection( reference( INDEX_NAME, "2" ) )
 				)
 		);
+	}
+
+	static class NoArgMyProjection {
+		public final DocumentReference documentReference;
+
+		@ProjectionConstructor
+		public NoArgMyProjection(@DocumentReferenceProjection DocumentReference documentReference) {
+			this.documentReference = documentReference;
+		}
 	}
 
 	@Test
@@ -83,37 +83,37 @@ class ProjectionConstructorDocumentReferenceProjectionIT extends AbstractProject
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final Object documentReference;
-
-			@ProjectionConstructor
-			public MyProjection(@DocumentReferenceProjection Object documentReference) {
-				this.documentReference = documentReference;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( SupertypeMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, SupertypeMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( reference( INDEX_NAME, "1" ) ),
 						Arrays.asList( reference( INDEX_NAME, "2" ) )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.documentReference()
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( reference( INDEX_NAME, "1" ) ),
-						new MyProjection( reference( INDEX_NAME, "2" ) )
+						new SupertypeMyProjection( reference( INDEX_NAME, "1" ) ),
+						new SupertypeMyProjection( reference( INDEX_NAME, "2" ) )
 				)
 		);
+	}
+
+	static class SupertypeMyProjection {
+		public final Object documentReference;
+
+		@ProjectionConstructor
+		public SupertypeMyProjection(@DocumentReferenceProjection Object documentReference) {
+			this.documentReference = documentReference;
+		}
 	}
 
 	@Test
@@ -125,28 +125,29 @@ class ProjectionConstructorDocumentReferenceProjectionIT extends AbstractProject
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final Integer documentReference;
-
-			@ProjectionConstructor
-			public MyProjection(@DocumentReferenceProjection Integer documentReference) {
-				this.documentReference = documentReference;
-			}
-		}
 
 		assertThatThrownBy( () -> setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( InvalidTypeMyProjection.class )
 				.setup( IndexedEntity.class ) )
 				.isInstanceOf( SearchException.class )
 				.satisfies( FailureReportUtils.hasFailureReport()
-						.typeContext( MyProjection.class.getName() )
-						.constructorContext( ProjectionConstructorDocumentReferenceProjectionIT.class, Integer.class )
-						.methodParameterContext( 1, "documentReference" )
+						.typeContext( InvalidTypeMyProjection.class.getName() )
+						.constructorContext( Integer.class )
+						.methodParameterContext( 0, "documentReference" )
 						.failure(
 								"Invalid projection definition for constructor parameter type '" + Integer.class.getName()
 										+ "'",
 								"This projection results in values of type '" + DocumentReference.class.getName() + "'" )
 				);
+	}
+
+	static class InvalidTypeMyProjection {
+		public final Integer documentReference;
+
+		@ProjectionConstructor
+		public InvalidTypeMyProjection(@DocumentReferenceProjection Integer documentReference) {
+			this.documentReference = documentReference;
+		}
 	}
 
 }

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorEntityProjectionIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorEntityProjectionIT.java
@@ -52,102 +52,100 @@ class ProjectionConstructorEntityProjectionIT extends AbstractProjectionConstruc
 
 	@Test
 	void noArg() {
-		class MyProjection {
-			public final IndexedEntity entity;
-
-			@ProjectionConstructor
-			public MyProjection(@EntityProjection IndexedEntity entity) {
-				this.entity = entity;
-			}
-		}
-
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
 				.expectCustomBeans()
-				.withAnnotatedTypes( IndexedEntity.class, MyProjection.class )
+				.withAnnotatedTypes( IndexedEntity.class, NoArgMyProjection.class )
 				.setup();
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, NoArgMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( StubBackendUtils.reference( IndexedEntity.NAME, "1" ) ),
 						Arrays.asList( StubBackendUtils.reference( IndexedEntity.NAME, "2" ) )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.entity( IndexedEntity.class )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( loadingContext.persistenceMap( IndexedEntity.PERSISTENCE_KEY ).get( 1 ) ),
-						new MyProjection( loadingContext.persistenceMap( IndexedEntity.PERSISTENCE_KEY ).get( 2 ) )
+						new NoArgMyProjection( loadingContext.persistenceMap( IndexedEntity.PERSISTENCE_KEY ).get( 1 ) ),
+						new NoArgMyProjection( loadingContext.persistenceMap( IndexedEntity.PERSISTENCE_KEY ).get( 2 ) )
 				)
 		);
 	}
 
+	static class NoArgMyProjection {
+		public final IndexedEntity entity;
+
+		@ProjectionConstructor
+		public NoArgMyProjection(@EntityProjection IndexedEntity entity) {
+			this.entity = entity;
+		}
+	}
+
 	@Test
 	void supertype() {
-		class MyProjection {
-			public final Object entity;
-
-			@ProjectionConstructor
-			public MyProjection(@EntityProjection Object entity) {
-				this.entity = entity;
-			}
-		}
-
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
 				.expectCustomBeans()
-				.withAnnotatedTypes( IndexedEntity.class, MyProjection.class )
+				.withAnnotatedTypes( IndexedEntity.class, SupertypeMyProjection.class )
 				.setup();
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, SupertypeMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( StubBackendUtils.reference( IndexedEntity.NAME, "1" ) ),
 						Arrays.asList( StubBackendUtils.reference( IndexedEntity.NAME, "2" ) )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.entity( Object.class )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( loadingContext.persistenceMap( IndexedEntity.PERSISTENCE_KEY ).get( 1 ) ),
-						new MyProjection( loadingContext.persistenceMap( IndexedEntity.PERSISTENCE_KEY ).get( 2 ) )
+						new SupertypeMyProjection( loadingContext.persistenceMap( IndexedEntity.PERSISTENCE_KEY ).get( 1 ) ),
+						new SupertypeMyProjection( loadingContext.persistenceMap( IndexedEntity.PERSISTENCE_KEY ).get( 2 ) )
 				)
 		);
 	}
 
+	static class SupertypeMyProjection {
+		public final Object entity;
+
+		@ProjectionConstructor
+		public SupertypeMyProjection(@EntityProjection Object entity) {
+			this.entity = entity;
+		}
+	}
+
 	@Test
 	void invalidType() {
-		class MyProjection {
-			public final Integer entity;
-
-			@ProjectionConstructor
-			public MyProjection(@EntityProjection Integer entity) {
-				this.entity = entity;
-			}
-		}
-
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
 				.expectCustomBeans()
-				.withAnnotatedTypes( IndexedEntity.class, MyProjection.class )
+				.withAnnotatedTypes( IndexedEntity.class, InvalidTypeMyProjection.class )
 				.setup();
 
 		try ( SearchSession session = createSession( mapping ) ) {
 			assertThatThrownBy( () -> session.search( IndexedEntity.class )
-					.select( MyProjection.class ) )
+					.select( InvalidTypeMyProjection.class ) )
 					.isInstanceOf( SearchException.class )
 					.hasMessageContainingAll(
 							"Invalid type for entity projection on type '" + IndexedEntity.NAME + "'",
 							"the entity type's Java class '" + IndexedEntity.class.getName()
 									+ "' does not extend the requested projection type '" + Integer.class.getName() + "'"
 					);
+		}
+	}
+
+	static class InvalidTypeMyProjection {
+		public final Integer entity;
+
+		@ProjectionConstructor
+		public InvalidTypeMyProjection(@EntityProjection Integer entity) {
+			this.entity = entity;
 		}
 	}
 

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorEntityReferenceProjectionIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorEntityReferenceProjectionIT.java
@@ -42,37 +42,37 @@ class ProjectionConstructorEntityReferenceProjectionIT extends AbstractProjectio
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final EntityReference entityReference;
-
-			@ProjectionConstructor
-			public MyProjection(@EntityReferenceProjection EntityReference entityReference) {
-				this.entityReference = entityReference;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( NoArgMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, NoArgMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( reference( INDEX_NAME, "1" ) ),
 						Arrays.asList( reference( INDEX_NAME, "2" ) )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.entityReference()
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( PojoEntityReference.withDefaultName( IndexedEntity.class, 1 ) ),
-						new MyProjection( PojoEntityReference.withDefaultName( IndexedEntity.class, 2 ) )
+						new NoArgMyProjection( PojoEntityReference.withDefaultName( IndexedEntity.class, 1 ) ),
+						new NoArgMyProjection( PojoEntityReference.withDefaultName( IndexedEntity.class, 2 ) )
 				)
 		);
+	}
+
+	static class NoArgMyProjection {
+		public final EntityReference entityReference;
+
+		@ProjectionConstructor
+		public NoArgMyProjection(@EntityReferenceProjection EntityReference entityReference) {
+			this.entityReference = entityReference;
+		}
 	}
 
 	@Test
@@ -84,37 +84,37 @@ class ProjectionConstructorEntityReferenceProjectionIT extends AbstractProjectio
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final Object entityReference;
-
-			@ProjectionConstructor
-			public MyProjection(@EntityReferenceProjection Object entityReference) {
-				this.entityReference = entityReference;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( SupertypeMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, SupertypeMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( reference( INDEX_NAME, "1" ) ),
 						Arrays.asList( reference( INDEX_NAME, "2" ) )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.entityReference()
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( PojoEntityReference.withDefaultName( IndexedEntity.class, 1 ) ),
-						new MyProjection( PojoEntityReference.withDefaultName( IndexedEntity.class, 2 ) )
+						new SupertypeMyProjection( PojoEntityReference.withDefaultName( IndexedEntity.class, 1 ) ),
+						new SupertypeMyProjection( PojoEntityReference.withDefaultName( IndexedEntity.class, 2 ) )
 				)
 		);
+	}
+
+	static class SupertypeMyProjection {
+		public final Object entityReference;
+
+		@ProjectionConstructor
+		public SupertypeMyProjection(@EntityReferenceProjection Object entityReference) {
+			this.entityReference = entityReference;
+		}
 	}
 
 	@Test
@@ -126,28 +126,29 @@ class ProjectionConstructorEntityReferenceProjectionIT extends AbstractProjectio
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final Integer entityReference;
-
-			@ProjectionConstructor
-			public MyProjection(@EntityReferenceProjection Integer entityReference) {
-				this.entityReference = entityReference;
-			}
-		}
 
 		assertThatThrownBy( () -> setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( InvalidTypeMyProjection.class )
 				.setup( IndexedEntity.class ) )
 				.isInstanceOf( SearchException.class )
 				.satisfies( FailureReportUtils.hasFailureReport()
-						.typeContext( MyProjection.class.getName() )
-						.constructorContext( ProjectionConstructorEntityReferenceProjectionIT.class, Integer.class )
-						.methodParameterContext( 1, "entityReference" )
+						.typeContext( InvalidTypeMyProjection.class.getName() )
+						.constructorContext( Integer.class )
+						.methodParameterContext( 0, "entityReference" )
 						.failure(
 								"Invalid projection definition for constructor parameter type '" + Integer.class.getName()
 										+ "'",
 								"This projection results in values of type '" + EntityReference.class.getName() + "'" )
 				);
+	}
+
+	static class InvalidTypeMyProjection {
+		public final Integer entityReference;
+
+		@ProjectionConstructor
+		public InvalidTypeMyProjection(@EntityReferenceProjection Integer entityReference) {
+			this.entityReference = entityReference;
+		}
 	}
 
 }

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorFieldProjectionIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorFieldProjectionIT.java
@@ -47,37 +47,37 @@ class ProjectionConstructorFieldProjectionIT extends AbstractProjectionConstruct
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final String text;
-
-			@ProjectionConstructor
-			public MyProjection(@FieldProjection String text) {
-				this.text = text;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( NoArgMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, NoArgMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "result1" ),
 						Arrays.asList( "result2" )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "text", String.class )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( "result1" ),
-						new MyProjection( "result2" )
+						new NoArgMyProjection( "result1" ),
+						new NoArgMyProjection( "result2" )
 				)
 		);
+	}
+
+	static class NoArgMyProjection {
+		public final String text;
+
+		@ProjectionConstructor
+		public NoArgMyProjection(@FieldProjection String text) {
+			this.text = text;
+		}
 	}
 
 	@Test
@@ -89,37 +89,37 @@ class ProjectionConstructorFieldProjectionIT extends AbstractProjectionConstruct
 			@FullTextField(name = "myText")
 			public String text;
 		}
-		class MyProjection {
-			public final String text;
-
-			@ProjectionConstructor
-			public MyProjection(@FieldProjection(path = "myText") String text) {
-				this.text = text;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( PathMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, PathMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "result1" ),
 						Arrays.asList( "result2" )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "myText", String.class )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( "result1" ),
-						new MyProjection( "result2" )
+						new PathMyProjection( "result1" ),
+						new PathMyProjection( "result2" )
 				)
 		);
+	}
+
+	static class PathMyProjection {
+		public final String text;
+
+		@ProjectionConstructor
+		public PathMyProjection(@FieldProjection(path = "myText") String text) {
+			this.text = text;
+		}
 	}
 
 	@Test
@@ -131,38 +131,38 @@ class ProjectionConstructorFieldProjectionIT extends AbstractProjectionConstruct
 			@GenericField
 			public MyEnum myEnum;
 		}
-		class MyProjection {
-			public final String myEnum;
-
-			@ProjectionConstructor
-			public MyProjection(
-					@FieldProjection(valueModel = ValueModel.INDEX) String myEnum) {
-				this.myEnum = myEnum;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( ValueModelMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, ValueModelMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "result1" ),
 						Arrays.asList( "result2" )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "myEnum", String.class, ValueModel.INDEX )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( "result1" ),
-						new MyProjection( "result2" )
+						new ValueModelMyProjection( "result1" ),
+						new ValueModelMyProjection( "result2" )
 				)
 		);
+	}
+
+	static class ValueModelMyProjection {
+		public final String myEnum;
+
+		@ProjectionConstructor
+		public ValueModelMyProjection(
+				@FieldProjection(valueModel = ValueModel.INDEX) String myEnum) {
+			this.myEnum = myEnum;
+		}
 	}
 
 	@Deprecated
@@ -175,38 +175,39 @@ class ProjectionConstructorFieldProjectionIT extends AbstractProjectionConstruct
 			@GenericField
 			public MyEnum myEnum;
 		}
-		class MyProjection {
-			public final String myEnum;
-
-			@ProjectionConstructor
-			public MyProjection(
-					@FieldProjection(convert = org.hibernate.search.engine.search.common.ValueConvert.NO) String myEnum) {
-				this.myEnum = myEnum;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( ValueConvert_nonDefaultMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, ValueConvert_nonDefaultMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "result1" ),
 						Arrays.asList( "result2" )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "myEnum", String.class, ValueModel.INDEX )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( "result1" ),
-						new MyProjection( "result2" )
+						new ValueConvert_nonDefaultMyProjection( "result1" ),
+						new ValueConvert_nonDefaultMyProjection( "result2" )
 				)
 		);
+	}
+
+	@Deprecated
+	static class ValueConvert_nonDefaultMyProjection {
+		public final String myEnum;
+
+		@ProjectionConstructor
+		public ValueConvert_nonDefaultMyProjection(
+				@FieldProjection(convert = org.hibernate.search.engine.search.common.ValueConvert.NO) String myEnum) {
+			this.myEnum = myEnum;
+		}
 	}
 
 	@Deprecated
@@ -219,23 +220,25 @@ class ProjectionConstructorFieldProjectionIT extends AbstractProjectionConstruct
 			@GenericField
 			public MyEnum myEnum;
 		}
-		class MyProjection {
-			public final String myEnum;
-
-			@ProjectionConstructor
-			public MyProjection(
-					@FieldProjection(convert = org.hibernate.search.engine.search.common.ValueConvert.NO,
-							valueModel = ValueModel.INDEX) String myEnum) {
-				this.myEnum = myEnum;
-			}
-		}
 
 		assertThatThrownBy( () -> setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( ValueConvertAndValueModel_nonDefaultFailsMyProjection.class )
 				.setup( IndexedEntity.class ) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContaining(
 						"Using non-default `valueModel=ValueModel.INDEX` and `convert=ValueConvert.NO` at the same time is not allowed. Remove the `convert` attribute and keep only the `valueModel=ValueModel.INDEX`." );
+	}
+
+	@Deprecated
+	static class ValueConvertAndValueModel_nonDefaultFailsMyProjection {
+		public final String myEnum;
+
+		@ProjectionConstructor
+		public ValueConvertAndValueModel_nonDefaultFailsMyProjection(
+				@FieldProjection(convert = org.hibernate.search.engine.search.common.ValueConvert.NO,
+						valueModel = ValueModel.INDEX) String myEnum) {
+			this.myEnum = myEnum;
+		}
 	}
 
 	enum MyEnum {
@@ -251,37 +254,37 @@ class ProjectionConstructorFieldProjectionIT extends AbstractProjectionConstruct
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final Object text;
-
-			@ProjectionConstructor
-			public MyProjection(@FieldProjection Object text) {
-				this.text = text;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( SupertypeMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, SupertypeMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "result1" ),
 						Arrays.asList( "result2" )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "text", Object.class )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( "result1" ),
-						new MyProjection( "result2" )
+						new SupertypeMyProjection( "result1" ),
+						new SupertypeMyProjection( "result2" )
 				)
 		);
+	}
+
+	static class SupertypeMyProjection {
+		public final Object text;
+
+		@ProjectionConstructor
+		public SupertypeMyProjection(@FieldProjection Object text) {
+			this.text = text;
+		}
 	}
 
 	@Test
@@ -293,37 +296,37 @@ class ProjectionConstructorFieldProjectionIT extends AbstractProjectionConstruct
 			@GenericField
 			public int integer;
 		}
-		class MyProjection {
-			public final int integer;
-
-			@ProjectionConstructor
-			public MyProjection(@FieldProjection int integer) {
-				this.integer = integer;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( PrimitiveTypeMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, PrimitiveTypeMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( 1 ),
 						Arrays.asList( 2 )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "integer", Integer.class )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( 1 ),
-						new MyProjection( 2 )
+						new PrimitiveTypeMyProjection( 1 ),
+						new PrimitiveTypeMyProjection( 2 )
 				)
 		);
+	}
+
+	static class PrimitiveTypeMyProjection {
+		public final int integer;
+
+		@ProjectionConstructor
+		public PrimitiveTypeMyProjection(@FieldProjection int integer) {
+			this.integer = integer;
+		}
 	}
 
 	@Test
@@ -345,32 +348,14 @@ class ProjectionConstructorFieldProjectionIT extends AbstractProjectionConstruct
 			@IndexedEmbedded
 			public Contained contained;
 		}
-		class MyInnerProjection {
-			public final String text;
-
-			@ProjectionConstructor
-			public MyInnerProjection(@FieldProjection String text) {
-				this.text = text;
-			}
-		}
-		class MyProjection {
-			public final String text;
-			public final MyInnerProjection contained;
-
-			@ProjectionConstructor
-			public MyProjection(@FieldProjection String text, MyInnerProjection contained) {
-				this.text = text;
-				this.contained = contained;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class, MyInnerProjection.class )
+				.withAnnotatedTypes( InObjectFieldMyProjection.class, InObjectFieldMyInnerProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, InObjectFieldMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "result1", Arrays.asList( "result1_1" ) ),
 						Arrays.asList( "result2", Arrays.asList( (Object) null ) ),
@@ -378,22 +363,40 @@ class ProjectionConstructorFieldProjectionIT extends AbstractProjectionConstruct
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "text", String.class ),
 								f.object( "contained" )
 										.from(
-												dummyProjectionForEnclosingClassInstance( f ),
 												f.field( "contained.text", String.class )
 										)
 										.asList()
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( "result1", new MyInnerProjection( "result1_1" ) ),
-						new MyProjection( "result2", new MyInnerProjection( null ) ),
-						new MyProjection( "result3", null )
+						new InObjectFieldMyProjection( "result1", new InObjectFieldMyInnerProjection( "result1_1" ) ),
+						new InObjectFieldMyProjection( "result2", new InObjectFieldMyInnerProjection( null ) ),
+						new InObjectFieldMyProjection( "result3", null )
 				)
 		);
+	}
+
+	static class InObjectFieldMyInnerProjection {
+		public final String text;
+
+		@ProjectionConstructor
+		public InObjectFieldMyInnerProjection(@FieldProjection String text) {
+			this.text = text;
+		}
+	}
+
+	static class InObjectFieldMyProjection {
+		public final String text;
+		public final InObjectFieldMyInnerProjection contained;
+
+		@ProjectionConstructor
+		public InObjectFieldMyProjection(@FieldProjection String text, InObjectFieldMyInnerProjection contained) {
+			this.text = text;
+			this.contained = contained;
+		}
 	}
 
 	@Test
@@ -415,46 +418,24 @@ class ProjectionConstructorFieldProjectionIT extends AbstractProjectionConstruct
 			@IndexedEmbedded
 			public Contained contained;
 		}
-		class MyInnerProjection {
-			public final String text;
-			public final Integer integer;
-
-			@ProjectionConstructor
-			public MyInnerProjection(@FieldProjection String text, @FieldProjection Integer integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
-		class MyProjection {
-			public final String text;
-			public final MyInnerProjection contained;
-
-			@ProjectionConstructor
-			public MyProjection(@FieldProjection String text,
-					@ObjectProjection(includePaths = { "text" }) MyInnerProjection contained) {
-				this.text = text;
-				this.contained = contained;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class, MyInnerProjection.class )
+				.withAnnotatedTypes( InObjectField_filteredOutMyProjection.class,
+						InObjectField_filteredOutMyInnerProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, InObjectField_filteredOutMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "result1", Arrays.asList( "result1_1", null ) ),
 						Arrays.asList( "result2", null )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "text", String.class ),
 								f.object( "contained" )
 										.from(
-												dummyProjectionForEnclosingClassInstance( f ),
 												f.field( "contained.text", String.class ),
 												// "contained.integer" got filtered out due to @ObjectProjection filters
 												f.constant( null )
@@ -463,10 +444,34 @@ class ProjectionConstructorFieldProjectionIT extends AbstractProjectionConstruct
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( "result1", new MyInnerProjection( "result1_1", null ) ),
-						new MyProjection( "result2", null )
+						new InObjectField_filteredOutMyProjection( "result1",
+								new InObjectField_filteredOutMyInnerProjection( "result1_1", null ) ),
+						new InObjectField_filteredOutMyProjection( "result2", null )
 				)
 		);
+	}
+
+	static class InObjectField_filteredOutMyInnerProjection {
+		public final String text;
+		public final Integer integer;
+
+		@ProjectionConstructor
+		public InObjectField_filteredOutMyInnerProjection(@FieldProjection String text, @FieldProjection Integer integer) {
+			this.text = text;
+			this.integer = integer;
+		}
+	}
+
+	static class InObjectField_filteredOutMyProjection {
+		public final String text;
+		public final InObjectField_filteredOutMyInnerProjection contained;
+
+		@ProjectionConstructor
+		public InObjectField_filteredOutMyProjection(@FieldProjection String text,
+				@ObjectProjection(includePaths = { "text" }) InObjectField_filteredOutMyInnerProjection contained) {
+			this.text = text;
+			this.contained = contained;
+		}
 	}
 
 	@Test
@@ -488,46 +493,24 @@ class ProjectionConstructorFieldProjectionIT extends AbstractProjectionConstruct
 			@IndexedEmbedded
 			public Contained contained;
 		}
-		class MyInnerProjection {
-			public final String text;
-			public final List<Integer> integer;
-
-			@ProjectionConstructor
-			public MyInnerProjection(@FieldProjection String text, @FieldProjection List<Integer> integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
-		class MyProjection {
-			public final String text;
-			public final MyInnerProjection contained;
-
-			@ProjectionConstructor
-			public MyProjection(@FieldProjection String text,
-					@ObjectProjection(includePaths = { "text" }) MyInnerProjection contained) {
-				this.text = text;
-				this.contained = contained;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class, MyInnerProjection.class )
+				.withAnnotatedTypes( InObjectField_multiValued_filteredOutMyProjection.class,
+						InObjectField_multiValued_filteredOutMyInnerProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, InObjectField_multiValued_filteredOutMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "result1", Arrays.asList( "result1_1", null ) ),
 						Arrays.asList( "result2", null )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "text", String.class ),
 								f.object( "contained" )
 										.from(
-												dummyProjectionForEnclosingClassInstance( f ),
 												f.field( "contained.text", String.class ),
 												// "contained.integer" got filtered out due to @ObjectProjection filters
 												f.constant( Collections.emptyList() )
@@ -536,10 +519,36 @@ class ProjectionConstructorFieldProjectionIT extends AbstractProjectionConstruct
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( "result1", new MyInnerProjection( "result1_1", Collections.emptyList() ) ),
-						new MyProjection( "result2", null )
+						new InObjectField_multiValued_filteredOutMyProjection( "result1",
+								new InObjectField_multiValued_filteredOutMyInnerProjection( "result1_1",
+										Collections.emptyList() ) ),
+						new InObjectField_multiValued_filteredOutMyProjection( "result2", null )
 				)
 		);
+	}
+
+	static class InObjectField_multiValued_filteredOutMyInnerProjection {
+		public final String text;
+		public final List<Integer> integer;
+
+		@ProjectionConstructor
+		public InObjectField_multiValued_filteredOutMyInnerProjection(@FieldProjection String text,
+				@FieldProjection List<Integer> integer) {
+			this.text = text;
+			this.integer = integer;
+		}
+	}
+
+	static class InObjectField_multiValued_filteredOutMyProjection {
+		public final String text;
+		public final InObjectField_multiValued_filteredOutMyInnerProjection contained;
+
+		@ProjectionConstructor
+		public InObjectField_multiValued_filteredOutMyProjection(@FieldProjection String text,
+				@ObjectProjection(includePaths = { "text" }) InObjectField_multiValued_filteredOutMyInnerProjection contained) {
+			this.text = text;
+			this.contained = contained;
+		}
 	}
 
 	@Test
@@ -553,24 +562,14 @@ class ProjectionConstructorFieldProjectionIT extends AbstractProjectionConstruct
 			@GenericField
 			public Set<Integer> integer;
 		}
-		class MyProjection {
-			public final List<String> text;
-			public final List<Integer> integer;
-
-			@ProjectionConstructor
-			public MyProjection(@FieldProjection List<String> text, @FieldProjection List<Integer> integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( MultiValued_listMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, MultiValued_listMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( Arrays.asList( "result1_1", "result1_2" ), Arrays.asList( 11, 12 ) ),
 						Arrays.asList( Arrays.asList( "result2_1" ), Arrays.asList( 21 ) ),
@@ -579,18 +578,28 @@ class ProjectionConstructorFieldProjectionIT extends AbstractProjectionConstruct
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "text", String.class ).collector( ProjectionCollector.list() ),
 								f.field( "integer", Integer.class ).collector( ProjectionCollector.list() )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( Arrays.asList( "result1_1", "result1_2" ), Arrays.asList( 11, 12 ) ),
-						new MyProjection( Arrays.asList( "result2_1" ), Arrays.asList( 21 ) ),
-						new MyProjection( Collections.emptyList(), Collections.emptyList() ),
-						new MyProjection( Arrays.asList( "result4_1" ), Arrays.asList( 41 ) )
+						new MultiValued_listMyProjection( Arrays.asList( "result1_1", "result1_2" ), Arrays.asList( 11, 12 ) ),
+						new MultiValued_listMyProjection( Arrays.asList( "result2_1" ), Arrays.asList( 21 ) ),
+						new MultiValued_listMyProjection( Collections.emptyList(), Collections.emptyList() ),
+						new MultiValued_listMyProjection( Arrays.asList( "result4_1" ), Arrays.asList( 41 ) )
 				)
 		);
+	}
+
+	static class MultiValued_listMyProjection {
+		public final List<String> text;
+		public final List<Integer> integer;
+
+		@ProjectionConstructor
+		public MultiValued_listMyProjection(@FieldProjection List<String> text, @FieldProjection List<Integer> integer) {
+			this.text = text;
+			this.integer = integer;
+		}
 	}
 
 	@Test
@@ -604,24 +613,14 @@ class ProjectionConstructorFieldProjectionIT extends AbstractProjectionConstruct
 			@GenericField
 			public Set<Integer> integer;
 		}
-		class MyProjection {
-			public final Collection<String> text;
-			public final Collection<Integer> integer;
-
-			@ProjectionConstructor
-			public MyProjection(@FieldProjection Collection<String> text, @FieldProjection Collection<Integer> integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( MultiValued_collectionMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, MultiValued_collectionMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( Arrays.asList( "result1_1", "result1_2" ), Arrays.asList( 11, 12 ) ),
 						Arrays.asList( Arrays.asList( "result2_1" ), Arrays.asList( 21 ) ),
@@ -630,18 +629,30 @@ class ProjectionConstructorFieldProjectionIT extends AbstractProjectionConstruct
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "text", String.class ).collector( ProjectionCollector.list() ),
 								f.field( "integer", Integer.class ).collector( ProjectionCollector.list() )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( Arrays.asList( "result1_1", "result1_2" ), Arrays.asList( 11, 12 ) ),
-						new MyProjection( Arrays.asList( "result2_1" ), Arrays.asList( 21 ) ),
-						new MyProjection( Collections.emptyList(), Collections.emptyList() ),
-						new MyProjection( Arrays.asList( "result4_1" ), Arrays.asList( 41 ) )
+						new MultiValued_collectionMyProjection( Arrays.asList( "result1_1", "result1_2" ),
+								Arrays.asList( 11, 12 ) ),
+						new MultiValued_collectionMyProjection( Arrays.asList( "result2_1" ), Arrays.asList( 21 ) ),
+						new MultiValued_collectionMyProjection( Collections.emptyList(), Collections.emptyList() ),
+						new MultiValued_collectionMyProjection( Arrays.asList( "result4_1" ), Arrays.asList( 41 ) )
 				)
 		);
+	}
+
+	static class MultiValued_collectionMyProjection {
+		public final Collection<String> text;
+		public final Collection<Integer> integer;
+
+		@ProjectionConstructor
+		public MultiValued_collectionMyProjection(@FieldProjection Collection<String> text,
+				@FieldProjection Collection<Integer> integer) {
+			this.text = text;
+			this.integer = integer;
+		}
 	}
 
 	@Test
@@ -655,24 +666,14 @@ class ProjectionConstructorFieldProjectionIT extends AbstractProjectionConstruct
 			@GenericField
 			public Set<Integer> integer;
 		}
-		class MyProjection {
-			public final Iterable<String> text;
-			public final Iterable<Integer> integer;
-
-			@ProjectionConstructor
-			public MyProjection(@FieldProjection Iterable<String> text, @FieldProjection Iterable<Integer> integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( MultiValued_iterableMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, MultiValued_iterableMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( Arrays.asList( "result1_1", "result1_2" ), Arrays.asList( 11, 12 ) ),
 						Arrays.asList( Arrays.asList( "result2_1" ), Arrays.asList( 21 ) ),
@@ -681,18 +682,30 @@ class ProjectionConstructorFieldProjectionIT extends AbstractProjectionConstruct
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "text", String.class ).collector( ProjectionCollector.list() ),
 								f.field( "integer", Integer.class ).collector( ProjectionCollector.list() )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( Arrays.asList( "result1_1", "result1_2" ), Arrays.asList( 11, 12 ) ),
-						new MyProjection( Arrays.asList( "result2_1" ), Arrays.asList( 21 ) ),
-						new MyProjection( Collections.emptyList(), Collections.emptyList() ),
-						new MyProjection( Arrays.asList( "result4_1" ), Arrays.asList( 41 ) )
+						new MultiValued_iterableMyProjection( Arrays.asList( "result1_1", "result1_2" ),
+								Arrays.asList( 11, 12 ) ),
+						new MultiValued_iterableMyProjection( Arrays.asList( "result2_1" ), Arrays.asList( 21 ) ),
+						new MultiValued_iterableMyProjection( Collections.emptyList(), Collections.emptyList() ),
+						new MultiValued_iterableMyProjection( Arrays.asList( "result4_1" ), Arrays.asList( 41 ) )
 				)
 		);
+	}
+
+	static class MultiValued_iterableMyProjection {
+		public final Iterable<String> text;
+		public final Iterable<Integer> integer;
+
+		@ProjectionConstructor
+		public MultiValued_iterableMyProjection(@FieldProjection Iterable<String> text,
+				@FieldProjection Iterable<Integer> integer) {
+			this.text = text;
+			this.integer = integer;
+		}
 	}
 
 	@Test
@@ -706,24 +719,14 @@ class ProjectionConstructorFieldProjectionIT extends AbstractProjectionConstruct
 			@GenericField
 			public Set<Integer> integer;
 		}
-		class MyProjection {
-			public final Set<String> text;
-			public final List<Integer> integer;
-
-			@ProjectionConstructor
-			public MyProjection(@FieldProjection Set<String> text, @FieldProjection List<Integer> integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( MultiValued_setMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, MultiValued_setMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( Set.of( "result1_1", "result1_2" ), Arrays.asList( 11, 12 ) ),
 						Arrays.asList( Set.of( "result2_1" ), Arrays.asList( 21 ) ),
@@ -732,18 +735,28 @@ class ProjectionConstructorFieldProjectionIT extends AbstractProjectionConstruct
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "text", String.class ).collector( ProjectionCollector.set() ),
 								f.field( "integer", Integer.class ).collector( ProjectionCollector.list() )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( Set.of( "result1_1", "result1_2" ), Arrays.asList( 11, 12 ) ),
-						new MyProjection( Set.of( "result2_1" ), Arrays.asList( 21 ) ),
-						new MyProjection( Set.of(), Collections.emptyList() ),
-						new MyProjection( Set.of( "result4_1" ), Arrays.asList( 41 ) )
+						new MultiValued_setMyProjection( Set.of( "result1_1", "result1_2" ), Arrays.asList( 11, 12 ) ),
+						new MultiValued_setMyProjection( Set.of( "result2_1" ), Arrays.asList( 21 ) ),
+						new MultiValued_setMyProjection( Set.of(), Collections.emptyList() ),
+						new MultiValued_setMyProjection( Set.of( "result4_1" ), Arrays.asList( 41 ) )
 				)
 		);
+	}
+
+	static class MultiValued_setMyProjection {
+		public final Set<String> text;
+		public final List<Integer> integer;
+
+		@ProjectionConstructor
+		public MultiValued_setMyProjection(@FieldProjection Set<String> text, @FieldProjection List<Integer> integer) {
+			this.text = text;
+			this.integer = integer;
+		}
 	}
 
 }

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorHighlightProjectionIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorHighlightProjectionIT.java
@@ -45,37 +45,37 @@ class ProjectionConstructorHighlightProjectionIT extends AbstractProjectionConst
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final List<String> text;
-
-			@ProjectionConstructor
-			public MyProjection(@HighlightProjection List<String> text) {
-				this.text = text;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( NoArgMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, NoArgMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( Arrays.asList( "result1_term1", "result1_term2" ) ),
 						Arrays.asList( Arrays.asList( "result1_term1" ) )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.highlight( "text" )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( Arrays.asList( "result1_term1", "result1_term2" ) ),
-						new MyProjection( Arrays.asList( "result1_term1" ) )
+						new NoArgMyProjection( Arrays.asList( "result1_term1", "result1_term2" ) ),
+						new NoArgMyProjection( Arrays.asList( "result1_term1" ) )
 				)
 		);
+	}
+
+	static class NoArgMyProjection {
+		public final List<String> text;
+
+		@ProjectionConstructor
+		public NoArgMyProjection(@HighlightProjection List<String> text) {
+			this.text = text;
+		}
 	}
 
 	@Test
@@ -87,37 +87,37 @@ class ProjectionConstructorHighlightProjectionIT extends AbstractProjectionConst
 			@FullTextField(name = "myText")
 			public String text;
 		}
-		class MyProjection {
-			public final List<String> text;
-
-			@ProjectionConstructor
-			public MyProjection(@HighlightProjection(path = "myText") List<String> text) {
-				this.text = text;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( PathMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, PathMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( Arrays.asList( "result1_term1", "result1_term2" ) ),
 						Arrays.asList( Arrays.asList( "result1_term1" ) )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.highlight( "myText" )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( Arrays.asList( "result1_term1", "result1_term2" ) ),
-						new MyProjection( Arrays.asList( "result1_term1" ) )
+						new PathMyProjection( Arrays.asList( "result1_term1", "result1_term2" ) ),
+						new PathMyProjection( Arrays.asList( "result1_term1" ) )
 				)
 		);
+	}
+
+	static class PathMyProjection {
+		public final List<String> text;
+
+		@ProjectionConstructor
+		public PathMyProjection(@HighlightProjection(path = "myText") List<String> text) {
+			this.text = text;
+		}
 	}
 
 	@Test
@@ -129,38 +129,38 @@ class ProjectionConstructorHighlightProjectionIT extends AbstractProjectionConst
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final List<String> text;
-
-			@ProjectionConstructor
-			public MyProjection(@HighlightProjection(highlighter = "foo") List<String> text) {
-				this.text = text;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( HighlighterMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, HighlighterMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( Arrays.asList( "result1_term1", "result1_term2" ) ),
 						Arrays.asList( Arrays.asList( "result1_term1" ) )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.highlight( "text" )
 										.highlighter( "foo" )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( Arrays.asList( "result1_term1", "result1_term2" ) ),
-						new MyProjection( Arrays.asList( "result1_term1" ) )
+						new HighlighterMyProjection( Arrays.asList( "result1_term1", "result1_term2" ) ),
+						new HighlighterMyProjection( Arrays.asList( "result1_term1" ) )
 				)
 		);
+	}
+
+	static class HighlighterMyProjection {
+		public final List<String> text;
+
+		@ProjectionConstructor
+		public HighlighterMyProjection(@HighlightProjection(highlighter = "foo") List<String> text) {
+			this.text = text;
+		}
 	}
 
 	@Test
@@ -172,37 +172,37 @@ class ProjectionConstructorHighlightProjectionIT extends AbstractProjectionConst
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final List<CharSequence> text;
-
-			@ProjectionConstructor
-			public MyProjection(@HighlightProjection List<CharSequence> text) {
-				this.text = text;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( SuperTypeMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, SuperTypeMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( Arrays.asList( "result1_term1", "result1_term2" ) ),
 						Arrays.asList( Arrays.asList( "result1_term1" ) )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.highlight( "text" )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( Arrays.asList( "result1_term1", "result1_term2" ) ),
-						new MyProjection( Arrays.asList( "result1_term1" ) )
+						new SuperTypeMyProjection( Arrays.asList( "result1_term1", "result1_term2" ) ),
+						new SuperTypeMyProjection( Arrays.asList( "result1_term1" ) )
 				)
 		);
+	}
+
+	static class SuperTypeMyProjection {
+		public final List<CharSequence> text;
+
+		@ProjectionConstructor
+		public SuperTypeMyProjection(@HighlightProjection List<CharSequence> text) {
+			this.text = text;
+		}
 	}
 
 	@Test
@@ -214,37 +214,37 @@ class ProjectionConstructorHighlightProjectionIT extends AbstractProjectionConst
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final String text;
-
-			@ProjectionConstructor
-			public MyProjection(@HighlightProjection String text) {
-				this.text = text;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( SingleValuedMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, SingleValuedMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "result1_term1" ),
 						Arrays.asList( "result1_term1" )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.highlight( "text" ).collector( ProjectionCollector.nullable() )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( "result1_term1" ),
-						new MyProjection( "result1_term1" )
+						new SingleValuedMyProjection( "result1_term1" ),
+						new SingleValuedMyProjection( "result1_term1" )
 				)
 		);
+	}
+
+	static class SingleValuedMyProjection {
+		public final String text;
+
+		@ProjectionConstructor
+		public SingleValuedMyProjection(@HighlightProjection String text) {
+			this.text = text;
+		}
 	}
 
 	// Technically this is not supported on the backend side,
@@ -268,32 +268,14 @@ class ProjectionConstructorHighlightProjectionIT extends AbstractProjectionConst
 			@IndexedEmbedded
 			public Contained contained;
 		}
-		class MyInnerProjection {
-			public final List<String> text;
-
-			@ProjectionConstructor
-			public MyInnerProjection(@HighlightProjection List<String> text) {
-				this.text = text;
-			}
-		}
-		class MyProjection {
-			public final List<String> text;
-			public final MyInnerProjection contained;
-
-			@ProjectionConstructor
-			public MyProjection(@HighlightProjection List<String> text, MyInnerProjection contained) {
-				this.text = text;
-				this.contained = contained;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class, MyInnerProjection.class )
+				.withAnnotatedTypes( InObjectFieldMyProjection.class, InObjectFieldMyInnerProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, InObjectFieldMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( Arrays.asList( "result1_term1", "result1_term2" ),
 								Arrays.asList( Arrays.asList( "result1_term2", "result1_term3" ) ) ),
@@ -302,23 +284,42 @@ class ProjectionConstructorHighlightProjectionIT extends AbstractProjectionConst
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.highlight( "text" ),
 								f.object( "contained" )
 										.from(
-												dummyProjectionForEnclosingClassInstance( f ),
 												f.highlight( "contained.text" )
 										)
 										.asList()
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( Arrays.asList( "result1_term1", "result1_term2" ),
-								new MyInnerProjection( Arrays.asList( "result1_term2", "result1_term3" ) ) ),
-						new MyProjection( Arrays.asList( "result2_term1" ), new MyInnerProjection( null ) ),
-						new MyProjection( Arrays.asList( "result3_term1" ), null )
+						new InObjectFieldMyProjection( Arrays.asList( "result1_term1", "result1_term2" ),
+								new InObjectFieldMyInnerProjection( Arrays.asList( "result1_term2", "result1_term3" ) ) ),
+						new InObjectFieldMyProjection( Arrays.asList( "result2_term1" ),
+								new InObjectFieldMyInnerProjection( null ) ),
+						new InObjectFieldMyProjection( Arrays.asList( "result3_term1" ), null )
 				)
 		);
+	}
+
+	static class InObjectFieldMyInnerProjection {
+		public final List<String> text;
+
+		@ProjectionConstructor
+		public InObjectFieldMyInnerProjection(@HighlightProjection List<String> text) {
+			this.text = text;
+		}
+	}
+
+	static class InObjectFieldMyProjection {
+		public final List<String> text;
+		public final InObjectFieldMyInnerProjection contained;
+
+		@ProjectionConstructor
+		public InObjectFieldMyProjection(@HighlightProjection List<String> text, InObjectFieldMyInnerProjection contained) {
+			this.text = text;
+			this.contained = contained;
+		}
 	}
 
 	@Test
@@ -330,37 +331,37 @@ class ProjectionConstructorHighlightProjectionIT extends AbstractProjectionConst
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final Collection<String> text;
-
-			@ProjectionConstructor
-			public MyProjection(@HighlightProjection Collection<String> text) {
-				this.text = text;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( CollectionMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, CollectionMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( Arrays.asList( "result1_term1", "result1_term2" ) ),
 						Arrays.asList( Arrays.asList( "result1_term1" ) )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.highlight( "text" )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( Arrays.asList( "result1_term1", "result1_term2" ) ),
-						new MyProjection( Arrays.asList( "result1_term1" ) )
+						new CollectionMyProjection( Arrays.asList( "result1_term1", "result1_term2" ) ),
+						new CollectionMyProjection( Arrays.asList( "result1_term1" ) )
 				)
 		);
+	}
+
+	static class CollectionMyProjection {
+		public final Collection<String> text;
+
+		@ProjectionConstructor
+		public CollectionMyProjection(@HighlightProjection Collection<String> text) {
+			this.text = text;
+		}
 	}
 
 	@Test
@@ -372,37 +373,37 @@ class ProjectionConstructorHighlightProjectionIT extends AbstractProjectionConst
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final Iterable<String> text;
-
-			@ProjectionConstructor
-			public MyProjection(@HighlightProjection Iterable<String> text) {
-				this.text = text;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( IterableMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, IterableMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( Arrays.asList( "result1_term1", "result1_term2" ) ),
 						Arrays.asList( Arrays.asList( "result1_term1" ) )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.highlight( "text" )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( Arrays.asList( "result1_term1", "result1_term2" ) ),
-						new MyProjection( Arrays.asList( "result1_term1" ) )
+						new IterableMyProjection( Arrays.asList( "result1_term1", "result1_term2" ) ),
+						new IterableMyProjection( Arrays.asList( "result1_term1" ) )
 				)
 		);
+	}
+
+	static class IterableMyProjection {
+		public final Iterable<String> text;
+
+		@ProjectionConstructor
+		public IterableMyProjection(@HighlightProjection Iterable<String> text) {
+			this.text = text;
+		}
 	}
 
 	@Test
@@ -414,37 +415,37 @@ class ProjectionConstructorHighlightProjectionIT extends AbstractProjectionConst
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final Set<String> text;
-
-			@ProjectionConstructor
-			public MyProjection(@HighlightProjection Set<String> text) {
-				this.text = text;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( SetMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, SetMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( Arrays.asList( "result1_term1", "result1_term2" ) ),
 						Arrays.asList( Arrays.asList( "result1_term1" ) )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.highlight( "text" )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( Set.of( "result1_term1", "result1_term2" ) ),
-						new MyProjection( Set.of( "result1_term1" ) )
+						new SetMyProjection( Set.of( "result1_term1", "result1_term2" ) ),
+						new SetMyProjection( Set.of( "result1_term1" ) )
 				)
 		);
+	}
+
+	static class SetMyProjection {
+		public final Set<String> text;
+
+		@ProjectionConstructor
+		public SetMyProjection(@HighlightProjection Set<String> text) {
+			this.text = text;
+		}
 	}
 
 	@Test
@@ -456,26 +457,27 @@ class ProjectionConstructorHighlightProjectionIT extends AbstractProjectionConst
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final List<Integer> text;
-
-			@ProjectionConstructor
-			public MyProjection(@HighlightProjection List<Integer> text) {
-				this.text = text;
-			}
-		}
 
 		assertThatThrownBy( () -> setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( InvalidElementTypeMyProjection.class )
 				.setup( IndexedEntity.class ) )
 				.isInstanceOf( SearchException.class )
 				.satisfies( FailureReportUtils.hasFailureReport()
-						.typeContext( MyProjection.class.getName() )
-						.constructorContext( ProjectionConstructorHighlightProjectionIT.class, List.class )
-						.methodParameterContext( 1, "text" )
+						.typeContext( InvalidElementTypeMyProjection.class.getName() )
+						.constructorContext( List.class )
+						.methodParameterContext( 0, "text" )
 						.failure( "Invalid multi-valued projection definition for constructor parameter type",
 								"'java.util.List<java.lang.Integer>'",
 								"This projection results in values of type 'java.lang.String'" ) );
+	}
+
+	static class InvalidElementTypeMyProjection {
+		public final List<Integer> text;
+
+		@ProjectionConstructor
+		public InvalidElementTypeMyProjection(@HighlightProjection List<Integer> text) {
+			this.text = text;
+		}
 	}
 
 }

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorIdProjectionIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorIdProjectionIT.java
@@ -38,37 +38,37 @@ class ProjectionConstructorIdProjectionIT extends AbstractProjectionConstructorI
 			@GenericField
 			public Integer identifier; // Not the ID -- we're trying to confuse Hibernate Search.
 		}
-		class MyProjection {
-			public final Integer identifier;
-
-			@ProjectionConstructor
-			public MyProjection(@IdProjection Integer identifier) {
-				this.identifier = identifier;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( NoArgMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, NoArgMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "11" ),
 						Arrays.asList( "21" )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.id( Integer.class )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( 11 ),
-						new MyProjection( 21 )
+						new NoArgMyProjection( 11 ),
+						new NoArgMyProjection( 21 )
 				)
 		);
+	}
+
+	static class NoArgMyProjection {
+		public final Integer identifier;
+
+		@ProjectionConstructor
+		public NoArgMyProjection(@IdProjection Integer identifier) {
+			this.identifier = identifier;
+		}
 	}
 
 	@Test
@@ -80,37 +80,37 @@ class ProjectionConstructorIdProjectionIT extends AbstractProjectionConstructorI
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final Object id;
-
-			@ProjectionConstructor
-			public MyProjection(@IdProjection Object id) {
-				this.id = id;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( SupertypeMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, SupertypeMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "11" ),
 						Arrays.asList( "21" )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.id( Object.class )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( 11 ),
-						new MyProjection( 21 )
+						new SupertypeMyProjection( 11 ),
+						new SupertypeMyProjection( 21 )
 				)
 		);
+	}
+
+	static class SupertypeMyProjection {
+		public final Object id;
+
+		@ProjectionConstructor
+		public SupertypeMyProjection(@IdProjection Object id) {
+			this.id = id;
+		}
 	}
 
 	@Test
@@ -122,37 +122,37 @@ class ProjectionConstructorIdProjectionIT extends AbstractProjectionConstructorI
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final int id;
-
-			@ProjectionConstructor
-			public MyProjection(@IdProjection int id) {
-				this.id = id;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( PrimitiveTypeMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, PrimitiveTypeMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "11" ),
 						Arrays.asList( "21" )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.id( Integer.class )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( 11 ),
-						new MyProjection( 21 )
+						new PrimitiveTypeMyProjection( 11 ),
+						new PrimitiveTypeMyProjection( 21 )
 				)
 		);
+	}
+
+	static class PrimitiveTypeMyProjection {
+		public final int id;
+
+		@ProjectionConstructor
+		public PrimitiveTypeMyProjection(@IdProjection int id) {
+			this.id = id;
+		}
 	}
 
 }

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorInnerInferredIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorInnerInferredIT.java
@@ -43,40 +43,40 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 			@GenericField
 			public Integer integer;
 		}
-		class MyProjection {
-			public final String text;
-			public final Integer integer;
-
-			@ProjectionConstructor
-			public MyProjection(String text, Integer integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( ValueMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, ValueMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "result1", 11 ),
 						Arrays.asList( "result2", 21 )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "text", String.class ),
 								f.field( "integer", Integer.class )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( "result1", 11 ),
-						new MyProjection( "result2", 21 )
+						new ValueMyProjection( "result1", 11 ),
+						new ValueMyProjection( "result2", 21 )
 				)
 		);
+	}
+
+	static class ValueMyProjection {
+		public final String text;
+		public final Integer integer;
+
+		@ProjectionConstructor
+		public ValueMyProjection(String text, Integer integer) {
+			this.text = text;
+			this.integer = integer;
+		}
 	}
 
 	@Test
@@ -90,24 +90,14 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 			@GenericField
 			public Set<Integer> integer;
 		}
-		class MyProjection {
-			public final List<String> text;
-			public final List<Integer> integer;
-
-			@ProjectionConstructor
-			public MyProjection(List<String> text, List<Integer> integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( Value_multiValued_listMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, Value_multiValued_listMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( Arrays.asList( "result1_1", "result1_2" ), Arrays.asList( 11, 12 ) ),
 						Arrays.asList( Arrays.asList( "result2_1" ), Arrays.asList( 21 ) ),
@@ -116,18 +106,29 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "text", String.class ).collector( ProjectionCollector.list() ),
 								f.field( "integer", Integer.class ).collector( ProjectionCollector.list() )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( Arrays.asList( "result1_1", "result1_2" ), Arrays.asList( 11, 12 ) ),
-						new MyProjection( Arrays.asList( "result2_1" ), Arrays.asList( 21 ) ),
-						new MyProjection( Collections.emptyList(), Collections.emptyList() ),
-						new MyProjection( Arrays.asList( "result4_1" ), Arrays.asList( 41 ) )
+						new Value_multiValued_listMyProjection( Arrays.asList( "result1_1", "result1_2" ),
+								Arrays.asList( 11, 12 ) ),
+						new Value_multiValued_listMyProjection( Arrays.asList( "result2_1" ), Arrays.asList( 21 ) ),
+						new Value_multiValued_listMyProjection( Collections.emptyList(), Collections.emptyList() ),
+						new Value_multiValued_listMyProjection( Arrays.asList( "result4_1" ), Arrays.asList( 41 ) )
 				)
 		);
+	}
+
+	static class Value_multiValued_listMyProjection {
+		public final List<String> text;
+		public final List<Integer> integer;
+
+		@ProjectionConstructor
+		public Value_multiValued_listMyProjection(List<String> text, List<Integer> integer) {
+			this.text = text;
+			this.integer = integer;
+		}
 	}
 
 	@Test
@@ -141,24 +142,14 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 			@GenericField
 			public Set<Integer> integer;
 		}
-		class MyProjection {
-			public final Collection<String> text;
-			public final Collection<Integer> integer;
-
-			@ProjectionConstructor
-			public MyProjection(Collection<String> text, Collection<Integer> integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( Value_multiValued_collectionMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, Value_multiValued_collectionMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( Arrays.asList( "result1_1", "result1_2" ), Arrays.asList( 11, 12 ) ),
 						Arrays.asList( Arrays.asList( "result2_1" ), Arrays.asList( 21 ) ),
@@ -167,18 +158,29 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "text", String.class ).collector( ProjectionCollector.list() ),
 								f.field( "integer", Integer.class ).collector( ProjectionCollector.list() )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( Arrays.asList( "result1_1", "result1_2" ), Arrays.asList( 11, 12 ) ),
-						new MyProjection( Arrays.asList( "result2_1" ), Arrays.asList( 21 ) ),
-						new MyProjection( Collections.emptyList(), Collections.emptyList() ),
-						new MyProjection( Arrays.asList( "result4_1" ), Arrays.asList( 41 ) )
+						new Value_multiValued_collectionMyProjection( Arrays.asList( "result1_1", "result1_2" ),
+								Arrays.asList( 11, 12 ) ),
+						new Value_multiValued_collectionMyProjection( Arrays.asList( "result2_1" ), Arrays.asList( 21 ) ),
+						new Value_multiValued_collectionMyProjection( Collections.emptyList(), Collections.emptyList() ),
+						new Value_multiValued_collectionMyProjection( Arrays.asList( "result4_1" ), Arrays.asList( 41 ) )
 				)
 		);
+	}
+
+	static class Value_multiValued_collectionMyProjection {
+		public final Collection<String> text;
+		public final Collection<Integer> integer;
+
+		@ProjectionConstructor
+		public Value_multiValued_collectionMyProjection(Collection<String> text, Collection<Integer> integer) {
+			this.text = text;
+			this.integer = integer;
+		}
 	}
 
 	@Test
@@ -192,24 +194,14 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 			@GenericField
 			public Set<Integer> integer;
 		}
-		class MyProjection {
-			public final Iterable<String> text;
-			public final Iterable<Integer> integer;
-
-			@ProjectionConstructor
-			public MyProjection(Iterable<String> text, Iterable<Integer> integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( Value_multiValued_iterableMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, Value_multiValued_iterableMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( Arrays.asList( "result1_1", "result1_2" ), Arrays.asList( 11, 12 ) ),
 						Arrays.asList( Arrays.asList( "result2_1" ), Arrays.asList( 21 ) ),
@@ -218,18 +210,29 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "text", String.class ).collector( ProjectionCollector.list() ),
 								f.field( "integer", Integer.class ).collector( ProjectionCollector.list() )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( Arrays.asList( "result1_1", "result1_2" ), Arrays.asList( 11, 12 ) ),
-						new MyProjection( Arrays.asList( "result2_1" ), Arrays.asList( 21 ) ),
-						new MyProjection( Collections.emptyList(), Collections.emptyList() ),
-						new MyProjection( Arrays.asList( "result4_1" ), Arrays.asList( 41 ) )
+						new Value_multiValued_iterableMyProjection( Arrays.asList( "result1_1", "result1_2" ),
+								Arrays.asList( 11, 12 ) ),
+						new Value_multiValued_iterableMyProjection( Arrays.asList( "result2_1" ), Arrays.asList( 21 ) ),
+						new Value_multiValued_iterableMyProjection( Collections.emptyList(), Collections.emptyList() ),
+						new Value_multiValued_iterableMyProjection( Arrays.asList( "result4_1" ), Arrays.asList( 41 ) )
 				)
 		);
+	}
+
+	static class Value_multiValued_iterableMyProjection {
+		public final Iterable<String> text;
+		public final Iterable<Integer> integer;
+
+		@ProjectionConstructor
+		public Value_multiValued_iterableMyProjection(Iterable<String> text, Iterable<Integer> integer) {
+			this.text = text;
+			this.integer = integer;
+		}
 	}
 
 	@Test
@@ -243,24 +246,14 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 			@GenericField
 			public Set<Integer> integer;
 		}
-		class MyProjection {
-			public final Set<String> text;
-			public final List<Integer> integer;
-
-			@ProjectionConstructor
-			public MyProjection(Set<String> text, List<Integer> integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( Value_multiValued_setMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, Value_multiValued_setMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( Set.of( "result1_1", "result1_2" ), Arrays.asList( 11, 12 ) ),
 						Arrays.asList( Set.of( "result2_1" ), Arrays.asList( 21 ) ),
@@ -269,18 +262,28 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "text", String.class ).collector( ProjectionCollector.set() ),
 								f.field( "integer", Integer.class ).collector( ProjectionCollector.list() )
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( Set.of( "result1_1", "result1_2" ), Arrays.asList( 11, 12 ) ),
-						new MyProjection( Set.of( "result2_1" ), Arrays.asList( 21 ) ),
-						new MyProjection( Set.of(), Collections.emptyList() ),
-						new MyProjection( Set.of( "result4_1" ), Arrays.asList( 41 ) )
+						new Value_multiValued_setMyProjection( Set.of( "result1_1", "result1_2" ), Arrays.asList( 11, 12 ) ),
+						new Value_multiValued_setMyProjection( Set.of( "result2_1" ), Arrays.asList( 21 ) ),
+						new Value_multiValued_setMyProjection( Set.of(), Collections.emptyList() ),
+						new Value_multiValued_setMyProjection( Set.of( "result4_1" ), Arrays.asList( 41 ) )
 				)
 		);
+	}
+
+	static class Value_multiValued_setMyProjection {
+		public final Set<String> text;
+		public final List<Integer> integer;
+
+		@ProjectionConstructor
+		public Value_multiValued_setMyProjection(Set<String> text, List<Integer> integer) {
+			this.text = text;
+			this.integer = integer;
+		}
 	}
 
 	@Test
@@ -302,34 +305,14 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 			@IndexedEmbedded
 			public Contained contained;
 		}
-		class MyInnerProjection {
-			public final String text;
-			public final Integer integer;
-
-			@ProjectionConstructor
-			public MyInnerProjection(String text, Integer integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
-		class MyProjection {
-			public final String text;
-			public final MyInnerProjection contained;
-
-			@ProjectionConstructor
-			public MyProjection(String text, MyInnerProjection contained) {
-				this.text = text;
-				this.contained = contained;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class, MyInnerProjection.class )
+				.withAnnotatedTypes( ObjectMyProjection.class, ObjectMyInnerProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, ObjectMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "result1", Arrays.asList( "result1_1", 11 ) ),
 						Arrays.asList( "result2", Arrays.asList( null, null ) ),
@@ -337,11 +320,9 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "text", String.class ),
 								f.object( "contained" )
 										.from(
-												dummyProjectionForEnclosingClassInstance( f ),
 												f.field( "contained.text", String.class ),
 												f.field( "contained.integer", Integer.class )
 										)
@@ -349,11 +330,33 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( "result1", new MyInnerProjection( "result1_1", 11 ) ),
-						new MyProjection( "result2", new MyInnerProjection( null, null ) ),
-						new MyProjection( "result3", null )
+						new ObjectMyProjection( "result1", new ObjectMyInnerProjection( "result1_1", 11 ) ),
+						new ObjectMyProjection( "result2", new ObjectMyInnerProjection( null, null ) ),
+						new ObjectMyProjection( "result3", null )
 				)
 		);
+	}
+
+	static class ObjectMyInnerProjection {
+		public final String text;
+		public final Integer integer;
+
+		@ProjectionConstructor
+		public ObjectMyInnerProjection(String text, Integer integer) {
+			this.text = text;
+			this.integer = integer;
+		}
+	}
+
+	static class ObjectMyProjection {
+		public final String text;
+		public final ObjectMyInnerProjection contained;
+
+		@ProjectionConstructor
+		public ObjectMyProjection(String text, ObjectMyInnerProjection contained) {
+			this.text = text;
+			this.contained = contained;
+		}
 	}
 
 	// If an inner projection type is not included in any Jandex index on startup,
@@ -377,36 +380,16 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 			@IndexedEmbedded
 			public Contained contained;
 		}
-		class MyInnerProjection {
-			public final String text;
-			public final Integer integer;
-
-			@ProjectionConstructor
-			public MyInnerProjection(String text, Integer integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
-		class MyProjection {
-			public final String text;
-			public final MyInnerProjection contained;
-
-			@ProjectionConstructor
-			public MyProjection(String text, MyInnerProjection contained) {
-				this.text = text;
-				this.contained = contained;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
 				// We're not processing annotations on MyInnerProjection on purpose:
 				// this simulates the class not being included in any Jandex index on startup.
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( Object_annotatedTypeDiscoveryMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, Object_annotatedTypeDiscoveryMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "result1", Arrays.asList( "result1_1", 11 ) ),
 						Arrays.asList( "result2", Arrays.asList( null, null ) ),
@@ -414,11 +397,9 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "text", String.class ),
 								f.object( "contained" )
 										.from(
-												dummyProjectionForEnclosingClassInstance( f ),
 												f.field( "contained.text", String.class ),
 												f.field( "contained.integer", Integer.class )
 										)
@@ -426,11 +407,36 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( "result1", new MyInnerProjection( "result1_1", 11 ) ),
-						new MyProjection( "result2", new MyInnerProjection( null, null ) ),
-						new MyProjection( "result3", null )
+						new Object_annotatedTypeDiscoveryMyProjection( "result1",
+								new Object_annotatedTypeDiscoveryMyInnerProjection( "result1_1", 11 ) ),
+						new Object_annotatedTypeDiscoveryMyProjection( "result2",
+								new Object_annotatedTypeDiscoveryMyInnerProjection( null, null ) ),
+						new Object_annotatedTypeDiscoveryMyProjection( "result3", null )
 				)
 		);
+	}
+
+	static class Object_annotatedTypeDiscoveryMyInnerProjection {
+		public final String text;
+		public final Integer integer;
+
+		@ProjectionConstructor
+		public Object_annotatedTypeDiscoveryMyInnerProjection(String text, Integer integer) {
+			this.text = text;
+			this.integer = integer;
+		}
+	}
+
+	static class Object_annotatedTypeDiscoveryMyProjection {
+		public final String text;
+		public final Object_annotatedTypeDiscoveryMyInnerProjection contained;
+
+		@ProjectionConstructor
+		public Object_annotatedTypeDiscoveryMyProjection(String text,
+				Object_annotatedTypeDiscoveryMyInnerProjection contained) {
+			this.text = text;
+			this.contained = contained;
+		}
 	}
 
 	@Test
@@ -452,34 +458,14 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 			@IndexedEmbedded
 			public Collection<Contained> contained;
 		}
-		class MyInnerProjection {
-			public final String text;
-			public final Integer integer;
-
-			@ProjectionConstructor
-			public MyInnerProjection(String text, Integer integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
-		class MyProjection {
-			public final String text;
-			public final List<MyInnerProjection> contained;
-
-			@ProjectionConstructor
-			public MyProjection(String text, List<MyInnerProjection> contained) {
-				this.text = text;
-				this.contained = contained;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class, MyInnerProjection.class )
+				.withAnnotatedTypes( Object_multiValued_listMyProjection.class, Object_multiValued_listMyInnerProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, Object_multiValued_listMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "result1", Arrays.asList(
 								Arrays.asList( "result1_1", 11 ),
@@ -495,11 +481,9 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "text", String.class ),
 								f.object( "contained" )
 										.from(
-												dummyProjectionForEnclosingClassInstance( f ),
 												f.field( "contained.text", String.class ),
 												f.field( "contained.integer", Integer.class )
 										)
@@ -508,19 +492,41 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( "result1", Arrays.asList(
-								new MyInnerProjection( "result1_1", 11 ),
-								new MyInnerProjection( "result1_2", 12 )
+						new Object_multiValued_listMyProjection( "result1", Arrays.asList(
+								new Object_multiValued_listMyInnerProjection( "result1_1", 11 ),
+								new Object_multiValued_listMyInnerProjection( "result1_2", 12 )
 						) ),
-						new MyProjection( "result2", Arrays.asList(
-								new MyInnerProjection( "result2_1", 21 )
+						new Object_multiValued_listMyProjection( "result2", Arrays.asList(
+								new Object_multiValued_listMyInnerProjection( "result2_1", 21 )
 						) ),
-						new MyProjection( "result3", Collections.emptyList() ),
-						new MyProjection( "result4", Arrays.asList(
-								new MyInnerProjection( "result4_1", 41 )
+						new Object_multiValued_listMyProjection( "result3", Collections.emptyList() ),
+						new Object_multiValued_listMyProjection( "result4", Arrays.asList(
+								new Object_multiValued_listMyInnerProjection( "result4_1", 41 )
 						) )
 				)
 		);
+	}
+
+	static class Object_multiValued_listMyInnerProjection {
+		public final String text;
+		public final Integer integer;
+
+		@ProjectionConstructor
+		public Object_multiValued_listMyInnerProjection(String text, Integer integer) {
+			this.text = text;
+			this.integer = integer;
+		}
+	}
+
+	static class Object_multiValued_listMyProjection {
+		public final String text;
+		public final List<Object_multiValued_listMyInnerProjection> contained;
+
+		@ProjectionConstructor
+		public Object_multiValued_listMyProjection(String text, List<Object_multiValued_listMyInnerProjection> contained) {
+			this.text = text;
+			this.contained = contained;
+		}
 	}
 
 	@Test
@@ -542,34 +548,15 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 			@IndexedEmbedded
 			public List<Contained> contained;
 		}
-		class MyInnerProjection {
-			public final String text;
-			public final Integer integer;
-
-			@ProjectionConstructor
-			public MyInnerProjection(String text, Integer integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
-		class MyProjection {
-			public final String text;
-			public final Collection<MyInnerProjection> contained;
-
-			@ProjectionConstructor
-			public MyProjection(String text, Collection<MyInnerProjection> contained) {
-				this.text = text;
-				this.contained = contained;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class, MyInnerProjection.class )
+				.withAnnotatedTypes( Object_multiValued_collectionMyProjection.class,
+						Object_multiValued_collectionMyInnerProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, Object_multiValued_collectionMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "result1", Arrays.asList(
 								Arrays.asList( "result1_1", 11 ),
@@ -585,11 +572,9 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "text", String.class ),
 								f.object( "contained" )
 										.from(
-												dummyProjectionForEnclosingClassInstance( f ),
 												f.field( "contained.text", String.class ),
 												f.field( "contained.integer", Integer.class )
 										)
@@ -598,19 +583,42 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( "result1", Arrays.asList(
-								new MyInnerProjection( "result1_1", 11 ),
-								new MyInnerProjection( "result1_2", 12 )
+						new Object_multiValued_collectionMyProjection( "result1", Arrays.asList(
+								new Object_multiValued_collectionMyInnerProjection( "result1_1", 11 ),
+								new Object_multiValued_collectionMyInnerProjection( "result1_2", 12 )
 						) ),
-						new MyProjection( "result2", Arrays.asList(
-								new MyInnerProjection( "result2_1", 21 )
+						new Object_multiValued_collectionMyProjection( "result2", Arrays.asList(
+								new Object_multiValued_collectionMyInnerProjection( "result2_1", 21 )
 						) ),
-						new MyProjection( "result3", Collections.emptyList() ),
-						new MyProjection( "result4", Arrays.asList(
-								new MyInnerProjection( "result4_1", 41 )
+						new Object_multiValued_collectionMyProjection( "result3", Collections.emptyList() ),
+						new Object_multiValued_collectionMyProjection( "result4", Arrays.asList(
+								new Object_multiValued_collectionMyInnerProjection( "result4_1", 41 )
 						) )
 				)
 		);
+	}
+
+	static class Object_multiValued_collectionMyInnerProjection {
+		public final String text;
+		public final Integer integer;
+
+		@ProjectionConstructor
+		public Object_multiValued_collectionMyInnerProjection(String text, Integer integer) {
+			this.text = text;
+			this.integer = integer;
+		}
+	}
+
+	static class Object_multiValued_collectionMyProjection {
+		public final String text;
+		public final Collection<Object_multiValued_collectionMyInnerProjection> contained;
+
+		@ProjectionConstructor
+		public Object_multiValued_collectionMyProjection(String text,
+				Collection<Object_multiValued_collectionMyInnerProjection> contained) {
+			this.text = text;
+			this.contained = contained;
+		}
 	}
 
 	@Test
@@ -632,34 +640,15 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 			@IndexedEmbedded
 			public List<Contained> contained;
 		}
-		class MyInnerProjection {
-			public final String text;
-			public final Integer integer;
-
-			@ProjectionConstructor
-			public MyInnerProjection(String text, Integer integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
-		class MyProjection {
-			public final String text;
-			public final Iterable<MyInnerProjection> contained;
-
-			@ProjectionConstructor
-			public MyProjection(String text, Iterable<MyInnerProjection> contained) {
-				this.text = text;
-				this.contained = contained;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class, MyInnerProjection.class )
+				.withAnnotatedTypes( Object_multiValued_iterableMyProjection.class,
+						Object_multiValued_iterableMyInnerProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, Object_multiValued_iterableMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "result1", Arrays.asList(
 								Arrays.asList( "result1_1", 11 ),
@@ -675,11 +664,9 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "text", String.class ),
 								f.object( "contained" )
 										.from(
-												dummyProjectionForEnclosingClassInstance( f ),
 												f.field( "contained.text", String.class ),
 												f.field( "contained.integer", Integer.class )
 										)
@@ -688,19 +675,42 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( "result1", Arrays.asList(
-								new MyInnerProjection( "result1_1", 11 ),
-								new MyInnerProjection( "result1_2", 12 )
+						new Object_multiValued_iterableMyProjection( "result1", Arrays.asList(
+								new Object_multiValued_iterableMyInnerProjection( "result1_1", 11 ),
+								new Object_multiValued_iterableMyInnerProjection( "result1_2", 12 )
 						) ),
-						new MyProjection( "result2", Arrays.asList(
-								new MyInnerProjection( "result2_1", 21 )
+						new Object_multiValued_iterableMyProjection( "result2", Arrays.asList(
+								new Object_multiValued_iterableMyInnerProjection( "result2_1", 21 )
 						) ),
-						new MyProjection( "result3", Collections.emptyList() ),
-						new MyProjection( "result4", Arrays.asList(
-								new MyInnerProjection( "result4_1", 41 )
+						new Object_multiValued_iterableMyProjection( "result3", Collections.emptyList() ),
+						new Object_multiValued_iterableMyProjection( "result4", Arrays.asList(
+								new Object_multiValued_iterableMyInnerProjection( "result4_1", 41 )
 						) )
 				)
 		);
+	}
+
+	static class Object_multiValued_iterableMyInnerProjection {
+		public final String text;
+		public final Integer integer;
+
+		@ProjectionConstructor
+		public Object_multiValued_iterableMyInnerProjection(String text, Integer integer) {
+			this.text = text;
+			this.integer = integer;
+		}
+	}
+
+	static class Object_multiValued_iterableMyProjection {
+		public final String text;
+		public final Iterable<Object_multiValued_iterableMyInnerProjection> contained;
+
+		@ProjectionConstructor
+		public Object_multiValued_iterableMyProjection(String text,
+				Iterable<Object_multiValued_iterableMyInnerProjection> contained) {
+			this.text = text;
+			this.contained = contained;
+		}
 	}
 
 	@Test
@@ -722,34 +732,14 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 			@IndexedEmbedded
 			public List<Contained> contained;
 		}
-		class MyInnerProjection {
-			public final String text;
-			public final Integer integer;
-
-			@ProjectionConstructor
-			public MyInnerProjection(String text, Integer integer) {
-				this.text = text;
-				this.integer = integer;
-			}
-		}
-		class MyProjection {
-			public final String text;
-			public final Set<MyInnerProjection> contained;
-
-			@ProjectionConstructor
-			public MyProjection(String text, Set<MyInnerProjection> contained) {
-				this.text = text;
-				this.contained = contained;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class, MyInnerProjection.class )
+				.withAnnotatedTypes( Object_multiValued_setMyProjection.class, Object_multiValued_setMyInnerProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, Object_multiValued_setMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( "result1", Set.of(
 								Arrays.asList( "result1_1", 11 ),
@@ -765,11 +755,9 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.field( "text", String.class ),
 								f.object( "contained" )
 										.from(
-												dummyProjectionForEnclosingClassInstance( f ),
 												f.field( "contained.text", String.class ),
 												f.field( "contained.integer", Integer.class )
 										)
@@ -778,19 +766,40 @@ class ProjectionConstructorInnerInferredIT extends AbstractProjectionConstructor
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( "result1", Set.of(
-								new MyInnerProjection( "result1_1", 11 ),
-								new MyInnerProjection( "result1_2", 12 )
+						new Object_multiValued_setMyProjection( "result1", Set.of(
+								new Object_multiValued_setMyInnerProjection( "result1_1", 11 ),
+								new Object_multiValued_setMyInnerProjection( "result1_2", 12 )
 						) ),
-						new MyProjection( "result2", Set.of(
-								new MyInnerProjection( "result2_1", 21 )
+						new Object_multiValued_setMyProjection( "result2", Set.of(
+								new Object_multiValued_setMyInnerProjection( "result2_1", 21 )
 						) ),
-						new MyProjection( "result3", Set.of() ),
-						new MyProjection( "result4", Set.of(
-								new MyInnerProjection( "result4_1", 41 )
+						new Object_multiValued_setMyProjection( "result3", Set.of() ),
+						new Object_multiValued_setMyProjection( "result4", Set.of(
+								new Object_multiValued_setMyInnerProjection( "result4_1", 41 )
 						) )
 				)
 		);
 	}
 
+	static class Object_multiValued_setMyInnerProjection {
+		public final String text;
+		public final Integer integer;
+
+		@ProjectionConstructor
+		public Object_multiValued_setMyInnerProjection(String text, Integer integer) {
+			this.text = text;
+			this.integer = integer;
+		}
+	}
+
+	static class Object_multiValued_setMyProjection {
+		public final String text;
+		public final Set<Object_multiValued_setMyInnerProjection> contained;
+
+		@ProjectionConstructor
+		public Object_multiValued_setMyProjection(String text, Set<Object_multiValued_setMyInnerProjection> contained) {
+			this.text = text;
+			this.contained = contained;
+		}
+	}
 }

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorObjectProjectionCycleIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorObjectProjectionCycleIT.java
@@ -55,7 +55,7 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 				Level1 level1;
 			}
 
-			class ProjectionLevel1 {
+			static class ProjectionLevel1 {
 				public final String text;
 				public final ProjectionLevel2 level2;
 
@@ -66,7 +66,7 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 				}
 			}
 
-			class ProjectionLevel2 {
+			static class ProjectionLevel2 {
 				public final String text;
 				public final ProjectionLevel1 level1;
 
@@ -84,17 +84,17 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 				.isInstanceOf( SearchException.class )
 				.satisfies( FailureReportUtils.hasFailureReport()
 						.typeContext( Model.ProjectionLevel1.class.getName() )
-						.constructorContext( Model.class, String.class, Model.ProjectionLevel2.class )
-						.methodParameterContext( 2, "level2" )
+						.constructorContext( String.class, Model.ProjectionLevel2.class )
+						.methodParameterContext( 1, "level2" )
 						.typeContext( Model.ProjectionLevel2.class.getName() )
-						.constructorContext( Model.class, String.class, Model.ProjectionLevel1.class )
-						.methodParameterContext( 2, "level1" )
+						.constructorContext( String.class, Model.ProjectionLevel1.class )
+						.methodParameterContext( 1, "level1" )
 						.typeContext( Model.ProjectionLevel1.class.getName() )
-						.constructorContext( Model.class, String.class, Model.ProjectionLevel2.class )
-						.methodParameterContext( 2, "level2" )
+						.constructorContext( String.class, Model.ProjectionLevel2.class )
+						.methodParameterContext( 1, "level2" )
 						.multilineFailure( "Cyclic recursion starting from 'ObjectProjectionBinder(...)'",
 								"on type '" + Model.ProjectionLevel1.class.getName()
-										+ "', projection constructor, parameter at index 2 (level2)",
+										+ "', projection constructor, parameter at index 1 (level2)",
 								"Index field path starting from that location and ending with a cycle: 'level2.level1.level2.'",
 								"A projection constructor cannot declare an unrestricted @ObjectProjection to itself, even indirectly",
 								"To break the cycle, you should consider adding filters to your @ObjectProjection: includePaths, includeDepth, excludePaths, ..." ) );
@@ -122,7 +122,7 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 				Level1 level1;
 			}
 
-			class ProjectionLevel1 {
+			static class ProjectionLevel1 {
 				public final String text;
 				public final ProjectionLevel2 level2;
 
@@ -134,7 +134,7 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 				}
 			}
 
-			class ProjectionLevel2 {
+			static class ProjectionLevel2 {
 				public final String text;
 				public final ProjectionLevel1 level1;
 
@@ -151,8 +151,6 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 				.withAnnotatedTypes( Model.ProjectionLevel1.class, Model.ProjectionLevel2.class )
 				.setup( Model.Level1.class );
 
-		Model model = new Model();
-
 		testSuccessfulRootProjectionExecutionOnly(
 				mapping, Model.Level1.class, Model.ProjectionLevel1.class,
 				Arrays.asList(
@@ -164,12 +162,12 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 										Arrays.asList( "result2_level2_level1", null ) ) )
 				),
 				Arrays.asList(
-						model.new ProjectionLevel1( "result1",
-								model.new ProjectionLevel2( "result1_level2",
-										model.new ProjectionLevel1( "result1_level2_level1", null ) ) ),
-						model.new ProjectionLevel1( "result2",
-								model.new ProjectionLevel2( "result2_level2",
-										model.new ProjectionLevel1( "result2_level2_level1", null ) ) )
+						new Model.ProjectionLevel1( "result1",
+								new Model.ProjectionLevel2( "result1_level2",
+										new Model.ProjectionLevel1( "result1_level2_level1", null ) ) ),
+						new Model.ProjectionLevel1( "result2",
+								new Model.ProjectionLevel2( "result2_level2",
+										new Model.ProjectionLevel1( "result2_level2_level1", null ) ) )
 				)
 		);
 	}
@@ -196,7 +194,7 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 				Level1 level1;
 			}
 
-			class ProjectionLevel1 {
+			static class ProjectionLevel1 {
 				public final String text;
 				public final ProjectionLevel2 level2;
 
@@ -208,7 +206,7 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 				}
 			}
 
-			class ProjectionLevel2 {
+			static class ProjectionLevel2 {
 				public final String text;
 				public final ProjectionLevel1 level1;
 
@@ -225,8 +223,6 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 				.withAnnotatedTypes( Model.ProjectionLevel1.class, Model.ProjectionLevel2.class )
 				.setup( Model.Level1.class );
 
-		Model model = new Model();
-
 		testSuccessfulRootProjectionExecutionOnly(
 				mapping, Model.Level1.class, Model.ProjectionLevel1.class,
 				Arrays.asList(
@@ -238,12 +234,12 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 										Arrays.asList( "result2_level2_level1", null ) ) )
 				),
 				Arrays.asList(
-						model.new ProjectionLevel1( "result1",
-								model.new ProjectionLevel2( "result1_level2",
-										model.new ProjectionLevel1( "result1_level2_level1", null ) ) ),
-						model.new ProjectionLevel1( "result2",
-								model.new ProjectionLevel2( "result2_level2",
-										model.new ProjectionLevel1( "result2_level2_level1", null ) ) )
+						new Model.ProjectionLevel1( "result1",
+								new Model.ProjectionLevel2( "result1_level2",
+										new Model.ProjectionLevel1( "result1_level2_level1", null ) ) ),
+						new Model.ProjectionLevel1( "result2",
+								new Model.ProjectionLevel2( "result2_level2",
+										new Model.ProjectionLevel1( "result2_level2_level1", null ) ) )
 				)
 		);
 	}
@@ -270,7 +266,7 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 				Level1 level1;
 			}
 
-			class ProjectionLevel1 {
+			static class ProjectionLevel1 {
 				public final String text;
 				public final ProjectionLevel2 level2;
 
@@ -282,7 +278,7 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 				}
 			}
 
-			class ProjectionLevel2 {
+			static class ProjectionLevel2 {
 				public final String text;
 				public final ProjectionLevel1 level1;
 
@@ -299,8 +295,6 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 				.withAnnotatedTypes( Model.ProjectionLevel1.class, Model.ProjectionLevel2.class )
 				.setup( Model.Level1.class );
 
-		Model model = new Model();
-
 		testSuccessfulRootProjectionExecutionOnly(
 				mapping, Model.Level1.class, Model.ProjectionLevel1.class,
 				Arrays.asList(
@@ -312,12 +306,12 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 										Arrays.asList( "result2_level2_level1", null ) ) )
 				),
 				Arrays.asList(
-						model.new ProjectionLevel1( "result1",
-								model.new ProjectionLevel2( "result1_level2",
-										model.new ProjectionLevel1( "result1_level2_level1", null ) ) ),
-						model.new ProjectionLevel1( "result2",
-								model.new ProjectionLevel2( "result2_level2",
-										model.new ProjectionLevel1( "result2_level2_level1", null ) ) )
+						new Model.ProjectionLevel1( "result1",
+								new Model.ProjectionLevel2( "result1_level2",
+										new Model.ProjectionLevel1( "result1_level2_level1", null ) ) ),
+						new Model.ProjectionLevel1( "result2",
+								new Model.ProjectionLevel2( "result2_level2",
+										new Model.ProjectionLevel1( "result2_level2_level1", null ) ) )
 				)
 		);
 	}
@@ -353,7 +347,7 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 				Level1 level1;
 			}
 
-			class ProjectionLevel1 {
+			static class ProjectionLevel1 {
 				public final String text;
 				public final ProjectionLevel2 level2;
 
@@ -364,7 +358,7 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 				}
 			}
 
-			class ProjectionLevel2 {
+			static class ProjectionLevel2 {
 				public final String text;
 				public final ProjectionLevel3 level3;
 
@@ -375,7 +369,7 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 				}
 			}
 
-			class ProjectionLevel3 {
+			static class ProjectionLevel3 {
 				public final String text;
 				public final ProjectionLevel1 level1;
 
@@ -393,20 +387,20 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 				.isInstanceOf( SearchException.class )
 				.satisfies( FailureReportUtils.hasFailureReport()
 						.typeContext( Model.ProjectionLevel1.class.getName() )
-						.constructorContext( Model.class, String.class, Model.ProjectionLevel2.class )
-						.methodParameterContext( 2, "level2" )
+						.constructorContext( String.class, Model.ProjectionLevel2.class )
+						.methodParameterContext( 1, "level2" )
 						.typeContext( Model.ProjectionLevel2.class.getName() )
-						.constructorContext( Model.class, String.class, Model.ProjectionLevel3.class )
-						.methodParameterContext( 2, "level3" )
+						.constructorContext( String.class, Model.ProjectionLevel3.class )
+						.methodParameterContext( 1, "level3" )
 						.typeContext( Model.ProjectionLevel3.class.getName() )
-						.constructorContext( Model.class, String.class, Model.ProjectionLevel1.class )
-						.methodParameterContext( 2, "level1" )
+						.constructorContext( String.class, Model.ProjectionLevel1.class )
+						.methodParameterContext( 1, "level1" )
 						.typeContext( Model.ProjectionLevel1.class.getName() )
-						.constructorContext( Model.class, String.class, Model.ProjectionLevel2.class )
-						.methodParameterContext( 2, "level2" )
+						.constructorContext( String.class, Model.ProjectionLevel2.class )
+						.methodParameterContext( 1, "level2" )
 						.multilineFailure( "Cyclic recursion starting from 'ObjectProjectionBinder(...)'",
 								"on type '" + Model.ProjectionLevel1.class.getName()
-										+ "', projection constructor, parameter at index 2 (level2)",
+										+ "', projection constructor, parameter at index 1 (level2)",
 								"Index field path starting from that location and ending with a cycle: 'level2.level3.level1.level2.'",
 								"A projection constructor cannot declare an unrestricted @ObjectProjection to itself, even indirectly",
 								"To break the cycle, you should consider adding filters to your @ObjectProjection: includePaths, includeDepth, excludePaths, ..." ) );
@@ -443,7 +437,7 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 				Level1 level1;
 			}
 
-			class ProjectionLevel1 {
+			static class ProjectionLevel1 {
 				public final String text;
 				public final ProjectionLevel2 level2;
 
@@ -454,7 +448,7 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 				}
 			}
 
-			class ProjectionLevel2 {
+			static class ProjectionLevel2 {
 				public final String text;
 				public final ProjectionLevel3 level3;
 
@@ -465,7 +459,7 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 				}
 			}
 
-			class ProjectionLevel3 {
+			static class ProjectionLevel3 {
 				public final String text;
 				public final ProjectionLevel2 level2;
 
@@ -483,20 +477,20 @@ class ProjectionConstructorObjectProjectionCycleIT extends AbstractProjectionCon
 				.isInstanceOf( SearchException.class )
 				.satisfies( FailureReportUtils.hasFailureReport()
 						.typeContext( Model.ProjectionLevel1.class.getName() )
-						.constructorContext( Model.class, String.class, Model.ProjectionLevel2.class )
-						.methodParameterContext( 2, "level2" )
+						.constructorContext( String.class, Model.ProjectionLevel2.class )
+						.methodParameterContext( 1, "level2" )
 						.typeContext( Model.ProjectionLevel2.class.getName() )
-						.constructorContext( Model.class, String.class, Model.ProjectionLevel3.class )
-						.methodParameterContext( 2, "level3" )
+						.constructorContext( String.class, Model.ProjectionLevel3.class )
+						.methodParameterContext( 1, "level3" )
 						.typeContext( Model.ProjectionLevel3.class.getName() )
-						.constructorContext( Model.class, String.class, Model.ProjectionLevel2.class )
-						.methodParameterContext( 2, "level2" )
+						.constructorContext( String.class, Model.ProjectionLevel2.class )
+						.methodParameterContext( 1, "level2" )
 						.typeContext( Model.ProjectionLevel2.class.getName() )
-						.constructorContext( Model.class, String.class, Model.ProjectionLevel3.class )
-						.methodParameterContext( 2, "level3" )
+						.constructorContext( String.class, Model.ProjectionLevel3.class )
+						.methodParameterContext( 1, "level3" )
 						.multilineFailure( "Cyclic recursion starting from 'ObjectProjectionBinder(...)'",
 								"on type '" + Model.ProjectionLevel2.class.getName()
-										+ "', projection constructor, parameter at index 2 (level3)",
+										+ "', projection constructor, parameter at index 1 (level3)",
 								"Index field path starting from that location and ending with a cycle: 'level3.level2.level3.'",
 								"A projection constructor cannot declare an unrestricted @ObjectProjection to itself, even indirectly",
 								"To break the cycle, you should consider adding filters to your @ObjectProjection: includePaths, includeDepth, excludePaths, ..." ) );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorScoreProjectionIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ProjectionConstructorScoreProjectionIT.java
@@ -39,37 +39,37 @@ class ProjectionConstructorScoreProjectionIT extends AbstractProjectionConstruct
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final Float score;
-
-			@ProjectionConstructor
-			public MyProjection(@ScoreProjection Float score) {
-				this.score = score;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( NoArgMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, NoArgMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( 1.0f ),
 						Arrays.asList( 2.0f )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.score()
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( 1.0f ),
-						new MyProjection( 2.0f )
+						new NoArgMyProjection( 1.0f ),
+						new NoArgMyProjection( 2.0f )
 				)
 		);
+	}
+
+	static class NoArgMyProjection {
+		public final Float score;
+
+		@ProjectionConstructor
+		public NoArgMyProjection(@ScoreProjection Float score) {
+			this.score = score;
+		}
 	}
 
 	@Test
@@ -81,37 +81,37 @@ class ProjectionConstructorScoreProjectionIT extends AbstractProjectionConstruct
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final Object score;
-
-			@ProjectionConstructor
-			public MyProjection(@ScoreProjection Object score) {
-				this.score = score;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( SupertypeMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, SupertypeMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( 1.0f ),
 						Arrays.asList( 2.0f )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.score()
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( 1.0f ),
-						new MyProjection( 2.0f )
+						new SupertypeMyProjection( 1.0f ),
+						new SupertypeMyProjection( 2.0f )
 				)
 		);
+	}
+
+	static class SupertypeMyProjection {
+		public final Object score;
+
+		@ProjectionConstructor
+		public SupertypeMyProjection(@ScoreProjection Object score) {
+			this.score = score;
+		}
 	}
 
 	@Test
@@ -123,37 +123,37 @@ class ProjectionConstructorScoreProjectionIT extends AbstractProjectionConstruct
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final float score;
-
-			@ProjectionConstructor
-			public MyProjection(@ScoreProjection float score) {
-				this.score = score;
-			}
-		}
 
 		backendMock.expectAnySchema( INDEX_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( PrimitiveTypeMyProjection.class )
 				.setup( IndexedEntity.class );
 
 		testSuccessfulRootProjection(
-				mapping, IndexedEntity.class, MyProjection.class,
+				mapping, IndexedEntity.class, PrimitiveTypeMyProjection.class,
 				Arrays.asList(
 						Arrays.asList( 1.0f ),
 						Arrays.asList( 2.0f )
 				),
 				f -> f.composite()
 						.from(
-								dummyProjectionForEnclosingClassInstance( f ),
 								f.score()
 						)
 						.asList(),
 				Arrays.asList(
-						new MyProjection( 1.0f ),
-						new MyProjection( 2.0f )
+						new PrimitiveTypeMyProjection( 1.0f ),
+						new PrimitiveTypeMyProjection( 2.0f )
 				)
 		);
+	}
+
+	static class PrimitiveTypeMyProjection {
+		public final float score;
+
+		@ProjectionConstructor
+		public PrimitiveTypeMyProjection(@ScoreProjection float score) {
+			this.score = score;
+		}
 	}
 
 	@Test
@@ -165,23 +165,15 @@ class ProjectionConstructorScoreProjectionIT extends AbstractProjectionConstruct
 			@FullTextField
 			public String text;
 		}
-		class MyProjection {
-			public final Integer score;
-
-			@ProjectionConstructor
-			public MyProjection(@ScoreProjection Integer score) {
-				this.score = score;
-			}
-		}
 
 		assertThatThrownBy( () -> setupHelper.start()
-				.withAnnotatedTypes( MyProjection.class )
+				.withAnnotatedTypes( InvalidTypeMyProjection.class )
 				.setup( IndexedEntity.class ) )
 				.isInstanceOf( SearchException.class )
 				.satisfies( FailureReportUtils.hasFailureReport()
-						.typeContext( MyProjection.class.getName() )
-						.constructorContext( ProjectionConstructorScoreProjectionIT.class, Integer.class )
-						.methodParameterContext( 1, "score" )
+						.typeContext( InvalidTypeMyProjection.class.getName() )
+						.constructorContext( Integer.class )
+						.methodParameterContext( 0, "score" )
 						.failure(
 								"Invalid projection definition for constructor parameter type '" + Integer.class.getName()
 										+ "'",
@@ -189,4 +181,12 @@ class ProjectionConstructorScoreProjectionIT extends AbstractProjectionConstruct
 				);
 	}
 
+	static class InvalidTypeMyProjection {
+		public final Integer score;
+
+		@ProjectionConstructor
+		public InvalidTypeMyProjection(@ScoreProjection Integer score) {
+			this.score = score;
+		}
+	}
 }

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/search/loading/SearchQueryEntityLoadingFallbackToProjectionConstructorIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/search/loading/SearchQueryEntityLoadingFallbackToProjectionConstructorIT.java
@@ -97,30 +97,18 @@ class SearchQueryEntityLoadingFallbackToProjectionConstructorIT {
 
 	@Test
 	void withoutLoadingStrategy_withProjectionConstructor() {
-		@SearchEntity(name = ENTITY_NAME)
-		@Indexed
-		class IndexedEntity {
-			@DocumentId
-			public Integer id;
-			@FullTextField
-			public String text;
-
-			@ProjectionConstructor
-			public IndexedEntity(@IdProjection Integer id, String text) {
-				this.id = id;
-				this.text = text;
-			}
-		}
-
 		backendMock.expectAnySchema( ENTITY_NAME );
 		SearchMapping mapping = setupHelper.start()
-				.withAnnotatedTypes( IndexedEntity.class )
+				.withAnnotatedTypes( WithoutLoadingStrategy_withProjectionConstructorIndexedEntity.class )
 				.setup();
 		backendMock.verifyExpectationsMet();
 
-		IndexedEntity instance1 = new IndexedEntity( 1, "text1" );
-		IndexedEntity instance2 = new IndexedEntity( 2, "text2" );
-		IndexedEntity instance3 = new IndexedEntity( 3, "text3" );
+		WithoutLoadingStrategy_withProjectionConstructorIndexedEntity instance1 =
+				new WithoutLoadingStrategy_withProjectionConstructorIndexedEntity( 1, "text1" );
+		WithoutLoadingStrategy_withProjectionConstructorIndexedEntity instance2 =
+				new WithoutLoadingStrategy_withProjectionConstructorIndexedEntity( 2, "text2" );
+		WithoutLoadingStrategy_withProjectionConstructorIndexedEntity instance3 =
+				new WithoutLoadingStrategy_withProjectionConstructorIndexedEntity( 3, "text3" );
 
 		try ( SearchSession session = mapping.createSession() ) {
 			backendMock.expectSearchProjection(
@@ -133,13 +121,28 @@ class SearchQueryEntityLoadingFallbackToProjectionConstructorIT {
 					)
 			);
 
-			assertThat( session.search( IndexedEntity.class )
+			assertThat( session.search( WithoutLoadingStrategy_withProjectionConstructorIndexedEntity.class )
 					.where( f -> f.matchAll() )
 					.fetchAllHits() )
 					.usingRecursiveComparison()
 					.isEqualTo( Arrays.asList( instance1, instance2, instance3 ) );
 		}
 		backendMock.verifyExpectationsMet();
+	}
+
+	@SearchEntity(name = ENTITY_NAME)
+	@Indexed
+	static class WithoutLoadingStrategy_withProjectionConstructorIndexedEntity {
+		@DocumentId
+		public Integer id;
+		@FullTextField
+		public String text;
+
+		@ProjectionConstructor
+		public WithoutLoadingStrategy_withProjectionConstructorIndexedEntity(@IdProjection Integer id, String text) {
+			this.id = id;
+			this.text = text;
+		}
 	}
 
 	@Test

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/PojoMapperLog.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/PojoMapperLog.java
@@ -55,7 +55,7 @@ public interface PojoMapperLog
 	 * here to the next value.
 	 */
 	@LogMessage(level = TRACE)
-	@Message(id = ID_OFFSET + 179, value = "")
+	@Message(id = ID_OFFSET + 180, value = "")
 	void nextLoggerIdForConvenience();
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/ProjectionLog.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/ProjectionLog.java
@@ -162,4 +162,9 @@ public interface ProjectionLog {
 	SearchException cannotBindSortedSetWithNonComparableElements(@FormatWith(ClassFormatter.class) Class<?> elementType,
 			@Param EventContext eventContext);
 
+	@Message(id = ID_OFFSET + 179,
+			value = "An enclosing instance constructor parameter on a projection constructor is not allowed. " +
+					"Make the projection class either static, or a top-level class to remove the enclosing instance constructor parameter.")
+	SearchException nullEnclosingParameterInProjectionConstructorNotAllowed(@Param EventContext eventContext);
+
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/spi/PojoMethodParameterModel.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/spi/PojoMethodParameterModel.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.hibernate.search.engine.mapper.model.spi.MappableTypeModel;
+import org.hibernate.search.util.common.annotation.Incubating;
 
 public interface PojoMethodParameterModel<T> {
 
@@ -25,6 +26,17 @@ public interface PojoMethodParameterModel<T> {
 	 * e.g. an instance of the enclosing class in the case of Java inner classes or method-local classes.
 	 */
 	boolean isEnclosingInstance();
+
+	/**
+	 * Starting with JDk 25, there is an additional check within the constructor itself,
+	 * that by default prevents passing {@code null} as a value for an enclosing instance.
+	 *
+	 * @return Whether {@code null} can be passed as an enclosing instance.
+	 */
+	@Incubating
+	default boolean enclosingInstanceCanBeNull() {
+		return Runtime.version().feature() < 25;
+	}
 
 	/**
 	 * @return {@code true} if {@code obj} is a {@link MappableTypeModel} referencing the exact same type

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/search/definition/binding/impl/ProjectionConstructorParameterBinder.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/search/definition/binding/impl/ProjectionConstructorParameterBinder.java
@@ -56,7 +56,16 @@ class ProjectionConstructorParameterBinder<P> implements EventContextProvider {
 			// and it's often useful to be able to declare a method-local type for projections
 			// (those types have a "surrounding instance" parameter in their constructor
 			// even if they don't use it).
-			return ConstantProjectionDefinition.nullValue();
+
+			// NOTE: with JDK 25+ this is no longer the case,
+			// and will fail further at runtime when such projection is created.
+			// Hence, let's fails faster instead;
+			if ( parameter.enclosingInstanceCanBeNull() ) {
+				return ConstantProjectionDefinition.nullValue();
+			}
+			else {
+				throw ProjectionLog.INSTANCE.nullEnclosingParameterInProjectionConstructorNotAllowed( eventContext() );
+			}
 		}
 
 		BeanHolder<? extends ProjectionDefinition<?>> result = null;


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5358

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
