### PR TITLE
HSEARCH-5309 Limit the time that the outbox polling processor spends trying to lock/load event entities after processing

### DIFF
--- a/integrationtest/mapper/orm-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/outboxpolling/testsupport/util/OutboxEventFilter.java
+++ b/integrationtest/mapper/orm-outbox-polling/src/test/java/org/hibernate/search/integrationtest/mapper/orm/outboxpolling/testsupport/util/OutboxEventFilter.java
@@ -125,6 +125,13 @@ public class OutboxEventFilter {
 		} ) );
 	}
 
+	public void awaitUntilNumberOfVisibleEvents(SessionFactory sessionFactory, int count) {
+		await().untilAsserted( () -> with( sessionFactory ).runInTransaction( session -> {
+			List<OutboxEvent> outboxEntries = visibleEventsAllShardsFinder.findOutboxEvents( session, count + 1 );
+			assertThat( outboxEntries ).hasSize( count );
+		} ) );
+	}
+
 	private class FilterById implements OutboxEventPredicate {
 		@Override
 		public String queryPart(String eventAlias) {

--- a/mapper/orm-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/outboxpolling/cfg/HibernateOrmMapperOutboxPollingSettings.java
+++ b/mapper/orm-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/outboxpolling/cfg/HibernateOrmMapperOutboxPollingSettings.java
@@ -270,6 +270,41 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 			PREFIX + Radicals.COORDINATION_EVENT_PROCESSOR_RETRY_DELAY;
 
 	/**
+	 * How many times the event processor must try locking the outbox event database records for processing
+	 * before leaving them to be processed in another batch.
+	 * <p>
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * {@value #COORDINATION_STRATEGY_NAME}.
+	 * <p>
+	 * Only applicable when the database supports skipping locked rows when locking.
+	 * <p>
+	 * Expects a positive integer value, such as {@code 10},
+	 * or a String that can be parsed into such Integer value.
+	 * <p>
+	 * Defaults to {@link Defaults#COORDINATION_EVENT_PROCESSOR_EVENT_LOCK_RETRY_MAX}.
+	 */
+	public static final String COORDINATION_EVENT_PROCESSOR_EVENT_LOCK_RETRY_MAX =
+			PREFIX + Radicals.COORDINATION_EVENT_PROCESSOR_EVENT_LOCK_RETRY_MAX;
+
+	/**
+	 * How long the event processor must wait before retrying to lock the outbox event database records.
+	 * <p>
+	 * Only available when {@value HibernateOrmMapperSettings#COORDINATION_STRATEGY} is
+	 * {@value #COORDINATION_STRATEGY_NAME}.
+	 * <p>
+	 * Only applicable when the database supports skipping locked rows when locking.
+	 * <p>
+	 * Expects a positive integer value in seconds, such as {@code 5},
+	 * or a String that can be parsed into such Integer value.
+	 * <p>
+	 * Use the value {@code 0} to retry locking events as soon as possible, with no delay.
+	 * <p>
+	 * Defaults to {@link Defaults#COORDINATION_EVENT_PROCESSOR_EVENT_LOCK_RETRY_DELAY}.
+	 */
+	public static final String COORDINATION_EVENT_PROCESSOR_EVENT_LOCK_RETRY_DELAY =
+			PREFIX + Radicals.COORDINATION_EVENT_PROCESSOR_EVENT_LOCK_RETRY_DELAY;
+
+	/**
 	 * In the mass indexer, how long to wait for another query to the agent table
 	 * when actively waiting for event processors to suspend themselves, in milliseconds.
 	 * <p>
@@ -516,6 +551,10 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 				COORDINATION_PREFIX + CoordinationRadicals.EVENT_PROCESSOR_TRANSACTION_TIMEOUT;
 		public static final String COORDINATION_EVENT_PROCESSOR_RETRY_DELAY =
 				COORDINATION_PREFIX + CoordinationRadicals.EVENT_PROCESSOR_RETRY_DELAY;
+		public static final String COORDINATION_EVENT_PROCESSOR_EVENT_LOCK_RETRY_MAX =
+				COORDINATION_PREFIX + CoordinationRadicals.EVENT_PROCESSOR_EVENT_LOCK_RETRY_MAX;
+		public static final String COORDINATION_EVENT_PROCESSOR_EVENT_LOCK_RETRY_DELAY =
+				COORDINATION_PREFIX + CoordinationRadicals.EVENT_PROCESSOR_EVENT_LOCK_RETRY_DELAY;
 		public static final String COORDINATION_MASS_INDEXER_POLLING_INTERVAL =
 				COORDINATION_PREFIX + CoordinationRadicals.MASS_INDEXER_POLLING_INTERVAL;
 		public static final String COORDINATION_MASS_INDEXER_PULSE_INTERVAL =
@@ -564,6 +603,8 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 		public static final String EVENT_PROCESSOR_BATCH_SIZE = EVENT_PROCESSOR_PREFIX + "batch_size";
 		public static final String EVENT_PROCESSOR_TRANSACTION_TIMEOUT = EVENT_PROCESSOR_PREFIX + "transaction_timeout";
 		public static final String EVENT_PROCESSOR_RETRY_DELAY = EVENT_PROCESSOR_PREFIX + "retry_delay";
+		public static final String EVENT_PROCESSOR_EVENT_LOCK_RETRY_MAX = EVENT_PROCESSOR_PREFIX + "event_lock_retry_max";
+		public static final String EVENT_PROCESSOR_EVENT_LOCK_RETRY_DELAY = EVENT_PROCESSOR_PREFIX + "event_lock_retry_delay";
 		public static final String MASS_INDEXER_PREFIX = "mass_indexer.";
 		public static final String MASS_INDEXER_POLLING_INTERVAL = MASS_INDEXER_PREFIX + "polling_interval";
 		public static final String MASS_INDEXER_PULSE_INTERVAL = MASS_INDEXER_PREFIX + "pulse_interval";
@@ -600,6 +641,8 @@ public final class HibernateOrmMapperOutboxPollingSettings {
 		public static final OutboxEventProcessingOrder COORDINATION_EVENT_PROCESSOR_ORDER = OutboxEventProcessingOrder.AUTO;
 		public static final int COORDINATION_EVENT_PROCESSOR_BATCH_SIZE = 50;
 		public static final int COORDINATION_EVENT_PROCESSOR_RETRY_DELAY = 30;
+		public static final int COORDINATION_EVENT_PROCESSOR_EVENT_LOCK_RETRY_MAX = 20;
+		public static final int COORDINATION_EVENT_PROCESSOR_EVENT_LOCK_RETRY_DELAY = 2;
 		public static final int COORDINATION_MASS_INDEXER_POLLING_INTERVAL = 100;
 		public static final int COORDINATION_MASS_INDEXER_PULSE_INTERVAL = 2000;
 		public static final int COORDINATION_MASS_INDEXER_PULSE_EXPIRATION = 30000;

--- a/mapper/orm-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/outboxpolling/event/impl/OutboxEventUpdater.java
+++ b/mapper/orm-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/outboxpolling/event/impl/OutboxEventUpdater.java
@@ -6,6 +6,7 @@ package org.hibernate.search.mapper.orm.outboxpolling.event.impl;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -46,6 +47,10 @@ public class OutboxEventUpdater {
 
 	public boolean thereAreStillEventsToProcess() {
 		return !eventsIds.isEmpty();
+	}
+
+	public Set<UUID> eventsToProcess() {
+		return Collections.unmodifiableSet( eventsIds );
 	}
 
 	public void process() {

--- a/mapper/orm-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/outboxpolling/logging/impl/OutboxPollingEventsLog.java
+++ b/mapper/orm-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/outboxpolling/logging/impl/OutboxPollingEventsLog.java
@@ -266,4 +266,10 @@ public interface OutboxPollingEventsLog {
 	@LogMessage(level = TRACE)
 	@Message(id = ID_OFFSET + 67, value = "Persisted %d outbox events: '%s'")
 	void eventPlanNumberOfPersistedEvents(int size, List<OutboxEvent> events);
+
+	@LogMessage(level = WARN)
+	@Message(id = ID_OFFSET + 70,
+			value = "Agent '%s': after %d retries, failed to acquire a lock on the following outbox events: %s. " +
+					"Events will be re-processed at a later time.")
+	void eventLockingRetryLimitReached(AgentReference agentReference, int numberOfRetries, Set<UUID> events);
 }

--- a/mapper/orm-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/outboxpolling/logging/impl/OutboxPollingLog.java
+++ b/mapper/orm-outbox-polling/src/main/java/org/hibernate/search/mapper/orm/outboxpolling/logging/impl/OutboxPollingLog.java
@@ -30,6 +30,6 @@ public interface OutboxPollingLog extends ConfigurationLog, DeprecationLog, Outb
 	 * here to the next value.
 	 */
 	@LogMessage(level = TRACE)
-	@Message(id = ID_OFFSET + 70, value = "")
+	@Message(id = ID_OFFSET + 71, value = "")
 	void nextLoggerIdForConvenience();
 }

--- a/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/extension/ExpectedLog4jLog.java
+++ b/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/extension/ExpectedLog4jLog.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.search.util.impl.test.extension;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
@@ -233,5 +234,9 @@ public class ExpectedLog4jLog implements BeforeEachCallback, AfterEachCallback {
 			failingChecker.appendFailure( description, "\n\t" );
 		}
 		return description.toString();
+	}
+
+	public void expectationsMet() {
+		assertThat( currentAppender.getFailingCheckers() ).isEmpty();
 	}
 }

--- a/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/extension/log4j/LogExpectation.java
+++ b/util/internal/test/common/src/main/java/org/hibernate/search/util/impl/test/extension/log4j/LogExpectation.java
@@ -9,7 +9,8 @@ import org.hamcrest.Matcher;
 public class LogExpectation {
 
 	private final Matcher<?> matcher;
-	private Integer expectedCount;
+	private Integer expectedMinCount;
+	private Integer expectedMaxCount;
 
 	public LogExpectation(Matcher<?> matcher) {
 		this.matcher = matcher;
@@ -24,10 +25,16 @@ public class LogExpectation {
 	}
 
 	public void times(int expectedCount) {
-		if ( this.expectedCount != null ) {
+		if ( this.expectedMinCount != null || this.expectedMaxCount != null ) {
 			throw new IllegalStateException( "Can only set log expectations once" );
 		}
-		this.expectedCount = expectedCount;
+		this.expectedMinCount = expectedCount;
+		this.expectedMaxCount = expectedCount;
+	}
+
+	public void atLeast(int expectedCount) {
+		this.expectedMaxCount = Integer.MAX_VALUE;
+		this.expectedMinCount = expectedCount;
 	}
 
 	public LogChecker createChecker() {
@@ -39,10 +46,10 @@ public class LogExpectation {
 	}
 
 	int getMinExpectedCount() {
-		return expectedCount == null ? 1 : expectedCount;
+		return expectedMinCount == null ? 1 : expectedMinCount;
 	}
 
 	Integer getMaxExpectedCount() {
-		return expectedCount;
+		return expectedMaxCount;
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5309

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
