### PR TITLE
Use Wildfly dist pom as a way to keep the version up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -88,7 +88,7 @@ updates:
           - "org.codehaus.plexus:*"
           - "org.eclipse.jdt:*"
           # We only use the version of WildFly for a link in the documentation
-          - "org.wildfly.bom:wildfly"
+          - "org.wildfly:wildfly-dist"
           # Used to generate reports during build time:
           - "org.yaml:snakeyaml"
     ignore:
@@ -132,7 +132,7 @@ updates:
         # Apparently patterns using wildcards are not supported here. Hopefully this will last until they drop these silly -jdk8 packages.
         versions: ["5.0-jdk8", "5.1-jdk8", "5.2-jdk8", "5.3-jdk8", "5.4-jdk8", "5.5-jdk8", "5.6-jdk8", "5.7-jdk8", "5.8-jdk8", "5.9-jdk8"]
       # We only use the major version of WildFly, and only for a link in the documentation
-      - dependency-name: "org.wildfly.bom:wildfly"
+      - dependency-name: "org.wildfly:wildfly-dist"
         update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
       # We ignore any plexus-compiler updates that are > 2.14.2 since that's the last version
       #  with which jboss-logging annotation processor can still work.

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -964,8 +964,8 @@
             <!-- The version is used to generate a link to the WildFly documentation -->
             <!-- This simply makes sure dependabot will automatically bump the version -->
             <dependency>
-                <groupId>org.wildfly.bom</groupId>
-                <artifactId>wildfly</artifactId>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-dist</artifactId>
                 <version>${version.org.wildfly}</version>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
There are no new bom versions that match the dist, let's stick to the dist artifact and use the pom type in the dependencies.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
