### PR TITLE
HSEARCH-5417 Deprecate for removal org.hibernate.search.util.common.serialization.spi.SerializationUtils

### DIFF
--- a/util/common/src/main/java/org/hibernate/search/util/common/serialization/spi/SerializationUtils.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/serialization/spi/SerializationUtils.java
@@ -10,6 +10,11 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
+/**
+ * @deprecated With no alternative provided. This util was mostly intended for testing purposes.
+ * Create your own copy if you were relying on the functionality it provides.
+ */
+@Deprecated(since = "8.1", forRemoval = true)
 public final class SerializationUtils {
 
 	private SerializationUtils() {

--- a/util/common/src/test/java/org/hibernate/search/util/common/serialization/spi/SerializationUtilsTest.java
+++ b/util/common/src/test/java/org/hibernate/search/util/common/serialization/spi/SerializationUtilsTest.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.util.common.serialization.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Serializable;
+
+import org.junit.jupiter.api.Test;
+
+@Deprecated(since = "8.1", forRemoval = true)
+class SerializationUtilsTest {
+
+	@SuppressWarnings({ "removal", "deprecation" })
+	@Test
+	void smoke() {
+		MyRecord test = new MyRecord( 1, "smth" );
+		byte[] serialized = SerializationUtils.serialize( test );
+
+		MyRecord deserialized = SerializationUtils.deserialize( MyRecord.class, serialized );
+		assertThat( deserialized ).isEqualTo( test );
+	}
+
+	record MyRecord(int number, String string) implements Serializable {
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5417

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
