### PR TITLE
[8.3] HSEARCH-5611 Update Apache HTTP Client components to 5.6.1 / HSEARCH-5612 Upgrade to commons-codec 1.22.0 / HSEARCH-5613 Use Maven 3.9.15 as a required minimum version for the build /  HSEARCH-5615   Update to Hibernate ORM 7.3.3.Final

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,4 +1,4 @@
 wrapperVersion=3.3.4
 distributionType=bin
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -38,7 +38,7 @@
         <version.bom.jakarta.xml.bind>4.0.4</version.bom.jakarta.xml.bind>
         <version.bom.org.jberet>3.1.0.Final</version.bom.org.jberet>
         <version.bom.com.fasterxml.jackson>2.21.2</version.bom.com.fasterxml.jackson>
-        <version.bom.org.apache.httpcomponents.client5>5.6</version.bom.org.apache.httpcomponents.client5>
+        <version.bom.org.apache.httpcomponents.client5>5.6.1</version.bom.org.apache.httpcomponents.client5>
         <version.bom.org.apache.httpcomponents.core5>5.4.2</version.bom.org.apache.httpcomponents.core5>
         <version.bom.org.apache.httpcomponents.httpclient>4.5.14</version.bom.org.apache.httpcomponents.httpclient>
         <version.bom.org.apache.httpcomponents.httpcore>4.4.16</version.bom.org.apache.httpcomponents.httpcore>

--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -18,7 +18,7 @@
         <deploy.skip>true</deploy.skip>
 
         <!-- These versions will be checked against the ones resolved by Maven for the project in the enforcer rule -->
-        <version.bom.org.hibernate.orm>7.3.0.Final</version.bom.org.hibernate.orm>
+        <version.bom.org.hibernate.orm>7.3.3.Final</version.bom.org.hibernate.orm>
         <version.bom.org.elasticsearch.client>9.3.2</version.bom.org.elasticsearch.client>
         <version.bom.org.elasticsearch.java.client>9.3.3</version.bom.org.elasticsearch.java.client>
         <version.bom.org.opensearch.client>3.5.0</version.bom.org.opensearch.client>
@@ -26,7 +26,7 @@
         <version.bom.io.smallrye>3.3.2</version.bom.io.smallrye>
         <version.bom.org.jboss.logging.processor>3.0.4.Final</version.bom.org.jboss.logging.processor>
         <version.bom.org.jboss.logging>3.6.3.Final</version.bom.org.jboss.logging>
-        <version.bom.org.hibernate.models>1.1.0</version.bom.org.hibernate.models>
+        <version.bom.org.hibernate.models>1.1.1</version.bom.org.hibernate.models>
         <version.bom.org.apache.avro>1.12.1</version.bom.org.apache.avro>
         <version.bom.com.carrotsearch>0.10.0</version.bom.com.carrotsearch>
         <version.bom.com.google.code.gson>2.13.2</version.bom.com.google.code.gson>

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -149,7 +149,7 @@
         <version.io.takari.junit>1.2.7</version.io.takari.junit>
         <version.org.wiremock.wiremock>3.13.2</version.org.wiremock.wiremock>
         <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
-        <version.commons-codec>1.21.0</version.commons-codec>
+        <version.commons-codec>1.22.0</version.commons-codec>
         <version.commons-logging>1.3.6</version.commons-logging>
         <!--
             When upgrading Avro:

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -102,7 +102,7 @@
             NOTE: when Hibernate ORM updates Byte Buddy, make sure to check Jenkinsfile to see if
             `net.bytebuddy.experimental` property can be removed.
          -->
-        <version.org.hibernate.orm>7.3.0.Final</version.org.hibernate.orm>
+        <version.org.hibernate.orm>7.3.3.Final</version.org.hibernate.orm>
 
         <javadoc.org.hibernate.orm.url>https://docs.hibernate.org/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/javadocs/</javadoc.org.hibernate.orm.url>
         <documentation.org.hibernate.orm.url>https://docs.hibernate.org/orm/${parsed-version.org.hibernate.orm.majorVersion}.${parsed-version.org.hibernate.orm.minorVersion}/userguide/html_single/Hibernate_User_Guide.html</documentation.org.hibernate.orm.url>

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -53,7 +53,7 @@
         <version.org.elasticsearch.java.client>9.3.3</version.org.elasticsearch.java.client>
         <version.org.opensearch.client>3.5.0</version.org.opensearch.client>
         <!-- Various HTTP client versions that our own Elasticsearch client implementations depend on -->
-        <version.org.apache.httpcomponents.client5>5.6</version.org.apache.httpcomponents.client5>
+        <version.org.apache.httpcomponents.client5>5.6.1</version.org.apache.httpcomponents.client5>
         <version.org.apache.httpcomponents.core5>5.4.2</version.org.apache.httpcomponents.core5>
         <version.org.apache.httpcomponents.httpclient>4.5.14</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.16</version.org.apache.httpcomponents.httpcore>

--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
              WARNING: Do not forget to call 'mvn wrapper:wrapper'
              when you update this property!
          -->
-        <maven.min.version>3.9.14</maven.min.version>
+        <maven.min.version>3.9.15</maven.min.version>
 
         <!-- Set this through a property so that it can be overridden from the commandline -->
         <maven.compiler.failOnWarning>true</maven.compiler.failOnWarning>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5611
https://hibernate.atlassian.net/browse/HSEARCH-5612
https://hibernate.atlassian.net/browse/HSEARCH-5613
https://hibernate.atlassian.net/browse/HSEARCH-5615

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
