### PR TITLE
HSEARCH-5300 Skip some metamodel ITs where vector search is not available

### DIFF
--- a/integrationtest/metamodel/orm-elasticsearch/src/test/java/org/hibernate/search/integrationtest/metamodel/orm/elasticsearch/FieldTypesIT.java
+++ b/integrationtest/metamodel/orm-elasticsearch/src/test/java/org/hibernate/search/integrationtest/metamodel/orm/elasticsearch/FieldTypesIT.java
@@ -6,6 +6,7 @@ package org.hibernate.search.integrationtest.metamodel.orm.elasticsearch;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -58,6 +59,7 @@ class FieldTypesIT {
 
 	@BeforeEach
 	void setup() {
+		assumeTrue( isVectorSearchSupported() );
 		sessionFactory = setupHelper.start()
 				.withAnnotatedTypes( FieldTypesEntity.class )
 				.withProperty( HibernateOrmMapperSettings.INDEXING_PLAN_SYNCHRONIZATION_STRATEGY,

--- a/integrationtest/metamodel/orm-elasticsearch/src/test/java/org/hibernate/search/integrationtest/metamodel/orm/elasticsearch/PredicateTypesIT.java
+++ b/integrationtest/metamodel/orm-elasticsearch/src/test/java/org/hibernate/search/integrationtest/metamodel/orm/elasticsearch/PredicateTypesIT.java
@@ -6,6 +6,7 @@ package org.hibernate.search.integrationtest.metamodel.orm.elasticsearch;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -42,6 +43,7 @@ class PredicateTypesIT {
 
 	@BeforeEach
 	void setup() {
+		assumeTrue( isVectorSearchSupported() );
 		sessionFactory = setupHelper.start()
 				.withAnnotatedTypes( IndexedEntity.class )
 				.withProperty( HibernateOrmMapperSettings.INDEXING_PLAN_SYNCHRONIZATION_STRATEGY,

--- a/integrationtest/metamodel/standalone-elasticsearch/src/test/java/org/hibernate/search/integrationtest/metamodel/standalone/elasticsearch/FieldTypesIT.java
+++ b/integrationtest/metamodel/standalone-elasticsearch/src/test/java/org/hibernate/search/integrationtest/metamodel/standalone/elasticsearch/FieldTypesIT.java
@@ -5,6 +5,7 @@
 package org.hibernate.search.integrationtest.metamodel.standalone.elasticsearch;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.lang.invoke.MethodHandles;
 import java.math.BigDecimal;
@@ -62,6 +63,7 @@ class FieldTypesIT {
 
 	@BeforeEach
 	void setup() {
+		assumeTrue( isVectorSearchSupported() );
 		mapping = setupHelper.start()
 				.withAnnotatedTypes( FieldTypesEntity.class )
 				.withProperty( StandalonePojoMapperSettings.INDEXING_PLAN_SYNCHRONIZATION_STRATEGY,

--- a/integrationtest/metamodel/standalone-elasticsearch/src/test/java/org/hibernate/search/integrationtest/metamodel/standalone/elasticsearch/PredicateTypesIT.java
+++ b/integrationtest/metamodel/standalone-elasticsearch/src/test/java/org/hibernate/search/integrationtest/metamodel/standalone/elasticsearch/PredicateTypesIT.java
@@ -5,6 +5,7 @@
 package org.hibernate.search.integrationtest.metamodel.standalone.elasticsearch;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
@@ -48,6 +49,7 @@ class PredicateTypesIT {
 
 	@BeforeEach
 	void setup() {
+		assumeTrue( isVectorSearchSupported() );
 		mapping = setupHelper.start()
 				.withAnnotatedTypes( IndexedEntity.class )
 				.withProperty( StandalonePojoMapperSettings.INDEXING_PLAN_SYNCHRONIZATION_STRATEGY,


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5300

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HSEARCH.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HSEARCH-<digits>`).
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
