### PR TITLE
Set GitHub workflow required permissions explicitly / Determine and checkout the original target branch when publishing the build scans

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -21,12 +21,38 @@ jobs:
     if: github.repository == 'hibernate/hibernate-search' && github.event.workflow_run.conclusion != 'cancelled'
     runs-on: ubuntu-latest
     steps:
+      # Different branches might have different versions of Develocity, and we want to make sure
+      #  that we publish with the one that we built the scan with in the first place:
+      - name: Determine the Branch Reference for which the original action was triggered
+        id: determine_branch_ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event.workflow_run.event }}" == "pull_request" ]; then
+            echo "::notice::Triggering workflow was executed for a pull request"
+          
+            FORK_OWNER="${{ github.event.workflow_run.head_repository.owner.login }}"
+            BRANCH_NAME="${{ github.event.workflow_run.head_branch }}"
+            if [ "${{ github.event.workflow_run.head_repository.owner.login }}" != "${{ github.event.workflow_run.repository.owner.login }}" ]; then
+              BRANCH_NAME="$FORK_OWNER:$BRANCH_NAME"
+            fi
+            TARGET_BRANCH=$(gh pr view "$BRANCH_NAME" --repo ${{ github.event.workflow_run.repository.full_name }} --json baseRefName -q .baseRefName)
+          
+            echo "::notice::PR found. Target branch is: $TARGET_BRANCH"
+            echo "original_branch_ref=$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Triggering workflow was executed for a push event? Using the head_branch value."
+            echo "original_branch_ref=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
+          fi
       # Checkout target branch which has trusted code
       - name: Check out target branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:
           persist-credentials: false
-          ref: ${{ github.ref }}
+          # By default, a workflow that is triggered with on workflow_run would run on the main (default) branch.
+          #  Different branches might have different versions of Develocity, and we want to make sure
+          #  that we publish with the one that we built the scan with in the first place.
+          ref: ${{ steps.determine_branch_ref.outputs.original_branch_ref }}
       - name: Set up Java 21
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # 4.7.1
         with:

--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -12,6 +12,9 @@ defaults:
 env:
   MAVEN_ARGS: "-e -B --settings .github/mvn-settings.xml --fail-at-end"
 
+permissions:
+  contents: read
+
 jobs:
   publish-build-scans:
     name: Publish Develocity build scans

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ env:
   MAVEN_ARGS: "-e -B --settings .github/mvn-settings.xml --fail-at-end"
   TESTCONTAINERS_REUSE_ENABLE: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: ${{matrix.os.name}}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HSEARCH.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HSEARCH-<digits>`).
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
