### PR TITLE
HSEARCH-5378 Add numbering/copytocliboard extensions from hibernate-asciidoctor-extensions

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -402,6 +402,14 @@
                         <gsonUrl>https://github.com/google/gson</gsonUrl>
                         <documentationConfigPropertiesOutputDirectory>${documentation.config.properties.output.directory}</documentationConfigPropertiesOutputDirectory>
                     </attributes>
+                    <extensions>
+                        <extension>
+                            <className>org.hibernate.infra.asciidoctor.extensions.customnumbering.CustomNumberingProcessor</className>
+                        </extension>
+                        <extension>
+                            <className>org.hibernate.infra.asciidoctor.extensions.copytoclipboard.CopyToClipboardProcessor</className>
+                        </extension>
+                    </extensions>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -353,6 +353,7 @@
 
         <version.asciidoctor.plugin>3.2.0</version.asciidoctor.plugin>
         <version.org.hibernate.infra.hibernate-asciidoctor-theme>5.0.7.Final</version.org.hibernate.infra.hibernate-asciidoctor-theme>
+        <version.org.hibernate.infra.hibernate-asciidoctor-extensions>3.1.0.Final</version.org.hibernate.infra.hibernate-asciidoctor-extensions>
         <version.org.asciidoctor.asciidoctorj>3.0.0</version.org.asciidoctor.asciidoctorj>
         <version.org.asciidoctor.asciidoctorj-pdf>2.3.19</version.org.asciidoctor.asciidoctorj-pdf>
 
@@ -912,6 +913,11 @@
                             <groupId>org.asciidoctor</groupId>
                             <artifactId>asciidoctorj-pdf</artifactId>
                             <version>${version.org.asciidoctor.asciidoctorj-pdf}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.hibernate.infra</groupId>
+                            <artifactId>hibernate-asciidoctor-extensions</artifactId>
+                            <version>${version.org.hibernate.infra.hibernate-asciidoctor-extensions}</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5378

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
