### PR TITLE
HSEARCH-5300 Adjust metamodel tests to account for backends that do not support vector search capabilities

### DIFF
--- a/integrationtest/metamodel/standalone-elasticsearch/src/test/java/org/hibernate/search/integrationtest/metamodel/standalone/elasticsearch/PredicateTypesIT.java
+++ b/integrationtest/metamodel/standalone-elasticsearch/src/test/java/org/hibernate/search/integrationtest/metamodel/standalone/elasticsearch/PredicateTypesIT.java
@@ -28,6 +28,7 @@ import org.hibernate.search.mapper.pojo.standalone.session.SearchSession;
 import org.hibernate.search.mapper.pojo.work.IndexingPlanSynchronizationStrategy;
 import org.hibernate.search.mapper.pojo.work.IndexingPlanSynchronizationStrategyNames;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.ElasticsearchBackendConfiguration;
+import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.ElasticsearchTestDialect;
 import org.hibernate.search.util.impl.integrationtest.mapper.pojo.standalone.StandalonePojoMappingSetupHelper;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -96,10 +97,6 @@ class PredicateTypesIT {
 									.circle( GeoPoint.of( 10.0, 20.0 ), 20.0 ) )
 							.should( f.exists().field( PredicateTypesIT_IndexedEntity__.INDEX.geoPoint ) )
 
-							.should( f.knn( 10 ).field( PredicateTypesIT_IndexedEntity__.INDEX.floatVector )
-									.matching( new float[] { 1.0f, 2.0f, 3.0f } ) )
-							.should( f.exists().field( PredicateTypesIT_IndexedEntity__.INDEX.floatVector ) )
-
 							.should( f.match().field( PredicateTypesIT_IndexedEntity__.INDEX.myEnum ).matching( MyEnum.B ) )
 							.should( f.range().field( PredicateTypesIT_IndexedEntity__.INDEX.myEnum ).atLeast( MyEnum.B ) )
 							.should( f.phrase().field( PredicateTypesIT_IndexedEntity__.INDEX.myEnum ).matching( "B" ) )
@@ -114,7 +111,26 @@ class PredicateTypesIT {
 					)
 					.fetchHits( 20 ) )
 					.hasSize( 2 );
+
+			if ( isVectorSearchSupported() ) {
+				assertThat( session.search( scope )
+						.where( f -> f.bool()
+								.should( f.knn( 10 ).field( PredicateTypesIT_IndexedEntity__.INDEX.floatVector )
+										.matching( new float[] { 1.0f, 2.0f, 3.0f } ) )
+								.should( f.exists().field( PredicateTypesIT_IndexedEntity__.INDEX.floatVector ) )
+						)
+						.fetchHits( 20 ) )
+						.hasSize( 2 );
+			}
 		}
+	}
+
+	private static boolean isVectorSearchSupported() {
+		return ElasticsearchTestDialect.isActualVersion(
+				es -> !es.isLessThan( "8.12.0" ),
+				os -> !os.isLessThan( "2.9.0" ),
+				aoss -> true
+		);
 	}
 
 	@SearchEntity(name = "IndexedEntity")


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5300

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
