### PR TITLE
HSEARCH-5435 Upgrade Jackson to 2.19.2 / HSEARCH-5436 Upgrade to AWS SDK 2.32.10 / Adjust CDI version to match the Jakarta EE 11 versions

### DIFF
--- a/backend/elasticsearch-aws/src/main/java/org/hibernate/search/backend/elasticsearch/aws/impl/ElasticsearchAwsBeanConfigurer.java
+++ b/backend/elasticsearch-aws/src/main/java/org/hibernate/search/backend/elasticsearch/aws/impl/ElasticsearchAwsBeanConfigurer.java
@@ -22,7 +22,7 @@ public class ElasticsearchAwsBeanConfigurer implements BeanConfigurer {
 		);
 		context.define(
 				ElasticsearchAwsCredentialsProvider.class, ElasticsearchAwsCredentialsTypeNames.DEFAULT,
-				beanResolver -> BeanHolder.of( ignored -> DefaultCredentialsProvider.create() )
+				beanResolver -> BeanHolder.of( ignored -> DefaultCredentialsProvider.builder().build() )
 		);
 		context.define(
 				ElasticsearchAwsCredentialsProvider.class, ElasticsearchAwsCredentialsTypeNames.STATIC,

--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -29,7 +29,7 @@
         <version.bom.com.carrotsearch>0.10.0</version.bom.com.carrotsearch>
         <version.bom.com.google.code.gson>2.13.1</version.bom.com.google.code.gson>
         <version.bom.jakarta.batch>2.1.1</version.bom.jakarta.batch>
-        <version.bom.jakarta.enterprise>4.0.1</version.bom.jakarta.enterprise>
+        <version.bom.jakarta.enterprise>4.1.0</version.bom.jakarta.enterprise>
         <version.bom.jakarta.inject>2.0.1</version.bom.jakarta.inject>
         <version.bom.jakarta.persistence>3.2.0</version.bom.jakarta.persistence>
         <version.bom.jakarta.transaction>2.0.1</version.bom.jakarta.transaction>
@@ -444,6 +444,11 @@
             <dependency>
                 <groupId>jakarta.enterprise</groupId>
                 <artifactId>jakarta.enterprise.lang-model</artifactId>
+                <version>${version.bom.jakarta.enterprise}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-el-api</artifactId>
                 <version>${version.bom.jakarta.enterprise}</version>
             </dependency>
 
@@ -881,6 +886,11 @@
                                         <dependency>
                                             <groupId>jakarta.enterprise</groupId>
                                             <artifactId>jakarta.enterprise.cdi-spec-doc</artifactId>
+                                            <version>${version.bom.jakarta.enterprise}</version>
+                                        </dependency>
+                                        <dependency>
+                                            <groupId>jakarta.enterprise</groupId>
+                                            <artifactId>cdi-ide-config</artifactId>
                                             <version>${version.bom.jakarta.enterprise}</version>
                                         </dependency>
                                         <dependency>

--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -20,7 +20,7 @@
         <!-- These versions will be checked against the ones resolved by Maven for the project in the enforcer rule -->
         <version.bom.org.hibernate.orm>7.0.8.Final</version.bom.org.hibernate.orm>
         <version.bom.org.elasticsearch.client>9.0.4</version.bom.org.elasticsearch.client>
-        <version.bom.software.amazon.awssdk>2.31.2</version.bom.software.amazon.awssdk>
+        <version.bom.software.amazon.awssdk>2.32.10</version.bom.software.amazon.awssdk>
         <version.bom.io.smallrye>3.3.0</version.bom.io.smallrye>
         <version.bom.org.jboss.logging.processor>3.0.4.Final</version.bom.org.jboss.logging.processor>
         <version.bom.org.jboss.logging>3.6.1.Final</version.bom.org.jboss.logging>

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -84,7 +84,7 @@
         <version.com.google.code.gson>2.13.1</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.32.10</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, by Avro, by the AWS SDK and in tests (wiremock, ...) -->
-        <version.com.fasterxml.jackson>2.19.1</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.19.2</version.com.fasterxml.jackson>
         <!-- slf4j: used by the AWS SDK -->
         <version.org.slf4j>1.7.36</version.org.slf4j>
 

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -98,13 +98,13 @@
 
         <javadoc.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/javadocs/</javadoc.org.hibernate.orm.url>
         <documentation.org.hibernate.orm.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/userguide/html_single/Hibernate_User_Guide.html</documentation.org.hibernate.orm.url>
-        <!-- These version must be kept in sync with the version of the dependency in Hibernate ORM 6.
+        <!-- These version must be kept in sync with the version of the dependency in Hibernate ORM 7.
              DO NOT USE DEPENDENCY MANAGEMENT FOR THESE DEPENDENCIES!
              Thanks to not using dependency management for these dependencies, we get a build failure
              when the versions start diverging, thanks to the maven-enforcer-plugin
              and to our own explicit dependencies in the relevant artifacts.
           -->
-        <version.jakarta.enterprise>4.0.1</version.jakarta.enterprise>
+        <version.jakarta.enterprise>4.1.0</version.jakarta.enterprise>
         <!--
             IMPORTANT:
             Even though we are importing the Hibernate ORM BOM where Jakarta Persistence is managed, we don't have easy access

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -82,7 +82,7 @@
         <documentation.org.opensearch.url>https://opensearch.org/docs/${parsed-version.org.opensearch.compatible.main.majorVersion}.${parsed-version.org.opensearch.compatible.main.minorVersion}</documentation.org.opensearch.url>
 
         <version.com.google.code.gson>2.13.1</version.com.google.code.gson>
-        <version.software.amazon.awssdk>2.31.2</version.software.amazon.awssdk>
+        <version.software.amazon.awssdk>2.32.10</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, by Avro, by the AWS SDK and in tests (wiremock, ...) -->
         <version.com.fasterxml.jackson>2.19.1</version.com.fasterxml.jackson>
         <!-- slf4j: used by the AWS SDK -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5435
https://hibernate.atlassian.net/browse/HSEARCH-5436

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
