### PR TITLE
HSEARCH-5631 Test against latest Elasticsearch 9.4.2 / HSEARCH-5633 Update Elasticsearch client (elasticsearch-rest-client) to 9.4.2 / HSEARCH-5634 Update Elasticsearch client (elasticsearch-rest5-client) to 9.4.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -262,7 +262,7 @@ stage('Configure') {
                     new LocalElasticsearchBuildEnvironment(version: '9.1.5', condition: TestCondition.ON_DEMAND),
                     new LocalElasticsearchBuildEnvironment(version: '9.2.6', condition: TestCondition.ON_DEMAND),
                     new LocalElasticsearchBuildEnvironment(version: '9.3.3', condition: TestCondition.ON_DEMAND),
-					new LocalElasticsearchBuildEnvironment(version: '9.4.1', condition: TestCondition.BEFORE_MERGE, isDefault: true),
+					new LocalElasticsearchBuildEnvironment(version: '9.4.2', condition: TestCondition.BEFORE_MERGE, isDefault: true),
 					// IMPORTANT: Make sure to update the documentation for any newly supported Elasticsearch versions
 					//            See version.org.elasticsearch.compatible.expected.text
 					//            and version.org.elasticsearch.compatible.regularly-tested.text in POMs.

--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -19,7 +19,7 @@
 
         <!-- These versions will be checked against the ones resolved by Maven for the project in the enforcer rule -->
         <version.bom.org.hibernate.orm>7.4.0.Final</version.bom.org.hibernate.orm>
-        <version.bom.org.elasticsearch.client>9.4.1</version.bom.org.elasticsearch.client>
+        <version.bom.org.elasticsearch.client>9.4.2</version.bom.org.elasticsearch.client>
         <version.bom.org.elasticsearch.java.client>9.4.1</version.bom.org.elasticsearch.java.client>
         <version.bom.org.opensearch.client>3.6.0</version.bom.org.opensearch.client>
         <version.bom.software.amazon.awssdk>2.44.1</version.bom.software.amazon.awssdk>

--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -20,7 +20,7 @@
         <!-- These versions will be checked against the ones resolved by Maven for the project in the enforcer rule -->
         <version.bom.org.hibernate.orm>7.4.0.Final</version.bom.org.hibernate.orm>
         <version.bom.org.elasticsearch.client>9.4.2</version.bom.org.elasticsearch.client>
-        <version.bom.org.elasticsearch.java.client>9.4.1</version.bom.org.elasticsearch.java.client>
+        <version.bom.org.elasticsearch.java.client>9.4.2</version.bom.org.elasticsearch.java.client>
         <version.bom.org.opensearch.client>3.6.0</version.bom.org.opensearch.client>
         <version.bom.software.amazon.awssdk>2.44.1</version.bom.software.amazon.awssdk>
         <version.bom.io.smallrye>3.3.2</version.bom.io.smallrye>

--- a/build/container/search-backend/elastic.Dockerfile
+++ b/build/container/search-backend/elastic.Dockerfile
@@ -5,4 +5,4 @@
 #  * update `version.org.elasticsearch.latest` property in a POM file.
 #  * update the tags for 'elasticsearch-current' and 'elasticsearch-next' builds in ci/dependency-update/Jenkinsfile
 #
-FROM docker.io/elastic/elasticsearch:9.4.1@sha256:74c82c22b899cdd184598c96456d0f2d254c17ab204210fb470c1901e0b646f4
+FROM docker.io/elastic/elasticsearch:9.4.2@sha256:be5f49784ff5ec8a5b5d7ba17f944d9d6b10c067f596ee93e6b6cb82d2dd874c

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -50,7 +50,7 @@
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.5+ -->
         <version.org.elasticsearch.client>9.4.2</version.org.elasticsearch.client>
-        <version.org.elasticsearch.java.client>9.4.1</version.org.elasticsearch.java.client>
+        <version.org.elasticsearch.java.client>9.4.2</version.org.elasticsearch.java.client>
         <version.org.opensearch.client>3.6.0</version.org.opensearch.client>
         <!-- Various HTTP client versions that our own Elasticsearch client implementations depend on -->
         <version.org.apache.httpcomponents.client5>5.6.1</version.org.apache.httpcomponents.client5>

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -49,7 +49,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.5+ -->
-        <version.org.elasticsearch.client>9.4.1</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>9.4.2</version.org.elasticsearch.client>
         <version.org.elasticsearch.java.client>9.4.1</version.org.elasticsearch.java.client>
         <version.org.opensearch.client>3.6.0</version.org.opensearch.client>
         <!-- Various HTTP client versions that our own Elasticsearch client implementations depend on -->

--- a/ci/dependency-update/Jenkinsfile
+++ b/ci/dependency-update/Jenkinsfile
@@ -53,7 +53,7 @@ Map settings() {
 					updateProperties: [],
 					onlyRunTestDependingOn: ['hibernate-search-backend-elasticsearch'],
 					// We want to use the snapshot version of an image from the ES registry since that's where they are publishing their snapshots.
-					additionalMavenArgs: '-Dtest.lucene.skip=true -Dtest.elasticsearch.run.elastic.image.name=docker.elastic.co/elasticsearch/elasticsearch -Dtest.elasticsearch.run.elastic.image.tag=9.4.2-SNAPSHOT',
+					additionalMavenArgs: '-Dtest.lucene.skip=true -Dtest.elasticsearch.run.elastic.image.name=docker.elastic.co/elasticsearch/elasticsearch -Dtest.elasticsearch.run.elastic.image.tag=9.4.3-SNAPSHOT',
 					// This job won't change the versions in the pom. We are passing the latest Elasticsearch version through an additional maven argument `-D`
 					skipSourceModifiedCheck: true
 			]

--- a/pom.xml
+++ b/pom.xml
@@ -391,7 +391,7 @@
 
         <!-- Container images for various integration tests -->
         <!-- The latest version of Elasticsearch tested against by default -->
-        <version.org.elasticsearch.latest>9.4.1</version.org.elasticsearch.latest>
+        <version.org.elasticsearch.latest>9.4.2</version.org.elasticsearch.latest>
         <test.elasticsearch.version></test.elasticsearch.version>
         <test.elasticsearch.distribution>elastic</test.elasticsearch.distribution>
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5634
https://hibernate.atlassian.net/browse/HSEARCH-5633
https://hibernate.atlassian.net/browse/HSEARCH-5631

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
