### PR TITLE
HSEARCH-5650 Update to commons-logging to 1.4.0 / HSEARCH-5651 Update documentation theme to the current latest 6.1.3.Final / HSEARCH-5652 Update to Jackson 2.22.0

### DIFF
--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -37,7 +37,7 @@
         <version.bom.jakarta.transaction>2.0.1</version.bom.jakarta.transaction>
         <version.bom.jakarta.xml.bind>4.0.5</version.bom.jakarta.xml.bind>
         <version.bom.org.jberet>3.1.0.Final</version.bom.org.jberet>
-        <version.bom.com.fasterxml.jackson>2.21.4</version.bom.com.fasterxml.jackson>
+        <version.bom.com.fasterxml.jackson>2.22.0</version.bom.com.fasterxml.jackson>
         <version.bom.org.apache.httpcomponents.client5>5.6.1</version.bom.org.apache.httpcomponents.client5>
         <version.bom.org.apache.httpcomponents.core5>5.4.2</version.bom.org.apache.httpcomponents.core5>
         <version.bom.org.apache.httpcomponents.httpclient>4.5.14</version.bom.org.apache.httpcomponents.httpclient>

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -150,7 +150,7 @@
         <version.org.wiremock.wiremock>3.13.2</version.org.wiremock.wiremock>
         <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
         <version.commons-codec>1.22.0</version.commons-codec>
-        <version.commons-logging>1.3.6</version.commons-logging>
+        <version.commons-logging>1.4.0</version.commons-logging>
         <!--
             When upgrading Avro:
                 - make sure to create a new payload in EventPayloadSerializationUtilsTest

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -92,7 +92,7 @@
         <version.com.google.code.gson>2.14.0</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.46.2</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, by Avro, by the AWS SDK and in tests (wiremock, ...) -->
-        <version.com.fasterxml.jackson>2.21.4</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.22.0</version.com.fasterxml.jackson>
         <!-- slf4j: used by the AWS SDK -->
         <version.org.slf4j>1.7.36</version.org.slf4j>
 

--- a/pom.xml
+++ b/pom.xml
@@ -357,7 +357,7 @@
         <!-- Asciidoctor -->
 
         <version.asciidoctor.plugin>3.2.0</version.asciidoctor.plugin>
-        <version.org.hibernate.infra.hibernate-asciidoctor-theme>6.1.2.Final</version.org.hibernate.infra.hibernate-asciidoctor-theme>
+        <version.org.hibernate.infra.hibernate-asciidoctor-theme>6.1.3.Final</version.org.hibernate.infra.hibernate-asciidoctor-theme>
         <version.org.hibernate.infra.hibernate-asciidoctor-extensions>3.2.0.Final</version.org.hibernate.infra.hibernate-asciidoctor-extensions>
         <version.org.asciidoctor.asciidoctorj>3.0.1</version.org.asciidoctor.asciidoctorj>
         <version.org.asciidoctor.asciidoctorj-pdf>2.3.23</version.org.asciidoctor.asciidoctorj-pdf>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5650
https://hibernate.atlassian.net/browse/HSEARCH-5651
https://hibernate.atlassian.net/browse/HSEARCH-5652

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
