### PR TITLE
[8.1] HSEARCH-5456 Adjust metric aggregation functions in the Lucene backend to account for null values / HSEARCH-5457 Enable count-values aggregation for string/boolean fields

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchBooleanIndexFieldTypeOptionsStep.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchBooleanIndexFieldTypeOptionsStep.java
@@ -5,6 +5,7 @@
 package org.hibernate.search.backend.elasticsearch.types.dsl.impl;
 
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.DataTypes;
+import org.hibernate.search.backend.elasticsearch.search.aggregation.impl.ElasticsearchCountValuesAggregation;
 import org.hibernate.search.backend.elasticsearch.search.aggregation.impl.ElasticsearchTermsAggregation;
 import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchExistsPredicate;
 import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchPredicateTypeKeys;
@@ -61,6 +62,7 @@ class ElasticsearchBooleanIndexFieldTypeOptionsStep
 		if ( resolvedAggregable ) {
 			builder.aggregable( true );
 			builder.queryElementFactory( AggregationTypeKeys.TERMS, new ElasticsearchTermsAggregation.Factory<>( codec ) );
+			builder.queryElementFactory( AggregationTypeKeys.COUNT, ElasticsearchCountValuesAggregation.factory() );
 		}
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchStringIndexFieldTypeOptionsStep.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchStringIndexFieldTypeOptionsStep.java
@@ -15,6 +15,7 @@ import org.hibernate.search.backend.elasticsearch.logging.impl.AnalysisLog;
 import org.hibernate.search.backend.elasticsearch.logging.impl.MappingLog;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.DataTypes;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.PropertyMapping;
+import org.hibernate.search.backend.elasticsearch.search.aggregation.impl.ElasticsearchCountValuesAggregation;
 import org.hibernate.search.backend.elasticsearch.search.aggregation.impl.ElasticsearchTermsAggregation;
 import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchExistsPredicate;
 import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchPredicateTypeKeys;
@@ -230,6 +231,7 @@ class ElasticsearchStringIndexFieldTypeOptionsStep
 		if ( resolvedAggregable ) {
 			builder.aggregable( true );
 			builder.queryElementFactory( AggregationTypeKeys.TERMS, new ElasticsearchTermsAggregation.Factory<>( codec ) );
+			builder.queryElementFactory( AggregationTypeKeys.COUNT, ElasticsearchCountValuesAggregation.factory() );
 		}
 
 		return builder.build();

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CompensatedSum.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CompensatedSum.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
 
+import java.util.Locale;
+
 /**
  * <p>
  * The algorithm is inspired by {@code org.opensearch.search.aggregations.metrics.SumAggregator}
@@ -21,16 +23,28 @@ public class CompensatedSum implements DoubleAggregationFunction<CompensatedSum>
 	@Override
 	public void merge(DoubleAggregationFunction<CompensatedSum> sibling) {
 		KahanSummation other = sibling.implementation().kahanSummation;
-		kahanSummation.add( other.value(), other.delta() );
+		if ( other.initialized() ) {
+			kahanSummation.add( other.value(), other.delta() );
+		}
 	}
 
 	@Override
 	public Double result() {
-		return kahanSummation.value();
+		if ( kahanSummation.initialized() ) {
+			return kahanSummation.value();
+		}
+		else {
+			return null;
+		}
 	}
 
 	@Override
 	public CompensatedSum implementation() {
 		return this;
+	}
+
+	@Override
+	public String toString() {
+		return String.format( Locale.ROOT, "CompensatedSum{kahanSummation=%s}", kahanSummation );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountDistinctTextValuesCollector.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountDistinctTextValuesCollector.java
@@ -1,0 +1,83 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
+
+import java.io.IOException;
+
+import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.TextMultiValues;
+import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.TextMultiValuesSource;
+
+import com.carrotsearch.hppc.LongHashSet;
+import com.carrotsearch.hppc.cursors.LongCursor;
+
+import org.apache.lucene.index.IndexReaderContext;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.MultiDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.SimpleCollector;
+
+public class CountDistinctTextValuesCollector extends SimpleCollector {
+
+	private final TextMultiValuesSource source;
+	private final String field;
+	private TextMultiValues values;
+
+	private final LongHashSet globalOrds = new LongHashSet();
+
+	private LongHashSet leafOrds = new LongHashSet();
+
+	private SortedSetDocValues sortedSetValues;
+
+	public CountDistinctTextValuesCollector(TextMultiValuesSource source, String field) {
+		this.source = source;
+		this.field = field;
+	}
+
+	@Override
+	public void collect(int doc) throws IOException {
+		if ( values.advanceExact( doc ) ) {
+			while ( values.hasNextValue() ) {
+				long ord = values.nextOrd();
+				leafOrds.add( ord );
+			}
+		}
+	}
+
+	@Override
+	public ScoreMode scoreMode() {
+		return ScoreMode.COMPLETE_NO_SCORES;
+	}
+
+	@Override
+	protected void doSetNextReader(LeafReaderContext context) throws IOException {
+		initRootSortedSetDocValues( context );
+		this.values = source.getValues( context );
+	}
+
+	@Override
+	public void finish() throws IOException {
+		for ( LongCursor value : leafOrds ) {
+			long globalOrd = sortedSetValues.lookupTerm( values.lookupOrd( value.value ) );
+			globalOrds.add( globalOrd );
+		}
+		values = null;
+		leafOrds.clear();
+	}
+
+	private void initRootSortedSetDocValues(IndexReaderContext ctx) throws IOException {
+		if ( sortedSetValues != null || ctx == null ) {
+			return;
+		}
+		if ( ctx.isTopLevel ) {
+			this.sortedSetValues = MultiDocValues.getSortedSetValues( ctx.reader(), field );
+		}
+		initRootSortedSetDocValues( ctx.parent );
+	}
+
+	public LongHashSet globalOrds() {
+		return globalOrds;
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountDistinctTextValuesCollectorFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountDistinctTextValuesCollectorFactory.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
+
+import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorExecutionContext;
+import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorFactory;
+import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorKey;
+import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.JoiningTextMultiValuesSource;
+
+public class CountDistinctTextValuesCollectorFactory
+		implements
+		CollectorFactory<CountDistinctTextValuesCollector, Long, CountDistinctTextValuesCollectorManager> {
+
+	private final JoiningTextMultiValuesSource source;
+	private final String field;
+	private final CollectorKey<CountDistinctTextValuesCollector, Long> key = CollectorKey.create();
+
+	public CountDistinctTextValuesCollectorFactory(JoiningTextMultiValuesSource source, String field) {
+		this.source = source;
+		this.field = field;
+	}
+
+	@Override
+	public CountDistinctTextValuesCollectorManager createCollectorManager(CollectorExecutionContext context) {
+		return new CountDistinctTextValuesCollectorManager( source, field );
+	}
+
+	@Override
+	public CollectorKey<CountDistinctTextValuesCollector, Long> getCollectorKey() {
+		return key;
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountDistinctTextValuesCollectorManager.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountDistinctTextValuesCollectorManager.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.JoiningTextMultiValuesSource;
+
+import com.carrotsearch.hppc.LongHashSet;
+
+import org.apache.lucene.search.CollectorManager;
+
+public class CountDistinctTextValuesCollectorManager implements CollectorManager<CountDistinctTextValuesCollector, Long> {
+
+	private final JoiningTextMultiValuesSource source;
+	private final String field;
+
+	public CountDistinctTextValuesCollectorManager(JoiningTextMultiValuesSource source, String field) {
+		this.source = source;
+		this.field = field;
+	}
+
+	@Override
+	public CountDistinctTextValuesCollector newCollector() throws IOException {
+		return new CountDistinctTextValuesCollector( source, field );
+	}
+
+	@Override
+	public Long reduce(Collection<CountDistinctTextValuesCollector> collectors) throws IOException {
+		if ( collectors.isEmpty() ) {
+			return 0L;
+		}
+		if ( collectors.size() == 1 ) {
+			return (long) collectors.iterator().next().globalOrds().size();
+		}
+		LongHashSet ords = new LongHashSet();
+		for ( CountDistinctTextValuesCollector collector : collectors ) {
+			ords.addAll( collector.globalOrds() );
+		}
+		return (long) ords.size();
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountDistinctValues.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountDistinctValues.java
@@ -5,6 +5,7 @@
 package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
 
 import java.util.BitSet;
+import java.util.Locale;
 
 import com.carrotsearch.hppc.LongHashSet;
 
@@ -43,5 +44,10 @@ public class CountDistinctValues implements AggregationFunction<CountDistinctVal
 	@Override
 	public CountDistinctValues implementation() {
 		return this;
+	}
+
+	@Override
+	public String toString() {
+		return String.format( Locale.ROOT, "CountDistinctValues{counts=%s}", counts );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountTextValuesCollector.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountTextValuesCollector.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
+
+import java.io.IOException;
+
+import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.TextMultiValues;
+import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.TextMultiValuesSource;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.SimpleCollector;
+
+public class CountTextValuesCollector extends SimpleCollector {
+
+	private final TextMultiValuesSource source;
+	private TextMultiValues values;
+	private long count;
+	LeafReaderContext context;
+
+	public CountTextValuesCollector(TextMultiValuesSource source) {
+		this.source = source;
+	}
+
+	@Override
+	public void collect(int doc) throws IOException {
+		if ( values.advanceExact( doc ) ) {
+			while ( values.hasNextValue() ) {
+				values.nextOrd();
+				count++;
+			}
+		}
+	}
+
+	@Override
+	public ScoreMode scoreMode() {
+		return ScoreMode.COMPLETE_NO_SCORES;
+	}
+
+	@Override
+	protected void doSetNextReader(LeafReaderContext context) throws IOException {
+		this.values = source.getValues( context );
+	}
+
+
+	@Override
+	public void finish() throws IOException {
+		this.values = null;
+	}
+
+	public long count() {
+		return count;
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountTextValuesCollectorFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountTextValuesCollectorFactory.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
+
+import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorExecutionContext;
+import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorFactory;
+import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorKey;
+import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.JoiningTextMultiValuesSource;
+
+public class CountTextValuesCollectorFactory
+		implements
+		CollectorFactory<CountTextValuesCollector, Long, CountTextValuesCollectorManager> {
+
+	private final JoiningTextMultiValuesSource source;
+	private final CollectorKey<CountTextValuesCollector, Long> key = CollectorKey.create();
+
+	public CountTextValuesCollectorFactory(JoiningTextMultiValuesSource source, String field) {
+		this.source = source;
+	}
+
+	@Override
+	public CountTextValuesCollectorManager createCollectorManager(CollectorExecutionContext context) {
+		return new CountTextValuesCollectorManager( source );
+	}
+
+	@Override
+	public CollectorKey<CountTextValuesCollector, Long> getCollectorKey() {
+		return key;
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountTextValuesCollectorManager.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountTextValuesCollectorManager.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.JoiningTextMultiValuesSource;
+
+import org.apache.lucene.search.CollectorManager;
+
+public class CountTextValuesCollectorManager implements CollectorManager<CountTextValuesCollector, Long> {
+
+	private final JoiningTextMultiValuesSource source;
+
+	public CountTextValuesCollectorManager(JoiningTextMultiValuesSource source) {
+		this.source = source;
+	}
+
+	@Override
+	public CountTextValuesCollector newCollector() throws IOException {
+		return new CountTextValuesCollector( source );
+	}
+
+	@Override
+	public Long reduce(Collection<CountTextValuesCollector> collectors) throws IOException {
+		long count = 0;
+		for ( CountTextValuesCollector collector : collectors ) {
+			count += collector.count();
+		}
+		return count;
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountValues.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountValues.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
 
+import java.util.Locale;
+
 public class CountValues implements AggregationFunction<CountValues> {
 
 	private long count = 0L;
@@ -26,5 +28,10 @@ public class CountValues implements AggregationFunction<CountValues> {
 	@Override
 	public CountValues implementation() {
 		return this;
+	}
+
+	@Override
+	public String toString() {
+		return String.format( Locale.ROOT, "CountValues{count=%d}", count );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/KahanSummation.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/KahanSummation.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
 
+import java.util.Locale;
+
 /**
  * <p>
  * Copied with some changes from {@code org.opensearch.search.aggregations.metrics.CompensatedSum}
@@ -15,6 +17,7 @@ public class KahanSummation {
 
 	private double value;
 	private double delta;
+	private boolean initialized;
 
 	/**
 	 * Used to calculate sums using the Kahan summation algorithm.
@@ -42,6 +45,13 @@ public class KahanSummation {
 	}
 
 	/**
+	 * Whether anything was actually added to this sum or is the result is supposed to be `null`.
+	 */
+	public boolean initialized() {
+		return initialized;
+	}
+
+	/**
 	 * Increments the Kahan sum by adding a value without a correction term.
 	 */
 	public KahanSummation add(double value) {
@@ -60,6 +70,7 @@ public class KahanSummation {
 	 * Increments the Kahan sum by adding two sums, and updating the correction term for reducing numeric errors.
 	 */
 	public KahanSummation add(double value, double delta) {
+		initialized = true;
 		// If the value is Inf or NaN, just add it to the running tally to "convert" to
 		// Inf/NaN. This keeps the behavior bwc from before kahan summing
 		if ( Double.isFinite( value ) ) {
@@ -75,4 +86,8 @@ public class KahanSummation {
 		return this;
 	}
 
+	@Override
+	public String toString() {
+		return String.format( Locale.ROOT, "{value=%s, delta=%s, initialized=%s}", value, delta, initialized );
+	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/Max.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/Max.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
 
+import java.util.Locale;
+
 public class Max implements AggregationFunction<Max> {
 
 	private Long max;
@@ -21,7 +23,9 @@ public class Max implements AggregationFunction<Max> {
 	@Override
 	public void merge(AggregationFunction<Max> sibling) {
 		Long other = sibling.implementation().max;
-		apply( other );
+		if ( other != null ) {
+			apply( other );
+		}
 	}
 
 	@Override
@@ -32,5 +36,10 @@ public class Max implements AggregationFunction<Max> {
 	@Override
 	public Max implementation() {
 		return this;
+	}
+
+	@Override
+	public String toString() {
+		return String.format( Locale.ROOT, "Max{max=%d}", max );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/Min.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/Min.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
 
+import java.util.Locale;
+
 public class Min implements AggregationFunction<Min> {
 
 	private Long min;
@@ -21,7 +23,9 @@ public class Min implements AggregationFunction<Min> {
 	@Override
 	public void merge(AggregationFunction<Min> sibling) {
 		Long other = sibling.implementation().min;
-		apply( other );
+		if ( other != null ) {
+			apply( other );
+		}
 	}
 
 	@Override
@@ -32,5 +36,10 @@ public class Min implements AggregationFunction<Min> {
 	@Override
 	public Min implementation() {
 		return this;
+	}
+
+	@Override
+	public String toString() {
+		return String.format( Locale.ROOT, "Min{min=%d}", min );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/Sum.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/Sum.java
@@ -4,18 +4,28 @@
  */
 package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
 
+import java.util.Locale;
+
 public class Sum implements AggregationFunction<Sum> {
 
-	private long sum = 0L;
+	private Long sum = null;
 
 	@Override
 	public void apply(long value) {
-		sum += value;
+		if ( sum == null ) {
+			sum = value;
+		}
+		else {
+			sum += value;
+		}
 	}
 
 	@Override
 	public void merge(AggregationFunction<Sum> sibling) {
-		apply( sibling.result() );
+		Long result = sibling.result();
+		if ( result != null ) {
+			apply( result );
+		}
 	}
 
 	@Override
@@ -26,5 +36,10 @@ public class Sum implements AggregationFunction<Sum> {
 	@Override
 	public Sum implementation() {
 		return this;
+	}
+
+	@Override
+	public String toString() {
+		return String.format( Locale.ROOT, "Sum{sum=%d}", sum );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/aggregation/impl/AbstractLuceneMetricNumericLongAggregation.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/aggregation/impl/AbstractLuceneMetricNumericLongAggregation.java
@@ -16,8 +16,6 @@ public abstract class AbstractLuceneMetricNumericLongAggregation extends Abstrac
 	private final Set<String> indexNames;
 	private final String absoluteFieldPath;
 
-	protected CollectorKey<?, Long> collectorKey;
-
 	AbstractLuceneMetricNumericLongAggregation(AbstractBuilder<Long> builder) {
 		super( builder );
 		this.indexNames = builder.scope.hibernateSearchIndexNames();
@@ -29,19 +27,19 @@ public abstract class AbstractLuceneMetricNumericLongAggregation extends Abstrac
 		JoiningLongMultiValuesSource source = JoiningLongMultiValuesSource.fromField(
 				absoluteFieldPath, createNestedDocsProvider( context )
 		);
-		fillCollectors( source, context );
 
-		return new LuceneNumericMetricLongAggregationExtraction();
+		return new LuceneNumericMetricLongAggregationExtractor( fillCollectors( source, context ) );
 	}
 
-	abstract void fillCollectors(JoiningLongMultiValuesSource source, AggregationRequestContext context);
+	abstract CollectorKey<?, Long> fillCollectors(JoiningLongMultiValuesSource source, AggregationRequestContext context);
 
 	@Override
 	public Set<String> indexNames() {
 		return indexNames;
 	}
 
-	private class LuceneNumericMetricLongAggregationExtraction implements Extractor<Long> {
+	private record LuceneNumericMetricLongAggregationExtractor(CollectorKey<?, Long> collectorKey) implements Extractor<Long> {
+
 		@Override
 		public Long extract(AggregationExtractContext context) {
 			return context.getCollectorResults( collectorKey );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/aggregation/impl/LuceneMaxNumericFieldAggregation.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/aggregation/impl/LuceneMaxNumericFieldAggregation.java
@@ -4,7 +4,10 @@
  */
 package org.hibernate.search.backend.lucene.types.aggregation.impl;
 
+import java.util.List;
+
 import org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl.MaxCollectorFactory;
+import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorKey;
 import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.JoiningLongMultiValuesSource;
 import org.hibernate.search.backend.lucene.search.aggregation.impl.AggregationRequestContext;
 import org.hibernate.search.backend.lucene.search.common.impl.AbstractLuceneCodecAwareSearchQueryElementFactory;
@@ -25,10 +28,10 @@ public class LuceneMaxNumericFieldAggregation<F, E extends Number, K>
 	}
 
 	@Override
-	void fillCollectors(JoiningLongMultiValuesSource source, AggregationRequestContext context) {
+	List<CollectorKey<?, Long>> fillCollectors(JoiningLongMultiValuesSource source, AggregationRequestContext context) {
 		MaxCollectorFactory collectorFactory = new MaxCollectorFactory( source );
-		collectorKey = collectorFactory.getCollectorKey();
 		context.requireCollector( collectorFactory );
+		return List.of( collectorFactory.getCollectorKey() );
 	}
 
 	public static class Factory<F>

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/aggregation/impl/LuceneMinNumericFieldAggregation.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/aggregation/impl/LuceneMinNumericFieldAggregation.java
@@ -4,7 +4,10 @@
  */
 package org.hibernate.search.backend.lucene.types.aggregation.impl;
 
+import java.util.List;
+
 import org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl.MinCollectorFactory;
+import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorKey;
 import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.JoiningLongMultiValuesSource;
 import org.hibernate.search.backend.lucene.search.aggregation.impl.AggregationRequestContext;
 import org.hibernate.search.backend.lucene.search.common.impl.AbstractLuceneCodecAwareSearchQueryElementFactory;
@@ -25,10 +28,10 @@ public class LuceneMinNumericFieldAggregation<F, E extends Number, K>
 	}
 
 	@Override
-	void fillCollectors(JoiningLongMultiValuesSource source, AggregationRequestContext context) {
+	List<CollectorKey<?, Long>> fillCollectors(JoiningLongMultiValuesSource source, AggregationRequestContext context) {
 		MinCollectorFactory collectorFactory = new MinCollectorFactory( source );
-		collectorKey = collectorFactory.getCollectorKey();
 		context.requireCollector( collectorFactory );
+		return List.of( collectorFactory.getCollectorKey() );
 	}
 
 	public static class Factory<F>

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/aggregation/impl/LuceneSumNumericFieldAggregation.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/aggregation/impl/LuceneSumNumericFieldAggregation.java
@@ -4,7 +4,10 @@
  */
 package org.hibernate.search.backend.lucene.types.aggregation.impl;
 
+import java.util.List;
+
 import org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl.SumCollectorFactory;
+import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorKey;
 import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.JoiningLongMultiValuesSource;
 import org.hibernate.search.backend.lucene.search.aggregation.impl.AggregationRequestContext;
 import org.hibernate.search.backend.lucene.search.common.impl.AbstractLuceneCodecAwareSearchQueryElementFactory;
@@ -25,10 +28,10 @@ public class LuceneSumNumericFieldAggregation<F, E extends Number, K>
 	}
 
 	@Override
-	void fillCollectors(JoiningLongMultiValuesSource source, AggregationRequestContext context) {
+	List<CollectorKey<?, Long>> fillCollectors(JoiningLongMultiValuesSource source, AggregationRequestContext context) {
 		SumCollectorFactory collectorFactory = new SumCollectorFactory( source );
-		collectorKey = collectorFactory.getCollectorKey();
 		context.requireCollector( collectorFactory );
+		return List.of( collectorFactory.getCollectorKey() );
 	}
 
 	public static class Factory<F>

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneBooleanIndexFieldTypeOptionsStep.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneBooleanIndexFieldTypeOptionsStep.java
@@ -6,6 +6,7 @@ package org.hibernate.search.backend.lucene.types.dsl.impl;
 
 import org.hibernate.search.backend.lucene.search.predicate.impl.LucenePredicateTypeKeys;
 import org.hibernate.search.backend.lucene.search.projection.impl.LuceneFieldProjection;
+import org.hibernate.search.backend.lucene.types.aggregation.impl.LuceneCountValuesAggregation;
 import org.hibernate.search.backend.lucene.types.aggregation.impl.LuceneNumericTermsAggregation;
 import org.hibernate.search.backend.lucene.types.codec.impl.DocValues;
 import org.hibernate.search.backend.lucene.types.codec.impl.Indexing;
@@ -82,6 +83,7 @@ class LuceneBooleanIndexFieldTypeOptionsStep
 		if ( resolvedAggregable ) {
 			builder.aggregable( true );
 			builder.queryElementFactory( AggregationTypeKeys.TERMS, new LuceneNumericTermsAggregation.Factory<>( codec ) );
+			builder.queryElementFactory( AggregationTypeKeys.COUNT, LuceneCountValuesAggregation.factory() );
 		}
 
 		return builder.build();

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexFieldTypeOptionsStep.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexFieldTypeOptionsStep.java
@@ -17,6 +17,7 @@ import org.hibernate.search.backend.lucene.lowlevel.common.impl.AnalyzerConstant
 import org.hibernate.search.backend.lucene.search.predicate.impl.LucenePredicateTypeKeys;
 import org.hibernate.search.backend.lucene.search.projection.impl.LuceneFieldHighlightProjection;
 import org.hibernate.search.backend.lucene.search.projection.impl.LuceneFieldProjection;
+import org.hibernate.search.backend.lucene.types.aggregation.impl.LuceneTextCountValuesAggregation;
 import org.hibernate.search.backend.lucene.types.aggregation.impl.LuceneTextTermsAggregation;
 import org.hibernate.search.backend.lucene.types.codec.impl.DocValues;
 import org.hibernate.search.backend.lucene.types.codec.impl.LuceneStringFieldCodec;
@@ -229,6 +230,7 @@ class LuceneStringIndexFieldTypeOptionsStep
 		if ( resolvedAggregable ) {
 			builder.aggregable( true );
 			builder.queryElementFactory( AggregationTypeKeys.TERMS, new LuceneTextTermsAggregation.Factory() );
+			builder.queryElementFactory( AggregationTypeKeys.COUNT, LuceneTextCountValuesAggregation.factory() );
 		}
 
 		return builder.build();

--- a/backend/lucene/src/test/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/AggregationFunctionTest.java
+++ b/backend/lucene/src/test/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/AggregationFunctionTest.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class AggregationFunctionTest {
+
+	public static Stream<Arguments> params() {
+		return Stream.of(
+				Arguments.of( new Min(), apply( new Min(), 1L ), 1L ),
+				Arguments.of( apply( new Min(), 1L ), new Min(), 1L ),
+				Arguments.of( apply( new Min(), 1L ), apply( new Min(), 1L ), 1L ),
+				Arguments.of( apply( new Min(), 10L ), apply( new Min(), 20L ), 10L ),
+				Arguments.of( new Min(), new Min(), null ),
+
+				Arguments.of( new Max(), apply( new Max(), 1L ), 1L ),
+				Arguments.of( apply( new Max(), 1L ), new Max(), 1L ),
+				Arguments.of( apply( new Max(), 1L ), apply( new Max(), 1L ), 1L ),
+				Arguments.of( apply( new Max(), 10L ), apply( new Max(), 20L ), 20L ),
+				Arguments.of( new Max(), new Max(), null ),
+
+				Arguments.of( new Sum(), apply( new Sum(), 1L ), 1L ),
+				Arguments.of( apply( new Sum(), 1L ), new Sum(), 1L ),
+				Arguments.of( apply( new Sum(), 1L ), apply( new Sum(), 1L ), 2L ),
+				Arguments.of( apply( new Sum(), 10L ), apply( new Sum(), 20L ), 30L ),
+				Arguments.of( new Sum(), new Sum(), null ),
+
+				Arguments.of( new CountValues(), apply( new CountValues(), 1L ), 1L ),
+				Arguments.of( apply( new CountValues(), 1L ), new CountValues(), 1L ),
+				Arguments.of( apply( new CountValues(), 1L ), apply( new CountValues(), 1L ), 2L ),
+				Arguments.of( apply( new CountValues(), 10L ), apply( new CountValues(), 20L ), 2L ),
+				Arguments.of( new CountValues(), new CountValues(), 0L ),
+
+				Arguments.of( new CountDistinctValues(), apply( new CountDistinctValues(), 1L ), 1L ),
+				Arguments.of( apply( new CountDistinctValues(), 1L ), new CountDistinctValues(), 1L ),
+				Arguments.of( apply( new CountDistinctValues(), 1L ), apply( new CountDistinctValues(), 1L ), 1L ),
+				Arguments.of( apply( new CountDistinctValues(), 10L ), apply( new CountDistinctValues(), 20L ), 2L ),
+				Arguments.of( new CountDistinctValues(), new CountDistinctValues(), 0L )
+		);
+	}
+
+	private static AggregationFunction<?> apply(AggregationFunction<?> function, Long value) {
+		function.apply( value );
+		return function;
+	}
+
+	@ParameterizedTest
+	@MethodSource("params")
+	<T extends AggregationFunction<?>> void merge(AggregationFunction<T> agg1, AggregationFunction<T> agg2, Long expected) {
+		agg1.merge( agg2 );
+
+		assertThat( agg1.result() ).isEqualTo( expected );
+	}
+}

--- a/backend/lucene/src/test/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/DoubleAggregationFunctionTest.java
+++ b/backend/lucene/src/test/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/DoubleAggregationFunctionTest.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class DoubleAggregationFunctionTest {
+
+	public static Stream<Arguments> params() {
+		return Stream.of(
+				Arguments.of( new CompensatedSum(), apply( new CompensatedSum(), 1.0 ), 1.0 ),
+				Arguments.of( apply( new CompensatedSum(), 1.0 ), new CompensatedSum(), 1.0 ),
+				Arguments.of( apply( new CompensatedSum(), 1.0 ), apply( new CompensatedSum(), 1.0 ), 2.0 ),
+				Arguments.of( apply( new CompensatedSum(), 10.0 ), apply( new CompensatedSum(), 20.0 ), 30.0 ),
+				Arguments.of( new CompensatedSum(), new CompensatedSum(), null )
+		);
+	}
+
+	private static DoubleAggregationFunction<?> apply(DoubleAggregationFunction<?> function, Double value) {
+		function.apply( value );
+		return function;
+	}
+
+	@ParameterizedTest
+	@MethodSource("params")
+	<T extends DoubleAggregationFunction<?>> void merge(DoubleAggregationFunction<T> agg1, DoubleAggregationFunction<T> agg2,
+			Double expected) {
+		agg1.merge( agg2 );
+
+		assertThat( agg1.result() ).isEqualTo( expected );
+	}
+}

--- a/build/enforcer/src/main/java/org/hibernate/search/build/enforcer/DependencyManagementIncludesAllGroupIdArtifactsRule.java
+++ b/build/enforcer/src/main/java/org/hibernate/search/build/enforcer/DependencyManagementIncludesAllGroupIdArtifactsRule.java
@@ -170,7 +170,7 @@ public class DependencyManagementIncludesAllGroupIdArtifactsRule extends Abstrac
 	private static String dependencyString(Dependency d) {
 		return String.format( Locale.ROOT, GAV_FORMAT, d.getGroupId(), d.getArtifactId(), d.getVersion() );
 	}
-	
+
 	private static boolean shouldSkip(String gav, Set<Pattern> skipPatterns) {
 		for ( Pattern skipPattern : skipPatterns ) {
 			if ( skipPattern.matcher( gav ).matches() ) {

--- a/documentation/src/main/asciidoc/public/reference/_search-dsl-aggregation.adoc
+++ b/documentation/src/main/asciidoc/public/reference/_search-dsl-aggregation.adoc
@@ -357,7 +357,7 @@ include::../components/_incubating-warning.adoc[]
 
 Hibernate Search provides a set of most common metric aggregations such as `sum`, `min`, `max`, `count` and `avg`.
 These aggregations can be requested for fields of numerical or temporal types,
-or, in the case of `count`, at the document level (counting documents).
+or, in the case of `count`, also for fields of text and boolean types as well as at the document level (counting documents).
 
 [IMPORTANT]
 ====

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/MetricNumericFieldsAggregationsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/MetricNumericFieldsAggregationsIT.java
@@ -273,22 +273,22 @@ class MetricNumericFieldsAggregationsIT {
 	}
 
 	private void initData() {
-		int[] integers = new int[] { 9, 18, 3, 18, 7, -10, 3, 0, 7, 0 };
+		Integer[] integers = new Integer[] { 9, 18, 3, 18, 7, -10, 3, 0, 7, 0, null };
 		String[] styles = new String[] { "bla", "aaa" };
 
 		BulkIndexer bulkIndexer = mainIndex.bulkIndexer();
 		for ( int i = 0; i < integers.length; i++ ) {
-			int value = integers[i];
+			Integer value = integers[i];
 			String style = styles[i % 2];
 			String id = i + ":" + value + ":" + style;
 
 			bulkIndexer.add( id, document -> {
 				document.addValue( mainIndex.binding().integer, value );
 				document.addValue( mainIndex.binding().converted, value );
-				document.addValue( mainIndex.binding().doubleF, (double) value );
-				document.addValue( mainIndex.binding().floatF, (float) value );
-				document.addValue( mainIndex.binding().bigInteger, BigInteger.valueOf( value ) );
-				document.addValue( mainIndex.binding().bigDecimal, BigDecimal.valueOf( value ) );
+				document.addValue( mainIndex.binding().doubleF, value == null ? null : Double.valueOf( value.doubleValue() ) );
+				document.addValue( mainIndex.binding().floatF, value == null ? null : Float.valueOf( value.floatValue() ) );
+				document.addValue( mainIndex.binding().bigInteger, value == null ? null : BigInteger.valueOf( value ) );
+				document.addValue( mainIndex.binding().bigDecimal, value == null ? null : BigDecimal.valueOf( value ) );
 				document.addValue( mainIndex.binding().style, style );
 
 				for ( int j = 0; j < 5; j++ ) {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/MetricTextBooleanFieldsAggregationsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/MetricTextBooleanFieldsAggregationsIT.java
@@ -1,0 +1,157 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.integrationtest.backend.tck.search.aggregation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hibernate.search.engine.backend.common.DocumentReference;
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.IndexObjectFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
+import org.hibernate.search.engine.backend.types.Aggregable;
+import org.hibernate.search.engine.backend.types.ObjectStructure;
+import org.hibernate.search.engine.search.aggregation.AggregationKey;
+import org.hibernate.search.engine.search.query.SearchQuery;
+import org.hibernate.search.engine.search.query.SearchResult;
+import org.hibernate.search.engine.search.query.dsl.SearchQueryOptionsStep;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.extension.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubLoadingOptionsStep;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class MetricTextBooleanFieldsAggregationsIT {
+
+	@RegisterExtension
+	public static final SearchSetupHelper setupHelper = SearchSetupHelper.create();
+
+	private final SimpleMappedIndex<IndexBinding> mainIndex = SimpleMappedIndex.of( IndexBinding::new ).name( "main" );
+
+	private final AggregationKey<Long> countTexts = AggregationKey.of( "countTexts" );
+	private final AggregationKey<Long> countDistinctTexts = AggregationKey.of( "countDistinctTexts" );
+	private final AggregationKey<Long> countValuesTextMultiValued = AggregationKey.of( "countValuesTextMultiValued" );
+	private final AggregationKey<Long> countDistinctValuesTextMultiValued =
+			AggregationKey.of( "countDistinctValuesTextMultiValued" );
+	private final AggregationKey<Long> countValuesNestedTextMultiValued =
+			AggregationKey.of( "countValuesNestedTextMultiValued" );
+	private final AggregationKey<Long> countDistinctValuesNestedTextMultiValued =
+			AggregationKey.of( "countDistinctValuesNestedTextMultiValued" );
+
+	@BeforeEach
+	void setup() {
+		setupHelper.start().withIndexes( mainIndex ).setup().integration();
+		initData();
+	}
+
+	@Test
+	void test_filteringResults() {
+		StubMappingScope scope = mainIndex.createScope();
+		SearchQueryOptionsStep<?, ?, DocumentReference, StubLoadingOptionsStep, ?, ?> options = scope.query()
+				.where( f -> f.match().field( "style" ).matching( "bla" ) );
+		SearchQuery<DocumentReference> query = defineAggregations( options );
+
+		SearchResult<DocumentReference> result = query.fetch( 0 );
+		assertThat( result.aggregation( countTexts ) ).isEqualTo( 5 );
+		assertThat( result.aggregation( countDistinctTexts ) ).isEqualTo( 3 );
+		assertThat( result.aggregation( countValuesTextMultiValued ) ).isEqualTo( 25 );
+		assertThat( result.aggregation( countDistinctValuesTextMultiValued ) ).isEqualTo( 15 );
+		assertThat( result.aggregation( countValuesNestedTextMultiValued ) ).isEqualTo( 25L );
+		assertThat( result.aggregation( countDistinctValuesNestedTextMultiValued ) ).isEqualTo( 15L );
+	}
+
+	@Test
+	void test_allResults() {
+		StubMappingScope scope = mainIndex.createScope();
+		SearchQueryOptionsStep<?, ?, DocumentReference, StubLoadingOptionsStep, ?, ?> options = scope.query()
+				.where( f -> f.matchAll() );
+		SearchQuery<DocumentReference> query = defineAggregations( options );
+
+		SearchResult<DocumentReference> result = query.fetch( 0 );
+		assertThat( result.aggregation( countTexts ) ).isEqualTo( 10 );
+		assertThat( result.aggregation( countDistinctTexts ) ).isEqualTo( 6 );
+		assertThat( result.aggregation( countValuesTextMultiValued ) ).isEqualTo( 50 );
+		assertThat( result.aggregation( countDistinctValuesTextMultiValued ) ).isEqualTo( 30 );
+		assertThat( result.aggregation( countValuesNestedTextMultiValued ) ).isEqualTo( 50L );
+		assertThat( result.aggregation( countDistinctValuesNestedTextMultiValued ) ).isEqualTo( 30L );
+	}
+
+	private SearchQuery<DocumentReference> defineAggregations(
+			SearchQueryOptionsStep<?, ?, DocumentReference, StubLoadingOptionsStep, ?, ?> options) {
+
+		return options
+				.aggregation( countTexts, f -> f.count().field( "text" ) )
+				.aggregation( countDistinctTexts, f -> f.count().field( "text" ).distinct() )
+				.aggregation( countDistinctValuesTextMultiValued, f -> f.count().field( "textMultiValued" ).distinct() )
+				.aggregation( countValuesTextMultiValued, f -> f.count().field( "textMultiValued" ) )
+				.aggregation( countValuesNestedTextMultiValued, f -> f.count().field( "object.nestedTextMultiValued" ) )
+				.aggregation( countDistinctValuesNestedTextMultiValued,
+						f -> f.count().field( "object.nestedTextMultiValued" ).distinct() )
+				.toQuery();
+	}
+
+	private void initData() {
+		Integer[] integers = new Integer[] { 9, 18, 3, 18, 7, -10, 3, 0, 7, 0, null };
+		String[] styles = new String[] { "bla", "aaa" };
+
+		BulkIndexer bulkIndexer = mainIndex.bulkIndexer();
+		for ( int i = 0; i < integers.length; i++ ) {
+			String value = integers[i] == null ? null : "text " + integers[i].toString();
+			String style = styles[i % 2];
+			String id = i + ":" + value + ":" + style;
+			boolean bool = i % 2 == 0;
+
+			bulkIndexer.add( id, document -> {
+				document.addValue( mainIndex.binding().text, value );
+				document.addValue( mainIndex.binding().bool, bool );
+				document.addValue( mainIndex.binding().style, style );
+
+				for ( int j = 0; j < 5; j++ ) {
+					String v = value == null ? null : value + "-" + j;
+					document.addValue( mainIndex.binding().textMultiValued, v );
+				}
+
+				DocumentElement object = document.addObject( mainIndex.binding().object );
+				object.addValue( mainIndex.binding().nestedText, value );
+				for ( int j = 0; j < 5; j++ ) {
+					String v = value == null ? null : value + "-" + j;
+					object.addValue( mainIndex.binding().nestedTextMultiValued, v );
+				}
+			} ).join();
+		}
+		bulkIndexer.add( "empty", document -> {} )
+				.join();
+	}
+
+	@SuppressWarnings("unused")
+	private static class IndexBinding {
+		final IndexFieldReference<String> text;
+		final IndexFieldReference<String> textMultiValued;
+		final IndexFieldReference<Boolean> bool;
+		final IndexFieldReference<String> style;
+		final IndexObjectFieldReference object;
+		final IndexFieldReference<String> nestedText;
+		final IndexFieldReference<String> nestedTextMultiValued;
+
+		IndexBinding(IndexSchemaElement root) {
+			text = root.field( "text", f -> f.asString().aggregable( Aggregable.YES ) ).toReference();
+			textMultiValued =
+					root.field( "textMultiValued", f -> f.asString().aggregable( Aggregable.YES ) ).multiValued().toReference();
+			bool = root.field( "bool", f -> f.asBoolean().aggregable( Aggregable.YES ) ).toReference();
+			style = root.field( "style", f -> f.asString() ).toReference();
+
+			IndexSchemaObjectField nested = root.objectField( "object", ObjectStructure.NESTED );
+			object = nested.toReference();
+			nestedText = nested.field( "nestedText", f -> f.asString().aggregable( Aggregable.YES ) ).toReference();
+			nestedTextMultiValued = nested.field( "nestedTextMultiValued", f -> f.asString().aggregable( Aggregable.YES ) )
+					.multiValued().toReference();
+		}
+	}
+}

--- a/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CompensatedSum.java
+++ b/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CompensatedSum.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
 
+import java.util.Locale;
+
 /**
  * <p>
  * The algorithm is inspired by {@code org.opensearch.search.aggregations.metrics.SumAggregator}
@@ -21,16 +23,28 @@ public class CompensatedSum implements DoubleAggregationFunction<CompensatedSum>
 	@Override
 	public void merge(DoubleAggregationFunction<CompensatedSum> sibling) {
 		KahanSummation other = sibling.implementation().kahanSummation;
-		kahanSummation.add( other.value(), other.delta() );
+		if ( other.initialized() ) {
+			kahanSummation.add( other.value(), other.delta() );
+		}
 	}
 
 	@Override
 	public Double result() {
-		return kahanSummation.value();
+		if ( kahanSummation.initialized() ) {
+			return kahanSummation.value();
+		}
+		else {
+			return null;
+		}
 	}
 
 	@Override
 	public CompensatedSum implementation() {
 		return this;
+	}
+
+	@Override
+	public String toString() {
+		return String.format( Locale.ROOT, "CompensatedSum{kahanSummation=%s}", kahanSummation );
 	}
 }

--- a/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountDistinctTextValuesCollector.java
+++ b/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountDistinctTextValuesCollector.java
@@ -1,0 +1,83 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
+
+import java.io.IOException;
+
+import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.TextMultiValues;
+import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.TextMultiValuesSource;
+
+import com.carrotsearch.hppc.LongHashSet;
+import com.carrotsearch.hppc.cursors.LongCursor;
+
+import org.apache.lucene.index.IndexReaderContext;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.MultiDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.SimpleCollector;
+
+public class CountDistinctTextValuesCollector extends SimpleCollector {
+
+	private final TextMultiValuesSource source;
+	private final String field;
+	private TextMultiValues values;
+
+	private final LongHashSet globalOrds = new LongHashSet();
+
+	private LongHashSet leafOrds = new LongHashSet();
+
+	private SortedSetDocValues sortedSetValues;
+
+	public CountDistinctTextValuesCollector(TextMultiValuesSource source, String field) {
+		this.source = source;
+		this.field = field;
+	}
+
+	@Override
+	public void collect(int doc) throws IOException {
+		if ( values.advanceExact( doc ) ) {
+			while ( values.hasNextValue() ) {
+				long ord = values.nextOrd();
+				leafOrds.add( ord );
+			}
+		}
+	}
+
+	@Override
+	public ScoreMode scoreMode() {
+		return ScoreMode.COMPLETE_NO_SCORES;
+	}
+
+	@Override
+	protected void doSetNextReader(LeafReaderContext context) throws IOException {
+		initRootSortedSetDocValues( context );
+		this.values = source.getValues( context );
+	}
+
+	@Override
+	public void finish() throws IOException {
+		for ( LongCursor value : leafOrds ) {
+			long globalOrd = sortedSetValues.lookupTerm( values.lookupOrd( value.value ) );
+			globalOrds.add( globalOrd );
+		}
+		values = null;
+		leafOrds.clear();
+	}
+
+	private void initRootSortedSetDocValues(IndexReaderContext ctx) throws IOException {
+		if ( sortedSetValues != null || ctx == null ) {
+			return;
+		}
+		if ( ctx.isTopLevel ) {
+			this.sortedSetValues = MultiDocValues.getSortedSetValues( ctx.reader(), field );
+		}
+		initRootSortedSetDocValues( ctx.parent );
+	}
+
+	public LongHashSet globalOrds() {
+		return globalOrds;
+	}
+}

--- a/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountDistinctTextValuesCollectorFactory.java
+++ b/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountDistinctTextValuesCollectorFactory.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
+
+import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorExecutionContext;
+import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorFactory;
+import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorKey;
+import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.JoiningTextMultiValuesSource;
+
+public class CountDistinctTextValuesCollectorFactory
+		implements
+		CollectorFactory<CountDistinctTextValuesCollector, Long, CountDistinctTextValuesCollectorManager> {
+
+	private final JoiningTextMultiValuesSource source;
+	private final String field;
+	private final CollectorKey<CountDistinctTextValuesCollector, Long> key = CollectorKey.create();
+
+	public CountDistinctTextValuesCollectorFactory(JoiningTextMultiValuesSource source, String field) {
+		this.source = source;
+		this.field = field;
+	}
+
+	@Override
+	public CountDistinctTextValuesCollectorManager createCollectorManager(CollectorExecutionContext context) {
+		return new CountDistinctTextValuesCollectorManager( source, field );
+	}
+
+	@Override
+	public CollectorKey<CountDistinctTextValuesCollector, Long> getCollectorKey() {
+		return key;
+	}
+}

--- a/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountDistinctTextValuesCollectorManager.java
+++ b/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountDistinctTextValuesCollectorManager.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.JoiningTextMultiValuesSource;
+
+import com.carrotsearch.hppc.LongHashSet;
+
+import org.apache.lucene.search.CollectorManager;
+
+public class CountDistinctTextValuesCollectorManager implements CollectorManager<CountDistinctTextValuesCollector, Long> {
+
+	private final JoiningTextMultiValuesSource source;
+	private final String field;
+
+	public CountDistinctTextValuesCollectorManager(JoiningTextMultiValuesSource source, String field) {
+		this.source = source;
+		this.field = field;
+	}
+
+	@Override
+	public CountDistinctTextValuesCollector newCollector() throws IOException {
+		return new CountDistinctTextValuesCollector( source, field );
+	}
+
+	@Override
+	public Long reduce(Collection<CountDistinctTextValuesCollector> collectors) throws IOException {
+		if ( collectors.isEmpty() ) {
+			return 0L;
+		}
+		if ( collectors.size() == 1 ) {
+			return (long) collectors.iterator().next().globalOrds().size();
+		}
+		LongHashSet ords = new LongHashSet();
+		for ( CountDistinctTextValuesCollector collector : collectors ) {
+			ords.addAll( collector.globalOrds() );
+		}
+		return (long) ords.size();
+	}
+}

--- a/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountDistinctValues.java
+++ b/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountDistinctValues.java
@@ -5,6 +5,7 @@
 package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
 
 import java.util.BitSet;
+import java.util.Locale;
 
 import com.carrotsearch.hppc.LongHashSet;
 
@@ -43,5 +44,10 @@ public class CountDistinctValues implements AggregationFunction<CountDistinctVal
 	@Override
 	public CountDistinctValues implementation() {
 		return this;
+	}
+
+	@Override
+	public String toString() {
+		return String.format( Locale.ROOT, "CountDistinctValues{counts=%s}", counts );
 	}
 }

--- a/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountTextValuesCollector.java
+++ b/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountTextValuesCollector.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
+
+import java.io.IOException;
+
+import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.TextMultiValues;
+import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.TextMultiValuesSource;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.SimpleCollector;
+
+public class CountTextValuesCollector extends SimpleCollector {
+
+	private final TextMultiValuesSource source;
+	private TextMultiValues values;
+	private long count;
+	LeafReaderContext context;
+
+	public CountTextValuesCollector(TextMultiValuesSource source) {
+		this.source = source;
+	}
+
+	@Override
+	public void collect(int doc) throws IOException {
+		if ( values.advanceExact( doc ) ) {
+			while ( values.hasNextValue() ) {
+				values.nextOrd();
+				count++;
+			}
+		}
+	}
+
+	@Override
+	public ScoreMode scoreMode() {
+		return ScoreMode.COMPLETE_NO_SCORES;
+	}
+
+	@Override
+	protected void doSetNextReader(LeafReaderContext context) throws IOException {
+		this.values = source.getValues( context );
+	}
+
+
+	@Override
+	public void finish() throws IOException {
+		this.values = null;
+	}
+
+	public long count() {
+		return count;
+	}
+}

--- a/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountTextValuesCollectorFactory.java
+++ b/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountTextValuesCollectorFactory.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
+
+import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorExecutionContext;
+import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorFactory;
+import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorKey;
+import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.JoiningTextMultiValuesSource;
+
+public class CountTextValuesCollectorFactory
+		implements
+		CollectorFactory<CountTextValuesCollector, Long, CountTextValuesCollectorManager> {
+
+	private final JoiningTextMultiValuesSource source;
+	private final CollectorKey<CountTextValuesCollector, Long> key = CollectorKey.create();
+
+	public CountTextValuesCollectorFactory(JoiningTextMultiValuesSource source, String field) {
+		this.source = source;
+	}
+
+	@Override
+	public CountTextValuesCollectorManager createCollectorManager(CollectorExecutionContext context) {
+		return new CountTextValuesCollectorManager( source );
+	}
+
+	@Override
+	public CollectorKey<CountTextValuesCollector, Long> getCollectorKey() {
+		return key;
+	}
+}

--- a/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountTextValuesCollectorManager.java
+++ b/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountTextValuesCollectorManager.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.JoiningTextMultiValuesSource;
+
+import org.apache.lucene.search.CollectorManager;
+
+public class CountTextValuesCollectorManager implements CollectorManager<CountTextValuesCollector, Long> {
+
+	private final JoiningTextMultiValuesSource source;
+
+	public CountTextValuesCollectorManager(JoiningTextMultiValuesSource source) {
+		this.source = source;
+	}
+
+	@Override
+	public CountTextValuesCollector newCollector() throws IOException {
+		return new CountTextValuesCollector( source );
+	}
+
+	@Override
+	public Long reduce(Collection<CountTextValuesCollector> collectors) throws IOException {
+		long count = 0;
+		for ( CountTextValuesCollector collector : collectors ) {
+			count += collector.count();
+		}
+		return count;
+	}
+}

--- a/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountValues.java
+++ b/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/CountValues.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
 
+import java.util.Locale;
+
 public class CountValues implements AggregationFunction<CountValues> {
 
 	private long count = 0L;
@@ -26,5 +28,10 @@ public class CountValues implements AggregationFunction<CountValues> {
 	@Override
 	public CountValues implementation() {
 		return this;
+	}
+
+	@Override
+	public String toString() {
+		return String.format( Locale.ROOT, "CountValues{count=%d}", count );
 	}
 }

--- a/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/KahanSummation.java
+++ b/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/KahanSummation.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
 
+import java.util.Locale;
+
 /**
  * <p>
  * Copied with some changes from {@code org.opensearch.search.aggregations.metrics.CompensatedSum}
@@ -15,6 +17,7 @@ public class KahanSummation {
 
 	private double value;
 	private double delta;
+	private boolean initialized;
 
 	/**
 	 * Used to calculate sums using the Kahan summation algorithm.
@@ -42,6 +45,13 @@ public class KahanSummation {
 	}
 
 	/**
+	 * Whether anything was actually added to this sum or is the result is supposed to be `null`.
+	 */
+	public boolean initialized() {
+		return initialized;
+	}
+
+	/**
 	 * Increments the Kahan sum by adding a value without a correction term.
 	 */
 	public KahanSummation add(double value) {
@@ -60,6 +70,7 @@ public class KahanSummation {
 	 * Increments the Kahan sum by adding two sums, and updating the correction term for reducing numeric errors.
 	 */
 	public KahanSummation add(double value, double delta) {
+		initialized = true;
 		// If the value is Inf or NaN, just add it to the running tally to "convert" to
 		// Inf/NaN. This keeps the behavior bwc from before kahan summing
 		if ( Double.isFinite( value ) ) {
@@ -75,4 +86,8 @@ public class KahanSummation {
 		return this;
 	}
 
+	@Override
+	public String toString() {
+		return String.format( Locale.ROOT, "{value=%s, delta=%s, initialized=%s}", value, delta, initialized );
+	}
 }

--- a/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/Max.java
+++ b/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/Max.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
 
+import java.util.Locale;
+
 public class Max implements AggregationFunction<Max> {
 
 	private Long max;
@@ -21,7 +23,9 @@ public class Max implements AggregationFunction<Max> {
 	@Override
 	public void merge(AggregationFunction<Max> sibling) {
 		Long other = sibling.implementation().max;
-		apply( other );
+		if ( other != null ) {
+			apply( other );
+		}
 	}
 
 	@Override
@@ -32,5 +36,10 @@ public class Max implements AggregationFunction<Max> {
 	@Override
 	public Max implementation() {
 		return this;
+	}
+
+	@Override
+	public String toString() {
+		return String.format( Locale.ROOT, "Max{max=%d}", max );
 	}
 }

--- a/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/Min.java
+++ b/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/Min.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
 
+import java.util.Locale;
+
 public class Min implements AggregationFunction<Min> {
 
 	private Long min;
@@ -21,7 +23,9 @@ public class Min implements AggregationFunction<Min> {
 	@Override
 	public void merge(AggregationFunction<Min> sibling) {
 		Long other = sibling.implementation().min;
-		apply( other );
+		if ( other != null ) {
+			apply( other );
+		}
 	}
 
 	@Override
@@ -32,5 +36,10 @@ public class Min implements AggregationFunction<Min> {
 	@Override
 	public Min implementation() {
 		return this;
+	}
+
+	@Override
+	public String toString() {
+		return String.format( Locale.ROOT, "Min{min=%d}", min );
 	}
 }

--- a/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/Sum.java
+++ b/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/Sum.java
@@ -4,18 +4,28 @@
  */
 package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
 
+import java.util.Locale;
+
 public class Sum implements AggregationFunction<Sum> {
 
-	private long sum = 0L;
+	private Long sum = null;
 
 	@Override
 	public void apply(long value) {
-		sum += value;
+		if ( sum == null ) {
+			sum = value;
+		}
+		else {
+			sum += value;
+		}
 	}
 
 	@Override
 	public void merge(AggregationFunction<Sum> sibling) {
-		apply( sibling.result() );
+		Long result = sibling.result();
+		if ( result != null ) {
+			apply( result );
+		}
 	}
 
 	@Override
@@ -26,5 +36,10 @@ public class Sum implements AggregationFunction<Sum> {
 	@Override
 	public Sum implementation() {
 		return this;
+	}
+
+	@Override
+	public String toString() {
+		return String.format( Locale.ROOT, "Sum{sum=%d}", sum );
 	}
 }

--- a/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/aggregation/impl/AbstractLuceneMetricNumericLongAggregation.java
+++ b/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/aggregation/impl/AbstractLuceneMetricNumericLongAggregation.java
@@ -16,8 +16,6 @@ public abstract class AbstractLuceneMetricNumericLongAggregation extends Abstrac
 	private final Set<String> indexNames;
 	private final String absoluteFieldPath;
 
-	protected CollectorKey<?, Long> collectorKey;
-
 	AbstractLuceneMetricNumericLongAggregation(AbstractBuilder<Long> builder) {
 		super( builder );
 		this.indexNames = builder.scope.hibernateSearchIndexNames();
@@ -29,19 +27,19 @@ public abstract class AbstractLuceneMetricNumericLongAggregation extends Abstrac
 		JoiningLongMultiValuesSource source = JoiningLongMultiValuesSource.fromField(
 				absoluteFieldPath, createNestedDocsProvider( context )
 		);
-		fillCollectors( source, context );
 
-		return new LuceneNumericMetricLongAggregationExtraction();
+		return new LuceneNumericMetricLongAggregationExtractor( fillCollectors( source, context ) );
 	}
 
-	abstract void fillCollectors(JoiningLongMultiValuesSource source, AggregationRequestContext context);
+	abstract CollectorKey<?, Long> fillCollectors(JoiningLongMultiValuesSource source, AggregationRequestContext context);
 
 	@Override
 	public Set<String> indexNames() {
 		return indexNames;
 	}
 
-	private class LuceneNumericMetricLongAggregationExtraction implements Extractor<Long> {
+	private record LuceneNumericMetricLongAggregationExtractor(CollectorKey<?, Long> collectorKey) implements Extractor<Long> {
+
 		@Override
 		public Long extract(AggregationExtractContext context) {
 			return context.getCollectorResults( collectorKey );

--- a/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/aggregation/impl/LuceneCountValuesAggregation.java
+++ b/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/aggregation/impl/LuceneCountValuesAggregation.java
@@ -10,6 +10,7 @@ import org.hibernate.search.backend.lucene.logging.impl.QueryLog;
 import org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl.CountDistinctValuesCollectorFactory;
 import org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl.CountValuesCollectorFactory;
 import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorFactory;
+import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorKey;
 import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.JoiningLongMultiValuesSource;
 import org.hibernate.search.backend.lucene.search.aggregation.impl.AggregationRequestContext;
 import org.hibernate.search.backend.lucene.search.common.impl.LuceneSearchIndexNodeContext;
@@ -65,10 +66,11 @@ public class LuceneCountValuesAggregation extends AbstractLuceneMetricNumericLon
 	}
 
 	@Override
-	void fillCollectors(JoiningLongMultiValuesSource source, AggregationRequestContext context) {
+	CollectorKey<?, Long> fillCollectors(JoiningLongMultiValuesSource source, AggregationRequestContext context) {
 		var collectorFactory = collectorFactorySupplier.apply( source );
-		collectorKey = collectorFactory.getCollectorKey();
+		var collectorKey = collectorFactory.getCollectorKey();
 		context.requireCollector( collectorFactory );
+		return collectorKey;
 	}
 
 	protected static class Builder extends AbstractBuilder<Long> implements CountValuesAggregationBuilder {

--- a/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/aggregation/impl/LuceneMaxNumericFieldAggregation.java
+++ b/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/aggregation/impl/LuceneMaxNumericFieldAggregation.java
@@ -4,7 +4,10 @@
  */
 package org.hibernate.search.backend.lucene.types.aggregation.impl;
 
+import java.util.List;
+
 import org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl.MaxCollectorFactory;
+import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorKey;
 import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.JoiningLongMultiValuesSource;
 import org.hibernate.search.backend.lucene.search.aggregation.impl.AggregationRequestContext;
 import org.hibernate.search.backend.lucene.search.common.impl.AbstractLuceneCodecAwareSearchQueryElementFactory;
@@ -25,10 +28,10 @@ public class LuceneMaxNumericFieldAggregation<F, E extends Number, K>
 	}
 
 	@Override
-	void fillCollectors(JoiningLongMultiValuesSource source, AggregationRequestContext context) {
+	List<CollectorKey<?, Long>> fillCollectors(JoiningLongMultiValuesSource source, AggregationRequestContext context) {
 		MaxCollectorFactory collectorFactory = new MaxCollectorFactory( source );
-		collectorKey = collectorFactory.getCollectorKey();
 		context.requireCollector( collectorFactory );
+		return List.of( collectorFactory.getCollectorKey() );
 	}
 
 	public static class Factory<F>

--- a/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/aggregation/impl/LuceneMinNumericFieldAggregation.java
+++ b/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/aggregation/impl/LuceneMinNumericFieldAggregation.java
@@ -4,7 +4,10 @@
  */
 package org.hibernate.search.backend.lucene.types.aggregation.impl;
 
+import java.util.List;
+
 import org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl.MinCollectorFactory;
+import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorKey;
 import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.JoiningLongMultiValuesSource;
 import org.hibernate.search.backend.lucene.search.aggregation.impl.AggregationRequestContext;
 import org.hibernate.search.backend.lucene.search.common.impl.AbstractLuceneCodecAwareSearchQueryElementFactory;
@@ -25,10 +28,10 @@ public class LuceneMinNumericFieldAggregation<F, E extends Number, K>
 	}
 
 	@Override
-	void fillCollectors(JoiningLongMultiValuesSource source, AggregationRequestContext context) {
+	List<CollectorKey<?, Long>> fillCollectors(JoiningLongMultiValuesSource source, AggregationRequestContext context) {
 		MinCollectorFactory collectorFactory = new MinCollectorFactory( source );
-		collectorKey = collectorFactory.getCollectorKey();
 		context.requireCollector( collectorFactory );
+		return List.of( collectorFactory.getCollectorKey() );
 	}
 
 	public static class Factory<F>

--- a/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/aggregation/impl/LuceneSumNumericFieldAggregation.java
+++ b/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/aggregation/impl/LuceneSumNumericFieldAggregation.java
@@ -4,7 +4,10 @@
  */
 package org.hibernate.search.backend.lucene.types.aggregation.impl;
 
+import java.util.List;
+
 import org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl.SumCollectorFactory;
+import org.hibernate.search.backend.lucene.lowlevel.collector.impl.CollectorKey;
 import org.hibernate.search.backend.lucene.lowlevel.docvalues.impl.JoiningLongMultiValuesSource;
 import org.hibernate.search.backend.lucene.search.aggregation.impl.AggregationRequestContext;
 import org.hibernate.search.backend.lucene.search.common.impl.AbstractLuceneCodecAwareSearchQueryElementFactory;
@@ -25,10 +28,10 @@ public class LuceneSumNumericFieldAggregation<F, E extends Number, K>
 	}
 
 	@Override
-	void fillCollectors(JoiningLongMultiValuesSource source, AggregationRequestContext context) {
+	List<CollectorKey<?, Long>> fillCollectors(JoiningLongMultiValuesSource source, AggregationRequestContext context) {
 		SumCollectorFactory collectorFactory = new SumCollectorFactory( source );
-		collectorKey = collectorFactory.getCollectorKey();
 		context.requireCollector( collectorFactory );
+		return List.of( collectorFactory.getCollectorKey() );
 	}
 
 	public static class Factory<F>

--- a/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneBooleanIndexFieldTypeOptionsStep.java
+++ b/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneBooleanIndexFieldTypeOptionsStep.java
@@ -6,6 +6,7 @@ package org.hibernate.search.backend.lucene.types.dsl.impl;
 
 import org.hibernate.search.backend.lucene.search.predicate.impl.LucenePredicateTypeKeys;
 import org.hibernate.search.backend.lucene.search.projection.impl.LuceneFieldProjection;
+import org.hibernate.search.backend.lucene.types.aggregation.impl.LuceneCountValuesAggregation;
 import org.hibernate.search.backend.lucene.types.aggregation.impl.LuceneNumericTermsAggregation;
 import org.hibernate.search.backend.lucene.types.codec.impl.DocValues;
 import org.hibernate.search.backend.lucene.types.codec.impl.Indexing;
@@ -82,6 +83,7 @@ class LuceneBooleanIndexFieldTypeOptionsStep
 		if ( resolvedAggregable ) {
 			builder.aggregable( true );
 			builder.queryElementFactory( AggregationTypeKeys.TERMS, new LuceneNumericTermsAggregation.Factory<>( codec ) );
+			builder.queryElementFactory( AggregationTypeKeys.COUNT, LuceneCountValuesAggregation.factory() );
 		}
 
 		return builder.build();

--- a/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexFieldTypeOptionsStep.java
+++ b/lucene-next/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexFieldTypeOptionsStep.java
@@ -17,6 +17,7 @@ import org.hibernate.search.backend.lucene.lowlevel.common.impl.AnalyzerConstant
 import org.hibernate.search.backend.lucene.search.predicate.impl.LucenePredicateTypeKeys;
 import org.hibernate.search.backend.lucene.search.projection.impl.LuceneFieldHighlightProjection;
 import org.hibernate.search.backend.lucene.search.projection.impl.LuceneFieldProjection;
+import org.hibernate.search.backend.lucene.types.aggregation.impl.LuceneTextCountValuesAggregation;
 import org.hibernate.search.backend.lucene.types.aggregation.impl.LuceneTextTermsAggregation;
 import org.hibernate.search.backend.lucene.types.codec.impl.DocValues;
 import org.hibernate.search.backend.lucene.types.codec.impl.LuceneStringFieldCodec;
@@ -229,6 +230,7 @@ class LuceneStringIndexFieldTypeOptionsStep
 		if ( resolvedAggregable ) {
 			builder.aggregable( true );
 			builder.queryElementFactory( AggregationTypeKeys.TERMS, new LuceneTextTermsAggregation.Factory() );
+			builder.queryElementFactory( AggregationTypeKeys.COUNT, LuceneTextCountValuesAggregation.factory() );
 		}
 
 		return builder.build();

--- a/lucene-next/backend/lucene/src/test/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/AggregationFunctionTest.java
+++ b/lucene-next/backend/lucene/src/test/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/AggregationFunctionTest.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class AggregationFunctionTest {
+
+	public static Stream<Arguments> params() {
+		return Stream.of(
+				Arguments.of( new Min(), apply( new Min(), 1L ), 1L ),
+				Arguments.of( apply( new Min(), 1L ), new Min(), 1L ),
+				Arguments.of( apply( new Min(), 1L ), apply( new Min(), 1L ), 1L ),
+				Arguments.of( apply( new Min(), 10L ), apply( new Min(), 20L ), 10L ),
+				Arguments.of( new Min(), new Min(), null ),
+
+				Arguments.of( new Max(), apply( new Max(), 1L ), 1L ),
+				Arguments.of( apply( new Max(), 1L ), new Max(), 1L ),
+				Arguments.of( apply( new Max(), 1L ), apply( new Max(), 1L ), 1L ),
+				Arguments.of( apply( new Max(), 10L ), apply( new Max(), 20L ), 20L ),
+				Arguments.of( new Max(), new Max(), null ),
+
+				Arguments.of( new Sum(), apply( new Sum(), 1L ), 1L ),
+				Arguments.of( apply( new Sum(), 1L ), new Sum(), 1L ),
+				Arguments.of( apply( new Sum(), 1L ), apply( new Sum(), 1L ), 2L ),
+				Arguments.of( apply( new Sum(), 10L ), apply( new Sum(), 20L ), 30L ),
+				Arguments.of( new Sum(), new Sum(), null ),
+
+				Arguments.of( new CountValues(), apply( new CountValues(), 1L ), 1L ),
+				Arguments.of( apply( new CountValues(), 1L ), new CountValues(), 1L ),
+				Arguments.of( apply( new CountValues(), 1L ), apply( new CountValues(), 1L ), 2L ),
+				Arguments.of( apply( new CountValues(), 10L ), apply( new CountValues(), 20L ), 2L ),
+				Arguments.of( new CountValues(), new CountValues(), 0L ),
+
+				Arguments.of( new CountDistinctValues(), apply( new CountDistinctValues(), 1L ), 1L ),
+				Arguments.of( apply( new CountDistinctValues(), 1L ), new CountDistinctValues(), 1L ),
+				Arguments.of( apply( new CountDistinctValues(), 1L ), apply( new CountDistinctValues(), 1L ), 1L ),
+				Arguments.of( apply( new CountDistinctValues(), 10L ), apply( new CountDistinctValues(), 20L ), 2L ),
+				Arguments.of( new CountDistinctValues(), new CountDistinctValues(), 0L )
+		);
+	}
+
+	private static AggregationFunction<?> apply(AggregationFunction<?> function, Long value) {
+		function.apply( value );
+		return function;
+	}
+
+	@ParameterizedTest
+	@MethodSource("params")
+	<T extends AggregationFunction<?>> void merge(AggregationFunction<T> agg1, AggregationFunction<T> agg2, Long expected) {
+		agg1.merge( agg2 );
+
+		assertThat( agg1.result() ).isEqualTo( expected );
+	}
+}

--- a/lucene-next/backend/lucene/src/test/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/DoubleAggregationFunctionTest.java
+++ b/lucene-next/backend/lucene/src/test/java/org/hibernate/search/backend/lucene/lowlevel/aggregation/collector/impl/DoubleAggregationFunctionTest.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.backend.lucene.lowlevel.aggregation.collector.impl;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class DoubleAggregationFunctionTest {
+
+	public static Stream<Arguments> params() {
+		return Stream.of(
+				Arguments.of( new CompensatedSum(), apply( new CompensatedSum(), 1.0 ), 1.0 ),
+				Arguments.of( apply( new CompensatedSum(), 1.0 ), new CompensatedSum(), 1.0 ),
+				Arguments.of( apply( new CompensatedSum(), 1.0 ), apply( new CompensatedSum(), 1.0 ), 2.0 ),
+				Arguments.of( apply( new CompensatedSum(), 10.0 ), apply( new CompensatedSum(), 20.0 ), 30.0 ),
+				Arguments.of( new CompensatedSum(), new CompensatedSum(), null )
+		);
+	}
+
+	private static DoubleAggregationFunction<?> apply(DoubleAggregationFunction<?> function, Double value) {
+		function.apply( value );
+		return function;
+	}
+
+	@ParameterizedTest
+	@MethodSource("params")
+	<T extends DoubleAggregationFunction<?>> void merge(DoubleAggregationFunction<T> agg1, DoubleAggregationFunction<T> agg2,
+			Double expected) {
+		agg1.merge( agg2 );
+
+		assertThat( agg1.result() ).isEqualTo( expected );
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5456
https://hibernate.atlassian.net/browse/HSEARCH-5457

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
