### PR TITLE
[8.1] HSEARCH-5481 Use different search API in DependencyManagementIncludesAllGroupIdArtifactsRule

### DIFF
--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -35,6 +35,7 @@
         <version.bom.jakarta.transaction>2.0.1</version.bom.jakarta.transaction>
         <version.bom.jakarta.xml.bind>4.0.2</version.bom.jakarta.xml.bind>
         <version.bom.org.jberet>3.1.0.Final</version.bom.org.jberet>
+        <version.bom.com.fasterxml.jackson>2.19.2</version.bom.com.fasterxml.jackson>
     </properties>
 
     <dependencyManagement>
@@ -241,6 +242,14 @@
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
                 <version>${version.bom.software.amazon.awssdk}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${version.bom.com.fasterxml.jackson}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5481

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
