### PR TITLE
Add testing of Hibernate ORM 7.1 in the dependency update job

### DIFF
--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -16,6 +16,13 @@ Map settings() {
 					// just rebuild all dependants since ORM7 upgrade will affect all mappers
 					additionalMavenArgs: '-am'
 			]
+		case 'orm7.1':
+			return [
+					updateProperties: ['version.org.hibernate.orm'],
+					onlyRunTestDependingOn: ['hibernate-search-mapper-orm'],
+					// just rebuild all dependants since ORM7 upgrade will affect all mappers
+					additionalMavenArgs: '-am'
+			]
 		case 'lucene9.12':
 			return [
 					updateProperties: ['version.org.apache.lucene'],
@@ -142,7 +149,7 @@ pipeline {
 	parameters {
 		// choice parameter doesn't have a default, but the first value should be treated as a default, if it wasn't specified manually.
 		// Make sure tp update axis and settings() when adding new choice parameter.
-		choice(name: 'UPDATE_JOB', choices: ['all', 'orm7', 'lucene9.12','lucene9', 'lucene10', 'lucene-future', 'elasticsearch-current', 'elasticsearch-next'], description: 'Select which update jobs to run. `All` will include all configured update jobs.')
+		choice(name: 'UPDATE_JOB', choices: ['all', 'orm7', 'orm7.1', 'lucene9.12','lucene9', 'lucene10', 'lucene-future', 'elasticsearch-current', 'elasticsearch-next'], description: 'Select which update jobs to run. `All` will include all configured update jobs.')
 		string(name: 'ORM_REPOSITORY', defaultValue: '', description: 'Git URL to Hibernate ORM repository. If provided, Hibernate ORM will be built locally. Works only in pair with ORM_BRANCH. Provide an http repository URL rather than an ssh one.')
 		string(name: 'ORM_BRANCH', defaultValue: '', description: 'Hibernate ORM branch to build from. If provided, Hibernate ORM will be built locally. Works only in pair with ORM_REPOSITORY. Either a pull request ID or a branch name should be provided, but not both at the same time. Use branch if you want to build from a fork repository.')
 		string(name: 'ORM_PULL_REQUEST_ID', defaultValue: '', description: 'Hibernate ORM pull request id to build from. If provided, Hibernate ORM will be built locally. Works only in pair with ORM_REPOSITORY. Either a pull request ID or a branch name should be provided, but not both at the same time.')
@@ -240,7 +247,7 @@ pipeline {
 						name 'DEPENDENCY_UPDATE_NAME'
 						// NOTE: Remember to update the settings() method above when changing this.
 						// And also add a new choice parameter in the parameters {} section of the pipeline
-						values 'orm7', 'lucene9.12','lucene9', 'lucene10', 'lucene-future', 'elasticsearch-current', 'elasticsearch-next'
+						values 'orm7', 'orm7.1', 'lucene9.12','lucene9', 'lucene10', 'lucene-future', 'elasticsearch-current', 'elasticsearch-next'
 					}
 				}
 				stages {

--- a/ci/dependency-update/rules-orm7.1.xml
+++ b/ci/dependency-update/rules-orm7.1.xml
@@ -7,6 +7,6 @@
     <ignoreVersion type="regex">.*\.(Alpha|Beta|CR).*</ignoreVersion>
     <!-- Restrict allowed versions to a particular major/minor, because forbidding major/minor upgrades
          in the version-maven-plugin configuration doesn't always work for some reason. -->
-    <ignoreVersion type="regex">(?!6\.[6-9]\.).*</ignoreVersion>
+    <ignoreVersion type="regex">(?!7\.1\.).*</ignoreVersion>
   </ignoreVersions>
 </ruleset>


### PR DESCRIPTION
as orm main moved to 7.1

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
