### PR TITLE
Update release instructions

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -184,16 +184,10 @@ and the documentation to [docs.jboss.org](https://docs.jboss.org/hibernate/searc
   * **Be careful** when filling the form with the build parameters.
   * Note that for new branches where the job has never run, the first run will not ask for parameters and thus will fail:
     that's expected, just run it again.
-* Release the artifacts on the [OSSRH repository manager](https://oss.sonatype.org/#stagingRepositories).
-  * Log into Nexus. The credentials can be found on Bitwarden; ask a teammate if you don't have access.
-  * Click "staging repositories" to the left.
-  * Examine your staging repository: check that all expected artifacts are there.
-  * If necessary (that's very rare), test the release in the staging repository.
-    You can drop the staging repo if there is a problem,
-    but you'll need to revert the commits pushed during the release.
-  * If everything is ok, select the staging repository and click the "Release" button.
-    * For Search 5.x and below, you will also need to "Close" the repository before you can release it.
-      A manual refresh may be necessary after closing.
+* If the release option `RELEASE_PUBLISH_AUTOMATICALLY` was selected as `false`-- release the artifacts on the [Maven Central portal](https://central.sonatype.com/).
+  * Log into Maven Central. The credentials can be found on Bitwarden; ask a teammate if you don't have access.
+  * Click on the profile circle at the top right and pick "View Deployments".
+  * Find your deployment on the left and click "Publish".
 
 ### Announcing the release
 


### PR DESCRIPTION
to point to the maven central portal instead of the nexus (oss.sonatype.org)

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
