### PR TITLE
[8.2] HSEARCH-5682 Tune the content of javadoc jars to reduce the size of files published to Maven Central

### DIFF
--- a/build/parents/public/pom.xml
+++ b/build/parents/public/pom.xml
@@ -358,6 +358,31 @@
                                     <goal>jar</goal>
                                 </goals>
                                 <phase>${javadoc.generate.jar.phase}</phase>
+                                <!--
+                                    Reduce the size of per-module javadoc jars published to Maven Central.
+                                    These options are intentionally NOT in the shared pluginManagement configuration,
+                                    so that the aggregated javadoc published to docs.hibernate.org is unaffected.
+                                 -->
+                                <configuration>
+                                    <!--
+                                        Use a separate output directory so that the reduced javadoc
+                                        does not get mixed with the full javadoc from the generate-javadoc execution.
+                                     -->
+                                    <outputDirectory>${project.build.directory}/javadoc-jar</outputDirectory>
+                                    <!-- SPI pages add bulk; SPI is for integrators who read the source -->
+                                    <excludePackageNames>*.impl,*.impl.*,*.spi,*.spi.*</excludePackageNames>
+                                    <additionalOptions>
+                                        <additionalOption>-html5</additionalOption>
+                                        <additionalOption>-Xdoclint:all,-missing</additionalOption>
+                                        <additionalOption>--add-script resources/theme-switch.js</additionalOption>
+                                        <!-- Don't repeat inherited method docs; link to the declaring type instead -->
+                                        <additionalOption>--override-methods summary</additionalOption>
+                                    </additionalOptions>
+                                    <!-- class-use pages add significant size; IDEs provide better "find usages" -->
+                                    <use>false</use>
+                                    <!-- Class hierarchy tree adds bulk; IDEs show this better -->
+                                    <notree>true</notree>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-5682

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-search/blob/main/CONTRIBUTING.md#legal).

----------------------
