### PR TITLE
Backport of HSEARCH-5351 to 5.10 : Switch to JReleaser for nexus publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ atlassian-ide-plugin.xml
 # Maven wrapper files
 .mvn
 mvnw*
+
+# Cache folders for formatting plugins:
+.cache

--- a/.release/.gitignore
+++ b/.release/.gitignore
@@ -1,0 +1,3 @@
+# The folder into which we checkout our release scripts into
+*
+!.gitignore

--- a/backends/jgroups/pom.xml
+++ b/backends/jgroups/pom.xml
@@ -19,6 +19,7 @@
 
     <name>Hibernate Search JGroups Backend</name>
     <description>Hibernate Search JGroup based backend</description>
+    <url>http://search.hibernate.org</url>
 
     <dependencies>
         <dependency>

--- a/backends/jgroups/src/main/java/org/hibernate/search/backend/jgroups/HibernateSearchJgroupsExtension.java
+++ b/backends/jgroups/src/main/java/org/hibernate/search/backend/jgroups/HibernateSearchJgroupsExtension.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.jgroups;
+
+/**
+ * This module provides the Hibernate Search JGroup based backend.
+ */
+// DO NOT actually remove this one! We need it to let the javadoc plugin to generate the "empty" javadoc jar to comply with the publishign rules.
+// (since = "5.10", forRemoval = true)
+@Deprecated
+public interface HibernateSearchJgroupsExtension {
+}

--- a/backends/jms/pom.xml
+++ b/backends/jms/pom.xml
@@ -19,6 +19,7 @@
 
     <name>Hibernate Search JMS Backend</name>
     <description>Hibernate Search JGroup based backend</description>
+    <url>http://search.hibernate.org</url>
 
     <dependencies>
         <dependency>

--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -16,6 +16,7 @@
 
     <name>Hibernate Search Build Configuration</name>
     <description>Configuration for the build of Hibernate Search</description>
+    <url>http://search.hibernate.org</url>
 
     <properties>
         <!--
@@ -30,13 +31,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -62,6 +62,7 @@ pipeline {
 
 					def releaseVersion = Version.parseReleaseVersion(params.RELEASE_VERSION)
 					def developmentVersion = Version.parseDevelopmentVersion(params.DEVELOPMENT_VERSION)
+					env.JRELEASER_DRY_RUN = params.RELEASE_DRY_RUN
 					echo "Performing full release for version ${releaseVersion.toString()}"
 
 					withMaven(mavenSettingsConfig: params.RELEASE_DRY_RUN ? null : 'ci-hibernate.deploy.settings.maven',
@@ -69,13 +70,21 @@ pipeline {
 						configFileProvider([configFile(fileId: 'release.config.ssh', targetLocation: env.HOME + '/.ssh/config'),
 											configFile(fileId: 'release.config.ssh.knownhosts', targetLocation: env.HOME + '/.ssh/known_hosts')]) {
 							withCredentials([file(credentialsId: 'release.gpg.private-key', variable: 'RELEASE_GPG_PRIVATE_KEY_PATH'),
-											 string(credentialsId: 'release.gpg.passphrase', variable: 'RELEASE_GPG_PASSPHRASE')]) {
+											 string(credentialsId: 'release.gpg.passphrase', variable: 'JRELEASER_GPG_PASSPHRASE'),
+											 // TODO: HSEARCH-5354
+											 //  Once we switch to maven-central publishing (from nexus2) we need to add a new credentials
+											 //  to use the following env variable names to set the user/password:
+											 //  JRELEASER_MAVENCENTRAL_USERNAME
+											 //  JRELEASER_MAVENCENTRAL_TOKEN
+											 usernamePassword(credentialsId: 'ossrh.sonatype.org', passwordVariable: 'JRELEASER_NEXUS2_PASSWORD', usernameVariable: 'JRELEASER_NEXUS2_USERNAME'),
+											 string(credentialsId: 'Hibernate-CI.github.com', variable: 'JRELEASER_GITHUB_TOKEN')]) {
 								sshagent(['ed25519.Hibernate-CI.github.com', 'hibernate.filemgmt.jboss.org', 'hibernate-ci.frs.sourceforge.net']) {
 									sh 'cat $HOME/.ssh/config'
-									sh 'git clone https://github.com/hibernate/hibernate-noorm-release-scripts.git'
-									env.RELEASE_GPG_HOMEDIR = env.WORKSPACE_TMP + '/.gpg'
+									dir('.release/scripts') {
+										sh 'git clone https://github.com/hibernate/hibernate-release-scripts.git .'
+									}
 									sh """
-										bash -xe hibernate-noorm-release-scripts/release.sh ${params.RELEASE_DRY_RUN ? '-d' : ''} \
+										bash -xe .release/scripts/release.sh -j ${params.RELEASE_DRY_RUN ? '-d' : ''} \
 												search ${releaseVersion.toString()} ${developmentVersion.toString()}
 									"""
 								}

--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -71,12 +71,7 @@ pipeline {
 											configFile(fileId: 'release.config.ssh.knownhosts', targetLocation: env.HOME + '/.ssh/known_hosts')]) {
 							withCredentials([file(credentialsId: 'release.gpg.private-key', variable: 'RELEASE_GPG_PRIVATE_KEY_PATH'),
 											 string(credentialsId: 'release.gpg.passphrase', variable: 'JRELEASER_GPG_PASSPHRASE'),
-											 // TODO: HSEARCH-5354
-											 //  Once we switch to maven-central publishing (from nexus2) we need to add a new credentials
-											 //  to use the following env variable names to set the user/password:
-											 //  JRELEASER_MAVENCENTRAL_USERNAME
-											 //  JRELEASER_MAVENCENTRAL_TOKEN
-											 usernamePassword(credentialsId: 'ossrh.sonatype.org', passwordVariable: 'JRELEASER_NEXUS2_PASSWORD', usernameVariable: 'JRELEASER_NEXUS2_USERNAME'),
+											 usernamePassword(credentialsId: 'central.sonatype.com', passwordVariable: 'JRELEASER_MAVENCENTRAL_TOKEN', usernameVariable: 'JRELEASER_MAVENCENTRAL_USERNAME'),
 											 string(credentialsId: 'Hibernate-CI.github.com', variable: 'JRELEASER_GITHUB_TOKEN')]) {
 								sshagent(['ed25519.Hibernate-CI.github.com', 'hibernate.filemgmt.jboss.org', 'hibernate-ci.frs.sourceforge.net']) {
 									sh 'cat $HOME/.ssh/config'

--- a/ci/snapshot-publish/Jenkinsfile
+++ b/ci/snapshot-publish/Jenkinsfile
@@ -33,13 +33,16 @@ pipeline {
 		stage('Publish') {
 			steps {
 				script {
-					withMaven(mavenSettingsConfig: 'ci-hibernate.deploy.settings.maven',
-							mavenLocalRepo: env.WORKSPACE_TMP + '/.m2repository') {
-						sh """mvn \
-								-Pci-build \
-								-DskipTests \
-								clean deploy \
-						"""
+					withMaven(mavenSettingsConfig: 'ci-hibernate.deploy.settings.maven', mavenLocalRepo: env.WORKSPACE_TMP + '/.m2repository') {
+						dir('.release/scripts') {
+							sh 'git clone https://github.com/hibernate/hibernate-release-scripts.git .'
+						}
+						def version = sh(
+								script: ".release/scripts/determine-current-version.sh search",
+								returnStdout: true
+						).trim()
+						echo "Current version: '${version}'"
+						sh "bash -xe .release/scripts/snapshot-deploy.sh search ${version}"
 					}
 				}
 			}

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -19,12 +19,12 @@
 
     <name>Hibernate Search Distribution</name>
     <description>Builds the distribution bundles</description>
+    <url>http://search.hibernate.org</url>
     <packaging>pom</packaging>
 
     <properties>
         <!-- Skip artifact deployment -->
         <maven.deploy.skip>true</maven.deploy.skip>
-        <gpg.skip>true</gpg.skip>
     </properties>
 
     <dependencies>

--- a/distribution/src/main/assembly/dist.xml
+++ b/distribution/src/main/assembly/dist.xml
@@ -214,8 +214,8 @@
                 <exclude>copyright.txt</exclude>
                 <exclude>lgpl.txt</exclude>
 
-                <!-- only needed for documentation and helper scripts, no need to include them -->
-                <exclude>hibernate-noorm-release-scripts/**</exclude>
+				<!-- only needed for documentation and helper scripts, no need to include them -->
+				<exclude>.release/**</exclude>
 
                 <!-- actual files which should be ignored -->
                 <exclude>.git</exclude>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -20,6 +20,7 @@
 
     <name>Hibernate Search Manual</name>
     <description>The Hibernate Search reference manual</description>
+    <url>http://search.hibernate.org</url>
 
     <properties>
         <asciidoctor.base-output-dir>${project.build.directory}/asciidoctor/en-US</asciidoctor.base-output-dir>
@@ -33,7 +34,6 @@
 
         <!-- Skip artifact deployment -->
         <maven.deploy.skip>true</maven.deploy.skip>
-        <gpg.skip>true</gpg.skip>
         <!-- Skip javadoc generation -->
         <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>

--- a/elasticsearch-aws/pom.xml
+++ b/elasticsearch-aws/pom.xml
@@ -19,6 +19,7 @@
 
     <name>Hibernate Search Elasticsearch AWS integration</name>
     <description>Configurer for the Hibernate Search Elasticsearch backend enabling connection to an AWS-hosted Elasticsearch cluster</description>
+    <url>http://search.hibernate.org</url>
     
     <dependencies>
         <dependency>

--- a/elasticsearch-aws/src/main/java/org/hibernate/search/elasticsearch/aws/HibernateSearchElasticsearchAwsExtension.java
+++ b/elasticsearch-aws/src/main/java/org/hibernate/search/elasticsearch/aws/HibernateSearchElasticsearchAwsExtension.java
@@ -1,0 +1,17 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.aws;
+
+/**
+ * Hibernate Search Elasticsearch AWS is an extension that is the
+ * configurer for the Hibernate Search Elasticsearch backend enabling connection to an AWS-hosted Elasticsearch cluster
+ */
+// DO NOT actually remove this one! We need it to let the javadoc plugin to generate the "empty" javadoc jar to comply with the publishign rules.
+// (since = "5.10", forRemoval = true)
+@Deprecated
+public interface HibernateSearchElasticsearchAwsExtension {
+}

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -19,6 +19,7 @@
 
     <name>Hibernate Search Elasticsearch</name>
     <description>Hibernate Search backend which has indexing operations forwarded to Elasticsearch</description>
+    <url>http://search.hibernate.org</url>
     
     <dependencies>
         <dependency>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -19,6 +19,7 @@
 
     <name>Hibernate Search Engine</name>
     <description>Core of the Object/Lucene mapper, query engine and index management</description>
+    <url>http://search.hibernate.org</url>
 
     <dependencies>
         <dependency>

--- a/infinispan/pom.xml
+++ b/infinispan/pom.xml
@@ -16,9 +16,11 @@
     </parent>
 
     <artifactId>hibernate-search-infinispan</artifactId>
+    <packaging>pom</packaging>
 
     <name>Hibernate Search Infinispan Directory Provider</name>
     <description>Hibernate Search Infinispan Directory Provider</description>
+    <url>http://search.hibernate.org</url>
 
     <distributionManagement>
         <relocation>
@@ -33,14 +35,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <!-- We need an empty JAR, otherwise the build will fail -->
-                    <skipIfEmpty>false</skipIfEmpty>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/integrationtest/elasticsearch/pom.xml
+++ b/integrationtest/elasticsearch/pom.xml
@@ -211,13 +211,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>

--- a/integrationtest/jdk9-modules/pom.xml
+++ b/integrationtest/jdk9-modules/pom.xml
@@ -100,13 +100,6 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
 
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>

--- a/integrationtest/jms/pom.xml
+++ b/integrationtest/jms/pom.xml
@@ -110,13 +110,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>

--- a/integrationtest/jsr352/pom.xml
+++ b/integrationtest/jsr352/pom.xml
@@ -154,13 +154,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>

--- a/integrationtest/narayana/pom.xml
+++ b/integrationtest/narayana/pom.xml
@@ -72,13 +72,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>

--- a/integrationtest/osgi/karaf-features/pom.xml
+++ b/integrationtest/osgi/karaf-features/pom.xml
@@ -82,13 +82,6 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
 
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>

--- a/integrationtest/osgi/karaf-it/pom.xml
+++ b/integrationtest/osgi/karaf-it/pom.xml
@@ -211,13 +211,6 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
 
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>

--- a/integrationtest/performance/engine-elasticsearch/pom.xml
+++ b/integrationtest/performance/engine-elasticsearch/pom.xml
@@ -91,13 +91,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>

--- a/integrationtest/performance/engine-lucene/pom.xml
+++ b/integrationtest/performance/engine-lucene/pom.xml
@@ -83,13 +83,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>

--- a/integrationtest/performance/orm/pom.xml
+++ b/integrationtest/performance/orm/pom.xml
@@ -225,13 +225,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>

--- a/integrationtest/performance/sandbox/pom.xml
+++ b/integrationtest/performance/sandbox/pom.xml
@@ -70,13 +70,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>

--- a/integrationtest/spring/pom.xml
+++ b/integrationtest/spring/pom.xml
@@ -147,13 +147,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>

--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -256,13 +256,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>

--- a/jbossmodules/backend-jgroups/pom.xml
+++ b/jbossmodules/backend-jgroups/pom.xml
@@ -17,6 +17,7 @@
 
     <name>Hibernate Search JBoss Modules JGroups Backend</name>
     <description>Hibernate Search JGroups Backend modules to use in JBoss AS / Wildfly</description>
+    <url>http://search.hibernate.org</url>
 
     <properties>
         <feature-pack.dir>${project.build.directory}/feature-pack/src/main/resources</feature-pack.dir>

--- a/jbossmodules/elasticsearch-aws/pom.xml
+++ b/jbossmodules/elasticsearch-aws/pom.xml
@@ -17,6 +17,7 @@
 
     <name>Hibernate Search JBoss Modules Elasticsearch AWS</name>
     <description>Hibernate Search Elasticsearch AWS modules to use in JBoss AS / Wildfly</description>
+    <url>http://search.hibernate.org</url>
 
     <properties>
         <feature-pack.dir>${project.build.directory}/feature-pack/src/main/resources</feature-pack.dir>

--- a/jbossmodules/elasticsearch/pom.xml
+++ b/jbossmodules/elasticsearch/pom.xml
@@ -17,6 +17,7 @@
 
     <name>Hibernate Search JBoss Modules Elasticsearch</name>
     <description>Hibernate Search Elasticsearch modules to use in JBoss AS / Wildfly</description>
+    <url>http://search.hibernate.org</url>
 
     <properties>
         <feature-pack.dir>${project.build.directory}/feature-pack/src/main/resources</feature-pack.dir>

--- a/jbossmodules/engine/pom.xml
+++ b/jbossmodules/engine/pom.xml
@@ -17,6 +17,7 @@
 
     <name>Hibernate Search JBoss Modules Engine</name>
     <description>Hibernate Search Engine modules to use in JBoss AS / Wildfly</description>
+    <url>http://search.hibernate.org</url>
 
     <properties>
         <feature-pack.dir>${project.build.directory}/feature-pack/src/main/resources</feature-pack.dir>

--- a/jbossmodules/orm/pom.xml
+++ b/jbossmodules/orm/pom.xml
@@ -17,6 +17,7 @@
 
     <name>Hibernate Search JBoss Modules ORM</name>
     <description>Hibernate Search ORM modules to use in JBoss AS / Wildfly</description>
+    <url>http://search.hibernate.org</url>
 
     <properties>
         <feature-pack.dir>${project.build.directory}/feature-pack/src/main/resources</feature-pack.dir>

--- a/jbossmodules/pom.xml
+++ b/jbossmodules/pom.xml
@@ -17,6 +17,7 @@
 
     <name>Hibernate Search JBoss Modules Aggregator</name>
     <description>Hibernate Search JBoss Modules Aggregator POM</description>
+    <url>http://search.hibernate.org</url>
 
     <modules>
         <module>engine</module>

--- a/jbossmodules/testing/pom.xml
+++ b/jbossmodules/testing/pom.xml
@@ -17,6 +17,7 @@
 
     <name>Hibernate Search JBoss Modules Testing</name>
     <description>Additional JBoss modules which are meant for internal testing exclusively</description>
+    <url>http://search.hibernate.org</url>
 
     <properties>
         <feature-pack.dir>${project.build.directory}/feature-pack/src/main/resources</feature-pack.dir>
@@ -62,13 +63,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/jsr352/core/pom.xml
+++ b/jsr352/core/pom.xml
@@ -19,6 +19,7 @@
 
     <name>Hibernate Search JSR-352 Core</name>
     <description>Core of the Hibernate Search JSR-352 integration</description>
+    <url>http://search.hibernate.org</url>
 
     <dependencies>
         <dependency>

--- a/jsr352/jberet/pom.xml
+++ b/jsr352/jberet/pom.xml
@@ -19,6 +19,7 @@
     
     <name>Hibernate Search JSR-352 JBeret</name>
     <description>Hibernate Search JSR-352 integration - for JBeret</description>
+    <url>http://search.hibernate.org</url>
 
     <dependencies>
         <dependency>

--- a/jsr352/jberet/src/main/java/org/hibernate/search/jsr352/jberet/HibernateSearchJBeretExtension.java
+++ b/jsr352/jberet/src/main/java/org/hibernate/search/jsr352/jberet/HibernateSearchJBeretExtension.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.jsr352.jberet;
+
+/**
+ * This module provides the Hibernate Search JSR-352 integration for JBeret.
+ */
+// DO NOT actually remove this one! We need it to let the javadoc plugin to generate the "empty" javadoc jar to comply with the publishign rules.
+// (since = "5.10", forRemoval = true)
+@Deprecated
+public interface HibernateSearchJBeretExtension {
+}

--- a/jsr352/pom.xml
+++ b/jsr352/pom.xml
@@ -20,6 +20,7 @@
 
     <name>Hibernate Search JSR-352 Aggregator</name>
     <description>Hibernate Search JSR-352 integration aggregator POM</description>
+    <url>http://search.hibernate.org</url>
 
     <modules>
         <module>core</module>

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -20,6 +20,7 @@
 
     <name>Hibernate Search [Deprecated Module]</name>
     <description>Hibernate Search [Deprecated Module]</description>
+    <url>http://search.hibernate.org</url>
 
     <distributionManagement>
         <relocation>

--- a/orm/pom.xml
+++ b/orm/pom.xml
@@ -19,6 +19,7 @@
 
     <name>Hibernate Search ORM</name>
     <description>Hibernate Search integration with Hibernate Core</description>
+    <url>http://search.hibernate.org</url>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -373,10 +373,10 @@
 
         <local.staging.releases.repo.id>staging-deploy</local.staging.releases.repo.id>
         <local.staging.releases.repo.url>file:${maven.multiModuleProjectDirectory}/target/staging-deploy/maven</local.staging.releases.repo.url>
-        <ossrh.releases.repo.id>ossrh</ossrh.releases.repo.id>
-        <ossrh.releases.repo.url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</ossrh.releases.repo.url>
-        <ossrh.snapshots.repo.id>ossrh</ossrh.snapshots.repo.id>
-        <ossrh.snapshots.repo.url>https://oss.sonatype.org/content/repositories/snapshots</ossrh.snapshots.repo.url>
+        <central.releases.repo.id>central-releases</central.releases.repo.id>
+        <central.releases.repo.url>https://central.sonatype.com/api/v1/publisher/</central.releases.repo.url>
+        <central.snapshots.repo.id>central-snapshots</central.snapshots.repo.id>
+        <central.snapshots.repo.url>https://central.sonatype.com/repository/maven-snapshots/</central.snapshots.repo.url>
 
         <!-- Build settings -->
 
@@ -1890,14 +1890,14 @@
 
     <distributionManagement>
         <repository>
-            <id>${ossrh.releases.repo.id}</id>
-            <name>OSSRH Releases Repository</name>
-            <url>${ossrh.releases.repo.url}</url>
+            <id>${central.releases.repo.id}</id>
+            <name>Maven Central Releases Repository</name>
+            <url>${central.releases.repo.url}</url>
         </repository>
         <snapshotRepository>
-            <id>${ossrh.snapshots.repo.id}</id>
-            <name>OSSRH Snapshots Repository</name>
-            <url>${ossrh.snapshots.repo.url}</url>
+            <id>${central.snapshots.repo.id}</id>
+            <name>Maven Central Snapshots Repository</name>
+            <url>${central.snapshots.repo.url}</url>
         </snapshotRepository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,11 @@
  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<!-- child.project.url.inherit.append.path is weird but necessary to have correct URLs in flattened POMs,
+     see XSD for more info. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
+         child.project.url.inherit.append.path="false">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.hibernate</groupId>
@@ -55,7 +59,11 @@
         <url>https://hibernate.atlassian.net/browse/HSEARCH</url>
     </issueManagement>
 
-    <scm>
+    <!-- The various child.*.append.path are weird but necessary to have correct URLs in flattened POMs,
+            see XSD for more info. -->
+    <scm child.scm.connection.inherit.append.path="false"
+         child.scm.developerConnection.inherit.append.path="false"
+         child.scm.url.inherit.append.path="false">
         <connection>scm:git:git://github.com/hibernate/hibernate-search.git</connection>
         <developerConnection>scm:git:git@github.com:hibernate/hibernate-search.git</developerConnection>
         <url>http://github.com/hibernate/hibernate-search</url>
@@ -320,7 +328,6 @@
         <version.jar.plugin>3.0.2</version.jar.plugin>
         <version.javadoc.plugin>3.0.0</version.javadoc.plugin>
         <version.jdeps.plugin>0.4.0</version.jdeps.plugin>
-        <version.nexus.plugin>2.1</version.nexus.plugin>
         <version.processor.plugin>3.2.0</version.processor.plugin>
         <version.project-info.plugin>2.9</version.project-info.plugin>
         <version.release.plugin>2.5.3</version.release.plugin>
@@ -335,7 +342,7 @@
         <version.jacoco.plugin>0.8.3</version.jacoco.plugin>
         <version.coveralls.plugin>4.3.0</version.coveralls.plugin>
         <version.org.jboss.bridger.plugin>1.5.Final</version.org.jboss.bridger.plugin>
-        <version.gpg.plugin>3.0.1</version.gpg.plugin>
+        <version.flatten-maven-plugin>1.7.0</version.flatten-maven-plugin>
 
         <!--
             Please don't change the name of this property, it may be used and
@@ -364,6 +371,8 @@
 
         <!-- Repository Deployment URLs -->
 
+        <local.staging.releases.repo.id>staging-deploy</local.staging.releases.repo.id>
+        <local.staging.releases.repo.url>file:${maven.multiModuleProjectDirectory}/target/staging-deploy/maven</local.staging.releases.repo.url>
         <ossrh.releases.repo.id>ossrh</ossrh.releases.repo.id>
         <ossrh.releases.repo.url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</ossrh.releases.repo.url>
         <ossrh.snapshots.repo.id>ossrh</ossrh.snapshots.repo.id>
@@ -1281,14 +1290,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-maven-plugin</artifactId>
-                <configuration>
-                    <nexusUrl>https://repository.jboss.org/nexus</nexusUrl>
-                    <automatic>true</automatic>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
@@ -1458,11 +1459,6 @@
                             <scope>compile</scope>
                         </dependency>
                     </dependencies>
-                </plugin>
-                <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-maven-plugin</artifactId>
-                    <version>${version.nexus.plugin}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -1869,13 +1865,24 @@
                     <version>${version.org.jboss.bridger.plugin}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-gpg-plugin</artifactId>
-                    <version>${version.gpg.plugin}</version>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>${version.flatten-maven-plugin}</version>
                     <configuration>
-                        <homedir>${env.RELEASE_GPG_HOMEDIR}</homedir>
-                        <passphrase>${env.RELEASE_GPG_PASSPHRASE}</passphrase>
+                        <outputDirectory>${project.build.directory}</outputDirectory>
+                        <!-- Keep things like url, inceptionYear, authors...
+                             everything that's required by the OSSRH Maven repository -->
+                        <flattenMode>ossrh</flattenMode>
                     </configuration>
+                    <executions>
+                        <execution>
+                            <id>flatten-pom</id>
+                            <phase>process-resources</phase>
+                            <goals>
+                                <goal>flatten</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -1957,6 +1964,27 @@
     </reporting>
 
     <profiles>
+        <profile>
+            <id>release</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <artifactId>maven-deploy-plugin</artifactId>
+                            <configuration>
+                                <altReleaseDeploymentRepository>${local.staging.releases.repo.id}::${local.staging.releases.repo.url}</altReleaseDeploymentRepository>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
 
         <!-- The profiles `skippingAllTests` and `skippingIntegrationTests` are currently duplicates,
             as one can't trigger the profile activation on either/or property -->
@@ -2082,33 +2110,6 @@
                     </snapshots>
                 </repository>
             </repositories>
-        </profile>
-
-        <profile>
-            <id>release</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
 
         <profile>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -23,7 +23,6 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <gpg.skip>true</gpg.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <!--
         Disable the dependency convergence rule, because the dependencies of various integration tests do not converge

--- a/serialization/avro/pom.xml
+++ b/serialization/avro/pom.xml
@@ -19,6 +19,7 @@
 
     <name>Hibernate Search Avro Serialization</name>
     <description>Implementation of the Hibernate Search serialization protocol for remote indexing using Avro</description>
+    <url>http://search.hibernate.org</url>
 
     <dependencies>
         <dependency>

--- a/serialization/avro/src/main/java/org/hibernate/search/indexes/serialization/avro/HibernateSearchAvroExtension.java
+++ b/serialization/avro/src/main/java/org/hibernate/search/indexes/serialization/avro/HibernateSearchAvroExtension.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.indexes.serialization.avro;
+
+/**
+ * This module provides the implementation of the Hibernate Search serialization protocol for remote indexing using Avro.
+ */
+// DO NOT actually remove this one! We need it to let the javadoc plugin to generate the "empty" javadoc jar to comply with the publishign rules.
+// (since = "5.10", forRemoval = true)
+@Deprecated
+public interface HibernateSearchAvroExtension {
+}

--- a/sharedtestresources/pom.xml
+++ b/sharedtestresources/pom.xml
@@ -17,18 +17,12 @@
 
     <name>Shared test resources</name>
     <description>Contains resources which we want to reuse across multiple modules for testing purposes</description>
+    <url>http://search.hibernate.org</url>
     
     <build>
         <plugins>
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -19,6 +19,7 @@
 
     <name>Hibernate Search Testing</name>
     <description>Hibernate Search Testing Utilities</description>
+    <url>http://search.hibernate.org</url>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
(cherry picked from commit 46f8046d067896da222f307a56df117a37521e38)
https://hibernate.atlassian.net/browse/HSEARCH-5351

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
