### PR TITLE
HSEARCH-5661 Update to AWS SDK 2.47.1 / HSEARCH-5662 Update to Jackson 2.22.1

### DIFF
--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -22,7 +22,7 @@
         <version.bom.org.elasticsearch.client>9.4.3</version.bom.org.elasticsearch.client>
         <version.bom.org.elasticsearch.java.client>9.4.3</version.bom.org.elasticsearch.java.client>
         <version.bom.org.opensearch.client>3.7.0</version.bom.org.opensearch.client>
-        <version.bom.software.amazon.awssdk>2.46.2</version.bom.software.amazon.awssdk>
+        <version.bom.software.amazon.awssdk>2.47.1</version.bom.software.amazon.awssdk>
         <version.bom.io.smallrye>3.6.0</version.bom.io.smallrye>
         <version.bom.org.jboss.logging.processor>3.0.4.Final</version.bom.org.jboss.logging.processor>
         <version.bom.org.jboss.logging>3.6.3.Final</version.bom.org.jboss.logging>

--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -37,7 +37,7 @@
         <version.bom.jakarta.transaction>2.0.1</version.bom.jakarta.transaction>
         <version.bom.jakarta.xml.bind>4.0.5</version.bom.jakarta.xml.bind>
         <version.bom.org.jberet>3.1.0.Final</version.bom.org.jberet>
-        <version.bom.com.fasterxml.jackson>2.22.0</version.bom.com.fasterxml.jackson>
+        <version.bom.com.fasterxml.jackson>2.22.1</version.bom.com.fasterxml.jackson>
         <version.bom.org.apache.httpcomponents.client5>5.6.2</version.bom.org.apache.httpcomponents.client5>
         <version.bom.org.apache.httpcomponents.core5>5.4.3</version.bom.org.apache.httpcomponents.core5>
         <version.bom.org.apache.httpcomponents.httpclient>4.5.14</version.bom.org.apache.httpcomponents.httpclient>

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -90,7 +90,7 @@
         <documentation.org.opensearch.url>https://opensearch.org/docs/${parsed-version.org.opensearch.compatible.main.majorVersion}.${parsed-version.org.opensearch.compatible.main.minorVersion}</documentation.org.opensearch.url>
 
         <version.com.google.code.gson>2.14.0</version.com.google.code.gson>
-        <version.software.amazon.awssdk>2.46.2</version.software.amazon.awssdk>
+        <version.software.amazon.awssdk>2.47.1</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, by Avro, by the AWS SDK and in tests (wiremock, ...) -->
         <version.com.fasterxml.jackson>2.22.1</version.com.fasterxml.jackson>
         <!-- slf4j: used by the AWS SDK -->

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -92,7 +92,7 @@
         <version.com.google.code.gson>2.14.0</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.46.2</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, by Avro, by the AWS SDK and in tests (wiremock, ...) -->
-        <version.com.fasterxml.jackson>2.22.0</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.22.1</version.com.fasterxml.jackson>
         <!-- slf4j: used by the AWS SDK -->
         <version.org.slf4j>1.7.36</version.org.slf4j>
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5661
https://hibernate.atlassian.net/browse/HSEARCH-5662

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
