### PR TITLE
Increase OpenSearch container memory (and Elasticsearch for consistency)

### DIFF
--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/SearchBackendContainer.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/SearchBackendContainer.java
@@ -97,7 +97,7 @@ public final class SearchBackendContainer {
 				// but on CI this is sometimes too much, as we also have the Maven JVM
 				// and the JVM that runs tests taking up a significant amount of RAM,
 				// leaving too little for filesystem caches and resulting in freezes:
-				.withEnv( "ES_JAVA_OPTS", "-Xms1g -Xmx1g" )
+				.withEnv( "ES_JAVA_OPTS", "-Xms1500m -Xmx1500m" )
 				// Disable disk-based shard allocation thresholds: on large, relatively full disks (>90% used),
 				// it will lead to index creation to get stuck waiting for other nodes to join the cluster,
 				// which will never happen since we only have one node.
@@ -147,7 +147,7 @@ public final class SearchBackendContainer {
 				// it's not practical for testing, so we disable that.
 				.withEnv( "plugins.security.disabled", "true" )
 				// Limit the RAM usage.
-				.withEnv( "OPENSEARCH_JAVA_OPTS", "-Xms1g -Xmx1g" )
+				.withEnv( "OPENSEARCH_JAVA_OPTS", "-Xms1500m -Xmx1500m" )
 				// ISM floods the logs with errors, and we don't need it.
 				// See https://docs-beta.opensearch.org/im-plugin/ism/settings/
 				.withEnv( "plugins.index_state_management.enabled", "false" )


### PR DESCRIPTION
to hopefully decrease the number of failing builds caused by OpenSearch timing out or OOMing in the tests.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
