### PR TITLE
Use JDK 21 to build Hibernate ORM in update job

### DIFF
--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -186,6 +186,9 @@ pipeline {
 							return params.ORM_REPOSITORY?.trim() || params.ORM_BRANCH?.trim() || params.ORM_PULL_REQUEST_ID?.trim()
 						}
 					}
+					tools {
+						jdk 'OpenJDK 21 Latest'
+					}
 					steps {
 						script {
 							if (params.ORM_BRANCH?.trim() && params.ORM_PULL_REQUEST_ID?.trim()) {


### PR DESCRIPTION
Since Hibernate ORM `main` requires JDK 21 to build from sources.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
