### PR TITLE
[7.2] HSEARCH-5473 Include license file in the META-INF of published artifacts

### DIFF
--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -1153,7 +1153,7 @@
                         <violationSeverity>error</violationSeverity>
                         <includeTestResources>true</includeTestResources>
                         <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                        <resourceIncludes>**/*.xml,**/*.properties</resourceIncludes>
+                        <resourceIncludes>${project.basedir}/**/*.xml,${project.basedir}/**/*.properties</resourceIncludes>
                         <!-- generated respectively copied code -->
                         <excludes>
                             **/Generated.java,**/TypeHelper*.java,**/MatchSuppressor.java,**/CommentSuppressor.java,**/NeverSuppress.java,

--- a/pom.xml
+++ b/pom.xml
@@ -496,6 +496,20 @@
 
     <build>
         <defaultGoal>install</defaultGoal>
+        <resources>
+            <resource>
+                <!-- The default resource dir: -->
+                <directory>${project.basedir}/src/main/resources</directory>
+            </resource>
+            <resource>
+                <!-- Extra dir to include the license file: -->
+                <directory>${rootProject.directory}</directory>
+                <includes>
+                    <include>LICENSE.txt</include>
+                </includes>
+                <targetPath>META-INF</targetPath>
+            </resource>
+        </resources>
         <pluginManagement>
             <plugins>
                 <!--


### PR DESCRIPTION
(cherry picked from commit 34f7ff9b42f406b7cc96f48b917b9b9c2333a3ed)

https://hibernate.atlassian.net/browse/HSEARCH-5473

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
