### PR TITLE
Backport to 8.0 HSEARCH-5406 Upgrade to Lucene 10.2.2

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -44,7 +44,7 @@
         <javadoc.org.apache.lucene.queryparser.url>https://lucene.apache.org/core/${javadoc.org.apache.lucene.tag}/queryparser/</javadoc.org.apache.lucene.queryparser.url>
 
         <version.com.carrotsearch.hppc>0.10.0</version.com.carrotsearch.hppc>
-        <version.org.apache.lucene.next>10.2.1</version.org.apache.lucene.next>
+        <version.org.apache.lucene.next>10.2.2</version.org.apache.lucene.next>
 
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5406

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
