### PR TITLE
Follow up on HSEARCH-3661 Use `aggregations` key more consistently

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/AbstractElasticsearchBucketAggregation.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/AbstractElasticsearchBucketAggregation.java
@@ -23,6 +23,9 @@ import com.google.gson.JsonObject;
 public abstract class AbstractElasticsearchBucketAggregation<K, V>
 		extends AbstractElasticsearchNestableAggregation<Map<K, V>> {
 
+	protected static final JsonAccessor<JsonObject> REQUEST_AGGREGATIONS_ACCESSOR =
+			JsonAccessor.root().property( "aggregations" ).asObject();
+
 	private static final JsonAccessor<JsonObject> REQUEST_REVERSE_NESTED_ACCESSOR =
 			JsonAccessor.root().property( "reverse_nested" ).asObject();
 
@@ -30,7 +33,6 @@ public abstract class AbstractElasticsearchBucketAggregation<K, V>
 	private static final JsonAccessor<JsonObject> REQUEST_AGGREGATIONS_ROOT_DOC_COUNT_ACCESSOR =
 			JsonAccessor.root().property( "aggregations" ).property( ROOT_DOC_COUNT_NAME ).asObject();
 
-	protected static final String INNER_EXTRACTOR_KEY = "innerExtractorKey";
 	protected static final String INNER_EXTRACTOR = "innerExtractor";
 
 	AbstractElasticsearchBucketAggregation(AbstractBuilder<K, V> builder) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/ElasticsearchRangeAggregation.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/ElasticsearchRangeAggregation.java
@@ -66,7 +66,7 @@ public class ElasticsearchRangeAggregation<F, K, V>
 				aggregation.request( context, AggregationKey.of( "agg" ), subOuterObject ) );
 
 		if ( !subOuterObject.isEmpty() ) {
-			outerObject.add( "aggs", subOuterObject );
+			REQUEST_AGGREGATIONS_ACCESSOR.set( outerObject, subOuterObject );
 		}
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/ElasticsearchTermsAggregation.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/ElasticsearchTermsAggregation.java
@@ -72,7 +72,7 @@ public class ElasticsearchTermsAggregation<F, K, T, V>
 				aggregation.request( context, AggregationKey.of( "agg" ), subOuterObject ) );
 
 		if ( !subOuterObject.isEmpty() ) {
-			outerObject.add( "aggs", subOuterObject );
+			REQUEST_AGGREGATIONS_ACCESSOR.set( outerObject, subOuterObject );
 		}
 	}
 


### PR DESCRIPTION
e.g. instead of `aggs` in bucket aggregations

https://hibernate.atlassian.net/browse/HSEARCH-3661

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
