### PR TITLE
HSEARCH-5656 Update Apache HTTP Client components to 5.6.2 / HSEARCH-5657 Update Apache HTTP Core client components to 5.4.3

### DIFF
--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -39,7 +39,7 @@
         <version.bom.org.jberet>3.1.0.Final</version.bom.org.jberet>
         <version.bom.com.fasterxml.jackson>2.22.0</version.bom.com.fasterxml.jackson>
         <version.bom.org.apache.httpcomponents.client5>5.6.2</version.bom.org.apache.httpcomponents.client5>
-        <version.bom.org.apache.httpcomponents.core5>5.4.2</version.bom.org.apache.httpcomponents.core5>
+        <version.bom.org.apache.httpcomponents.core5>5.4.3</version.bom.org.apache.httpcomponents.core5>
         <version.bom.org.apache.httpcomponents.httpclient>4.5.14</version.bom.org.apache.httpcomponents.httpclient>
         <version.bom.org.apache.httpcomponents.httpcore>4.4.16</version.bom.org.apache.httpcomponents.httpcore>
         <version.bom.org.apache.httpcomponents.httpasyncclient>4.1.5</version.bom.org.apache.httpcomponents.httpasyncclient>

--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -38,7 +38,7 @@
         <version.bom.jakarta.xml.bind>4.0.5</version.bom.jakarta.xml.bind>
         <version.bom.org.jberet>3.1.0.Final</version.bom.org.jberet>
         <version.bom.com.fasterxml.jackson>2.22.0</version.bom.com.fasterxml.jackson>
-        <version.bom.org.apache.httpcomponents.client5>5.6.1</version.bom.org.apache.httpcomponents.client5>
+        <version.bom.org.apache.httpcomponents.client5>5.6.2</version.bom.org.apache.httpcomponents.client5>
         <version.bom.org.apache.httpcomponents.core5>5.4.2</version.bom.org.apache.httpcomponents.core5>
         <version.bom.org.apache.httpcomponents.httpclient>4.5.14</version.bom.org.apache.httpcomponents.httpclient>
         <version.bom.org.apache.httpcomponents.httpcore>4.4.16</version.bom.org.apache.httpcomponents.httpcore>

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -54,7 +54,7 @@
         <version.org.opensearch.client>3.7.0</version.org.opensearch.client>
         <!-- Various HTTP client versions that our own Elasticsearch client implementations depend on -->
         <version.org.apache.httpcomponents.client5>5.6.2</version.org.apache.httpcomponents.client5>
-        <version.org.apache.httpcomponents.core5>5.4.2</version.org.apache.httpcomponents.core5>
+        <version.org.apache.httpcomponents.core5>5.4.3</version.org.apache.httpcomponents.core5>
         <version.org.apache.httpcomponents.httpclient>4.5.14</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.16</version.org.apache.httpcomponents.httpcore>
         <version.org.apache.httpcomponents.httpasyncclient>4.1.5</version.org.apache.httpcomponents.httpasyncclient>

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -53,7 +53,7 @@
         <version.org.elasticsearch.java.client>9.4.2</version.org.elasticsearch.java.client>
         <version.org.opensearch.client>3.7.0</version.org.opensearch.client>
         <!-- Various HTTP client versions that our own Elasticsearch client implementations depend on -->
-        <version.org.apache.httpcomponents.client5>5.6.1</version.org.apache.httpcomponents.client5>
+        <version.org.apache.httpcomponents.client5>5.6.2</version.org.apache.httpcomponents.client5>
         <version.org.apache.httpcomponents.core5>5.4.2</version.org.apache.httpcomponents.core5>
         <version.org.apache.httpcomponents.httpclient>4.5.14</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.16</version.org.apache.httpcomponents.httpcore>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5656
https://hibernate.atlassian.net/browse/HSEARCH-5657

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
