### PR TITLE
Downgrade Derby to 10.16 to be compatible with JDK 17 in tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -111,6 +111,10 @@ updates:
       # we don't want always want to get the latest Weld version:
       - dependency-name: "org.jboss.weld.se:*"
         update-types: ["version-update:semver-major"]
+      # Sticking to Derby 10.16 for now since later versions require JDK 21+, and we need to test with JDK 17.
+      # See https://db.apache.org/derby/derby_downloads.html
+      - dependency-name: "org.apache.derby:*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       # Sticking to SLF4J 1.x for now since later versions require to upgrade providers
       # (Log4j, ... see https://www.slf4j.org/faq.html#changesInVersion200),
       # and also because we only need this dependency for AWS SDK,

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -158,9 +158,9 @@
 
         <!-- >>> JDBC Drivers -->
         <version.com.h2database>2.3.232</version.com.h2database>
-        <!-- Sticking to Derby 10.15 for now since later versions require JDK 17+, and we need to test with JDK 11.
+        <!-- Sticking to Derby 10.16 for now since later versions require JDK 21+, and we need to test with JDK 17.
              See https://db.apache.org/derby/derby_downloads.html -->
-        <version.org.apache.derby>10.17.1.0</version.org.apache.derby>
+        <version.org.apache.derby>10.16.1.1</version.org.apache.derby>
         <version.org.postgresql>42.7.7</version.org.postgresql>
         <version.org.mariadb.jdbc>3.5.3</version.org.mariadb.jdbc>
         <version.mysql.mysql-connector-j>9.3.0</version.mysql.mysql-connector-j>

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,7 @@
         <!-- The lowest supported version of Java for applications using Hibernate Search -->
         <!-- Set statically, independently from the current JDK: we want our code to comply with this version -->
         <!-- Adjust the contributing guide when changing the release Java version -->
+        <!-- Once upgrading review the dependency list to see if any major versions can be updated e.g. Derby 10.17 requires JDK 21 (see dependabot config and comments in POMs). -->
         <java-version.main.release>17</java-version.main.release>
         <java-version.main.compiler.java_home>${java.home}</java-version.main.compiler.java_home>
         <java-version.main.compiler>${java-version.main.compiler.java_home}/bin/javac</java-version.main.compiler>


### PR DESCRIPTION
https://db.apache.org/derby/derby_downloads.html

(10.17 requires JDK 21, and we still should be compatible with JDK 17 and we test against it...)

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
