### PR TITLE
Fix build cache relocatability for checkstyle:check

### DIFF
--- a/.mvn/develocity-custom-user-data.groovy
+++ b/.mvn/develocity-custom-user-data.groovy
@@ -1,0 +1,9 @@
+buildCache.registerMojoMetadataProvider(context -> {
+    context.withPlugin("maven-checkstyle-plugin", () -> {
+        context.inputs(inputs -> {
+            inputs.fileSet("testSourceDirectories", fileSet ->
+                fileSet.excludes("**/target/**")
+            )
+        })
+    })
+})

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -1288,6 +1288,7 @@
                         <excludes>
                             **/Generated.java,**/TypeHelper*.java,**/MatchSuppressor.java,**/CommentSuppressor.java,**/NeverSuppress.java,
                             **/*_$logger.java,**/*_$bundle.java,
+                            **/*__.java,
                             **/module-info.java,
                             **/avro/generated/**/*.java
                         </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -511,14 +511,6 @@
                 <!-- The default resource dir: -->
                 <directory>${project.basedir}/src/main/resources</directory>
             </resource>
-            <resource>
-                <!-- Extra dir to include the license file: -->
-                <directory>${rootProject.directory}</directory>
-                <includes>
-                    <include>LICENSE.txt</include>
-                </includes>
-                <targetPath>META-INF</targetPath>
-            </resource>
         </resources>
         <pluginManagement>
             <plugins>
@@ -1154,6 +1146,37 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!--
+                            Copy LICENSE.txt to META-INF in the build output directory.
+                            Previously done via a project-level <resource> pointing at ${rootProject.directory},
+                            but that caused the entire workspace root to be fingerprinted as a build cache input
+                            for all goals consuming project resources (e.g. checkstyle:check), breaking
+                            build cache relocatability.
+                        -->
+                        <id>copy-license</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.outputDirectory}/META-INF</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${rootProject.directory}</directory>
+                                    <includes>
+                                        <include>LICENSE.txt</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
## Summary

`checkstyle:check` has 83 cache misses across all modules because the project-level `<resource>` in the root `pom.xml` points at `${rootProject.directory}` (to include `LICENSE.txt` in `META-INF`). This causes the Develocity Maven extension to fingerprint the entire workspace root directory tree as a build cache input for all goals consuming project resources. After a first build, `target/` directories appear under the root, changing the fingerprint and invalidating the cache for `checkstyle:check` in every module.

**Fix:** replace the resource declaration with a dedicated `maven-resources-plugin:copy-resources` execution.

**Evidence:**
- [Build cache experiment (CI run)](https://github.com/gradle/develocity-oss-projects/actions/runs/23278945495)
- [Build scan comparison — 83 cacheable goals with differences](https://ge.solutions-team.gradle.com/c/gxp5vhb5ek3v4/5xuoompq3okou/goal-inputs?cacheability=cacheable)
- [Executed cacheable goals in second build](https://ge.solutions-team.gradle.com/s/veym7v657oq7c/timeline?cacheability=cacheable&outcome=success,failed&sort=longest)

JIRA: https://hibernate.atlassian.net/browse/HSEARCH-5595

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------