### PR TITLE
Include response body in the exception message when failing to parse a response (enforcer rule)

### DIFF
--- a/build/enforcer/src/main/java/org/hibernate/search/build/enforcer/DependencyManagementIncludesAllGroupIdArtifactsRule.java
+++ b/build/enforcer/src/main/java/org/hibernate/search/build/enforcer/DependencyManagementIncludesAllGroupIdArtifactsRule.java
@@ -38,6 +38,7 @@ import javax.inject.Named;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import com.google.gson.JsonSyntaxException;
 import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.execution.MavenSession;
@@ -303,8 +304,12 @@ public class DependencyManagementIncludesAllGroupIdArtifactsRule extends Abstrac
 					getLog().info( "Fetching from " + url );
 					HttpResponse<String> response = client.send( request, HttpResponse.BodyHandlers.ofString() );
 
-					return gson.fromJson( response.body(), klass );
-				}, empty
+                    try {
+                        return gson.fromJson( response.body(), klass );
+                    } catch (JsonSyntaxException e) {
+						throw new RuntimeException( "Received response: " + response.body(), e );
+                    }
+                }, empty
 		);
 	}
 
@@ -321,7 +326,11 @@ public class DependencyManagementIncludesAllGroupIdArtifactsRule extends Abstrac
 
 					HttpResponse<String> response = client.send( request, HttpResponse.BodyHandlers.ofString() );
 
-					return gson.fromJson( response.body(), klass );
+					try {
+						return gson.fromJson( response.body(), klass );
+					} catch (JsonSyntaxException e) {
+						throw new RuntimeException( "Received response: " + response.body(), e );
+					}
 				}, empty
 		);
 	}


### PR DESCRIPTION
…

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HSEARCH.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HSEARCH-<digits>`).
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
