### PR TITLE
HSEARCH-5351 Generate missing javadoc jars

### DIFF
--- a/mapper/orm-jakarta-batch/jberet/pom.xml
+++ b/mapper/orm-jakarta-batch/jberet/pom.xml
@@ -22,6 +22,16 @@
         <deploy.skip>false</deploy.skip>
         <java.module.name>org.hibernate.search.jakarta.batch.jberet</java.module.name>
         <documentation.config.properties.skip>true</documentation.config.properties.skip>
+        <!--
+            We want to skip the javadoc warnings for this module, since Jakarta Batch API is using proper modules,
+            resulting in a warning like:
+                [WARNING] Javadoc Warnings
+                [WARNING] warning: The code being documented uses packages in the unnamed module, but the packages defined in https://jakarta.ee/specifications/batch/2.1/apidocs/ are in named modules.
+                [WARNING] 1 warning
+            when trying to build this module. Since it cannot be suppressed, but the generated docs are actually OK
+            and links point to correct addresses, we just ignore all warnings for this module.
+        -->
+        <failOnJavadocWarning>false</failOnJavadocWarning>
     </properties>
 
     <dependencies>

--- a/mapper/orm-jakarta-batch/jberet/src/main/java/org/hibernate/search/jakarta/batch/jberet/HibernateSearchJakartaBatchMapperExtension.java
+++ b/mapper/orm-jakarta-batch/jberet/src/main/java/org/hibernate/search/jakarta/batch/jberet/HibernateSearchJakartaBatchMapperExtension.java
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.jakarta.batch.jberet;
+
+import org.hibernate.search.util.common.annotation.Incubating;
+
+/**
+ * Hibernate Search Jakarta Batch JBeret is an extension to the `hibernate-search-mapper-orm-jakarta-batch-core`
+ * that is aware of JBeret-specific things.
+ *
+ * @see org.hibernate.search.jakarta.batch.core.massindexing.MassIndexingJob
+ */
+@Incubating
+@Deprecated(since = "8.0", forRemoval = true) // DO NOT actually remove this one! We need it to let the javadoc plugin to generate the "empty" javadoc jar to comply with the publishign rules.
+public interface HibernateSearchJakartaBatchMapperExtension {
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5351

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
