### PR TITLE
Downgrade Eclipse compiler to 3.41

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -145,7 +145,9 @@ updates:
       - dependency-name: "org.skyscreamer:jsonassert"
       # Because of https://github.com/apache/logging-log4j2/issues/3234
       - dependency-name: "org.apache.logging.log4j:*"
-        versions: ["2.24.2"]
+        versions: [ "2.24.2" ]
+      - dependency-name: "org.eclipse.jdt:ecj"
+        versions: [ "3.42.0" ]
   - package-ecosystem: "docker"
     registries:
       - dockerhub

--- a/pom.xml
+++ b/pom.xml
@@ -349,7 +349,7 @@
                 is outdated and leads to compilation errors.
          -->
         <version.org.codehaus.plexus.plexus-compiler.compiler-eclipse>2.14.2</version.org.codehaus.plexus.plexus-compiler.compiler-eclipse>
-        <version.org.eclipse.jdt.ecj>3.42.0</version.org.eclipse.jdt.ecj>
+        <version.org.eclipse.jdt.ecj>3.41.0</version.org.eclipse.jdt.ecj>
 
         <!-- Asciidoctor -->
 


### PR DESCRIPTION
as this version is causing unnecessary trouble.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
