### PR TITLE
HSEARCH-5632 Do not fully boot the standalone mapper in the annotation processor

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationPartialBuildStateImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationPartialBuildStateImpl.java
@@ -115,6 +115,12 @@ class SearchIntegrationPartialBuildStateImpl implements SearchIntegrationPartial
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
+	public <PBM extends MappingPartialBuildState> PBM mappingPartialBuildState(MappingKey<PBM, ?> mappingKey) {
+		return (PBM) partiallyBuiltMappings.get( mappingKey );
+	}
+
+	@Override
 	public SearchIntegrationFinalizer finalizer(ConfigurationPropertySource propertySource,
 			ConfigurationPropertyChecker configurationPropertyChecker) {
 		return new SearchIntegrationFinalizerImpl(

--- a/engine/src/main/java/org/hibernate/search/engine/common/spi/SearchIntegrationPartialBuildState.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/spi/SearchIntegrationPartialBuildState.java
@@ -7,6 +7,9 @@ package org.hibernate.search.engine.common.spi;
 import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertyChecker;
 import org.hibernate.search.engine.environment.bean.BeanResolver;
+import org.hibernate.search.engine.mapper.mapping.building.spi.MappingKey;
+import org.hibernate.search.engine.mapper.mapping.building.spi.MappingPartialBuildState;
+import org.hibernate.search.util.common.annotation.Incubating;
 
 public interface SearchIntegrationPartialBuildState {
 
@@ -32,5 +35,13 @@ public interface SearchIntegrationPartialBuildState {
 	 */
 	SearchIntegrationFinalizer finalizer(ConfigurationPropertySource propertySource,
 			ConfigurationPropertyChecker propertyChecker);
+
+	/**
+	 * @param mappingKey The mapping key to look up.
+	 * @return The partial build state for the given mapping key.
+	 * @param <PBM> The type of the partial build state.
+	 */
+	@Incubating
+	<PBM extends MappingPartialBuildState> PBM mappingPartialBuildState(MappingKey<PBM, ?> mappingKey);
 
 }

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/bootstrap/impl/StandalonePojoIntegrationBooterImpl.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/bootstrap/impl/StandalonePojoIntegrationBooterImpl.java
@@ -26,6 +26,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.AnnotatedT
 import org.hibernate.search.mapper.pojo.model.spi.PojoBootstrapIntrospector;
 import org.hibernate.search.mapper.pojo.standalone.bootstrap.spi.StandalonePojoIntegrationBooter;
 import org.hibernate.search.mapper.pojo.standalone.bootstrap.spi.StandalonePojoIntegrationBooterBehavior;
+import org.hibernate.search.mapper.pojo.standalone.bootstrap.spi.StandalonePojoPartialMapping;
 import org.hibernate.search.mapper.pojo.standalone.cfg.spi.StandalonePojoMapperSpiSettings;
 import org.hibernate.search.mapper.pojo.standalone.logging.impl.ConfigurationLog;
 import org.hibernate.search.mapper.pojo.standalone.mapping.impl.StandalonePojoMapping;
@@ -126,6 +127,11 @@ public class StandalonePojoIntegrationBooterImpl implements StandalonePojoIntegr
 				SearchIntegrationEnvironment.builder( propertySource, propertyChecker );
 		BEAN_PROVIDER.get( propertySource ).ifPresent( environmentBuilder::beanProvider );
 		return environmentBuilder.build();
+	}
+
+	@Override
+	public StandalonePojoPartialMapping bootPartial() {
+		return doBootFirstPhase().mappingPartialBuildState();
 	}
 
 	@Override

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/bootstrap/impl/StandalonePojoIntegrationPartialBuildState.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/bootstrap/impl/StandalonePojoIntegrationPartialBuildState.java
@@ -17,6 +17,7 @@ import org.hibernate.search.engine.environment.bean.BeanResolver;
 import org.hibernate.search.mapper.pojo.standalone.cfg.spi.StandalonePojoMapperSpiSettings;
 import org.hibernate.search.mapper.pojo.standalone.mapping.impl.StandalonePojoMapping;
 import org.hibernate.search.mapper.pojo.standalone.mapping.impl.StandalonePojoMappingKey;
+import org.hibernate.search.mapper.pojo.standalone.mapping.impl.StandalonePojoMappingPartialBuildState;
 import org.hibernate.search.util.common.AssertionFailure;
 
 final class StandalonePojoIntegrationPartialBuildState {
@@ -56,6 +57,10 @@ final class StandalonePojoIntegrationPartialBuildState {
 		propertyCollector.accept( StandalonePojoMapperSpiSettings.INTEGRATION_PARTIAL_BUILD_STATE, this );
 	}
 
+	StandalonePojoMappingPartialBuildState mappingPartialBuildState() {
+		return integrationBuildState.mappingPartialBuildState( mappingKey );
+	}
+
 	BeanResolver beanResolver() {
 		return integrationBuildState.beanResolver();
 	}
@@ -64,7 +69,7 @@ final class StandalonePojoIntegrationPartialBuildState {
 			ConfigurationPropertyChecker propertyChecker) {
 		SearchIntegrationFinalizer finalizer = integrationBuildState.finalizer( propertySource, propertyChecker );
 
-		@SuppressWarnings("resource") // For the eclipse-compiler: complains on mapping not bing closed
+		@SuppressWarnings("resource") // For the eclipse-compiler: complains on mapping not being closed
 		StandalonePojoMapping mapping = finalizer.finalizeMapping(
 				mappingKey,
 				(context, partialMapping) -> partialMapping.finalizeMapping( context )

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/bootstrap/spi/StandalonePojoIntegrationBooter.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/bootstrap/spi/StandalonePojoIntegrationBooter.java
@@ -41,4 +41,17 @@ public interface StandalonePojoIntegrationBooter {
 
 	CloseableSearchMapping boot();
 
+	/**
+	 * Runs only Phase 1 of bootstrap (mapping and index model creation),
+	 * skipping Phase 2 (backend and index manager startup).
+	 * <p>
+	 * The returned partial mapping provides access to indexed entity metadata
+	 * (including index field descriptors).
+	 *
+	 * @return A partial mapping that must be {@link StandalonePojoPartialMapping#close() closed}
+	 * to release Phase 1 resources.
+	 */
+	@Incubating
+	StandalonePojoPartialMapping bootPartial();
+
 }

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/bootstrap/spi/StandalonePojoPartialMapping.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/bootstrap/spi/StandalonePojoPartialMapping.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.search.mapper.pojo.standalone.bootstrap.spi;
+
+import java.util.Collection;
+
+import org.hibernate.search.mapper.pojo.standalone.entity.SearchIndexedEntity;
+import org.hibernate.search.util.common.annotation.Incubating;
+
+/**
+ * A partial mapping obtained after completing only Phase 1 of bootstrap.
+ * <p>
+ * Provides access to indexed entity metadata (including index field descriptors)
+ * without starting backends or index managers.
+ * <p>
+ * Must be {@link #close() closed} to release Phase 1 resources.
+ */
+@Incubating
+public interface StandalonePojoPartialMapping extends AutoCloseable {
+
+	Collection<SearchIndexedEntity<?>> allIndexedEntities();
+
+	@Override
+	void close();
+}

--- a/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoMappingPartialBuildState.java
+++ b/mapper/pojo-standalone/src/main/java/org/hibernate/search/mapper/pojo/standalone/mapping/impl/StandalonePojoMappingPartialBuildState.java
@@ -4,16 +4,21 @@
  */
 package org.hibernate.search.mapper.pojo.standalone.mapping.impl;
 
+import java.util.Collection;
+import java.util.Collections;
+
 import org.hibernate.search.engine.cfg.spi.ConfigurationProperty;
 import org.hibernate.search.engine.mapper.mapping.building.spi.MappingFinalizationContext;
 import org.hibernate.search.engine.mapper.mapping.building.spi.MappingPartialBuildState;
 import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingDelegate;
 import org.hibernate.search.mapper.pojo.massindexing.MassIndexingDefaultCleanOperation;
+import org.hibernate.search.mapper.pojo.standalone.bootstrap.spi.StandalonePojoPartialMapping;
 import org.hibernate.search.mapper.pojo.standalone.cfg.StandalonePojoMapperSettings;
+import org.hibernate.search.mapper.pojo.standalone.entity.SearchIndexedEntity;
 import org.hibernate.search.mapper.pojo.standalone.schema.management.SchemaManagementStrategyName;
 import org.hibernate.search.mapper.pojo.standalone.schema.management.impl.SchemaManagementListener;
 
-public class StandalonePojoMappingPartialBuildState implements MappingPartialBuildState {
+public class StandalonePojoMappingPartialBuildState implements MappingPartialBuildState, StandalonePojoPartialMapping {
 
 	private static final ConfigurationProperty<SchemaManagementStrategyName> SCHEMA_MANAGEMENT_STRATEGY =
 			ConfigurationProperty.forKey( StandalonePojoMapperSettings.Radicals.SCHEMA_MANAGEMENT_STRATEGY )
@@ -36,11 +41,6 @@ public class StandalonePojoMappingPartialBuildState implements MappingPartialBui
 		this.typeContextContainer = typeContextContainer;
 	}
 
-	@Override
-	public void closeOnFailure() {
-		mappingDelegate.close();
-	}
-
 	public StandalonePojoMapping finalizeMapping(MappingFinalizationContext context) {
 		SchemaManagementStrategyName schemaManagementStrategyName = SCHEMA_MANAGEMENT_STRATEGY.get(
 				context.configurationPropertySource() );
@@ -49,4 +49,18 @@ public class StandalonePojoMappingPartialBuildState implements MappingPartialBui
 				INDEXING_MASS_DEFAULT_CLEAN_OPERATION.get( context.configurationPropertySource() ) );
 	}
 
+	@Override
+	public Collection<SearchIndexedEntity<?>> allIndexedEntities() {
+		return Collections.unmodifiableCollection( typeContextContainer.allIndexed() );
+	}
+
+	@Override
+	public void closeOnFailure() {
+		mappingDelegate.close();
+	}
+
+	@Override
+	public void close() {
+		closeOnFailure();
+	}
 }

--- a/metamodel/metamodel-processor/src/main/java/org/hibernate/search/processor/impl/IndexedEntityMetamodelAnnotationProcessor.java
+++ b/metamodel/metamodel-processor/src/main/java/org/hibernate/search/processor/impl/IndexedEntityMetamodelAnnotationProcessor.java
@@ -34,9 +34,9 @@ import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.Property
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
 import org.hibernate.search.mapper.pojo.model.spi.PojoBootstrapIntrospector;
 import org.hibernate.search.mapper.pojo.standalone.bootstrap.spi.StandalonePojoIntegrationBooter;
+import org.hibernate.search.mapper.pojo.standalone.bootstrap.spi.StandalonePojoPartialMapping;
 import org.hibernate.search.mapper.pojo.standalone.cfg.StandalonePojoMapperSettings;
 import org.hibernate.search.mapper.pojo.standalone.entity.SearchIndexedEntity;
-import org.hibernate.search.mapper.pojo.standalone.mapping.CloseableSearchMapping;
 import org.hibernate.search.mapper.pojo.standalone.mapping.StandalonePojoMappingConfigurer;
 import org.hibernate.search.processor.annotation.processing.impl.ProcessorAnnotationProcessorContext;
 import org.hibernate.search.processor.annotation.processing.impl.ProcessorPropertyMappingAnnotationProcessor;
@@ -64,7 +64,7 @@ public class IndexedEntityMetamodelAnnotationProcessor implements MetamodelAnnot
 		TypeElement indexedAnnotation = context.elementUtils().getTypeElement( ANNOTATION_INDEXED );
 		Set<? extends Element> indexedEntities = roundEnv.getElementsAnnotatedWith( indexedAnnotation );
 
-		try ( CloseableSearchMapping searchMapping = StandalonePojoIntegrationBooter.builder()
+		try ( StandalonePojoPartialMapping partialMapping = StandalonePojoIntegrationBooter.builder()
 				.introspectorCustomizer( this::wrapIntrospector )
 				.property( "hibernate.search.backend.directory.type", "local-heap" )
 				.property( "hibernate.search.backend.version_check.enabled", "false" )
@@ -121,11 +121,11 @@ public class IndexedEntityMetamodelAnnotationProcessor implements MetamodelAnnot
 								}
 							}
 						} )
-				).build().boot() ) {
+				).build().bootPartial() ) {
 
 			boolean ormMapperPresent = context.isOrmMapperPresent();
 
-			for ( SearchIndexedEntity<?> entity : searchMapping.allIndexedEntities() ) {
+			for ( SearchIndexedEntity<?> entity : partialMapping.allIndexedEntities() ) {
 				TypeElement typeElement = introspectorContext.typeElementsByName( entity.name() );
 				String packageName = context.elementUtils().getPackageOf( typeElement ).getQualifiedName().toString();
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5632

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
