### PR TITLE
Determine and checkout the original target branch when publishing the build scans

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -18,12 +18,23 @@ jobs:
     if: github.repository == 'hibernate/hibernate-search' && github.event.workflow_run.conclusion != 'cancelled'
     runs-on: ubuntu-latest
     steps:
+      # Different branches might have different versions of Develocity, and we want to make sure
+      #  that we publish with the one that we built the scan with in the first place:
+      - name: Determine the Branch Reference for which the original action was triggered
+        id: determine_branch_ref
+        run: |
+          if [ -n "${{ github.event.workflow_run.pull_requests[0].base.ref }}" ]; then
+            BRANCH_REF="${{ github.event.workflow_run.pull_requests[0].base.ref }}"
+          else
+            BRANCH_REF="${{ github.event.workflow_run.head_branch }}"
+          fi
+          echo "original_branch_ref=$BRANCH_REF" >> "$GITHUB_OUTPUT"
       # Checkout target branch which has trusted code
       - name: Check out target branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:
           persist-credentials: false
-          ref: ${{ github.ref }}
+          ref: ${{ steps.determine_branch_ref.outputs.original_branch_ref }}
       - name: Set up Java 21
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # 4.7.1
         with:


### PR DESCRIPTION
The publishing workflow checks out the main branch, and it results in a more recent develocity plugin being used to publish the previous scans. And that... seems to be failing...

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
