### PR TITLE
HSEARCH-5437 Deprecate JPA/ORM query extension and Search#toOrmQuery / Search#toOrmQuery for removal

### DIFF
--- a/documentation/src/main/asciidoc/migration/index.adoc
+++ b/documentation/src/main/asciidoc/migration/index.adoc
@@ -85,6 +85,7 @@ in Hibernate Search {hibernateSearchVersion}
 is, in general, backward-compatible with Hibernate Search {hibernateSearchPreviousStableVersionShort}.
 
 * Metic aggregation `countDistinct()` is deprecated in favor of an option in the `count()` aggregation: `.count().field(..).distinct()`.
+* Both JPA and Hibernate ORM query adapters alongside with `Search#toJpaQuery` and `Search#toOrmQuery` are deprecated for removal without any alternatives.
 
 [[spi]]
 == SPI

--- a/documentation/src/main/asciidoc/public/reference/_search-dsl-query.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_search-dsl-query.adoc
@@ -689,6 +689,10 @@ include::{sourcedir}/org/hibernate/search/documentation/search/query/QueryDslIT.
 <3> Turn the `SearchQuery` object into a JPA query.
 <4> Turn the `SearchQuery` object into a Hibernate ORM query.
 ====
+[WARNING]
+====
+Both JPA and Hibernate ORM query adapters are deprecated and will be removed in the future version of Hibernate Search.
+====
 
 // Search 5 anchors backward compatibility
 [[_resulttransformer]]

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/query/QueryDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/query/QueryDslIT.java
@@ -287,6 +287,7 @@ class QueryDslIT {
 		} );
 	}
 
+	@SuppressWarnings("removal")
 	@Test
 	void searchQuery() {
 		with( entityManagerFactory ).runInTransaction( entityManager -> {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToHibernateOrmQueryIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToHibernateOrmQueryIT.java
@@ -50,6 +50,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  * Test the compatibility layer between our APIs and Hibernate ORM APIs
  * for the {@link Query} class.
  */
+@SuppressWarnings("removal")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ToHibernateOrmQueryIT {
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToHibernateOrmScrollableResultsIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToHibernateOrmScrollableResultsIT.java
@@ -48,6 +48,7 @@ import org.assertj.core.api.InstanceOfAssertFactories;
  * Test the compatibility layer between our APIs and Hibernate ORM APIs
  * for the {@link Query} class.
  */
+@SuppressWarnings("removal")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ToHibernateOrmScrollableResultsIT {
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToJpaQueryIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToJpaQueryIT.java
@@ -52,6 +52,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  * Test the compatibility layer between our APIs and JPA APIs
  * for the {@link TypedQuery} class.
  */
+@SuppressWarnings("removal")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ToJpaQueryIT {
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/Search.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/Search.java
@@ -16,7 +16,6 @@ import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.mapper.orm.common.impl.HibernateOrmUtils;
 import org.hibernate.search.mapper.orm.mapping.SearchMapping;
 import org.hibernate.search.mapper.orm.mapping.impl.HibernateSearchContextProviderService;
-import org.hibernate.search.mapper.orm.search.query.impl.HibernateOrmSearchQueryAdapter;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.orm.session.impl.DelegatingSearchSession;
 
@@ -95,9 +94,14 @@ public final class Search {
 	 * @param searchQuery The search query to convert.
 	 * @param <H> The type of query hits.
 	 * @return A representation of the given query as a JPA query.
+	 *
+	 * @deprecated This method is deprecated for removal with no alternative.
+	 * Use Hibernate Search query DSL API to work with your query and results.
 	 */
+	@SuppressWarnings("removal")
+	@Deprecated(since = "8.1", forRemoval = true)
 	public static <H> TypedQuery<H> toJpaQuery(SearchQuery<H> searchQuery) {
-		return HibernateOrmSearchQueryAdapter.create( searchQuery );
+		return org.hibernate.search.mapper.orm.search.query.impl.HibernateOrmSearchQueryAdapter.create( searchQuery );
 	}
 
 	/**
@@ -112,9 +116,14 @@ public final class Search {
 	 * @param searchQuery The search query to convert.
 	 * @param <H> The type of query hits.
 	 * @return A representation of the given query as a Hibernate ORM query.
+	 *
+	 * @deprecated This method is deprecated for removal with no alternative.
+	 * Use Hibernate Search query DSL API to work with your query and results.
 	 */
+	@SuppressWarnings("removal")
+	@Deprecated(since = "8.1", forRemoval = true)
 	public static <H> Query<H> toOrmQuery(SearchQuery<H> searchQuery) {
-		return HibernateOrmSearchQueryAdapter.create( searchQuery );
+		return org.hibernate.search.mapper.orm.search.query.impl.HibernateOrmSearchQueryAdapter.create( searchQuery );
 	}
 
 	private static SearchMapping getSearchMapping(SessionFactoryImplementor sessionFactoryImplementor) {

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java
@@ -45,9 +45,10 @@ import org.hibernate.search.mapper.orm.search.query.spi.HibernateOrmSearchScroll
 import org.hibernate.search.util.common.SearchTimeoutException;
 import org.hibernate.search.util.common.annotation.impl.SuppressForbiddenApis;
 
+@Deprecated(since = "8.1", forRemoval = true)
 @SuppressForbiddenApis(reason = "We need to use the internal QueryOptionsImpl"
 		+ " in order to implement a org.hibernate.query.Query")
-@SuppressWarnings("unchecked") // For some reason javac issues warnings for all methods returning this; IDEA doesn't.
+@SuppressWarnings({ "unchecked", "removal" }) // For some reason javac issues warnings for all methods returning this; IDEA doesn't.
 public final class HibernateOrmSearchQueryAdapter<R> extends AbstractQuery<R> {
 
 	public static <R> HibernateOrmSearchQueryAdapter<R> create(SearchQuery<R> query) {

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapterExtension.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapterExtension.java
@@ -12,6 +12,8 @@ import org.hibernate.search.engine.search.query.SearchQueryExtension;
 import org.hibernate.search.engine.search.query.spi.SearchQueryImplementor;
 import org.hibernate.search.mapper.orm.loading.impl.HibernateOrmSelectionLoadingContext;
 
+@SuppressWarnings("removal")
+@Deprecated(since = "8.1", forRemoval = true)
 final class HibernateOrmSearchQueryAdapterExtension<H>
 		implements
 		SearchQueryExtension<HibernateOrmSearchQueryAdapter<H>, H> {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5437

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
