### PR TITLE
HSEARCH-5611   Update Apache HTTP Client components to 5.6.1 /  HSEARCH-5612   Upgrade to commons-codec 1.22.0 / HSEARCH-5613   Use Maven 3.9.15 as a required minimum version for the build

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -7,7 +7,7 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>common-custom-user-data-maven-extension</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
     </extension>
     <extension>
         <groupId>org.hibernate.infra.develocity</groupId>

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,4 +1,4 @@
 wrapperVersion=3.3.4
 distributionType=bin
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -38,7 +38,7 @@
         <version.bom.jakarta.xml.bind>4.0.4</version.bom.jakarta.xml.bind>
         <version.bom.org.jberet>3.1.0.Final</version.bom.org.jberet>
         <version.bom.com.fasterxml.jackson>2.21.2</version.bom.com.fasterxml.jackson>
-        <version.bom.org.apache.httpcomponents.client5>5.6</version.bom.org.apache.httpcomponents.client5>
+        <version.bom.org.apache.httpcomponents.client5>5.6.1</version.bom.org.apache.httpcomponents.client5>
         <version.bom.org.apache.httpcomponents.core5>5.4.2</version.bom.org.apache.httpcomponents.core5>
         <version.bom.org.apache.httpcomponents.httpclient>4.5.14</version.bom.org.apache.httpcomponents.httpclient>
         <version.bom.org.apache.httpcomponents.httpcore>4.4.16</version.bom.org.apache.httpcomponents.httpcore>

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -139,7 +139,7 @@
         <version.junit-jupiter>6.0.3</version.junit-jupiter>
         <version.org.osgi.core>6.0.0</version.org.osgi.core>
         <!-- Make sure to update Ryuk container version in `ryuk.Dockerfile` whenever updating testcontainers to align it with the lib. -->
-        <version.testcontainers>2.0.4</version.testcontainers>
+        <version.testcontainers>2.0.5</version.testcontainers>
 
         <version.org.hamcrest>3.0</version.org.hamcrest>
         <version.org.mockito>5.23.0</version.org.mockito>
@@ -165,7 +165,7 @@
         <version.com.h2database>2.4.240</version.com.h2database>
         <version.org.postgresql>42.7.10</version.org.postgresql>
         <version.org.mariadb.jdbc>3.5.8</version.org.mariadb.jdbc>
-        <version.mysql.mysql-connector-j>9.6.0</version.mysql.mysql-connector-j>
+        <version.mysql.mysql-connector-j>9.7.0</version.mysql.mysql-connector-j>
         <version.com.ibm.db2.jcc>12.1.4.0</version.com.ibm.db2.jcc>
         <version.com.oracle.database.jdbc>23.26.1.0.0</version.com.oracle.database.jdbc>
         <version.com.microsoft.sqlserver.mssql-jdbc>13.4.0.jre11</version.com.microsoft.sqlserver.mssql-jdbc>
@@ -188,7 +188,7 @@
         <version.dev.snowdrop>4.0.0</version.dev.snowdrop>
         <version.io.agroal>3.0.1</version.io.agroal>
 
-        <version.jsoup>1.22.1</version.jsoup>
+        <version.jsoup>1.22.2</version.jsoup>
         <version.snakeyaml>2.6</version.snakeyaml>
 
         <!-- Whether javadoc warnings should fail the build -->

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -149,7 +149,7 @@
         <version.io.takari.junit>1.2.7</version.io.takari.junit>
         <version.org.wiremock.wiremock>3.13.2</version.org.wiremock.wiremock>
         <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
-        <version.commons-codec>1.21.0</version.commons-codec>
+        <version.commons-codec>1.22.0</version.commons-codec>
         <version.commons-logging>1.3.6</version.commons-logging>
         <!--
             When upgrading Avro:

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -53,7 +53,7 @@
         <version.org.elasticsearch.java.client>9.3.4</version.org.elasticsearch.java.client>
         <version.org.opensearch.client>3.6.0</version.org.opensearch.client>
         <!-- Various HTTP client versions that our own Elasticsearch client implementations depend on -->
-        <version.org.apache.httpcomponents.client5>5.6</version.org.apache.httpcomponents.client5>
+        <version.org.apache.httpcomponents.client5>5.6.1</version.org.apache.httpcomponents.client5>
         <version.org.apache.httpcomponents.core5>5.4.2</version.org.apache.httpcomponents.core5>
         <version.org.apache.httpcomponents.httpclient>4.5.14</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.16</version.org.apache.httpcomponents.httpcore>

--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
         <version.install.plugin>3.1.4</version.install.plugin>
         <version.enforcer.plugin>3.6.2</version.enforcer.plugin>
         <version.project-info.plugin>3.9.0</version.project-info.plugin>
-        <version.japicmp.plugin>0.25.5</version.japicmp.plugin>
+        <version.japicmp.plugin>0.25.6</version.japicmp.plugin>
         <version.deploy.plugin>3.1.4</version.deploy.plugin>
         <version.flatten-maven-plugin>1.7.3</version.flatten-maven-plugin>
         <version.assembly.plugin>3.8.0</version.assembly.plugin>
@@ -311,7 +311,7 @@
             e.g. 4.0.13 won't work with JDK 23, while 4.0.26 is working just fine.
          -->
         <version.org.apache.groovy.groovy-jsr223>5.0.5</version.org.apache.groovy.groovy-jsr223>
-        <version.com.puppycrawl.tools.checkstyle>13.4.0</version.com.puppycrawl.tools.checkstyle>
+        <version.com.puppycrawl.tools.checkstyle>13.4.1</version.com.puppycrawl.tools.checkstyle>
         <version.versions.plugin>2.21.0</version.versions.plugin>
         <version.maven-wrapper-plugin>3.3.4</version.maven-wrapper-plugin>
         <version.org.eclipse.m2e.lifecycle-mapping>1.0.0</version.org.eclipse.m2e.lifecycle-mapping>

--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
              WARNING: Do not forget to call 'mvn wrapper:wrapper'
              when you update this property!
          -->
-        <maven.min.version>3.9.14</maven.min.version>
+        <maven.min.version>3.9.15</maven.min.version>
 
         <!-- Set this through a property so that it can be overridden from the commandline -->
         <maven.compiler.failOnWarning>true</maven.compiler.failOnWarning>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5611
https://hibernate.atlassian.net/browse/HSEARCH-5612
https://hibernate.atlassian.net/browse/HSEARCH-5613

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
