### PR TITLE
HSEARCH-5664 Split hppc version update between the Lucene and Lucene-next backends

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -94,6 +94,8 @@ updates:
       # These dependencies are updated manually
       - dependency-name: "org.hibernate:*"
       - dependency-name: "org.hibernate.*:*"
+      # We align this dependency on the Lucene version (more recent hppc versiosn need JDK 21+).
+      - dependency-name: "com.carrotsearch:*"
       # AWS SDK releases way too often (every week?); ignore all patch updates
       - dependency-name: "software.amazon.awssdk:*"
         update-types: ["version-update:semver-patch"]

--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -28,7 +28,6 @@
         <version.bom.org.jboss.logging>3.6.3.Final</version.bom.org.jboss.logging>
         <version.bom.org.hibernate.models>1.2.0</version.bom.org.hibernate.models>
         <version.bom.org.apache.avro>1.12.1</version.bom.org.apache.avro>
-        <version.bom.com.carrotsearch>0.11.1</version.bom.com.carrotsearch>
         <version.bom.com.google.code.gson>2.14.0</version.bom.com.google.code.gson>
         <version.bom.jakarta.batch>2.1.1</version.bom.jakarta.batch>
         <version.bom.jakarta.enterprise>4.1.0</version.bom.jakarta.enterprise>
@@ -461,12 +460,6 @@
                 <groupId>org.apache.avro</groupId>
                 <artifactId>trevni-java</artifactId>
                 <version>${version.bom.org.apache.avro}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.carrotsearch</groupId>
-                <artifactId>hppc</artifactId>
-                <version>${version.bom.com.carrotsearch}</version>
             </dependency>
 
             <dependency>

--- a/bom/platform-next/pom.xml
+++ b/bom/platform-next/pom.xml
@@ -20,6 +20,7 @@
 
         <!-- These versions will be checked against the ones resolved by Maven for the project in the enforcer rule -->
         <version.bom.org.apache.lucene>10.5.0</version.bom.org.apache.lucene>
+        <version.bom.com.carrotsearch.next>0.11.1</version.bom.com.carrotsearch.next>
         <version.bom.org.jboss.logging.processor>3.0.4.Final</version.bom.org.jboss.logging.processor>
     </properties>
 
@@ -37,6 +38,12 @@
                 <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.carrotsearch</groupId>
+                <artifactId>hppc</artifactId>
+                <version>${version.bom.com.carrotsearch.next}</version>
             </dependency>
 
             <!-- Lucene dependencies -->

--- a/bom/platform/pom.xml
+++ b/bom/platform/pom.xml
@@ -20,6 +20,7 @@
 
         <!-- These versions will be checked against the ones resolved by Maven for the project in the enforcer rule -->
         <version.bom.org.apache.lucene>9.12.3</version.bom.org.apache.lucene>
+        <version.bom.com.carrotsearch>0.10.0</version.bom.com.carrotsearch>
         <version.bom.org.jboss.logging.processor>3.0.4.Final</version.bom.org.jboss.logging.processor>
     </properties>
 
@@ -193,6 +194,12 @@
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-analysis-stempel</artifactId>
                 <version>${version.bom.org.apache.lucene}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.carrotsearch</groupId>
+                <artifactId>hppc</artifactId>
+                <version>${version.bom.com.carrotsearch}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -43,7 +43,8 @@
         <javadoc.org.apache.lucene.analysis.common.url>https://lucene.apache.org/core/${javadoc.org.apache.lucene.tag}/analysis/common/</javadoc.org.apache.lucene.analysis.common.url>
         <javadoc.org.apache.lucene.queryparser.url>https://lucene.apache.org/core/${javadoc.org.apache.lucene.tag}/queryparser/</javadoc.org.apache.lucene.queryparser.url>
 
-        <version.com.carrotsearch.hppc>0.11.1</version.com.carrotsearch.hppc>
+        <version.com.carrotsearch.hppc>0.10.0</version.com.carrotsearch.hppc>
+        <version.com.carrotsearch.hppc.next>0.11.1</version.com.carrotsearch.hppc.next>
         <version.org.apache.lucene.next>10.5.0</version.org.apache.lucene.next>
 
         <!-- >>> Elasticsearch -->

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -229,7 +229,7 @@
                                 <artifactItem>
                                     <groupId>com.carrotsearch</groupId>
                                     <artifactId>hppc</artifactId>
-                                    <version>${version.com.carrotsearch.hppc}</version>
+                                    <version>${version.com.carrotsearch.hppc.next}</version>
                                 </artifactItem>
                             </artifactItems>
                             <outputDirectory>${project.build.directory}/dependencies-lucene-next</outputDirectory>

--- a/lucene-next/build/parents/integrationtest/pom.xml
+++ b/lucene-next/build/parents/integrationtest/pom.xml
@@ -65,6 +65,12 @@
                 <artifactId>lucene-highlighter</artifactId>
                 <version>${version.org.apache.lucene.next.updatable}</version>
             </dependency>
+
+            <dependency>
+                <groupId>com.carrotsearch</groupId>
+                <artifactId>hppc</artifactId>
+                <version>${version.com.carrotsearch.hppc.next}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/lucene-next/build/parents/internal/pom.xml
+++ b/lucene-next/build/parents/internal/pom.xml
@@ -56,6 +56,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.carrotsearch</groupId>
+                <artifactId>hppc</artifactId>
+                <version>${version.com.carrotsearch.hppc.next}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-util-internal-integrationtest-backend-lucene-next</artifactId>
                 <version>${project.version}</version>

--- a/lucene-next/build/parents/public/pom.xml
+++ b/lucene-next/build/parents/public/pom.xml
@@ -56,6 +56,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.carrotsearch</groupId>
+                <artifactId>hppc</artifactId>
+                <version>${version.com.carrotsearch.hppc.next}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-util-internal-integrationtest-backend-lucene-next</artifactId>
                 <version>${project.version}</version>

--- a/lucene-next/build/parents/springtest/pom.xml
+++ b/lucene-next/build/parents/springtest/pom.xml
@@ -66,6 +66,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.carrotsearch</groupId>
+                <artifactId>hppc</artifactId>
+                <version>${version.com.carrotsearch.hppc.next}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-util-internal-integrationtest-backend-lucene-next</artifactId>
                 <version>${project.version}</version>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5664

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
