### PR TITLE
HSEARCH-5624 Update Elasticsearch client (elasticsearch-rest5-client) to 9.4.1

### DIFF
--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -20,7 +20,7 @@
         <!-- These versions will be checked against the ones resolved by Maven for the project in the enforcer rule -->
         <version.bom.org.hibernate.orm>7.4.0.CR1</version.bom.org.hibernate.orm>
         <version.bom.org.elasticsearch.client>9.4.1</version.bom.org.elasticsearch.client>
-        <version.bom.org.elasticsearch.java.client>9.4.0</version.bom.org.elasticsearch.java.client>
+        <version.bom.org.elasticsearch.java.client>9.4.1</version.bom.org.elasticsearch.java.client>
         <version.bom.org.opensearch.client>3.6.0</version.bom.org.opensearch.client>
         <version.bom.software.amazon.awssdk>2.44.1</version.bom.software.amazon.awssdk>
         <version.bom.io.smallrye>3.3.2</version.bom.io.smallrye>

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -50,7 +50,7 @@
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.5+ -->
         <version.org.elasticsearch.client>9.4.1</version.org.elasticsearch.client>
-        <version.org.elasticsearch.java.client>9.4.0</version.org.elasticsearch.java.client>
+        <version.org.elasticsearch.java.client>9.4.1</version.org.elasticsearch.java.client>
         <version.org.opensearch.client>3.6.0</version.org.opensearch.client>
         <!-- Various HTTP client versions that our own Elasticsearch client implementations depend on -->
         <version.org.apache.httpcomponents.client5>5.6.1</version.org.apache.httpcomponents.client5>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5624

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
