### PR TITLE
Enable adding label/prefix to PRs opened for non-main branch

### DIFF
--- a/.github/hibernate-github-bot.yml
+++ b/.github/hibernate-github-bot.yml
@@ -69,3 +69,11 @@ licenseAgreement:
     # See the `build-dependencies` group in the Dependabot's configuration file
     - user: dependabot[bot]
       titlePattern: "Bump.*"
+branches:
+  enabled: true
+  titlePrefix: "[%s]"
+  label: "%s"
+  ignore:
+    # We ignore all dependabot PRs for a license check:
+    - user: dependabot[bot]
+      titlePattern: "Bump.*"


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HSEARCH.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HSEARCH-<digits>`).
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
