### PR TITLE
HSEARCH-5370 Upgrade to GSON 2.13.1 /  HSEARCH-5371 Upgrade to Jackson 2.19.0

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -84,7 +84,7 @@
         <version.com.google.code.gson>2.13.1</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.31.2</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, by Avro, by the AWS SDK and in tests (wiremock, ...) -->
-        <version.com.fasterxml.jackson>2.18.3</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.19.0</version.com.fasterxml.jackson>
         <!-- slf4j: used by the AWS SDK -->
         <version.org.slf4j>1.7.36</version.org.slf4j>
 

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -81,7 +81,7 @@
         <version.org.opensearch.compatible.main>${version.org.opensearch.latest}</version.org.opensearch.compatible.main>
         <documentation.org.opensearch.url>https://opensearch.org/docs/${parsed-version.org.opensearch.compatible.main.majorVersion}.${parsed-version.org.opensearch.compatible.main.minorVersion}</documentation.org.opensearch.url>
 
-        <version.com.google.code.gson>2.13.0</version.com.google.code.gson>
+        <version.com.google.code.gson>2.13.1</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.31.2</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, by Avro, by the AWS SDK and in tests (wiremock, ...) -->
         <version.com.fasterxml.jackson>2.18.3</version.com.fasterxml.jackson>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5370
https://hibernate.atlassian.net/browse/HSEARCH-5371

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
