### PR TITLE
Use JDK 24 when running dependency update job for Lucene > 10 (lucene-future)

### DIFF
--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -40,7 +40,7 @@ Map settings() {
 			]
 		case 'lucene-future':
 			return [
-					testCompilerTool: 'OpenJDK 23 Latest',
+					testCompilerTool: 'OpenJDK 24 Latest',
 					updateProperties: ['version.org.apache.lucene.next.updatable'],
 					onlyRunTestDependingOn: ['hibernate-search-backend-lucene-next'],
 					additionalMavenArgs: '-Dtest.elasticsearch.skip=true -pl :hibernate-search-backend-lucene-next,:hibernate-search-util-internal-integrationtest-backend-lucene-next'


### PR DESCRIPTION
Lucene 11 requires jdk24+ if we do not use it we get a 

>  TestEngine with ID 'junit-jupiter' failed to discover tests

which actually is

> Caused by: java.lang.UnsupportedClassVersionError: org/apache/lucene/search/highlight/Encoder has been compiled by a more recent version of the Java Runtime (class file version 68.0), this version of the Java Runtime only recognizes class file versions up to 67.0

But won't show up unless we run tests unforked.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
