### PR TITLE
HSEARCH-5396 Upgrade to Hibernate Models 1.0.0

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -93,8 +93,11 @@
         <!--
             NOTE: when Hibernate ORM updates Byte Buddy, make sure to check Jenkinsfile to see if
             `net.bytebuddy.experimental` property can be removed.
+
+            NOTE 2: with the next release of Hibernate ORM remove the hibernate-models dependency override
          -->
         <version.org.hibernate.orm>7.0.0.Final</version.org.hibernate.orm>
+        <version.org.hibernate.models>1.0.0</version.org.hibernate.models>
 
         <javadoc.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/javadocs/</javadoc.org.hibernate.orm.url>
         <documentation.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/userguide/html_single/Hibernate_User_Guide.html</documentation.org.hibernate.orm.url>
@@ -405,6 +408,12 @@
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging</artifactId>
                 <version>${version.org.jboss.logging.jboss-logging}</version>
+            </dependency>
+            <!-- Remove with the next Hibernate ORM upgrade -->
+            <dependency>
+                <groupId>org.hibernate.models</groupId>
+                <artifactId>hibernate-models</artifactId>
+                <version>${version.org.hibernate.models}</version>
             </dependency>
 
             <!-- Other public dependencies -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5396

to make sure that in the generated module-infos for Search modules, the correct hibernate-models module is referenced:

```java
 requires transitive org.hibernate.models;
```

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
