### PR TITLE
HSEARCH-5666 Test against latest Elasticsearch 9.4.4 / HSEARCH-5668 Update Elasticsearch client (elasticsearch-rest5-client) to 9.4.4 / HSEARCH-5667 Update Elasticsearch client (elasticsearch-rest-client) to 9.4.4

### DIFF
--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -19,7 +19,7 @@
 
         <!-- These versions will be checked against the ones resolved by Maven for the project in the enforcer rule -->
         <version.bom.org.hibernate.orm>8.0.0.Beta1</version.bom.org.hibernate.orm>
-        <version.bom.org.elasticsearch.client>9.4.3</version.bom.org.elasticsearch.client>
+        <version.bom.org.elasticsearch.client>9.4.4</version.bom.org.elasticsearch.client>
         <version.bom.org.elasticsearch.java.client>9.4.3</version.bom.org.elasticsearch.java.client>
         <version.bom.org.opensearch.client>3.7.0</version.bom.org.opensearch.client>
         <version.bom.software.amazon.awssdk>2.48.0</version.bom.software.amazon.awssdk>

--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -20,7 +20,7 @@
         <!-- These versions will be checked against the ones resolved by Maven for the project in the enforcer rule -->
         <version.bom.org.hibernate.orm>8.0.0.Beta1</version.bom.org.hibernate.orm>
         <version.bom.org.elasticsearch.client>9.4.4</version.bom.org.elasticsearch.client>
-        <version.bom.org.elasticsearch.java.client>9.4.3</version.bom.org.elasticsearch.java.client>
+        <version.bom.org.elasticsearch.java.client>9.4.4</version.bom.org.elasticsearch.java.client>
         <version.bom.org.opensearch.client>3.7.0</version.bom.org.opensearch.client>
         <version.bom.software.amazon.awssdk>2.48.0</version.bom.software.amazon.awssdk>
         <version.bom.io.smallrye>3.6.0</version.bom.io.smallrye>

--- a/build/container/search-backend/elastic.Dockerfile
+++ b/build/container/search-backend/elastic.Dockerfile
@@ -5,4 +5,4 @@
 #  * update `version.org.elasticsearch.latest` property in a POM file.
 #  * update the tags for 'elasticsearch-current' and 'elasticsearch-next' builds in ci/dependency-update/Jenkinsfile
 #
-FROM docker.io/elastic/elasticsearch:9.4.3@sha256:851ff5f9615ab7d2f00931114f6db32850f0208ec9fe7e841f135ac78f5f13d5
+FROM docker.io/elastic/elasticsearch:9.4.4@sha256:a3545404e436e348721786bed638042a81f2181ebe2e2636501bb43940677747

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -50,7 +50,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.5+ -->
-        <version.org.elasticsearch.client>9.4.3</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>9.4.4</version.org.elasticsearch.client>
         <version.org.elasticsearch.java.client>9.4.3</version.org.elasticsearch.java.client>
         <version.org.opensearch.client>3.7.0</version.org.opensearch.client>
         <!-- Various HTTP client versions that our own Elasticsearch client implementations depend on -->

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -51,7 +51,7 @@
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.5+ -->
         <version.org.elasticsearch.client>9.4.4</version.org.elasticsearch.client>
-        <version.org.elasticsearch.java.client>9.4.3</version.org.elasticsearch.java.client>
+        <version.org.elasticsearch.java.client>9.4.4</version.org.elasticsearch.java.client>
         <version.org.opensearch.client>3.7.0</version.org.opensearch.client>
         <!-- Various HTTP client versions that our own Elasticsearch client implementations depend on -->
         <version.org.apache.httpcomponents.client5>5.6.2</version.org.apache.httpcomponents.client5>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5666
https://hibernate.atlassian.net/browse/HSEARCH-5667
https://hibernate.atlassian.net/browse/HSEARCH-5668

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
