### PR TITLE
HSEARCH-5675 Update to commons-codec to 1.22.1  HSEARCH-5674 Update Apache HTTP Client components to 5.6.3 HSEARCH-5673 Update to AWS SDK 2.50.2  HSEARCH-5672 Update Elasticsearch client (elasticsearch-rest5-client) to 9.4.5 

### DIFF
--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -20,7 +20,7 @@
         <!-- These versions will be checked against the ones resolved by Maven for the project in the enforcer rule -->
         <version.bom.org.hibernate.orm>8.0.0.Beta1</version.bom.org.hibernate.orm>
         <version.bom.org.elasticsearch.client>9.4.4</version.bom.org.elasticsearch.client>
-        <version.bom.org.elasticsearch.java.client>9.4.4</version.bom.org.elasticsearch.java.client>
+        <version.bom.org.elasticsearch.java.client>9.4.5</version.bom.org.elasticsearch.java.client>
         <version.bom.org.opensearch.client>3.7.0</version.bom.org.opensearch.client>
         <version.bom.software.amazon.awssdk>2.48.0</version.bom.software.amazon.awssdk>
         <version.bom.io.smallrye>3.6.0</version.bom.io.smallrye>

--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -22,7 +22,7 @@
         <version.bom.org.elasticsearch.client>9.4.4</version.bom.org.elasticsearch.client>
         <version.bom.org.elasticsearch.java.client>9.4.5</version.bom.org.elasticsearch.java.client>
         <version.bom.org.opensearch.client>3.7.0</version.bom.org.opensearch.client>
-        <version.bom.software.amazon.awssdk>2.48.0</version.bom.software.amazon.awssdk>
+        <version.bom.software.amazon.awssdk>2.50.2</version.bom.software.amazon.awssdk>
         <version.bom.io.smallrye>3.6.0</version.bom.io.smallrye>
         <version.bom.org.jboss.logging.processor>3.0.4.Final</version.bom.org.jboss.logging.processor>
         <version.bom.org.jboss.logging>3.6.3.Final</version.bom.org.jboss.logging>

--- a/bom/platform-common/pom.xml
+++ b/bom/platform-common/pom.xml
@@ -37,7 +37,7 @@
         <version.bom.jakarta.xml.bind>4.0.5</version.bom.jakarta.xml.bind>
         <version.bom.org.jberet>3.1.0.Final</version.bom.org.jberet>
         <version.bom.com.fasterxml.jackson>2.22.1</version.bom.com.fasterxml.jackson>
-        <version.bom.org.apache.httpcomponents.client5>5.6.2</version.bom.org.apache.httpcomponents.client5>
+        <version.bom.org.apache.httpcomponents.client5>5.6.3</version.bom.org.apache.httpcomponents.client5>
         <version.bom.org.apache.httpcomponents.core5>5.4.3</version.bom.org.apache.httpcomponents.core5>
         <version.bom.org.apache.httpcomponents.httpclient>4.5.14</version.bom.org.apache.httpcomponents.httpclient>
         <version.bom.org.apache.httpcomponents.httpcore>4.4.16</version.bom.org.apache.httpcomponents.httpcore>

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -150,7 +150,7 @@
         <version.io.takari.junit>1.2.7</version.io.takari.junit>
         <version.org.wiremock.wiremock>3.13.2</version.org.wiremock.wiremock>
         <version.org.apache.commons.math3>3.6.1</version.org.apache.commons.math3>
-        <version.commons-codec>1.22.0</version.commons-codec>
+        <version.commons-codec>1.22.1</version.commons-codec>
         <version.commons-logging>1.4.0</version.commons-logging>
         <!--
             When upgrading Avro:

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -54,7 +54,7 @@
         <version.org.elasticsearch.java.client>9.4.5</version.org.elasticsearch.java.client>
         <version.org.opensearch.client>3.7.0</version.org.opensearch.client>
         <!-- Various HTTP client versions that our own Elasticsearch client implementations depend on -->
-        <version.org.apache.httpcomponents.client5>5.6.2</version.org.apache.httpcomponents.client5>
+        <version.org.apache.httpcomponents.client5>5.6.3</version.org.apache.httpcomponents.client5>
         <version.org.apache.httpcomponents.core5>5.4.3</version.org.apache.httpcomponents.core5>
         <version.org.apache.httpcomponents.httpclient>4.5.14</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.16</version.org.apache.httpcomponents.httpcore>

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -91,7 +91,7 @@
         <documentation.org.opensearch.url>https://opensearch.org/docs/${parsed-version.org.opensearch.compatible.main.majorVersion}.${parsed-version.org.opensearch.compatible.main.minorVersion}</documentation.org.opensearch.url>
 
         <version.com.google.code.gson>2.14.0</version.com.google.code.gson>
-        <version.software.amazon.awssdk>2.48.0</version.software.amazon.awssdk>
+        <version.software.amazon.awssdk>2.50.2</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, by Avro, by the AWS SDK and in tests (wiremock, ...) -->
         <version.com.fasterxml.jackson>2.22.1</version.com.fasterxml.jackson>
         <!-- slf4j: used by the AWS SDK -->

--- a/build/parents/build/pom.xml
+++ b/build/parents/build/pom.xml
@@ -51,7 +51,7 @@
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently of the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 8.5+ -->
         <version.org.elasticsearch.client>9.4.4</version.org.elasticsearch.client>
-        <version.org.elasticsearch.java.client>9.4.4</version.org.elasticsearch.java.client>
+        <version.org.elasticsearch.java.client>9.4.5</version.org.elasticsearch.java.client>
         <version.org.opensearch.client>3.7.0</version.org.opensearch.client>
         <!-- Various HTTP client versions that our own Elasticsearch client implementations depend on -->
         <version.org.apache.httpcomponents.client5>5.6.2</version.org.apache.httpcomponents.client5>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5672
https://hibernate.atlassian.net/browse/HSEARCH-5673
https://hibernate.atlassian.net/browse/HSEARCH-5674
https://hibernate.atlassian.net/browse/HSEARCH-5675



<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
