### PR TITLE
Rename copyright.txt to AUTHORS.txt

### DIFF
--- a/.github/hibernate-github-bot.yml
+++ b/.github/hibernate-github-bot.yml
@@ -20,7 +20,7 @@ jira:
     - "*.Jenkinsfile"
     - "*.sh"
     # In-repo documentation
-    - "copyright.txt"
+    - "AUTHORS.txt"
     - "README.md"
     - "MAINTAINERS.md"
     - "CONTRIBUTING.md"

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,4 +1,13 @@
+# This file lists copyright owners of the project.
+# The list is not exhaustive: other copyright owners exist.
+# See CONTRIBUTING.md for instructions regarding how to be added to this list.
+
+# Corporate contributors
+
 Red Hat, Inc.
+
+# Individual contributors
+
 Adam Harris
 Adrian Nistor
 Ales Justin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,12 @@ To allow for backports, the Hibernate team may ask contributors to dual-license 
 All contributions are subject to the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
 The DCO text is also included verbatim in the [dco.txt](dco.txt) file in the root directory of the repository.
 
+Copyright owners are listed in [AUTHORS.txt](AUTHORS.txt).
+Contributors with a valid copyright claim can request to be added to that list
+by sending a pull request to the project's GitHub repository,
+listing at least one relevant contribution in the pull request description.
+Note: one-liner or repetitive patches may not be sufficient to claim copyright.
+
 ## Finding something to contribute
 
 Our [JIRA instance](https://hibernate.atlassian.net/browse/HSEARCH) is where all tasks are reported and tracked.

--- a/distribution/src/main/assembly/dist.xml
+++ b/distribution/src/main/assembly/dist.xml
@@ -187,7 +187,7 @@
 			<outputDirectory></outputDirectory>
 		</file>
 		<file>
-			<source>../copyright.txt</source>
+			<source>../AUTHORS.txt</source>
 			<outputDirectory></outputDirectory>
 		</file>
 	</files>
@@ -208,7 +208,7 @@
 				<exclude>README.md</exclude>
 				<exclude>CONTRIBUTING.md</exclude>
 				<exclude>changelog.txt</exclude>
-				<exclude>copyright.txt</exclude>
+				<exclude>AUTHORS.txt</exclude>
 				<exclude>LICENSE.txt</exclude>
 
 				<!-- only needed for documentation and helper scripts, no need to include them -->

--- a/documentation/src/main/asciidoc/public/reference/_credits.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_credits.adoc
@@ -3,8 +3,8 @@
 [[credits]]
 = Credits
 
-The full list of contributors to Hibernate Search can be found in the `copyright.txt` file in the Hibernate Search sources,
-available in particular in our https://github.com/hibernate/hibernate-search/blob/main/copyright.txt[git repository].
+The list of contributors to Hibernate Search can be found in the `AUTHORS.txt` file in the Hibernate Search sources,
+available in particular in our https://github.com/hibernate/hibernate-search/blob/main/AUTHORS.txt[git repository].
 
 The following contributors have been involved in this documentation:
 


### PR DESCRIPTION
see https://github.com/hibernate/hibernate-orm/pull/10266

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
