### PR TITLE
[8.3] HSEARCH-5616 Update Elasticsearch client (elasticsearch-rest-client) to 9.3.4 / HSEARCH-5618 Update Jackson to 2.21.3 

### DIFF
--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -19,8 +19,8 @@
 
         <!-- These versions will be checked against the ones resolved by Maven for the project in the enforcer rule -->
         <version.bom.org.hibernate.orm>7.3.3.Final</version.bom.org.hibernate.orm>
-        <version.bom.org.elasticsearch.client>9.3.2</version.bom.org.elasticsearch.client>
-        <version.bom.org.elasticsearch.java.client>9.3.3</version.bom.org.elasticsearch.java.client>
+        <version.bom.org.elasticsearch.client>9.3.4</version.bom.org.elasticsearch.client>
+        <version.bom.org.elasticsearch.java.client>9.3.4</version.bom.org.elasticsearch.java.client>
         <version.bom.org.opensearch.client>3.5.0</version.bom.org.opensearch.client>
         <version.bom.software.amazon.awssdk>2.42.14</version.bom.software.amazon.awssdk>
         <version.bom.io.smallrye>3.3.2</version.bom.io.smallrye>

--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -37,7 +37,7 @@
         <version.bom.jakarta.transaction>2.0.1</version.bom.jakarta.transaction>
         <version.bom.jakarta.xml.bind>4.0.4</version.bom.jakarta.xml.bind>
         <version.bom.org.jberet>3.1.0.Final</version.bom.org.jberet>
-        <version.bom.com.fasterxml.jackson>2.21.2</version.bom.com.fasterxml.jackson>
+        <version.bom.com.fasterxml.jackson>2.21.3</version.bom.com.fasterxml.jackson>
         <version.bom.org.apache.httpcomponents.client5>5.6.1</version.bom.org.apache.httpcomponents.client5>
         <version.bom.org.apache.httpcomponents.core5>5.4.2</version.bom.org.apache.httpcomponents.core5>
         <version.bom.org.apache.httpcomponents.httpclient>4.5.14</version.bom.org.apache.httpcomponents.httpclient>

--- a/build/container/search-backend/elastic.Dockerfile
+++ b/build/container/search-backend/elastic.Dockerfile
@@ -5,4 +5,4 @@
 #  * update `version.org.elasticsearch.latest` property in a POM file.
 #  * update the tags for 'elasticsearch-current' and 'elasticsearch-next' builds in ci/dependency-update/Jenkinsfile
 #
-FROM docker.io/elastic/elasticsearch:9.3.2@sha256:d2f73c2f05476fe0a528b429656f3de22f3f50db62d3d79ea2c87995f7f4c938
+FROM docker.io/elastic/elasticsearch:9.3.4@sha256:5111553c2a04b2a1782c7881248c6b6cceabbcf34758e778ee387f5843745e58

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -92,7 +92,7 @@
         <version.com.google.code.gson>2.13.2</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.42.14</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, by Avro, by the AWS SDK and in tests (wiremock, ...) -->
-        <version.com.fasterxml.jackson>2.21.2</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.21.3</version.com.fasterxml.jackson>
         <!-- slf4j: used by the AWS SDK -->
         <version.org.slf4j>1.7.36</version.org.slf4j>
 

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -49,8 +49,8 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.5+ -->
-        <version.org.elasticsearch.client>9.3.2</version.org.elasticsearch.client>
-        <version.org.elasticsearch.java.client>9.3.3</version.org.elasticsearch.java.client>
+        <version.org.elasticsearch.client>9.3.4</version.org.elasticsearch.client>
+        <version.org.elasticsearch.java.client>9.3.4</version.org.elasticsearch.java.client>
         <version.org.opensearch.client>3.5.0</version.org.opensearch.client>
         <!-- Various HTTP client versions that our own Elasticsearch client implementations depend on -->
         <version.org.apache.httpcomponents.client5>5.6.1</version.org.apache.httpcomponents.client5>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5616
https://hibernate.atlassian.net/browse/HSEARCH-5618

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
